### PR TITLE
test(admin): add post-merge smoke coverage

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -68,6 +68,8 @@ jobs:
       - name: Smoke test admin
         env:
           DATABASE_URL: ${{ env.RUNTIME_AUDIT_DATABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
         run: pnpm run test:admin-smoke
 
       - name: Upload Playwright admin report

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -61,3 +61,18 @@ jobs:
 
       - name: Validate tests
         run: pnpm run test:validate
+
+      - name: Install Playwright browser
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Smoke test admin
+        env:
+          DATABASE_URL: ${{ env.RUNTIME_AUDIT_DATABASE_URL }}
+        run: pnpm run test:admin-smoke
+
+      - name: Upload Playwright admin report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-admin-report
+          path: output/playwright/**

--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,7 @@ private/
 .reports/
 .playwright-cli/
 output/playwright/
+playwright-report/
+test-results/
 output/internal-link-audit-live.json
+frontend/.tmp/

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "sources:check": "node scripts/sources-check.mjs",
     "engine:catalog": "./frontend/node_modules/.bin/tsx scripts/build-engine-catalog.ts",
     "jobs:export": "tsx scripts/export-latest-jobs.ts",
+    "test:admin-smoke": "playwright test -c playwright.admin.config.ts",
     "test-videos:process": "node scripts/process-video-gallery.mjs",
     "test-videos:serve": "node scripts/serve-video-gallery.mjs",
     "test:validate": "tsx --tsconfig frontend/tsconfig.json --test tests/*.test.ts"
@@ -37,6 +38,7 @@
   },
   "packageManager": "pnpm@10.18.2+sha512.9fb969fa749b3ade6035e0f109f0b8a60b5d08a1a87fdf72e337da90dcc93336e2280ca4e44f2358a649b83c17959e9993e777c2080879f3801e6f0d999ad3dd",
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/pg": "^8.10.2",
     "tsx": "^4.20.6"
   }

--- a/playwright.admin.config.ts
+++ b/playwright.admin.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from '@playwright/test';
+
+const port = 3001;
+const baseURL = `http://localhost:${port}`;
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  testMatch: ['**/*.spec.ts'],
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI
+    ? [['list'], ['html', { open: 'never', outputFolder: 'output/playwright/admin-report' }]]
+    : [['list']],
+  use: {
+    baseURL,
+    browserName: 'chromium',
+    headless: true,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  webServer: {
+    command: `pnpm --dir frontend exec next dev --hostname localhost --port ${port}`,
+    url: baseURL,
+    timeout: 180_000,
+    reuseExistingServer: !process.env.CI,
+    env: {
+      ...process.env,
+      LOCAL_ADMIN_BYPASS: '1',
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
         specifier: ^14.24.0
         version: 14.25.0
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@types/pg':
         specifier: ^8.10.2
         version: 8.15.5
@@ -41,7 +44,7 @@ importers:
         version: 1.7.0
       '@fal-ai/server-proxy':
         specifier: ^1.2.1
-        version: 1.2.1(express@4.21.2)(next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.2.1(express@4.21.2)(next@14.2.35(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@ffmpeg-installer/ffmpeg':
         specifier: ^1.1.0
         version: 1.1.0
@@ -68,10 +71,10 @@ importers:
         version: 2.76.1(bufferutil@4.0.9)
       '@vercel/analytics':
         specifier: ^1.5.0
-        version: 1.5.0(next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 1.5.0(next@14.2.35(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@vercel/speed-insights':
         specifier: ^1.2.0
-        version: 1.2.0(next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 1.2.0(next@14.2.35(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
@@ -104,10 +107,10 @@ importers:
         version: 10.0.1
       next:
         specifier: ^14.2.35
-        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-intl:
         specifier: ^4.4.0
-        version: 4.4.0(next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+        version: 4.4.0(next@14.2.35(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       nodemailer:
         specifier: ^7.0.13
         version: 7.0.13
@@ -207,7 +210,7 @@ importers:
         version: 15.5.2
       next-sitemap:
         specifier: ^4.2.3
-        version: 4.2.3(next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 4.2.3(next@14.2.35(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       postcss:
         specifier: ^8.4.35
         version: 8.5.6
@@ -937,6 +940,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@puppeteer/browsers@2.10.13':
     resolution: {integrity: sha512-a9Ruw3j3qlnB5a/zHRTkruppynxqaeE4H9WNj5eYGRWqw0ZauZ23f4W2ARf3hghF5doozyD+CRtt7XSYuYRI/Q==}
@@ -2627,6 +2635,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3742,6 +3755,16 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -5405,12 +5428,12 @@ snapshots:
       eventsource-parser: 1.1.2
       robot3: 0.4.1
 
-  '@fal-ai/server-proxy@1.2.1(express@4.21.2)(next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fal-ai/server-proxy@1.2.1(express@4.21.2)(next@14.2.35(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       picomatch: 4.0.3
     optionalDependencies:
       express: 4.21.2
-      next: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.35(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
@@ -5696,6 +5719,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@puppeteer/browsers@2.10.13':
     dependencies:
@@ -6532,14 +6559,14 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@1.5.0(next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@vercel/analytics@1.5.0(next@14.2.35(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     optionalDependencies:
-      next: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.35(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
 
-  '@vercel/speed-insights@1.2.0(next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@vercel/speed-insights@1.2.0(next@14.2.35(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     optionalDependencies:
-      next: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.35(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
 
   '@webgpu/types@0.1.69': {}
@@ -7713,6 +7740,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -8753,25 +8783,25 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next-intl@4.4.0(next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.3):
+  next-intl@4.4.0(next@14.2.35(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.5.10
       negotiator: 1.0.0
-      next: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.35(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       use-intl: 4.4.0(react@18.3.1)
     optionalDependencies:
       typescript: 5.9.3
 
-  next-sitemap@4.2.3(next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  next-sitemap@4.2.3(next@14.2.35(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
       '@corex/deepmerge': 4.0.43
       '@next/env': 13.5.11
       fast-glob: 3.3.3
       minimist: 1.2.8
-      next: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.35(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.35(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.35
       '@swc/helpers': 0.5.5
@@ -8792,6 +8822,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.33
       '@next/swc-win32-ia32-msvc': 14.2.33
       '@next/swc-win32-x64-msvc': 14.2.33
+      '@playwright/test': 1.59.1
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -9038,6 +9069,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/tests/e2e/admin-smoke.spec.ts
+++ b/tests/e2e/admin-smoke.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test, type Page } from '@playwright/test';
+
+type SmokeRoute = {
+  path: string;
+  heading: string;
+  section: string;
+};
+
+type ClientErrors = {
+  consoleErrors: string[];
+  pageErrors: string[];
+};
+
+const smokeRoutes: SmokeRoute[] = [
+  {
+    path: '/admin',
+    heading: 'Operations control',
+    section: 'Signal Board',
+  },
+  {
+    path: '/admin/insights',
+    heading: 'Workspace insights',
+    section: 'Trend Workspace',
+  },
+  {
+    path: '/admin/jobs',
+    heading: 'Jobs',
+    section: 'Job Workspace',
+  },
+  {
+    path: '/admin/transactions',
+    heading: 'Transactions',
+    section: 'Transaction Workspace',
+  },
+  {
+    path: '/admin/video-seo',
+    heading: 'Video SEO watch pages',
+    section: 'Watch Page Inventory',
+  },
+];
+
+test.describe('admin smoke', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  for (const route of smokeRoutes) {
+    test(`${route.path} renders without client errors`, async ({ page }) => {
+      const errors = await openAdminRoute(page, route.path);
+
+      await expect(page.getByRole('heading', { level: 1, name: route.heading })).toBeVisible();
+      await expect(page.locator('body')).toContainText(route.section);
+
+      assertNoClientErrors(errors);
+    });
+  }
+
+  test('video seo remains stable in dark theme', async ({ page }) => {
+    const errors = await openAdminRoute(page, '/admin/video-seo');
+
+    await page.evaluate(() => {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    });
+
+    await expect(page.getByRole('heading', { level: 1, name: 'Video SEO watch pages' })).toBeVisible();
+    await expect(page.locator('body')).toContainText('Watch Page Inventory');
+
+    assertNoClientErrors(errors);
+  });
+
+  test('admin home remains usable on mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    const errors = await openAdminRoute(page, '/admin');
+
+    await expect(page.getByRole('heading', { level: 1, name: 'Operations control' })).toBeVisible();
+    await expect(page.locator('body')).toContainText('Signal Board');
+    await expect(page.getByRole('button', { name: 'Go' })).toBeVisible();
+
+    assertNoClientErrors(errors);
+  });
+});
+
+async function openAdminRoute(page: Page, path: string): Promise<ClientErrors> {
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      consoleErrors.push(message.text());
+    }
+  });
+
+  page.on('pageerror', (error) => {
+    pageErrors.push(error.message);
+  });
+
+  await page.goto(`/api/dev/admin-session?redirectTo=${encodeURIComponent(path)}`, {
+    waitUntil: 'domcontentloaded',
+  });
+
+  await expect(page).toHaveURL(new RegExp(`${escapeForRegExp(path)}$`));
+  await page.waitForLoadState('load');
+  await page.waitForLoadState('networkidle', { timeout: 5_000 }).catch(() => undefined);
+
+  return { consoleErrors, pageErrors };
+}
+
+function assertNoClientErrors(errors: ClientErrors) {
+  expect(errors.pageErrors, `Unexpected page errors:\n${errors.pageErrors.join('\n')}`).toEqual([]);
+  expect(errors.consoleErrors, `Unexpected console errors:\n${errors.consoleErrors.join('\n')}`).toEqual([]);
+}
+
+function escapeForRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
## Summary
- add a focused Playwright admin smoke suite for the core admin routes
- run it in CI after lint, typecheck, and existing validation tests
- ignore local Playwright artifacts and temp admin outputs

## Validation
- pnpm --dir frontend exec tsc --noEmit
- pnpm --dir frontend run lint
- pnpm run test:validate
- pnpm run test:admin-smoke