### PR TITLE
ci: update workflows for node24-compatible actions

### DIFF
--- a/.github/workflows/indexnow.yml
+++ b/.github/workflows/indexnow.yml
@@ -17,9 +17,11 @@ on:
 jobs:
   indexnow:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -7,14 +7,17 @@ on:
 jobs:
   lighthouse:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
+          package-manager-cache: false
 
       - name: Enable Corepack
         run: corepack enable
@@ -44,7 +47,7 @@ jobs:
         run: pnpm --dir frontend run lighthouse:contact
 
       - name: Upload Lighthouse reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lighthouse-reports
           path: frontend/lighthouse-reports/**

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,17 +10,19 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
       RUNTIME_AUDIT_DATABASE_URL: ${{ secrets.RUNTIME_AUDIT_DATABASE_URL }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
+          package-manager-cache: false
 
       - name: Enable Corepack
         run: corepack enable
@@ -75,7 +77,7 @@ jobs:
 
       - name: Upload Playwright admin report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-admin-report
           path: output/playwright/**


### PR DESCRIPTION
## Summary
- upgrade GitHub Actions workflow dependencies to Node 24-compatible major versions
- remove the temporary force flag from quality CI
- add read-only workflow permissions and disable implicit setup-node package-manager caching

## Validation
- ruby YAML parse for all workflow files
- confirmed no targeted workflow still references checkout/setup-node/upload-artifact v4
