### PR TITLE
[codex] Refactor media workspace library outputs

### DIFF
--- a/frontend/app/(core)/(workspace)/app/AppClient.tsx
+++ b/frontend/app/(core)/(workspace)/app/AppClient.tsx
@@ -389,9 +389,11 @@ type UserAsset = {
   source?: string | null;
   createdAt?: string;
   canDelete?: boolean;
+  jobId?: string | null;
+  sourceOutputId?: string | null;
 };
 
-type AssetLibrarySource = 'all' | 'upload' | 'generated' | 'character' | 'angle' | 'upscale';
+type AssetLibrarySource = 'all' | 'upload' | 'generated' | 'recent' | 'character' | 'angle' | 'upscale';
 type AssetLibraryKind = 'image' | 'video';
 type UploadableAssetKind = 'image' | 'video' | 'audio';
 type UploadFailurePayload = { error?: unknown; maxMB?: unknown } | null;
@@ -2889,18 +2891,15 @@ const showNotice = useCallback((message: string) => {
     setIsAssetLibraryLoading(true);
     setAssetLibraryError(null);
     try {
-      const assetUrl =
-        source === 'all'
-          ? '/api/user-assets?limit=60'
-          : `/api/user-assets?limit=60&source=${encodeURIComponent(source)}`;
-      const requests: Array<Promise<Response>> = [authFetch(assetUrl)];
-      if (kind === 'video' && source !== 'upload') {
-        const jobsUrl = source === 'upscale' ? '/api/jobs?limit=60&surface=upscale' : '/api/jobs?limit=60&type=video';
-        requests.push(authFetch(jobsUrl));
-      }
+      const isRecentOutputSource = source === 'recent';
+      const assetUrl = isRecentOutputSource
+        ? `/api/media-library/recent-outputs?limit=60&kind=${encodeURIComponent(kind)}`
+        : source === 'all'
+          ? `/api/media-library/assets?limit=60&kind=${encodeURIComponent(kind)}`
+          : `/api/media-library/assets?limit=60&kind=${encodeURIComponent(kind)}&source=${encodeURIComponent(source)}`;
 
-      const [assetResponse, jobsResponse] = await Promise.all(requests);
-      if (assetResponse.status === 401 || jobsResponse?.status === 401) {
+      const assetResponse = await authFetch(assetUrl);
+      if (assetResponse.status === 401) {
         setAssetLibrary([]);
         setAssetLibraryError(
           kind === 'video' ? 'Sign in to access your video library.' : 'Sign in to access your image library.'
@@ -2918,8 +2917,9 @@ const showNotice = useCallback((message: string) => {
               : 'Failed to load images';
         throw new Error(message);
       }
-      const assets = Array.isArray(payload.assets)
-        ? (payload.assets as Array<Omit<UserAsset, 'kind' | 'canDelete'>>).map((asset) => {
+      const rawItems = isRecentOutputSource ? payload.outputs : payload.assets;
+      const assets = Array.isArray(rawItems)
+        ? (rawItems as Array<Omit<UserAsset, 'canDelete'> & { thumbUrl?: string | null; sourceOutputId?: string | null; jobId?: string | null }>).map((asset) => {
             const mime = asset.mime ?? null;
             return {
               id: asset.id,
@@ -2929,9 +2929,11 @@ const showNotice = useCallback((message: string) => {
               height: asset.height ?? null,
               size: asset.size ?? null,
               mime,
-              source: asset.source ?? null,
+              source: isRecentOutputSource ? 'recent' : asset.source ?? null,
               createdAt: asset.createdAt,
-              canDelete: true,
+              canDelete: !isRecentOutputSource,
+              jobId: asset.jobId ?? null,
+              sourceOutputId: asset.sourceOutputId ?? (isRecentOutputSource ? asset.id : null),
             } satisfies UserAsset;
           })
         : [];
@@ -2941,28 +2943,7 @@ const showNotice = useCallback((message: string) => {
           : !asset.mime || asset.mime.startsWith('image/')
       );
 
-      let generatedVideos: UserAsset[] = [];
-      if (kind === 'video' && jobsResponse) {
-        const jobsPayload = await jobsResponse.json().catch(() => null);
-        if (jobsResponse.ok && Array.isArray(jobsPayload?.jobs)) {
-          generatedVideos = (jobsPayload.jobs as Job[])
-            .filter((job) => typeof job.videoUrl === 'string' && job.videoUrl.trim().length > 0)
-            .map((job) => ({
-              id: `job:${job.jobId}`,
-              url: job.videoUrl as string,
-              kind: 'video',
-              mime: 'video/mp4',
-              source: 'generated',
-              createdAt: job.createdAt,
-              canDelete: false,
-            }));
-        }
-      }
-
-      const combined =
-        kind === 'video'
-          ? [...filteredUploads, ...generatedVideos]
-          : filteredUploads;
+      const combined = filteredUploads;
       const deduped = combined.filter(
         (asset, index, list) => list.findIndex((entry) => entry.url === asset.url) === index
       );
@@ -3091,7 +3072,7 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
         showNotice(blockedMessage);
         return;
       }
-      const nextSource: AssetLibrarySource = field.type === 'video' ? 'generated' : 'all';
+      const nextSource: AssetLibrarySource = field.type === 'video' ? 'recent' : 'all';
       if (nextSource !== assetLibrarySource) {
         setAssetLibrarySource(nextSource);
         setAssetLibrary([]);
@@ -3139,6 +3120,7 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
           const host = new URL(asset.url).host.toLowerCase();
           const shouldMirrorVideo =
             asset.source === 'generated' ||
+            asset.source === 'recent' ||
             host === 'fal.media' ||
             host.endsWith('.fal.media');
           if (shouldMirrorVideo) {
@@ -3148,8 +3130,10 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
                 field.label ??
                 asset.url.split('/').pop() ??
                 'Video',
-              source: asset.source,
+              source: asset.source === 'recent' ? 'saved_job_output' : asset.source,
               kind: 'video',
+              jobId: asset.jobId ?? null,
+              sourceOutputId: asset.sourceOutputId ?? null,
             });
             resolvedAsset = {
               ...asset,

--- a/frontend/app/(core)/(workspace)/app/library/page.tsx
+++ b/frontend/app/(core)/(workspace)/app/library/page.tsx
@@ -69,6 +69,7 @@ interface LibraryCopy {
     all: string;
     upload: string;
     generated: string;
+    recent: string;
     character: string;
     angle: string;
     upscale: string;
@@ -123,6 +124,7 @@ const DEFAULT_LIBRARY_COPY: LibraryCopy = {
     all: 'All images',
     upload: 'Uploaded images',
     generated: 'Generated images',
+    recent: 'Recent outputs',
     character: 'Character assets',
     angle: 'Angle assets',
     upscale: 'Upscale assets',
@@ -201,7 +203,7 @@ export default function LibraryPage() {
   const copy = useMemo<LibraryCopy>(() => {
     return deepmerge<LibraryCopy>(DEFAULT_LIBRARY_COPY, (rawCopy ?? {}) as Partial<LibraryCopy>);
   }, [rawCopy]);
-  const [activeSource, setActiveSource] = useState<'all' | 'upload' | 'generated' | 'character' | 'angle' | 'upscale'>('all');
+  const [activeSource, setActiveSource] = useState<'all' | 'upload' | 'generated' | 'recent' | 'character' | 'angle' | 'upscale'>('all');
   const assetsKey = user
     ? activeSource === 'all'
       ? '/api/user-assets?limit=200'

--- a/frontend/app/api/jobs/[jobId]/route.ts
+++ b/frontend/app/api/jobs/[jobId]/route.ts
@@ -22,6 +22,7 @@ import { VISITOR_WORKSPACE_ENABLED } from '@/lib/visitor-access';
 import { getVisitorImageLikeJob, getVisitorStarterJob } from '@/server/visitor-workspace';
 import { deriveJobSurface } from '@/lib/job-surface';
 import { updateJobFromFalWebhook } from '@/server/fal-webhook-handler';
+import { applyOutputsToJobPayload, listJobOutputsByJobIds, upsertLegacyJobOutputs } from '@/server/media-library';
 
 export const dynamic = 'force-dynamic';
 
@@ -48,6 +49,7 @@ type DbJobRow = {
   preview_video_url: string | null;
   audio_url: string | null;
   thumb_url: string | null;
+  preview_frame: string | null;
   engine_id: string;
   engine_label: string;
   duration_sec: number;
@@ -74,7 +76,7 @@ type DbJobRow = {
   aspect_ratio: string | null;
 };
 
-const JOB_DETAIL_SELECT = `SELECT id, job_id, user_id, status, progress, provider_job_id, provider, surface, billing_product_key, video_url, preview_video_url, audio_url, thumb_url, engine_id, engine_label, duration_sec, prompt, created_at, final_price_cents, pricing_snapshot, settings_snapshot, currency, payment_status, vendor_account_id, stripe_payment_intent_id, stripe_charge_id, batch_id, group_id, iteration_index, iteration_count, render_ids, hero_render_id, local_key, message, eta_seconds, eta_label, aspect_ratio
+const JOB_DETAIL_SELECT = `SELECT id, job_id, user_id, status, progress, provider_job_id, provider, surface, billing_product_key, video_url, preview_video_url, audio_url, thumb_url, preview_frame, engine_id, engine_label, duration_sec, prompt, created_at, final_price_cents, pricing_snapshot, settings_snapshot, currency, payment_status, vendor_account_id, stripe_payment_intent_id, stripe_charge_id, batch_id, group_id, iteration_index, iteration_count, render_ids, hero_render_id, local_key, message, eta_seconds, eta_label, aspect_ratio
        FROM app_jobs
        WHERE job_id = $1
        LIMIT 1`;
@@ -266,6 +268,43 @@ export async function GET(_req: NextRequest, props: { params: Promise<{ jobId: s
     videoUrl: job.video_url,
     renderIds: job.render_ids,
   });
+
+  try {
+    let outputMap = await listJobOutputsByJobIds([job.job_id]);
+    if (!outputMap.has(job.job_id)) {
+      await upsertLegacyJobOutputs({
+        job_id: job.job_id,
+        user_id: job.user_id,
+        surface: job.surface,
+        video_url: job.video_url,
+        audio_url: job.audio_url,
+        thumb_url: job.thumb_url,
+        preview_frame: job.preview_frame,
+        render_ids: job.render_ids,
+        duration_sec: job.duration_sec,
+        status: job.status,
+      });
+      outputMap = await listJobOutputsByJobIds([job.job_id]);
+    }
+    const enriched = applyOutputsToJobPayload(
+      {
+        jobId: job.job_id,
+        videoUrl: normalizedVideoUrl,
+        audioUrl: normalizedAudioUrl,
+        thumbUrl: normalizedThumbUrl,
+        renderIds: parsedRenderIds ?? null,
+        renderThumbUrls: parsedRenderThumbUrls ?? null,
+      },
+      outputMap.get(job.job_id)
+    );
+    normalizedVideoUrl = enriched.videoUrl ?? null;
+    normalizedAudioUrl = enriched.audioUrl ?? null;
+    normalizedThumbUrl = enriched.thumbUrl ?? null;
+    parsedRenderIds = enriched.renderIds ?? parsedRenderIds;
+    parsedRenderThumbUrls = enriched.renderThumbUrls ?? parsedRenderThumbUrls;
+  } catch (error) {
+    console.warn('[api/jobs] media output detail enrichment failed', { jobId, error });
+  }
 
   // Optionally poll FAL once if pending and we have provider job id
   if (surface !== 'audio' && shouldUseFalApis() && job.provider_job_id && job.status !== 'completed' && job.status !== 'failed') {
@@ -526,4 +565,40 @@ export async function GET(_req: NextRequest, props: { params: Promise<{ jobId: s
     etaSeconds: job.eta_seconds ?? undefined,
     etaLabel: job.eta_label ?? undefined,
   });
+}
+
+export async function PATCH(req: NextRequest, props: { params: Promise<{ jobId: string }> }) {
+  const { jobId } = await props.params;
+  if (!isDatabaseConfigured()) {
+    return json({ ok: false, error: 'Database unavailable' }, { status: 503 });
+  }
+
+  const { userId } = await getRouteAuthContext(req);
+  if (!userId) {
+    return json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const payload = (await req.json().catch(() => null)) as { hidden?: unknown } | null;
+  if (payload?.hidden !== true) {
+    return json({ ok: false, error: 'Unsupported patch' }, { status: 400 });
+  }
+
+  try {
+    const rows = await query<{ job_id: string }>(
+      `UPDATE app_jobs
+          SET hidden = $1,
+              updated_at = NOW()
+        WHERE job_id = $2
+          AND user_id = $3
+        RETURNING job_id`,
+      [true, jobId, userId]
+    );
+    if (!rows.length) {
+      return json({ ok: false, error: 'Not found' }, { status: 404 });
+    }
+    return json({ ok: true, jobId, hidden: true });
+  } catch (error) {
+    console.warn('[api/jobs] failed to patch job', { jobId, error });
+    return json({ ok: false, error: 'Database unavailable' }, { status: 503 });
+  }
 }

--- a/frontend/app/api/jobs/route.ts
+++ b/frontend/app/api/jobs/route.ts
@@ -14,6 +14,7 @@ import { extractRenderIds, extractRenderThumbUrls, parseStoredImageRenders } fro
 import { VISITOR_WORKSPACE_ENABLED } from '@/lib/visitor-access';
 import { listVisitorImageLikeJobs, listVisitorStarterJobs } from '@/server/visitor-workspace';
 import { deriveJobSurface, isImageLikeSurface, normalizeJobSurface } from '@/lib/job-surface';
+import { applyOutputsToJobPayload, listJobOutputsByJobIds, upsertLegacyJobOutputs } from '@/server/media-library';
 
 export const dynamic = 'force-dynamic';
 
@@ -357,6 +358,7 @@ export async function GET(req: NextRequest) {
 type JobRow = {
       id: number;
       job_id: string;
+      user_id: string | null;
       updated_at: string;
       surface: string | null;
       billing_product_key: string | null;
@@ -400,7 +402,7 @@ type JobRow = {
     };
 
     let rows = await query<JobRow>(
-    `SELECT id, job_id, updated_at, surface, billing_product_key, settings_snapshot, engine_id, engine_label, duration_sec, prompt, thumb_url, video_url, preview_video_url, audio_url, created_at, aspect_ratio, has_audio, can_upscale, preview_frame, final_price_cents, pricing_snapshot, currency, vendor_account_id, payment_status, stripe_payment_intent_id, stripe_charge_id, batch_id, group_id, iteration_index, iteration_count, render_ids, hero_render_id, local_key, message, eta_seconds, eta_label, visibility, indexable, status, progress, provider, provider_job_id
+    `SELECT id, job_id, user_id, updated_at, surface, billing_product_key, settings_snapshot, engine_id, engine_label, duration_sec, prompt, thumb_url, video_url, preview_video_url, audio_url, created_at, aspect_ratio, has_audio, can_upscale, preview_frame, final_price_cents, pricing_snapshot, currency, vendor_account_id, payment_status, stripe_payment_intent_id, stripe_charge_id, batch_id, group_id, iteration_index, iteration_count, render_ids, hero_render_id, local_key, message, eta_seconds, eta_label, visibility, indexable, status, progress, provider, provider_job_id
       FROM app_jobs
       ${where}
       ORDER BY created_at DESC, id DESC
@@ -432,7 +434,7 @@ type JobRow = {
       }
       if (expiredIds.length) {
         const refreshedRows = await query<JobRow>(
-          `SELECT id, job_id, updated_at, surface, billing_product_key, settings_snapshot, engine_id, engine_label, duration_sec, prompt, thumb_url, video_url, preview_video_url, audio_url, created_at, aspect_ratio, has_audio, can_upscale, preview_frame, final_price_cents, pricing_snapshot, currency, vendor_account_id, payment_status, stripe_payment_intent_id, stripe_charge_id, batch_id, group_id, iteration_index, iteration_count, render_ids, hero_render_id, local_key, message, eta_seconds, eta_label, visibility, indexable, status, progress, provider, provider_job_id
+          `SELECT id, job_id, user_id, updated_at, surface, billing_product_key, settings_snapshot, engine_id, engine_label, duration_sec, prompt, thumb_url, video_url, preview_video_url, audio_url, created_at, aspect_ratio, has_audio, can_upscale, preview_frame, final_price_cents, pricing_snapshot, currency, vendor_account_id, payment_status, stripe_payment_intent_id, stripe_charge_id, batch_id, group_id, iteration_index, iteration_count, render_ids, hero_render_id, local_key, message, eta_seconds, eta_label, visibility, indexable, status, progress, provider, provider_job_id
              FROM app_jobs
             WHERE job_id = ANY($1::text[])`,
           [expiredIds]
@@ -639,7 +641,7 @@ type JobRow = {
 
       if (refreshedIds.length) {
         const refreshedRows = await query<JobRow>(
-          `SELECT id, job_id, updated_at, surface, billing_product_key, settings_snapshot, engine_id, engine_label, duration_sec, prompt, thumb_url, video_url, preview_video_url, audio_url, created_at, aspect_ratio, has_audio, can_upscale, preview_frame, final_price_cents, pricing_snapshot, currency, vendor_account_id, payment_status, stripe_payment_intent_id, stripe_charge_id, batch_id, group_id, iteration_index, iteration_count, render_ids, hero_render_id, local_key, message, eta_seconds, eta_label, visibility, indexable, status, progress, provider, provider_job_id
+          `SELECT id, job_id, user_id, updated_at, surface, billing_product_key, settings_snapshot, engine_id, engine_label, duration_sec, prompt, thumb_url, video_url, preview_video_url, audio_url, created_at, aspect_ratio, has_audio, can_upscale, preview_frame, final_price_cents, pricing_snapshot, currency, vendor_account_id, payment_status, stripe_payment_intent_id, stripe_charge_id, batch_id, group_id, iteration_index, iteration_count, render_ids, hero_render_id, local_key, message, eta_seconds, eta_label, visibility, indexable, status, progress, provider, provider_job_id
              FROM app_jobs
              WHERE job_id = ANY($1::text[])`,
           [refreshedIds]
@@ -739,6 +741,38 @@ type JobRow = {
         indexable: r.indexable ?? true,
       };
     });
+
+    if (mapped.length) {
+      try {
+        const jobIds = mapped.map((job) => job.jobId);
+        let outputMap = await listJobOutputsByJobIds(jobIds);
+        const missingOutputRows = items.filter((row) => !outputMap.has(row.job_id));
+        if (missingOutputRows.length) {
+          await Promise.all(
+            missingOutputRows.map((row) =>
+              upsertLegacyJobOutputs({
+                job_id: row.job_id,
+                user_id: row.user_id,
+                surface: row.surface,
+                video_url: row.video_url,
+                audio_url: row.audio_url,
+                thumb_url: row.thumb_url,
+                preview_frame: row.preview_frame,
+                render_ids: row.render_ids,
+                duration_sec: row.duration_sec,
+                status: row.status,
+              }).catch((error) => {
+                console.warn('[api/jobs] failed to backfill media outputs', row.job_id, error);
+              })
+            )
+          );
+          outputMap = await listJobOutputsByJobIds(jobIds);
+        }
+        mapped = mapped.map((job) => applyOutputsToJobPayload(job, outputMap.get(job.jobId)));
+      } catch (error) {
+        console.warn('[api/jobs] media output enrichment failed', error);
+      }
+    }
 
     if (!mapped.length && shouldUseStarterFallback(feedType, cursor)) {
       const starterVideos = await listStarterPlaylistVideos(limit);

--- a/frontend/app/api/media-library/assets/[assetId]/route.ts
+++ b/frontend/app/api/media-library/assets/[assetId]/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getRouteAuthContext } from '@/lib/supabase-ssr';
+import { deleteLibraryAsset } from '@/server/media-library';
+
+export const runtime = 'nodejs';
+
+export async function DELETE(_req: NextRequest, props: { params: Promise<{ assetId: string }> }) {
+  const { userId } = await getRouteAuthContext(_req);
+  if (!userId) {
+    return NextResponse.json({ ok: false, error: 'UNAUTHORIZED' }, { status: 401 });
+  }
+  const { assetId } = await props.params;
+  const result = await deleteLibraryAsset({ userId, assetId });
+  if (result === 'not_found') {
+    return NextResponse.json({ ok: false, error: 'NOT_FOUND' }, { status: 404 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/frontend/app/api/media-library/assets/route.ts
+++ b/frontend/app/api/media-library/assets/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getRouteAuthContext } from '@/lib/supabase-ssr';
+import { deleteLibraryAsset, listLibraryAssets, type MediaKind } from '@/server/media-library';
+
+export const runtime = 'nodejs';
+
+function normalizeKind(value: string | null): MediaKind | null {
+  if (value === 'image' || value === 'video' || value === 'audio') return value;
+  return null;
+}
+
+export async function GET(req: NextRequest) {
+  const { userId } = await getRouteAuthContext(req);
+  if (!userId) {
+    return NextResponse.json({ ok: false, assets: [], error: 'UNAUTHORIZED' }, { status: 401 });
+  }
+
+  const assets = await listLibraryAssets({
+    userId,
+    kind: normalizeKind(req.nextUrl.searchParams.get('kind')),
+    source: req.nextUrl.searchParams.get('source'),
+    limit: Number(req.nextUrl.searchParams.get('limit') ?? 50),
+  });
+
+  return NextResponse.json({
+    ok: true,
+    assets: assets.map((asset) => ({
+      id: asset.id,
+      url: asset.url,
+      thumbUrl: asset.thumbUrl,
+      mime: asset.mimeType,
+      width: asset.width,
+      height: asset.height,
+      size: asset.sizeBytes,
+      kind: asset.kind,
+      source: asset.source,
+      jobId: asset.sourceJobId,
+      sourceOutputId: asset.sourceOutputId,
+      createdAt: asset.createdAt,
+    })),
+  });
+}
+
+export async function DELETE(req: NextRequest) {
+  const { userId } = await getRouteAuthContext(req);
+  if (!userId) {
+    return NextResponse.json({ ok: false, error: 'UNAUTHORIZED' }, { status: 401 });
+  }
+  const payload = (await req.json().catch(() => null)) as { id?: unknown } | null;
+  const assetId = typeof payload?.id === 'string' ? payload.id.trim() : req.nextUrl.searchParams.get('id')?.trim();
+  if (!assetId) {
+    return NextResponse.json({ ok: false, error: 'ASSET_ID_REQUIRED' }, { status: 400 });
+  }
+
+  const result = await deleteLibraryAsset({ userId, assetId });
+  if (result === 'not_found') {
+    return NextResponse.json({ ok: false, error: 'NOT_FOUND' }, { status: 404 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/frontend/app/api/media-library/ensure/route.ts
+++ b/frontend/app/api/media-library/ensure/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getRouteAuthContext } from '@/lib/supabase-ssr';
+import { ensureReusableAsset, type MediaKind } from '@/server/media-library';
+
+export const runtime = 'nodejs';
+
+function normalizeKind(value: unknown): MediaKind {
+  if (value === 'video' || value === 'audio' || value === 'image') return value;
+  return 'image';
+}
+
+export async function POST(req: NextRequest) {
+  const { userId } = await getRouteAuthContext(req);
+  if (!userId) {
+    return NextResponse.json({ ok: false, error: 'UNAUTHORIZED' }, { status: 401 });
+  }
+
+  const payload = (await req.json().catch(() => null)) as Record<string, unknown> | null;
+  const url = typeof payload?.url === 'string' ? payload.url.trim() : '';
+  if (!url) {
+    return NextResponse.json({ ok: false, error: 'URL_REQUIRED' }, { status: 400 });
+  }
+
+  try {
+    const asset = await ensureReusableAsset({
+      userId,
+      url,
+      kind: normalizeKind(payload?.kind),
+      source: payload?.source,
+      sourceJobId: typeof payload?.jobId === 'string' ? payload.jobId : typeof payload?.sourceJobId === 'string' ? payload.sourceJobId : null,
+      sourceOutputId: typeof payload?.sourceOutputId === 'string' ? payload.sourceOutputId : null,
+      label: typeof payload?.label === 'string' ? payload.label : typeof payload?.name === 'string' ? payload.name : null,
+      mimeType: typeof payload?.mime === 'string' ? payload.mime : null,
+      thumbUrl: typeof payload?.thumbUrl === 'string' ? payload.thumbUrl : null,
+      width: typeof payload?.width === 'number' ? payload.width : null,
+      height: typeof payload?.height === 'number' ? payload.height : null,
+      sizeBytes: typeof payload?.size === 'number' ? payload.size : null,
+    });
+
+    return NextResponse.json({
+      ok: true,
+      asset: {
+        id: asset.id,
+        url: asset.url,
+        width: asset.width,
+        height: asset.height,
+        mime: asset.mimeType,
+        size: asset.sizeBytes,
+        source: asset.source,
+        jobId: asset.sourceJobId,
+        sourceOutputId: asset.sourceOutputId,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'SAVE_FAILED';
+    return NextResponse.json({ ok: false, error: message }, { status: 422 });
+  }
+}

--- a/frontend/app/api/media-library/recent-outputs/route.ts
+++ b/frontend/app/api/media-library/recent-outputs/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getRouteAuthContext } from '@/lib/supabase-ssr';
+import { listRecentOutputs, type MediaKind } from '@/server/media-library';
+
+export const runtime = 'nodejs';
+
+function normalizeKind(value: string | null): MediaKind | null {
+  if (value === 'image' || value === 'video' || value === 'audio') return value;
+  return null;
+}
+
+export async function GET(req: NextRequest) {
+  const { userId } = await getRouteAuthContext(req);
+  if (!userId) {
+    return NextResponse.json({ ok: false, outputs: [], error: 'UNAUTHORIZED' }, { status: 401 });
+  }
+
+  const outputs = await listRecentOutputs({
+    userId,
+    kind: normalizeKind(req.nextUrl.searchParams.get('kind')),
+    surface: req.nextUrl.searchParams.get('surface'),
+    limit: Number(req.nextUrl.searchParams.get('limit') ?? 50),
+  });
+
+  return NextResponse.json({
+    ok: true,
+    outputs: outputs.map((output) => ({
+      id: output.id,
+      jobId: output.jobId,
+      url: output.url,
+      thumbUrl: output.thumbUrl,
+      mime: output.mimeType,
+      width: output.width,
+      height: output.height,
+      durationSec: output.durationSec,
+      kind: output.kind,
+      position: output.position,
+      status: output.status,
+      createdAt: output.createdAt,
+    })),
+  });
+}

--- a/frontend/app/api/media-library/save-output/route.ts
+++ b/frontend/app/api/media-library/save-output/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getRouteAuthContext } from '@/lib/supabase-ssr';
+import { saveJobOutputToLibrary } from '@/server/media-library';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: NextRequest) {
+  const { userId } = await getRouteAuthContext(req);
+  if (!userId) {
+    return NextResponse.json({ ok: false, error: 'UNAUTHORIZED' }, { status: 401 });
+  }
+
+  const payload = (await req.json().catch(() => null)) as { jobId?: unknown; outputId?: unknown } | null;
+  const jobId = typeof payload?.jobId === 'string' ? payload.jobId.trim() : '';
+  const outputId = typeof payload?.outputId === 'string' ? payload.outputId.trim() : '';
+  if (!jobId || !outputId) {
+    return NextResponse.json({ ok: false, error: 'JOB_OUTPUT_REQUIRED' }, { status: 400 });
+  }
+
+  try {
+    const asset = await saveJobOutputToLibrary({ userId, jobId, outputId });
+    return NextResponse.json({
+      ok: true,
+      asset: {
+        id: asset.id,
+        url: asset.url,
+        width: asset.width,
+        height: asset.height,
+        mime: asset.mimeType,
+        size: asset.sizeBytes,
+        source: asset.source,
+        jobId: asset.sourceJobId,
+        sourceOutputId: asset.sourceOutputId,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'SAVE_FAILED';
+    const status = message === 'OUTPUT_NOT_FOUND' ? 404 : 422;
+    return NextResponse.json({ ok: false, error: message }, { status });
+  }
+}

--- a/frontend/app/api/uploads/audio/route.ts
+++ b/frontend/app/api/uploads/audio/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { uploadFileBuffer, recordUserAsset } from '@/server/storage';
 import { getRouteAuthContext } from '@/lib/supabase-ssr';
+import { ensureReusableAsset } from '@/server/media-library';
 
 export const runtime = 'nodejs';
 
@@ -59,6 +60,17 @@ export async function POST(req: NextRequest) {
       size: buffer.length,
       source: 'upload',
       metadata: { originalName: blob.name, kind: 'audio' },
+    });
+
+    await ensureReusableAsset({
+      userId,
+      url: uploadResult.url,
+      kind: 'audio',
+      source: 'upload',
+      mimeType: mime,
+      sizeBytes: buffer.length,
+    }).catch((error) => {
+      console.warn('[upload] failed to mirror audio into media_assets', error);
     });
 
     return NextResponse.json({

--- a/frontend/app/api/uploads/image/route.ts
+++ b/frontend/app/api/uploads/image/route.ts
@@ -5,6 +5,7 @@ import { uploadImageToStorage, recordUserAsset } from '@/server/storage';
 import { getRouteAuthContext } from '@/lib/supabase-ssr';
 import { ensureAssetSchema } from '@/lib/schema';
 import { query } from '@/lib/db';
+import { ensureReusableAsset } from '@/server/media-library';
 
 export const runtime = 'nodejs';
 
@@ -200,6 +201,19 @@ export async function POST(req: NextRequest) {
         normalizedFromMime,
         contentSha256,
       },
+    });
+
+    await ensureReusableAsset({
+      userId,
+      url: uploadResult.url,
+      kind: 'image',
+      source: 'upload',
+      mimeType: uploadResult.mime,
+      width: uploadResult.width,
+      height: uploadResult.height,
+      sizeBytes: uploadResult.size,
+    }).catch((error) => {
+      console.warn('[upload] failed to mirror image into media_assets', error);
     });
 
     return NextResponse.json({

--- a/frontend/app/api/uploads/video/route.ts
+++ b/frontend/app/api/uploads/video/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { uploadFileBuffer, recordUserAsset } from '@/server/storage';
 import { getRouteAuthContext } from '@/lib/supabase-ssr';
+import { ensureReusableAsset } from '@/server/media-library';
 
 export const runtime = 'nodejs';
 
@@ -87,6 +88,17 @@ export async function POST(req: NextRequest) {
       size: buffer.length,
       source: 'upload',
       metadata: { originalName: blob.name, kind: 'video' },
+    });
+
+    await ensureReusableAsset({
+      userId,
+      url: uploadResult.url,
+      kind: 'video',
+      source: 'upload',
+      mimeType: mime,
+      sizeBytes: buffer.length,
+    }).catch((error) => {
+      console.warn('[upload] failed to mirror video into media_assets', error);
     });
 
     return NextResponse.json({

--- a/frontend/app/api/user-assets/route.ts
+++ b/frontend/app/api/user-assets/route.ts
@@ -1,15 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { ensureAssetSchema } from '@/lib/schema';
-import { query } from '@/lib/db';
-import { deleteUserAsset, StorageUploadError, uploadFileBuffer, uploadImageToStorage, recordUserAsset } from '@/server/storage';
 import { getRouteAuthContext } from '@/lib/supabase-ssr';
 import { VISITOR_WORKSPACE_ENABLED } from '@/lib/visitor-access';
-import { normalizeUserAssetSource } from '@/lib/job-surface';
+import {
+  deleteLibraryAsset,
+  ensureReusableAsset,
+  listLibraryAssets,
+  type MediaKind,
+} from '@/server/media-library';
 
 export const runtime = 'nodejs';
 
-const MAX_IMAGE_BYTES = 25 * 1024 * 1024;
-const MAX_VIDEO_BYTES = Number(process.env.ASSET_MAX_VIDEO_MB ?? '30') * 1024 * 1024;
+function normalizeKindFromRequest(value: unknown): MediaKind {
+  if (value === 'video' || value === 'audio' || value === 'image') return value;
+  return 'image';
+}
 
 export async function GET(req: NextRequest) {
   const { userId } = await getRouteAuthContext(req);
@@ -20,51 +24,28 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ ok: false, error: 'UNAUTHORIZED' }, { status: 401 });
   }
 
-  await ensureAssetSchema();
+  const assets = await listLibraryAssets({
+    userId,
+    source: req.nextUrl.searchParams.get('source'),
+    originUrl: req.nextUrl.searchParams.get('originUrl'),
+    limit: Number(req.nextUrl.searchParams.get('limit') ?? 50),
+  });
 
-  const limit = Math.min(200, Number(req.nextUrl.searchParams.get('limit') ?? 50));
-  const source = (req.nextUrl.searchParams.get('source') ?? '').trim() || null;
-  const originUrl = (req.nextUrl.searchParams.get('originUrl') ?? '').trim() || null;
-  const rows = await query<{
-    asset_id: string;
-    url: string;
-    mime_type: string | null;
-    width: number | null;
-    height: number | null;
-    size_bytes: string | number | null;
-    source: string | null;
-    metadata: unknown;
-    created_at: string;
-  }>(
-    `SELECT asset_id, url, mime_type, width, height, size_bytes, source, metadata, created_at
-     FROM user_assets
-     WHERE user_id = $1
-       AND ($3::text IS NULL OR source = $3::text)
-       AND ($4::text IS NULL OR metadata->>'originUrl' = $4::text)
-     ORDER BY created_at DESC
-     LIMIT $2`,
-    [userId, limit, source, originUrl]
-  );
-
-  const assets = rows.map((row) => ({
-    id: row.asset_id,
-    url: row.url,
-    mime: row.mime_type,
-    width: row.width,
-    height: row.height,
-    size: typeof row.size_bytes === 'string' ? Number(row.size_bytes) : row.size_bytes,
-    source: row.source,
-    jobId:
-      row.metadata &&
-      typeof row.metadata === 'object' &&
-      'jobId' in (row.metadata as Record<string, unknown>) &&
-      typeof (row.metadata as Record<string, unknown>).jobId === 'string'
-        ? (row.metadata as Record<string, unknown>).jobId
-        : null,
-    createdAt: row.created_at,
-  }));
-
-  return NextResponse.json({ ok: true, assets });
+  return NextResponse.json({
+    ok: true,
+    assets: assets.map((asset) => ({
+      id: asset.id,
+      url: asset.url,
+      mime: asset.mimeType,
+      width: asset.width,
+      height: asset.height,
+      size: asset.sizeBytes,
+      source: asset.source === 'saved_job_output' ? 'generated' : asset.source,
+      kind: asset.kind,
+      jobId: asset.sourceJobId,
+      createdAt: asset.createdAt,
+    })),
+  });
 }
 
 export async function DELETE(req: NextRequest) {
@@ -89,7 +70,7 @@ export async function DELETE(req: NextRequest) {
     return NextResponse.json({ ok: false, error: 'ASSET_ID_REQUIRED' }, { status: 400 });
   }
 
-  const result = await deleteUserAsset({ assetId, userId });
+  const result = await deleteLibraryAsset({ assetId, userId });
   if (result === 'not_found') {
     return NextResponse.json({ ok: false, error: 'NOT_FOUND' }, { status: 404 });
   }
@@ -103,185 +84,55 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ ok: false, error: 'UNAUTHORIZED' }, { status: 401 });
   }
 
-  let payload: { url?: string; name?: string; label?: string; jobId?: string; source?: string; kind?: string } | null = null;
-  try {
-    payload = (await req.json()) as {
-      url?: string;
-      name?: string;
-      label?: string;
-      jobId?: string;
-      source?: string;
-      kind?: string;
-    } | null;
-  } catch {
-    return NextResponse.json({ ok: false, error: 'INVALID_JSON' }, { status: 400 });
-  }
+  const payload = (await req.json().catch(() => null)) as {
+    url?: unknown;
+    name?: unknown;
+    label?: unknown;
+    jobId?: unknown;
+    source?: unknown;
+    kind?: unknown;
+    mime?: unknown;
+    width?: unknown;
+    height?: unknown;
+    size?: unknown;
+    thumbUrl?: unknown;
+    sourceOutputId?: unknown;
+  } | null;
 
   const sourceUrl = typeof payload?.url === 'string' ? payload.url.trim() : '';
   if (!sourceUrl) {
     return NextResponse.json({ ok: false, error: 'URL_REQUIRED' }, { status: 400 });
   }
 
-  const requestedKind = payload?.kind === 'video' ? 'video' : 'image';
+  try {
+    const asset = await ensureReusableAsset({
+      userId,
+      url: sourceUrl,
+      kind: normalizeKindFromRequest(payload?.kind),
+      source: payload?.source,
+      sourceJobId: typeof payload?.jobId === 'string' ? payload.jobId : null,
+      sourceOutputId: typeof payload?.sourceOutputId === 'string' ? payload.sourceOutputId : null,
+      label: typeof payload?.label === 'string' ? payload.label : typeof payload?.name === 'string' ? payload.name : null,
+      mimeType: typeof payload?.mime === 'string' ? payload.mime : null,
+      width: typeof payload?.width === 'number' ? payload.width : null,
+      height: typeof payload?.height === 'number' ? payload.height : null,
+      sizeBytes: typeof payload?.size === 'number' ? payload.size : null,
+      thumbUrl: typeof payload?.thumbUrl === 'string' ? payload.thumbUrl : null,
+    });
 
-  await ensureAssetSchema();
-
-  const existing = await query<{
-    asset_id: string;
-    url: string;
-    mime_type: string | null;
-    width: number | null;
-    height: number | null;
-    size_bytes: string | number | null;
-  }>(
-    `SELECT asset_id, url, mime_type, width, height, size_bytes
-     FROM user_assets
-     WHERE user_id = $1
-       AND metadata->>'originUrl' = $2
-     ORDER BY created_at DESC
-     LIMIT 1`,
-    [userId, sourceUrl]
-  );
-
-  if (existing.length) {
-    const [asset] = existing;
     return NextResponse.json({
       ok: true,
       asset: {
-        id: asset.asset_id,
+        id: asset.id,
         url: asset.url,
         width: asset.width,
         height: asset.height,
-        mime: asset.mime_type,
-        size: typeof asset.size_bytes === 'string' ? Number(asset.size_bytes) : asset.size_bytes,
-      },
-    });
-  }
-
-  let parsed: URL;
-  try {
-    parsed = new URL(sourceUrl);
-    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
-      throw new Error('unsupported protocol');
-    }
-  } catch {
-    return NextResponse.json({ ok: false, error: 'INVALID_URL' }, { status: 400 });
-  }
-
-  try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 8000);
-    const response = await fetch(parsed.toString(), { signal: controller.signal });
-    clearTimeout(timeout);
-    if (!response.ok) {
-      return NextResponse.json(
-        { ok: false, error: 'FETCH_FAILED', status: response.status },
-        { status: 422 }
-      );
-    }
-    const mime = response.headers.get('content-type') ?? (requestedKind === 'video' ? 'video/mp4' : 'image/png');
-    const isImage = mime.startsWith('image/');
-    const isVideo = mime.startsWith('video/');
-    if ((requestedKind === 'image' && !isImage) || (requestedKind === 'video' && !isVideo)) {
-      return NextResponse.json({ ok: false, error: 'UNSUPPORTED_TYPE' }, { status: 415 });
-    }
-    const arrayBuffer = await response.arrayBuffer();
-    const buffer = Buffer.from(arrayBuffer);
-    if (!buffer.length) {
-      return NextResponse.json({ ok: false, error: requestedKind === 'video' ? 'EMPTY_VIDEO' : 'EMPTY_IMAGE' }, { status: 422 });
-    }
-    const maxBytes = requestedKind === 'video' ? MAX_VIDEO_BYTES : MAX_IMAGE_BYTES;
-    if (buffer.length > maxBytes) {
-      return NextResponse.json(
-        { ok: false, error: requestedKind === 'video' ? 'VIDEO_TOO_LARGE' : 'IMAGE_TOO_LARGE' },
-        { status: 422 }
-      );
-    }
-
-    const fileName =
-      payload?.name ??
-      payload?.label ??
-      parsed.pathname.split('/').pop() ??
-      (requestedKind === 'video' ? 'video.mp4' : 'image.png');
-
-    let uploadUrl = '';
-    let uploadMime = mime;
-    let uploadWidth: number | null = null;
-    let uploadHeight: number | null = null;
-
-    if (requestedKind === 'video') {
-      const upload = await uploadFileBuffer({
-        data: buffer,
-        mime,
-        userId,
-        prefix: 'library',
-        fileName,
-      });
-      uploadUrl = upload.url;
-    } else {
-      const upload = await uploadImageToStorage({
-        data: buffer,
-        mime,
-        userId,
-        prefix: 'library',
-        fileName,
-      });
-      uploadUrl = upload.url;
-      uploadMime = upload.mime;
-      uploadWidth = upload.width;
-      uploadHeight = upload.height;
-    }
-
-    const assetId = await recordUserAsset({
-      userId,
-      url: uploadUrl,
-      mime: uploadMime,
-      width: uploadWidth,
-      height: uploadHeight,
-      size: buffer.length,
-      source: normalizeUserAssetSource(payload?.source),
-      metadata: {
-        originUrl: sourceUrl,
-        jobId: payload?.jobId ?? null,
-        label: payload?.label ?? payload?.name ?? null,
-        kind: requestedKind,
-      },
-    });
-
-    return NextResponse.json({
-      ok: true,
-      asset: {
-        id: assetId,
-        url: uploadUrl,
-        width: uploadWidth,
-        height: uploadHeight,
-        mime: uploadMime,
-        size: buffer.length,
+        mime: asset.mimeType,
+        size: asset.sizeBytes,
       },
     });
   } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
-      return NextResponse.json({ ok: false, error: 'FETCH_TIMEOUT' }, { status: 504 });
-    }
-    if (error instanceof StorageUploadError) {
-      console.error('[user-assets] storage upload failed', {
-        message: error.message,
-        key: error.context.key ?? null,
-        keyBytes: error.context.keyBytes ?? null,
-        prefix: error.context.prefix ?? 'library',
-        userId,
-        originalFileName: error.context.originalFileName ?? payload?.name ?? payload?.label ?? null,
-        originalFileNameBytes: Buffer.byteLength(
-          String(error.context.originalFileName ?? payload?.name ?? payload?.label ?? ''),
-          'utf8'
-        ),
-        labelBytes: Buffer.byteLength(String(payload?.label ?? ''), 'utf8'),
-        nameBytes: Buffer.byteLength(String(payload?.name ?? ''), 'utf8'),
-        sourceUrlBytes: Buffer.byteLength(sourceUrl, 'utf8'),
-      });
-    } else {
-      console.error('[user-assets] save failed', error);
-    }
-    return NextResponse.json({ ok: false, error: 'SAVE_FAILED' }, { status: 500 });
+    const message = error instanceof Error ? error.message : 'STORE_FAILED';
+    return NextResponse.json({ ok: false, error: message }, { status: 422 });
   }
 }

--- a/frontend/components/library/AssetLibraryBrowser.tsx
+++ b/frontend/components/library/AssetLibraryBrowser.tsx
@@ -6,7 +6,7 @@ import { useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { Button, ButtonLink } from '@/components/ui/Button';
 
-export type AssetLibrarySource = 'all' | 'upload' | 'generated' | 'character' | 'angle' | 'upscale';
+export type AssetLibrarySource = 'all' | 'upload' | 'generated' | 'recent' | 'character' | 'angle' | 'upscale';
 
 export type AssetBrowserAsset = {
   id: string;

--- a/frontend/components/library/AssetLibraryModal.tsx
+++ b/frontend/components/library/AssetLibraryModal.tsx
@@ -11,7 +11,7 @@ import { translateError } from '@/lib/error-messages';
 import { useI18n } from '@/lib/i18n/I18nProvider';
 import { normalizeUiLocale } from '@/lib/ltx-localization';
 
-export type AssetLibrarySource = 'all' | 'upload' | 'generated' | 'character' | 'angle' | 'upscale';
+export type AssetLibrarySource = 'all' | 'upload' | 'generated' | 'recent' | 'character' | 'angle' | 'upscale';
 export type AssetLibraryKind = 'image' | 'video';
 
 export type UserAsset = {
@@ -25,6 +25,8 @@ export type UserAsset = {
   source?: string | null;
   createdAt?: string;
   canDelete?: boolean;
+  jobId?: string | null;
+  sourceOutputId?: string | null;
 };
 
 export type AssetLibraryModalProps = {
@@ -66,6 +68,7 @@ const DEFAULT_ASSET_LIBRARY_COPY = {
   empty: 'No saved images yet. Upload a reference image to see it here.',
   emptyUploads: 'No uploaded images yet. Upload a reference image to see it here.',
   emptyGenerated: 'No generated images saved yet. Save a generated image to see it here.',
+  emptyRecent: 'No recent outputs yet. Run a generation to reuse an output here.',
   emptyCharacter: 'No character assets saved yet. Generate one in Character Builder first.',
   emptyAngle: 'No angle assets saved yet. Generate one in the Angle tool first.',
   emptyUpscale: 'No upscale assets saved yet. Save an upscale result first.',
@@ -73,6 +76,7 @@ const DEFAULT_ASSET_LIBRARY_COPY = {
     all: 'All',
     upload: 'Uploaded',
     generated: 'Generated',
+    recent: 'Recent outputs',
     character: 'Character',
     angle: 'Angle',
     upscale: 'Upscale',
@@ -221,7 +225,15 @@ export function AssetLibraryModal({
   const importAccept = assetType === 'video' ? 'video/*' : 'image/*';
   const importEndpoint = assetType === 'video' ? '/api/uploads/video' : '/api/uploads/image';
   const emptyLabel =
-    source === 'generated'
+    source === 'recent'
+      ? assetType === 'video'
+        ? uiLocale === 'fr'
+          ? "Aucune sortie recente pour l'instant. Lancez un rendu pour reutiliser une video ici."
+          : uiLocale === 'es'
+            ? 'Aun no hay salidas recientes. Renderiza un video para reutilizarlo aqui.'
+            : copyAssetLibrary.emptyRecent
+        : copyAssetLibrary.emptyRecent
+    : source === 'generated'
       ? assetType === 'video'
         ? uiLocale === 'fr'
           ? "Aucune video generee pour l'instant. Lancez un rendu video pour la reutiliser ici."
@@ -307,7 +319,7 @@ export function AssetLibraryModal({
   );
 
   const sourceOptions = assetType === 'video'
-    ? (['all', 'upload', 'generated', 'upscale'] as const)
+    ? (['all', 'upload', 'recent', 'generated', 'upscale'] as const)
     : (['all', 'upload', 'generated', 'character', 'angle', 'upscale'] as const);
   const searchPlaceholder =
     copyAssetLibrary.searchPlaceholder ??

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -947,8 +947,9 @@ export async function saveAssetToLibrary(payload: {
   label?: string | null;
   source?: string | null;
   kind?: 'image' | 'video';
+  sourceOutputId?: string | null;
 }) {
-  const response = await authFetch('/api/user-assets', {
+  const response = await authFetch('/api/media-library/ensure', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -958,6 +959,7 @@ export async function saveAssetToLibrary(payload: {
       label: payload.label ?? null,
       source: payload.source ?? null,
       kind: payload.kind ?? 'image',
+      sourceOutputId: payload.sourceOutputId ?? null,
     }),
   });
   const data = (await response.json().catch(() => null)) as { ok?: boolean; error?: string; asset?: SavedAsset } | null;
@@ -980,6 +982,15 @@ export async function saveImageToLibrary(payload: {
 }
 
 export async function hideJob(jobId: string): Promise<void> {
+  const response = await authFetch(`/api/jobs/${encodeURIComponent(jobId)}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ hidden: true }),
+  });
+  const payload = (await response.json().catch(() => null)) as { ok?: boolean; error?: string } | null;
+  if (!response.ok || payload?.ok === false) {
+    throw new Error(payload?.error ?? `Failed to hide job (${response.status})`);
+  }
   if (typeof window !== 'undefined') {
     window.dispatchEvent(new CustomEvent('jobs:hidden', { detail: { jobId } }));
   }

--- a/frontend/lib/seedance-workflow.ts
+++ b/frontend/lib/seedance-workflow.ts
@@ -49,7 +49,7 @@ export function getSeedanceAssetState(inputAssets: SeedanceAssetMap) {
 
 export function getUnifiedSeedanceMode(inputAssets: SeedanceAssetMap): Mode {
   const state = getSeedanceAssetState(inputAssets);
-  if (state.hasReferenceVideo && state.hasReferenceImage) return 'v2v';
+  if (state.hasReferenceImage) return 'ref2v';
   if (state.hasReferenceVideo && !state.hasReferenceAudio) return 'extend';
   if (state.hasReferenceInputs) return 'ref2v';
   if (state.hasStartOrEndImage) return 'i2v';

--- a/frontend/server/fal-webhook-handler.ts
+++ b/frontend/server/fal-webhook-handler.ts
@@ -20,6 +20,7 @@ import { getFalEngineById } from '@/config/falEngines';
 import { fetchFalJobMedia } from '@/server/fal-job-sync';
 import { detectHasAudioStream, detectVideoDimensions } from '@/server/media/detect-has-audio';
 import { listUpscaleToolEngines } from '@/config/tools-upscale-engines';
+import { upsertLegacyJobOutputs } from '@/server/media-library';
 
 function fallbackThumbnail(aspectRatio?: string | null): string {
   const normalized = aspectRatio?.trim().toLowerCase();
@@ -1114,6 +1115,21 @@ export async function updateJobFromFalWebhook(rawPayload: unknown): Promise<void
       providerVideoCopyStateJson,
     ]
   );
+
+  await upsertLegacyJobOutputs({
+    job_id: job.job_id,
+    user_id: job.user_id,
+    surface: isImageEngine ? 'image' : 'video',
+    video_url: shouldClearVideo ? null : finalVideoUrl ?? job.video_url,
+    audio_url: null,
+    thumb_url: shouldClearThumb ? null : finalThumbUrl ?? job.thumb_url,
+    preview_frame: shouldClearThumb ? null : finalPreviewFrame ?? job.preview_frame,
+    render_ids: renderIdsJson ? JSON.parse(renderIdsJson) : job.render_ids,
+    duration_sec: job.duration_sec,
+    status: nextStatus,
+  }).catch((error) => {
+    console.warn('[fal-webhook] failed to persist job outputs', { jobId: job.job_id }, error);
+  });
 
   if (nextStatus === 'completed' && finalVideoUrl && !isImageEngine) {
     await Promise.allSettled([

--- a/frontend/server/media-library.ts
+++ b/frontend/server/media-library.ts
@@ -1,0 +1,777 @@
+import { randomUUID } from 'crypto';
+import { query } from '@/lib/db';
+import { buildStoredImageRenderEntries, parseStoredImageRenders } from '@/lib/image-renders';
+import { normalizeMediaUrl } from '@/lib/media';
+import { ensureAssetSchema, ensureMediaLibrarySchema } from '@/lib/schema';
+import { recordUserAsset, uploadFileBuffer, uploadImageToStorage } from '@/server/storage';
+
+export type MediaKind = 'image' | 'video' | 'audio';
+export type MediaAssetSource = 'upload' | 'saved_job_output' | 'character' | 'angle' | 'upscale' | 'import';
+
+export type LegacyJobMediaRow = {
+  job_id: string;
+  user_id?: string | null;
+  surface?: string | null;
+  video_url?: string | null;
+  audio_url?: string | null;
+  thumb_url?: string | null;
+  preview_frame?: string | null;
+  render_ids?: unknown;
+  duration_sec?: number | null;
+  status?: string | null;
+};
+
+export type JobOutputRecord = {
+  id: string;
+  jobId: string;
+  userId: string | null;
+  kind: MediaKind;
+  url: string;
+  storageUrl: string | null;
+  thumbUrl: string | null;
+  mimeType: string | null;
+  width: number | null;
+  height: number | null;
+  durationSec: number | null;
+  position: number;
+  status: string;
+  metadata: Record<string, unknown>;
+  createdAt?: string;
+};
+
+export type MediaAssetRecord = {
+  id: string;
+  userId: string | null;
+  kind: MediaKind;
+  url: string;
+  thumbUrl: string | null;
+  mimeType: string | null;
+  width: number | null;
+  height: number | null;
+  sizeBytes: number | null;
+  source: MediaAssetSource;
+  sourceJobId: string | null;
+  sourceOutputId: string | null;
+  status: string;
+  metadata: Record<string, unknown>;
+  createdAt?: string;
+};
+
+export type MediaAssetInsert = {
+  id: string;
+  userId: string;
+  kind: MediaKind;
+  url: string;
+  thumbUrl: string | null;
+  mimeType: string | null;
+  width: number | null;
+  height: number | null;
+  sizeBytes: number | null;
+  source: MediaAssetSource;
+  sourceJobId: string | null;
+  sourceOutputId: string | null;
+  status: 'ready';
+  metadata: Record<string, unknown>;
+};
+
+type DbJobOutputRow = {
+  id: string;
+  job_id: string;
+  user_id: string | null;
+  kind: MediaKind;
+  url: string;
+  storage_url: string | null;
+  thumb_url: string | null;
+  mime_type: string | null;
+  width: number | null;
+  height: number | null;
+  duration_sec: number | null;
+  position: number;
+  status: string;
+  metadata: unknown;
+  created_at: string;
+};
+
+type DbMediaAssetRow = {
+  id: string;
+  user_id: string | null;
+  kind: MediaKind;
+  url: string;
+  thumb_url: string | null;
+  mime_type: string | null;
+  width: number | null;
+  height: number | null;
+  size_bytes: string | number | null;
+  source: MediaAssetSource | string | null;
+  source_job_id: string | null;
+  source_output_id: string | null;
+  status: string | null;
+  metadata: unknown;
+  created_at: string;
+};
+
+function normalizeString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return normalizeMediaUrl(trimmed) ?? trimmed;
+}
+
+function normalizeInteger(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  const rounded = Math.round(value);
+  return rounded > 0 ? rounded : null;
+}
+
+function normalizeMetadata(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+function inferMimeFromUrl(url: string, kind: MediaKind, fallback?: string | null): string {
+  if (fallback && fallback.trim()) return fallback.trim();
+  const clean = url.split('?')[0]?.toLowerCase() ?? '';
+  if (kind === 'video') {
+    if (clean.endsWith('.webm')) return 'video/webm';
+    if (clean.endsWith('.mov')) return 'video/quicktime';
+    return 'video/mp4';
+  }
+  if (kind === 'audio') {
+    if (clean.endsWith('.wav')) return 'audio/wav';
+    if (clean.endsWith('.ogg')) return 'audio/ogg';
+    if (clean.endsWith('.m4a')) return 'audio/mp4';
+    return 'audio/mpeg';
+  }
+  if (clean.endsWith('.jpg') || clean.endsWith('.jpeg')) return 'image/jpeg';
+  if (clean.endsWith('.webp')) return 'image/webp';
+  if (clean.endsWith('.gif')) return 'image/gif';
+  return 'image/png';
+}
+
+function outputId(jobId: string, kind: MediaKind, position: number): string {
+  return `${jobId}:${kind}:${position}`;
+}
+
+export function normalizeMediaAssetSource(value: unknown): MediaAssetSource {
+  if (typeof value !== 'string') return 'import';
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'upload' || normalized === 'character' || normalized === 'angle' || normalized === 'upscale') {
+    return normalized;
+  }
+  if (normalized === 'generated' || normalized === 'job_output' || normalized === 'saved_job_output') {
+    return 'saved_job_output';
+  }
+  return 'import';
+}
+
+export function mapLegacyJobRowToOutputs(row: LegacyJobMediaRow): JobOutputRecord[] {
+  const jobId = row.job_id;
+  const userId = row.user_id ?? null;
+  const status = row.status === 'failed' ? 'failed' : 'ready';
+  const outputs: JobOutputRecord[] = [];
+  const thumbUrl = normalizeString(row.thumb_url) ?? normalizeString(row.preview_frame);
+
+  const videoUrl = normalizeString(row.video_url);
+  if (videoUrl) {
+    outputs.push({
+      id: outputId(jobId, 'video', 0),
+      jobId,
+      userId,
+      kind: 'video',
+      url: videoUrl,
+      storageUrl: null,
+      thumbUrl,
+      mimeType: inferMimeFromUrl(videoUrl, 'video'),
+      width: null,
+      height: null,
+      durationSec: normalizeInteger(row.duration_sec),
+      position: 0,
+      status,
+      metadata: { legacy: true, surface: row.surface ?? null },
+    });
+  }
+
+  const audioUrl = normalizeString(row.audio_url);
+  if (audioUrl) {
+    outputs.push({
+      id: outputId(jobId, 'audio', 0),
+      jobId,
+      userId,
+      kind: 'audio',
+      url: audioUrl,
+      storageUrl: null,
+      thumbUrl: null,
+      mimeType: inferMimeFromUrl(audioUrl, 'audio'),
+      width: null,
+      height: null,
+      durationSec: normalizeInteger(row.duration_sec),
+      position: 0,
+      status,
+      metadata: { legacy: true, surface: row.surface ?? null },
+    });
+  }
+
+  parseStoredImageRenders(row.render_ids).entries.forEach((entry, index) => {
+    const url = normalizeString(entry.url);
+    if (!url) return;
+    outputs.push({
+      id: outputId(jobId, 'image', index),
+      jobId,
+      userId,
+      kind: 'image',
+      url,
+      storageUrl: null,
+      thumbUrl: normalizeString(entry.thumbUrl) ?? url,
+      mimeType: inferMimeFromUrl(url, 'image', entry.mimeType),
+      width: normalizeInteger(entry.width),
+      height: normalizeInteger(entry.height),
+      durationSec: null,
+      position: index,
+      status,
+      metadata: { legacy: true, surface: row.surface ?? null },
+    });
+  });
+
+  return outputs;
+}
+
+export function resolveLibraryAssetIdentity(params: {
+  userId: string;
+  kind: MediaKind;
+  url: string;
+  source: MediaAssetSource;
+  sourceOutputId?: string | null;
+}): string {
+  if (params.sourceOutputId) return `output:${params.sourceOutputId}`;
+  return `url:${params.userId}:${params.kind}:${params.url}`;
+}
+
+export function buildMediaAssetInsert(params: {
+  userId: string;
+  kind: MediaKind;
+  url: string;
+  thumbUrl?: string | null;
+  mimeType?: string | null;
+  width?: number | null;
+  height?: number | null;
+  sizeBytes?: number | null;
+  source?: unknown;
+  sourceJobId?: string | null;
+  sourceOutputId?: string | null;
+  metadata?: Record<string, unknown>;
+}): MediaAssetInsert {
+  const source = normalizeMediaAssetSource(params.source);
+  return {
+    id: resolveLibraryAssetIdentity({
+      userId: params.userId,
+      kind: params.kind,
+      url: params.url,
+      source,
+      sourceOutputId: params.sourceOutputId ?? null,
+    }),
+    userId: params.userId,
+    kind: params.kind,
+    url: params.url,
+    thumbUrl: params.thumbUrl ?? null,
+    mimeType: params.mimeType ?? inferMimeFromUrl(params.url, params.kind),
+    width: params.width ?? null,
+    height: params.height ?? null,
+    sizeBytes: params.sizeBytes ?? null,
+    source,
+    sourceJobId: params.sourceJobId ?? null,
+    sourceOutputId: params.sourceOutputId ?? null,
+    status: 'ready',
+    metadata: params.metadata ?? {},
+  };
+}
+
+function mapOutputRow(row: DbJobOutputRow): JobOutputRecord {
+  return {
+    id: row.id,
+    jobId: row.job_id,
+    userId: row.user_id,
+    kind: row.kind,
+    url: row.storage_url ?? row.url,
+    storageUrl: row.storage_url,
+    thumbUrl: row.thumb_url,
+    mimeType: row.mime_type,
+    width: row.width,
+    height: row.height,
+    durationSec: row.duration_sec,
+    position: row.position,
+    status: row.status,
+    metadata: normalizeMetadata(row.metadata),
+    createdAt: row.created_at,
+  };
+}
+
+function mapAssetRow(row: DbMediaAssetRow): MediaAssetRecord {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    kind: row.kind,
+    url: row.url,
+    thumbUrl: row.thumb_url,
+    mimeType: row.mime_type,
+    width: row.width,
+    height: row.height,
+    sizeBytes: typeof row.size_bytes === 'string' ? Number(row.size_bytes) : row.size_bytes,
+    source: normalizeMediaAssetSource(row.source),
+    sourceJobId: row.source_job_id,
+    sourceOutputId: row.source_output_id,
+    status: row.status ?? 'ready',
+    metadata: normalizeMetadata(row.metadata),
+    createdAt: row.created_at,
+  };
+}
+
+export async function upsertJobOutputs(outputs: JobOutputRecord[]): Promise<void> {
+  if (!outputs.length) return;
+  await ensureMediaLibrarySchema();
+  for (const output of outputs) {
+    await query(
+      `INSERT INTO job_outputs (
+         id, job_id, user_id, kind, url, storage_url, thumb_url, mime_type, width, height,
+         duration_sec, position, status, metadata
+       )
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14::jsonb)
+       ON CONFLICT (job_id, kind, position)
+       DO UPDATE SET
+         url = EXCLUDED.url,
+         storage_url = EXCLUDED.storage_url,
+         thumb_url = EXCLUDED.thumb_url,
+         mime_type = EXCLUDED.mime_type,
+         width = EXCLUDED.width,
+         height = EXCLUDED.height,
+         duration_sec = EXCLUDED.duration_sec,
+         status = EXCLUDED.status,
+         metadata = COALESCE(job_outputs.metadata, '{}'::jsonb) || EXCLUDED.metadata,
+         updated_at = NOW()`,
+      [
+        output.id,
+        output.jobId,
+        output.userId,
+        output.kind,
+        output.url,
+        output.storageUrl,
+        output.thumbUrl,
+        output.mimeType,
+        output.width,
+        output.height,
+        output.durationSec,
+        output.position,
+        output.status,
+        JSON.stringify(output.metadata ?? {}),
+      ]
+    );
+  }
+}
+
+export async function upsertLegacyJobOutputs(row: LegacyJobMediaRow): Promise<void> {
+  await upsertJobOutputs(mapLegacyJobRowToOutputs(row));
+}
+
+export async function listJobOutputsByJobIds(jobIds: string[]): Promise<Map<string, JobOutputRecord[]>> {
+  const ids = Array.from(new Set(jobIds.filter(Boolean)));
+  const map = new Map<string, JobOutputRecord[]>();
+  if (!ids.length) return map;
+  await ensureMediaLibrarySchema();
+  const rows = await query<DbJobOutputRow>(
+    `SELECT id, job_id, user_id, kind, url, storage_url, thumb_url, mime_type, width, height,
+            duration_sec, position, status, metadata, created_at
+       FROM job_outputs
+      WHERE job_id = ANY($1::text[])
+        AND status <> 'deleted'
+      ORDER BY job_id ASC, kind ASC, position ASC`,
+    [ids]
+  );
+  rows.forEach((row) => {
+    const output = mapOutputRow(row);
+    const existing = map.get(output.jobId) ?? [];
+    existing.push(output);
+    map.set(output.jobId, existing);
+  });
+  return map;
+}
+
+export function applyOutputsToJobPayload<T extends {
+  jobId: string;
+  thumbUrl?: string | null;
+  videoUrl?: string | null;
+  audioUrl?: string | null;
+  renderIds?: string[] | null;
+  renderThumbUrls?: string[] | null;
+}>(job: T, outputs: JobOutputRecord[] | undefined): T {
+  if (!outputs?.length) return job;
+  const videos = outputs.filter((output) => output.kind === 'video').sort((a, b) => a.position - b.position);
+  const audios = outputs.filter((output) => output.kind === 'audio').sort((a, b) => a.position - b.position);
+  const images = outputs.filter((output) => output.kind === 'image').sort((a, b) => a.position - b.position);
+  const firstVideo = videos[0];
+  const firstAudio = audios[0];
+  const imageEntries = images.map((output) => ({
+    url: output.url,
+    thumbUrl: output.thumbUrl ?? output.url,
+    width: output.width,
+    height: output.height,
+    mimeType: output.mimeType,
+  }));
+  const renderEntries = buildStoredImageRenderEntries(imageEntries);
+  return {
+    ...job,
+    videoUrl: firstVideo?.url ?? job.videoUrl,
+    audioUrl: firstAudio?.url ?? job.audioUrl,
+    thumbUrl: firstVideo?.thumbUrl ?? images[0]?.thumbUrl ?? job.thumbUrl,
+    renderIds: images.length ? images.map((output) => output.url) : job.renderIds,
+    renderThumbUrls: renderEntries.length ? renderEntries.map((entry) => entry.thumb_url) : job.renderThumbUrls,
+  };
+}
+
+export async function listLibraryAssets(params: {
+  userId: string;
+  kind?: MediaKind | null;
+  source?: string | null;
+  originUrl?: string | null;
+  limit?: number;
+}): Promise<MediaAssetRecord[]> {
+  await ensureMediaLibrarySchema();
+  await ensureAssetSchema();
+  const limit = Math.min(200, Math.max(1, params.limit ?? 50));
+  const source = params.source && params.source !== 'all' ? normalizeMediaAssetSource(params.source) : null;
+  const originUrl = normalizeString(params.originUrl) ?? null;
+  const values: unknown[] = [params.userId, limit, params.kind ?? null, source, originUrl];
+  const rows = await query<DbMediaAssetRow>(
+    `SELECT id, user_id, kind, url, thumb_url, mime_type, width, height, size_bytes, source,
+            source_job_id, source_output_id, status, metadata, created_at
+       FROM media_assets
+      WHERE user_id = $1
+        AND deleted_at IS NULL
+        AND ($3::text IS NULL OR kind = $3::text)
+        AND ($4::text IS NULL OR source = $4::text)
+        AND ($5::text IS NULL OR url = $5::text OR metadata->>'originUrl' = $5::text)
+      ORDER BY created_at DESC
+      LIMIT $2`,
+    values
+  );
+  const assets = rows.map(mapAssetRow);
+
+  const legacyRows = await query<{
+    asset_id: string;
+    user_id: string | null;
+    url: string;
+    mime_type: string | null;
+    width: number | null;
+    height: number | null;
+    size_bytes: string | number | null;
+    source: string | null;
+    metadata: unknown;
+    created_at: string;
+  }>(
+    `SELECT asset_id, user_id, url, mime_type, width, height, size_bytes, source, metadata, created_at
+       FROM user_assets
+      WHERE user_id = $1
+        AND ($3::text IS NULL OR (
+          CASE
+            WHEN COALESCE(mime_type, '') LIKE 'video/%' THEN 'video'
+            WHEN COALESCE(mime_type, '') LIKE 'audio/%' THEN 'audio'
+            ELSE 'image'
+          END
+        ) = $3::text)
+        AND ($4::text IS NULL OR (
+          CASE
+            WHEN source IN ('upload', 'character', 'angle', 'upscale') THEN source
+            WHEN source = 'generated' THEN 'saved_job_output'
+            ELSE 'import'
+          END
+        ) = $4::text)
+        AND ($5::text IS NULL OR url = $5::text OR metadata->>'originUrl' = $5::text)
+      ORDER BY created_at DESC
+      LIMIT $2`,
+    values
+  );
+
+  const seen = new Set(assets.map((asset) => asset.id));
+  legacyRows.forEach((row) => {
+    if (seen.has(row.asset_id)) return;
+    const kind: MediaKind = row.mime_type?.startsWith('video/')
+      ? 'video'
+      : row.mime_type?.startsWith('audio/')
+        ? 'audio'
+        : 'image';
+    const metadata = normalizeMetadata(row.metadata);
+    assets.push({
+      id: row.asset_id,
+      userId: row.user_id,
+      kind,
+      url: row.url,
+      thumbUrl: typeof metadata.thumbUrl === 'string' ? metadata.thumbUrl : null,
+      mimeType: row.mime_type,
+      width: row.width,
+      height: row.height,
+      sizeBytes: typeof row.size_bytes === 'string' ? Number(row.size_bytes) : row.size_bytes,
+      source: normalizeMediaAssetSource(row.source),
+      sourceJobId: typeof metadata.jobId === 'string' ? metadata.jobId : null,
+      sourceOutputId: null,
+      status: 'ready',
+      metadata,
+      createdAt: row.created_at,
+    });
+    seen.add(row.asset_id);
+  });
+
+  return assets
+    .sort((a, b) => Date.parse(b.createdAt ?? '') - Date.parse(a.createdAt ?? ''))
+    .slice(0, limit);
+}
+
+export async function listRecentOutputs(params: {
+  userId: string;
+  kind?: MediaKind | null;
+  surface?: string | null;
+  limit?: number;
+}): Promise<JobOutputRecord[]> {
+  await ensureMediaLibrarySchema();
+  const limit = Math.min(200, Math.max(1, params.limit ?? 50));
+  const rows = await query<DbJobOutputRow>(
+    `SELECT o.id, o.job_id, o.user_id, o.kind, o.url, o.storage_url, o.thumb_url, o.mime_type,
+            o.width, o.height, o.duration_sec, o.position, o.status, o.metadata, o.created_at
+       FROM job_outputs o
+       JOIN app_jobs j ON j.job_id = o.job_id
+      WHERE o.user_id = $1
+        AND j.hidden IS NOT TRUE
+        AND o.status = 'ready'
+        AND ($3::text IS NULL OR o.kind = $3::text)
+        AND ($4::text IS NULL OR j.surface = $4::text OR j.settings_snapshot->>'surface' = $4::text)
+      ORDER BY o.created_at DESC
+      LIMIT $2`,
+    [params.userId, limit, params.kind ?? null, params.surface ?? null]
+  );
+  return rows.map(mapOutputRow);
+}
+
+async function copyRemoteMedia(params: {
+  userId: string;
+  url: string;
+  kind: MediaKind;
+  mimeType?: string | null;
+  fileName?: string | null;
+}): Promise<{ url: string; mimeType: string | null; width: number | null; height: number | null; sizeBytes: number | null }> {
+  const parsed = new URL(params.url);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8000);
+  const response = await fetch(parsed.toString(), { signal: controller.signal });
+  clearTimeout(timeout);
+  if (!response.ok) {
+    throw new Error(`FETCH_FAILED:${response.status}`);
+  }
+  const mimeType = response.headers.get('content-type') ?? params.mimeType ?? inferMimeFromUrl(params.url, params.kind);
+  const buffer = Buffer.from(await response.arrayBuffer());
+  if (!buffer.length) throw new Error('EMPTY_MEDIA');
+  if (params.kind === 'image') {
+    const upload = await uploadImageToStorage({
+      data: buffer,
+      mime: mimeType,
+      userId: params.userId,
+      prefix: 'media-assets',
+      fileName: params.fileName,
+    });
+    return {
+      url: upload.url,
+      mimeType: upload.mime,
+      width: upload.width,
+      height: upload.height,
+      sizeBytes: upload.size,
+    };
+  }
+  const upload = await uploadFileBuffer({
+    data: buffer,
+    mime: mimeType,
+    userId: params.userId,
+    prefix: 'media-assets',
+    fileName: params.fileName,
+  });
+  return {
+    url: upload.url,
+    mimeType,
+    width: null,
+    height: null,
+    sizeBytes: buffer.length,
+  };
+}
+
+export async function ensureReusableAsset(params: {
+  userId: string;
+  url: string;
+  kind: MediaKind;
+  source?: unknown;
+  sourceJobId?: string | null;
+  sourceOutputId?: string | null;
+  label?: string | null;
+  mimeType?: string | null;
+  width?: number | null;
+  height?: number | null;
+  sizeBytes?: number | null;
+  thumbUrl?: string | null;
+}): Promise<MediaAssetRecord> {
+  await ensureMediaLibrarySchema();
+  const source = normalizeMediaAssetSource(params.source);
+  const normalizedUrl = normalizeString(params.url);
+  if (!normalizedUrl) throw new Error('URL_REQUIRED');
+  const identity = resolveLibraryAssetIdentity({
+    userId: params.userId,
+    kind: params.kind,
+    url: normalizedUrl,
+    source,
+    sourceOutputId: params.sourceOutputId ?? null,
+  });
+
+  const existing = await query<DbMediaAssetRow>(
+    `SELECT id, user_id, kind, url, thumb_url, mime_type, width, height, size_bytes, source,
+            source_job_id, source_output_id, status, metadata, created_at
+       FROM media_assets
+      WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL
+      LIMIT 1`,
+    [identity, params.userId]
+  );
+  if (existing[0]) return mapAssetRow(existing[0]);
+
+  const host = new URL(normalizedUrl).host.toLowerCase();
+  const shouldCopy = source === 'saved_job_output' || host === 'fal.media' || host.endsWith('.fal.media');
+  const copied = shouldCopy
+    ? await copyRemoteMedia({
+        userId: params.userId,
+        url: normalizedUrl,
+        kind: params.kind,
+        mimeType: params.mimeType,
+        fileName: params.label,
+      })
+    : {
+        url: normalizedUrl,
+        mimeType: params.mimeType ?? inferMimeFromUrl(normalizedUrl, params.kind),
+        width: params.width ?? null,
+        height: params.height ?? null,
+        sizeBytes: params.sizeBytes ?? null,
+      };
+
+  const insert = buildMediaAssetInsert({
+    userId: params.userId,
+    kind: params.kind,
+    url: copied.url,
+    thumbUrl: params.thumbUrl ?? null,
+    mimeType: copied.mimeType,
+    width: copied.width ?? params.width ?? null,
+    height: copied.height ?? params.height ?? null,
+    sizeBytes: copied.sizeBytes ?? params.sizeBytes ?? null,
+    source,
+    sourceJobId: params.sourceJobId ?? null,
+    sourceOutputId: params.sourceOutputId ?? null,
+    metadata: {
+      originUrl: normalizedUrl,
+      label: params.label ?? null,
+      jobId: params.sourceJobId ?? null,
+      sourceOutputId: params.sourceOutputId ?? null,
+    },
+  });
+  insert.id = identity;
+
+  const rows = await query<DbMediaAssetRow>(
+    `INSERT INTO media_assets (
+       id, user_id, kind, url, thumb_url, mime_type, width, height, size_bytes, source,
+       source_job_id, source_output_id, status, metadata
+     )
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14::jsonb)
+     ON CONFLICT (id)
+     DO UPDATE SET
+       deleted_at = NULL,
+       url = EXCLUDED.url,
+       thumb_url = EXCLUDED.thumb_url,
+       mime_type = EXCLUDED.mime_type,
+       width = EXCLUDED.width,
+       height = EXCLUDED.height,
+       size_bytes = EXCLUDED.size_bytes,
+       source = EXCLUDED.source,
+       source_job_id = EXCLUDED.source_job_id,
+       source_output_id = EXCLUDED.source_output_id,
+       status = EXCLUDED.status,
+       metadata = COALESCE(media_assets.metadata, '{}'::jsonb) || EXCLUDED.metadata,
+       updated_at = NOW()
+     RETURNING id, user_id, kind, url, thumb_url, mime_type, width, height, size_bytes, source,
+               source_job_id, source_output_id, status, metadata, created_at`,
+    [
+      insert.id,
+      insert.userId,
+      insert.kind,
+      insert.url,
+      insert.thumbUrl,
+      insert.mimeType,
+      insert.width,
+      insert.height,
+      insert.sizeBytes,
+      insert.source,
+      insert.sourceJobId,
+      insert.sourceOutputId,
+      insert.status,
+      JSON.stringify(insert.metadata),
+    ]
+  );
+
+  await recordUserAsset({
+    assetId: rows[0]?.id ?? randomUUID(),
+    userId: params.userId,
+    url: rows[0]?.url ?? insert.url,
+    mime: rows[0]?.mime_type ?? insert.mimeType ?? inferMimeFromUrl(insert.url, insert.kind),
+    width: rows[0]?.width ?? insert.width,
+    height: rows[0]?.height ?? insert.height,
+    size: rows[0]?.size_bytes == null ? insert.sizeBytes : Number(rows[0].size_bytes),
+    source: insert.source === 'saved_job_output' ? 'generated' : insert.source,
+    metadata: insert.metadata,
+  }).catch((error) => {
+    console.warn('[media-library] failed to mirror media asset into user_assets', error);
+  });
+
+  return mapAssetRow(rows[0]);
+}
+
+export async function saveJobOutputToLibrary(params: {
+  userId: string;
+  jobId: string;
+  outputId: string;
+}): Promise<MediaAssetRecord> {
+  await ensureMediaLibrarySchema();
+  const rows = await query<DbJobOutputRow>(
+    `SELECT id, job_id, user_id, kind, url, storage_url, thumb_url, mime_type, width, height,
+            duration_sec, position, status, metadata, created_at
+       FROM job_outputs
+      WHERE id = $1 AND job_id = $2 AND user_id = $3
+      LIMIT 1`,
+    [params.outputId, params.jobId, params.userId]
+  );
+  if (!rows[0]) throw new Error('OUTPUT_NOT_FOUND');
+  const output = mapOutputRow(rows[0]);
+  return ensureReusableAsset({
+    userId: params.userId,
+    url: output.url,
+    kind: output.kind,
+    source: 'saved_job_output',
+    sourceJobId: output.jobId,
+    sourceOutputId: output.id,
+    mimeType: output.mimeType,
+    width: output.width,
+    height: output.height,
+    thumbUrl: output.thumbUrl,
+  });
+}
+
+export async function deleteLibraryAsset(params: { userId: string; assetId: string }): Promise<'deleted' | 'not_found'> {
+  await ensureMediaLibrarySchema();
+  const rows = await query<{ id: string }>(
+    `UPDATE media_assets
+        SET deleted_at = NOW(), updated_at = NOW(), status = 'deleted'
+      WHERE id = $1
+        AND user_id = $2
+        AND deleted_at IS NULL
+      RETURNING id`,
+    [params.assetId, params.userId]
+  );
+  if (!rows.length) return 'not_found';
+  return 'deleted';
+}

--- a/frontend/server/seo/gsc.ts
+++ b/frontend/server/seo/gsc.ts
@@ -170,6 +170,13 @@ export async function fetchGscDashboardData(options?: {
     if (cached) {
       return withCacheAge(cached.data, cached.createdAt);
     }
+    return buildEmptyDashboard({
+      range,
+      windows,
+      configured: true,
+      siteUrl: config.siteUrl,
+      error: 'No cached GSC snapshot is available. Use force refresh to fetch fresh Search Console data.',
+    });
   }
 
   try {

--- a/frontend/src/lib/schema.ts
+++ b/frontend/src/lib/schema.ts
@@ -12,6 +12,7 @@ const FEATURE_LAUNCH_TIMESTAMP: string = (() => {
 
 let ensurePromise: Promise<void> | null = null;
 let ensureAssetsPromise: Promise<void> | null = null;
+let ensureMediaLibraryPromise: Promise<void> | null = null;
 let ensureEmailPromise: Promise<void> | null = null;
 
 export async function ensureBillingSchema(): Promise<void> {
@@ -775,6 +776,117 @@ export async function ensureAssetSchema(): Promise<void> {
   });
 
   await ensureAssetsPromise;
+}
+
+export async function ensureMediaLibrarySchema(): Promise<void> {
+  if (ensureMediaLibraryPromise) return ensureMediaLibraryPromise;
+
+  const ensure = async () => {
+    await query(`
+      CREATE TABLE IF NOT EXISTS job_outputs (
+        id TEXT PRIMARY KEY,
+        job_id TEXT NOT NULL,
+        user_id TEXT,
+        workspace_id TEXT,
+        kind TEXT NOT NULL CHECK (kind IN ('image','video','audio')),
+        url TEXT NOT NULL,
+        storage_url TEXT,
+        thumb_url TEXT,
+        mime_type TEXT,
+        width INTEGER,
+        height INTEGER,
+        duration_sec INTEGER,
+        position INTEGER NOT NULL DEFAULT 0,
+        status TEXT NOT NULL DEFAULT 'ready',
+        metadata JSONB,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      );
+    `);
+
+    await query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS job_outputs_job_kind_position_idx
+        ON job_outputs (job_id, kind, position);
+    `);
+
+    await query(`
+      CREATE INDEX IF NOT EXISTS job_outputs_user_created_idx
+        ON job_outputs (user_id, created_at DESC)
+        WHERE user_id IS NOT NULL;
+    `);
+
+    await query(`
+      CREATE INDEX IF NOT EXISTS job_outputs_job_idx ON job_outputs (job_id);
+    `);
+
+    await query(`
+      CREATE INDEX IF NOT EXISTS job_outputs_kind_idx ON job_outputs (kind);
+    `);
+
+    await query(`
+      CREATE TABLE IF NOT EXISTS media_assets (
+        id TEXT PRIMARY KEY,
+        user_id TEXT,
+        workspace_id TEXT,
+        kind TEXT NOT NULL CHECK (kind IN ('image','video','audio')),
+        url TEXT NOT NULL,
+        thumb_url TEXT,
+        mime_type TEXT,
+        width INTEGER,
+        height INTEGER,
+        size_bytes BIGINT,
+        source TEXT NOT NULL CHECK (source IN ('upload','saved_job_output','character','angle','upscale','import')),
+        source_job_id TEXT,
+        source_output_id TEXT,
+        status TEXT NOT NULL DEFAULT 'ready',
+        metadata JSONB,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        deleted_at TIMESTAMPTZ
+      );
+    `);
+
+    await query(`
+      CREATE INDEX IF NOT EXISTS media_assets_user_created_idx
+        ON media_assets (user_id, created_at DESC)
+        WHERE user_id IS NOT NULL AND deleted_at IS NULL;
+    `);
+
+    await query(`
+      CREATE INDEX IF NOT EXISTS media_assets_user_kind_created_idx
+        ON media_assets (user_id, kind, created_at DESC)
+        WHERE user_id IS NOT NULL AND deleted_at IS NULL;
+    `);
+
+    await query(`
+      CREATE INDEX IF NOT EXISTS media_assets_source_output_idx
+        ON media_assets (source_output_id)
+        WHERE source_output_id IS NOT NULL AND deleted_at IS NULL;
+    `);
+
+    await query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS media_assets_user_source_output_unique_idx
+        ON media_assets (user_id, source_output_id)
+        WHERE source_output_id IS NOT NULL AND deleted_at IS NULL;
+    `);
+
+    await query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS media_assets_user_kind_url_unique_idx
+        ON media_assets (user_id, kind, url)
+        WHERE source_output_id IS NULL AND deleted_at IS NULL;
+    `);
+
+    await query(`
+      CREATE INDEX IF NOT EXISTS media_assets_kind_idx ON media_assets (kind);
+    `);
+  };
+
+  ensureMediaLibraryPromise = ensure().catch((error) => {
+    ensureMediaLibraryPromise = null;
+    console.error('[schema] Failed to ensure media library schema', error);
+    throw error;
+  });
+  return ensureMediaLibraryPromise;
 }
 
 export async function ensureEmailSchema(): Promise<void> {

--- a/frontend/src/server/audio/generate-audio.ts
+++ b/frontend/src/server/audio/generate-audio.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { upsertLegacyJobOutputs } from '@/server/media-library';
 
 import {
   AUDIO_MAX_DURATION_SEC,
@@ -941,6 +942,21 @@ export async function generateAudioRun(params: {
       hasAudio: true,
       paymentStatus: 'paid_wallet',
       settingsSnapshotJson: finalSettingsSnapshotJson,
+    });
+
+    await upsertLegacyJobOutputs({
+      job_id: jobId,
+      user_id: params.userId,
+      surface: 'audio',
+      video_url: uploadedVideoUrl,
+      audio_url: uploadedAudioUrl,
+      thumb_url: uploadedThumbUrl ?? initialThumb,
+      preview_frame: uploadedThumbUrl ?? initialThumb,
+      render_ids: null,
+      duration_sec: durationSec,
+      status: 'completed',
+    }).catch((outputError) => {
+      console.warn('[audio] failed to persist job outputs', { jobId }, outputError);
     });
 
     return {

--- a/frontend/src/server/images/execute-image-generation.ts
+++ b/frontend/src/server/images/execute-image-generation.ts
@@ -29,6 +29,7 @@ import {
 } from '@/server/storage';
 import { createImageThumbnailBatch } from '@/server/image-thumbnails';
 import { buildStoredImageRenderEntries, parseStoredImageRenders, resolveHeroThumbFromRenders } from '@/lib/image-renders';
+import { ensureReusableAsset, upsertLegacyJobOutputs } from '@/server/media-library';
 import {
   formatSupportedImageFormatsLabel,
   getSupportedImageFormats,
@@ -1621,6 +1622,40 @@ export async function executeImageGeneration({
         hero,
       ]
     );
+
+    await upsertLegacyJobOutputs({
+      job_id: jobId,
+      user_id: userId,
+      surface: jobSurface,
+      video_url: null,
+      audio_url: null,
+      thumb_url: heroThumb ?? PLACEHOLDER_THUMB,
+      preview_frame: heroThumb ?? PLACEHOLDER_THUMB,
+      render_ids: storedRenderEntries,
+      duration_sec: 1,
+      status: 'completed',
+    }).catch((outputError) => {
+      console.warn('[images] failed to persist job outputs', { jobId }, outputError);
+    });
+
+    if (jobSurface === 'character') {
+      await Promise.allSettled(
+        normalizedImagesWithThumbs.map((image, index) =>
+          ensureReusableAsset({
+            userId,
+            url: image.url,
+            kind: 'image',
+            source: 'character',
+            sourceJobId: jobId,
+            sourceOutputId: `${jobId}:image:${index}`,
+            mimeType: image.mimeType ?? 'image/png',
+            width: image.width ?? null,
+            height: image.height ?? null,
+            thumbUrl: image.thumbUrl ?? null,
+          })
+        )
+      );
+    }
 
     try {
       await query(

--- a/frontend/src/server/tools/angle.ts
+++ b/frontend/src/server/tools/angle.ts
@@ -14,6 +14,7 @@ import { receiptsPriceOnlyEnabled } from '@/lib/env';
 import { isStorageConfigured, recordUserAsset, uploadImageToStorage } from '@/server/storage';
 import { createImageThumbnailBatch } from '@/server/image-thumbnails';
 import { buildStoredImageRenderEntries, resolveHeroThumbFromRenders } from '@/lib/image-renders';
+import { ensureReusableAsset, upsertLegacyJobOutputs } from '@/server/media-library';
 import {
   applyCinemaSafeParams,
   buildBestAngleVariantParams,
@@ -832,6 +833,38 @@ export async function runAngleTool(input: RunAngleToolInput): Promise<AngleToolR
         JSON.stringify(storedRenderEntries),
         heroRenderId,
       ]
+    );
+
+    await upsertLegacyJobOutputs({
+      job_id: jobId,
+      user_id: input.userId,
+      surface: 'angle',
+      video_url: null,
+      audio_url: null,
+      thumb_url: heroThumb,
+      preview_frame: heroThumb,
+      render_ids: storedRenderEntries,
+      duration_sec: 1,
+      status: 'completed',
+    }).catch((outputError) => {
+      console.warn('[tools/angle] failed to persist job outputs', { jobId }, outputError);
+    });
+
+    await Promise.allSettled(
+      outputsWithThumbs.map((output, index) =>
+        ensureReusableAsset({
+          userId: input.userId,
+          url: output.url,
+          kind: 'image',
+          source: 'angle',
+          sourceJobId: jobId,
+          sourceOutputId: `${jobId}:image:${index}`,
+          mimeType: output.mimeType ?? 'image/png',
+          width: output.width ?? null,
+          height: output.height ?? null,
+          thumbUrl: output.thumbUrl ?? null,
+        })
+      )
     );
 
     await insertToolEvent({

--- a/frontend/src/server/tools/upscale.ts
+++ b/frontend/src/server/tools/upscale.ts
@@ -13,6 +13,7 @@ import { reserveWalletChargeInExecutor } from '@/lib/wallet';
 import { receiptsPriceOnlyEnabled } from '@/lib/env';
 import { isStorageConfigured, recordUserAsset, uploadFileBuffer, uploadImageToStorage } from '@/server/storage';
 import { buildStoredImageRenderEntries, resolveHeroThumbFromRenders } from '@/lib/image-renders';
+import { ensureReusableAsset, upsertLegacyJobOutputs } from '@/server/media-library';
 import {
   UPSCALE_VIDEO_DYNAMIC_MARGIN_MULTIPLIER,
   clampUpscaleFactor,
@@ -1014,6 +1015,36 @@ export async function runUpscaleToolBase(
         heroRenderId,
       ]
     );
+
+    await upsertLegacyJobOutputs({
+      job_id: jobId,
+      user_id: input.userId,
+      surface: 'upscale',
+      video_url: mediaType === 'video' ? persistedOutput.url : null,
+      audio_url: null,
+      thumb_url: thumbUrl,
+      preview_frame: thumbUrl,
+      render_ids: renderIdsJson ? JSON.parse(renderIdsJson) : null,
+      duration_sec: videoMetadata?.durationSec ?? 1,
+      status: 'completed',
+    }).catch((outputError) => {
+      console.warn('[tools/upscale] failed to persist job outputs', { jobId }, outputError);
+    });
+
+    await ensureReusableAsset({
+      userId: input.userId,
+      url: persistedOutput.url,
+      kind: mediaType,
+      source: 'upscale',
+      sourceJobId: jobId,
+      sourceOutputId: `${jobId}:${mediaType}:0`,
+      mimeType: persistedOutput.mimeType ?? (mediaType === 'video' ? 'video/mp4' : 'image/png'),
+      width: persistedOutput.width ?? null,
+      height: persistedOutput.height ?? null,
+      thumbUrl,
+    }).catch((assetError) => {
+      console.warn('[tools/upscale] failed to persist media asset', { jobId }, assetError);
+    });
 
     await insertToolEvent({
       jobId,

--- a/scripts/generate-model-roster.mjs
+++ b/scripts/generate-model-roster.mjs
@@ -99,19 +99,24 @@ function computeRosterEntry(entry) {
   };
 }
 
-function ensureNoShrink(currentRoster, generatedRoster) {
+function hasPublishedModelPage(entry) {
+  return entry?.surfaces?.modelPage?.indexable !== false || entry?.surfaces?.modelPage?.includeInSitemap !== false;
+}
+
+function ensureNoShrink(currentRoster, generatedRoster, allowedRemovedSlugs = new Set()) {
   const currentSlugs = currentRoster.map((entry) => entry?.modelSlug).filter((slug) => typeof slug === 'string');
   const generatedSlugs = generatedRoster.map((entry) => entry.modelSlug);
   const generatedSet = new Set(generatedSlugs);
   const missingSlugs = currentSlugs.filter((slug) => !generatedSet.has(slug));
+  const blockedMissingSlugs = missingSlugs.filter((slug) => !allowedRemovedSlugs.has(slug));
 
-  if (generatedRoster.length < currentRoster.length) {
+  if (generatedRoster.length < currentRoster.length && blockedMissingSlugs.length > 0) {
     throw new Error(
       `Generated roster would shrink from ${currentRoster.length} to ${generatedRoster.length}. Aborting to prevent page removals.`
     );
   }
-  if (missingSlugs.length > 0) {
-    throw new Error(`Generated roster is missing existing slugs: ${missingSlugs.join(', ')}`);
+  if (blockedMissingSlugs.length > 0) {
+    throw new Error(`Generated roster is missing existing slugs: ${blockedMissingSlugs.join(', ')}`);
   }
 }
 
@@ -196,7 +201,14 @@ async function main() {
     throw new Error('frontend/config/model-roster.json must be an array when present.');
   }
 
-  const roster = catalog
+  const publicCatalog = catalog.filter((entry) => hasPublishedModelPage(entry));
+  const publicSlugs = new Set(publicCatalog.map((entry) => entry.modelSlug).filter((slug) => typeof slug === 'string'));
+  const allowedRemovedSlugs = new Set(
+    currentRoster
+      .map((entry) => entry?.modelSlug)
+      .filter((slug) => typeof slug === 'string' && !publicSlugs.has(slug))
+  );
+  const roster = publicCatalog
     .map((entry) => computeRosterEntry(entry))
     .sort((a, b) => {
       if (a.brandId === b.brandId) {
@@ -205,7 +217,7 @@ async function main() {
       return a.brandId.localeCompare(b.brandId, 'en');
     });
 
-  ensureNoShrink(currentRoster, roster);
+  ensureNoShrink(currentRoster, roster, allowedRemovedSlugs);
   const currentJson = JSON.stringify(currentRoster, null, 2);
   const generatedJson = JSON.stringify(roster, null, 2);
   const hasChanges = currentJson !== generatedJson;

--- a/scripts/models-audit.mjs
+++ b/scripts/models-audit.mjs
@@ -97,6 +97,10 @@ function setFromSlugs(entries, key = 'modelSlug') {
   return new Set(entries.map((entry) => entry?.[key]).filter((slug) => typeof slug === 'string' && slug.length));
 }
 
+function hasPublishedModelPage(entry) {
+  return entry?.surfaces?.modelPage?.indexable !== false || entry?.surfaces?.modelPage?.includeInSitemap !== false;
+}
+
 function diffSet(left, right) {
   const missing = [];
   left.forEach((value) => {
@@ -778,7 +782,8 @@ async function main() {
     LOCALES.map(async (locale) => ({ locale, slugs: await loadLocaleContentSlugs(locale) }))
   );
 
-  const catalogSlugs = setFromSlugs(catalog, 'modelSlug');
+  const publicCatalog = catalog.filter((entry) => hasPublishedModelPage(entry));
+  const catalogSlugs = setFromSlugs(publicCatalog, 'modelSlug');
   const rosterSlugs = setFromSlugs(roster, 'modelSlug');
   const catalogBySlug = new Map(catalog.map((entry) => [entry.modelSlug, entry]));
 

--- a/supabase/migrations/20260504120000_media_workspace_scalable.sql
+++ b/supabase/migrations/20260504120000_media_workspace_scalable.sql
@@ -1,0 +1,245 @@
+CREATE TABLE IF NOT EXISTS job_outputs (
+  id TEXT PRIMARY KEY,
+  job_id TEXT NOT NULL,
+  user_id TEXT,
+  workspace_id TEXT,
+  kind TEXT NOT NULL CHECK (kind IN ('image','video','audio')),
+  url TEXT NOT NULL,
+  storage_url TEXT,
+  thumb_url TEXT,
+  mime_type TEXT,
+  width INTEGER,
+  height INTEGER,
+  duration_sec INTEGER,
+  position INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'ready',
+  metadata JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS job_outputs_job_kind_position_idx
+  ON job_outputs (job_id, kind, position);
+
+CREATE INDEX IF NOT EXISTS job_outputs_user_created_idx
+  ON job_outputs (user_id, created_at DESC)
+  WHERE user_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS job_outputs_job_idx ON job_outputs (job_id);
+CREATE INDEX IF NOT EXISTS job_outputs_kind_idx ON job_outputs (kind);
+
+CREATE TABLE IF NOT EXISTS media_assets (
+  id TEXT PRIMARY KEY,
+  user_id TEXT,
+  workspace_id TEXT,
+  kind TEXT NOT NULL CHECK (kind IN ('image','video','audio')),
+  url TEXT NOT NULL,
+  thumb_url TEXT,
+  mime_type TEXT,
+  width INTEGER,
+  height INTEGER,
+  size_bytes BIGINT,
+  source TEXT NOT NULL CHECK (source IN ('upload','saved_job_output','character','angle','upscale','import')),
+  source_job_id TEXT,
+  source_output_id TEXT,
+  status TEXT NOT NULL DEFAULT 'ready',
+  metadata JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS media_assets_user_created_idx
+  ON media_assets (user_id, created_at DESC)
+  WHERE user_id IS NOT NULL AND deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS media_assets_user_kind_created_idx
+  ON media_assets (user_id, kind, created_at DESC)
+  WHERE user_id IS NOT NULL AND deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS media_assets_source_output_idx
+  ON media_assets (source_output_id)
+  WHERE source_output_id IS NOT NULL AND deleted_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS media_assets_user_source_output_unique_idx
+  ON media_assets (user_id, source_output_id)
+  WHERE source_output_id IS NOT NULL AND deleted_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS media_assets_user_kind_url_unique_idx
+  ON media_assets (user_id, kind, url)
+  WHERE source_output_id IS NULL AND deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS media_assets_kind_idx ON media_assets (kind);
+
+INSERT INTO job_outputs (
+  id,
+  job_id,
+  user_id,
+  kind,
+  url,
+  thumb_url,
+  mime_type,
+  duration_sec,
+  position,
+  status,
+  metadata,
+  created_at,
+  updated_at
+)
+SELECT
+  app_jobs.job_id || ':video:0',
+  app_jobs.job_id,
+  app_jobs.user_id,
+  'video',
+  app_jobs.video_url,
+  COALESCE(NULLIF(app_jobs.thumb_url, ''), app_jobs.preview_frame),
+  'video/mp4',
+  app_jobs.duration_sec,
+  0,
+  CASE WHEN app_jobs.status = 'failed' THEN 'failed' ELSE 'ready' END,
+  jsonb_build_object('legacy', true, 'surface', app_jobs.surface),
+  app_jobs.created_at,
+  app_jobs.updated_at
+FROM app_jobs
+WHERE COALESCE(app_jobs.video_url, '') <> ''
+ON CONFLICT (job_id, kind, position) DO NOTHING;
+
+INSERT INTO job_outputs (
+  id,
+  job_id,
+  user_id,
+  kind,
+  url,
+  mime_type,
+  duration_sec,
+  position,
+  status,
+  metadata,
+  created_at,
+  updated_at
+)
+SELECT
+  app_jobs.job_id || ':audio:0',
+  app_jobs.job_id,
+  app_jobs.user_id,
+  'audio',
+  app_jobs.audio_url,
+  'audio/mpeg',
+  app_jobs.duration_sec,
+  0,
+  CASE WHEN app_jobs.status = 'failed' THEN 'failed' ELSE 'ready' END,
+  jsonb_build_object('legacy', true, 'surface', app_jobs.surface),
+  app_jobs.created_at,
+  app_jobs.updated_at
+FROM app_jobs
+WHERE COALESCE(app_jobs.audio_url, '') <> ''
+ON CONFLICT (job_id, kind, position) DO NOTHING;
+
+INSERT INTO job_outputs (
+  id,
+  job_id,
+  user_id,
+  kind,
+  url,
+  thumb_url,
+  mime_type,
+  width,
+  height,
+  position,
+  status,
+  metadata,
+  created_at,
+  updated_at
+)
+SELECT
+  app_jobs.job_id || ':image:' || (render_entry.ordinality - 1)::text,
+  app_jobs.job_id,
+  app_jobs.user_id,
+  'image',
+  CASE
+    WHEN jsonb_typeof(render_entry.value) = 'string' THEN trim(both '"' from render_entry.value::text)
+    ELSE render_entry.value->>'url'
+  END,
+  CASE
+    WHEN jsonb_typeof(render_entry.value) = 'object' THEN COALESCE(render_entry.value->>'thumb_url', render_entry.value->>'thumbUrl', render_entry.value->>'url')
+    ELSE trim(both '"' from render_entry.value::text)
+  END,
+  CASE
+    WHEN jsonb_typeof(render_entry.value) = 'object' THEN render_entry.value->>'mime_type'
+    ELSE 'image/png'
+  END,
+  CASE
+    WHEN jsonb_typeof(render_entry.value) = 'object' AND (render_entry.value->>'width') ~ '^[0-9]+$'
+      THEN (render_entry.value->>'width')::integer
+    ELSE NULL
+  END,
+  CASE
+    WHEN jsonb_typeof(render_entry.value) = 'object' AND (render_entry.value->>'height') ~ '^[0-9]+$'
+      THEN (render_entry.value->>'height')::integer
+    ELSE NULL
+  END,
+  render_entry.ordinality - 1,
+  CASE WHEN app_jobs.status = 'failed' THEN 'failed' ELSE 'ready' END,
+  jsonb_build_object('legacy', true, 'surface', app_jobs.surface),
+  app_jobs.created_at,
+  app_jobs.updated_at
+FROM app_jobs
+CROSS JOIN LATERAL jsonb_array_elements(
+  CASE
+    WHEN jsonb_typeof(to_jsonb(app_jobs.render_ids)) = 'array' THEN to_jsonb(app_jobs.render_ids)
+    ELSE '[]'::jsonb
+  END
+) WITH ORDINALITY AS render_entry(value, ordinality)
+WHERE COALESCE(app_jobs.render_ids::text, '') <> ''
+  AND COALESCE(
+    CASE
+      WHEN jsonb_typeof(render_entry.value) = 'string' THEN trim(both '"' from render_entry.value::text)
+      ELSE render_entry.value->>'url'
+    END,
+    ''
+  ) <> ''
+ON CONFLICT (job_id, kind, position) DO NOTHING;
+
+INSERT INTO media_assets (
+  id,
+  user_id,
+  kind,
+  url,
+  thumb_url,
+  mime_type,
+  width,
+  height,
+  size_bytes,
+  source,
+  source_job_id,
+  status,
+  metadata,
+  created_at,
+  updated_at
+)
+SELECT
+  user_assets.asset_id,
+  user_assets.user_id,
+  CASE
+    WHEN COALESCE(user_assets.mime_type, '') LIKE 'video/%' THEN 'video'
+    WHEN COALESCE(user_assets.mime_type, '') LIKE 'audio/%' THEN 'audio'
+    ELSE 'image'
+  END,
+  user_assets.url,
+  user_assets.metadata->>'thumbUrl',
+  user_assets.mime_type,
+  user_assets.width,
+  user_assets.height,
+  user_assets.size_bytes,
+  CASE
+    WHEN user_assets.source IN ('upload', 'character', 'angle', 'upscale') THEN user_assets.source
+    WHEN user_assets.source = 'generated' THEN 'saved_job_output'
+    ELSE 'import'
+  END,
+  user_assets.metadata->>'jobId',
+  'ready',
+  COALESCE(user_assets.metadata, '{}'::jsonb) || jsonb_build_object('legacyUserAsset', true),
+  user_assets.created_at,
+  user_assets.created_at
+FROM user_assets
+ON CONFLICT (id) DO NOTHING;

--- a/tests/dark-mode-theme.test.ts
+++ b/tests/dark-mode-theme.test.ts
@@ -167,13 +167,15 @@ test('tools pricing and blog hero images use compare-style derived dark assets',
     },
   ] as const;
 
-  assert.match(comparePageSource, /compare-hero-reference-light\.webp/);
-  assert.match(comparePageSource, /dark:bg-\[url\('\/assets\/compare\/compare-hero-reference-dark\.webp'\)\] dark:opacity-70/);
+  assert.match(comparePageSource, /src="\/assets\/compare\/compare-hero-reference-light\.webp"/);
+  assert.match(comparePageSource, /darkSrc="\/assets\/compare\/compare-hero-reference-dark\.webp"/);
+  assert.match(comparePageSource, /className="opacity-55 dark:opacity-70"/);
 
   for (const hero of heroAssets) {
     assert.ok(existsSync(hero.darkFile), `${hero.name} should have a derived dark hero asset`);
-    assert.match(hero.source, new RegExp(`bg-\\[url\\('${escapeRegExp(hero.lightUrl)}'\\)\\]`));
-    assert.match(hero.source, new RegExp(`dark:bg-\\[url\\('${escapeRegExp(hero.darkUrl)}'\\)\\] dark:opacity-70`));
+    assert.match(hero.source, new RegExp(`src="${escapeRegExp(hero.lightUrl)}"`));
+    assert.match(hero.source, new RegExp(`darkSrc="${escapeRegExp(hero.darkUrl)}"`));
+    assert.match(hero.source, /className="opacity-55 dark:opacity-70"/);
     assert.match(hero.source, hero.overlay);
     assert.doesNotMatch(hero.source, /dark:(brightness|contrast|saturate|invert)/, `${hero.name} should use a dark asset instead of CSS image filters`);
   }

--- a/tests/gsc-oauth-auth.test.ts
+++ b/tests/gsc-oauth-auth.test.ts
@@ -82,7 +82,7 @@ test('GSC dashboard can authenticate with OAuth refresh-token credentials when s
     assert.equal(data.configured, true);
     assert.equal(data.siteUrl, 'sc-domain:maxvideoai.com');
     assert.equal(tokenRequests.length, 1);
-    assert.equal(searchRequests.length, 3);
+    assert.equal(searchRequests.length, 5);
     assert.ok(searchRequests.every((request) => request.authorization === 'Bearer oauth-access-token'));
     assert.ok(searchRequests.every((request) => request.url.includes('/sites/sc-domain%3Amaxvideoai.com/searchAnalytics/query')));
     assert.ok(searchRequests.every((request) => (request.body as { type?: string }).type === 'web'));

--- a/tests/homepage-real-examples-preview.test.ts
+++ b/tests/homepage-real-examples-preview.test.ts
@@ -142,11 +142,11 @@ test('homepage hero avoids initial mobile video downloads', () => {
 
   assert.match(showcaseSource, /const \[shouldAutoplayPreview, setShouldAutoplayPreview\]/);
   assert.match(showcaseSource, /window\.matchMedia\('\(min-width: 768px\)'\)/);
-  assert.match(showcaseSource, /setShouldLoadVideo\(Boolean\(selected\?\.videoSrc && shouldAutoplayPreview\)\)/);
+  assert.match(showcaseSource, /if \(!selected\?\.videoSrc \|\| !shouldAutoplayPreview\) \{\n\s+setShouldLoadVideo\(false\);/);
+  assert.match(showcaseSource, /window\.requestIdleCallback\(loadPreview, \{ timeout: 1800 \}\)/);
   assert.match(showcaseSource, /selected\.videoSrc && shouldLoadVideo/);
   assert.match(showcaseSource, /autoPlay=\{shouldAutoplayPreview\}/);
   assert.doesNotMatch(showcaseSource, /loading="eager"/);
-  assert.doesNotMatch(showcaseSource, /fetchPriority="high"/);
 });
 
 test('homepage hero model CTA says specs and pricing instead of open model', () => {

--- a/tests/media-library-contract.test.ts
+++ b/tests/media-library-contract.test.ts
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  buildMediaAssetInsert,
+  mapLegacyJobRowToOutputs,
+  normalizeMediaAssetSource,
+  resolveLibraryAssetIdentity,
+} from '../frontend/server/media-library';
+
+test('maps legacy app_jobs media columns into ordered job outputs', () => {
+  const outputs = mapLegacyJobRowToOutputs({
+    job_id: 'job_123',
+    user_id: 'user_1',
+    surface: 'image',
+    video_url: 'https://cdn.example.com/video.mp4',
+    audio_url: 'https://cdn.example.com/audio.wav',
+    thumb_url: 'https://cdn.example.com/poster.webp',
+    preview_frame: null,
+    render_ids: [
+      {
+        url: 'https://cdn.example.com/image-1.png',
+        thumb_url: 'https://cdn.example.com/image-1-thumb.webp',
+        width: 1024,
+        height: 768,
+        mime_type: 'image/png',
+      },
+      'https://cdn.example.com/image-2.png',
+    ],
+    duration_sec: 8,
+    status: 'completed',
+  });
+
+  assert.deepEqual(
+    outputs.map((output) => ({
+      kind: output.kind,
+      url: output.url,
+      thumbUrl: output.thumbUrl,
+      position: output.position,
+      mimeType: output.mimeType,
+    })),
+    [
+      {
+        kind: 'video',
+        url: 'https://cdn.example.com/video.mp4',
+        thumbUrl: 'https://cdn.example.com/poster.webp',
+        position: 0,
+        mimeType: 'video/mp4',
+      },
+      {
+        kind: 'audio',
+        url: 'https://cdn.example.com/audio.wav',
+        thumbUrl: null,
+        position: 0,
+        mimeType: 'audio/wav',
+      },
+      {
+        kind: 'image',
+        url: 'https://cdn.example.com/image-1.png',
+        thumbUrl: 'https://cdn.example.com/image-1-thumb.webp',
+        position: 0,
+        mimeType: 'image/png',
+      },
+      {
+        kind: 'image',
+        url: 'https://cdn.example.com/image-2.png',
+        thumbUrl: 'https://cdn.example.com/image-2.png',
+        position: 1,
+        mimeType: 'image/png',
+      },
+    ]
+  );
+});
+
+test('normalizes library sources to the canonical allowed set', () => {
+  assert.equal(normalizeMediaAssetSource('generated'), 'saved_job_output');
+  assert.equal(normalizeMediaAssetSource('character'), 'character');
+  assert.equal(normalizeMediaAssetSource('angle'), 'angle');
+  assert.equal(normalizeMediaAssetSource('upscale'), 'upscale');
+  assert.equal(normalizeMediaAssetSource('upload'), 'upload');
+  assert.equal(normalizeMediaAssetSource('anything-else'), 'import');
+  assert.equal(normalizeMediaAssetSource(null), 'import');
+});
+
+test('builds idempotent media asset identity from source output when available', () => {
+  assert.equal(
+    resolveLibraryAssetIdentity({
+      userId: 'user_1',
+      kind: 'video',
+      url: 'https://cdn.example.com/render.mp4',
+      source: 'saved_job_output',
+      sourceOutputId: 'out_123',
+    }),
+    'output:out_123'
+  );
+
+  assert.equal(
+    resolveLibraryAssetIdentity({
+      userId: 'user_1',
+      kind: 'image',
+      url: 'https://cdn.example.com/render.png',
+      source: 'import',
+    }),
+    'url:user_1:image:https://cdn.example.com/render.png'
+  );
+});
+
+test('media asset insert keeps saved job output linked to the source output', () => {
+  const insert = buildMediaAssetInsert({
+    userId: 'user_1',
+    kind: 'video',
+    url: 'https://storage.example.com/render.mp4',
+    thumbUrl: 'https://storage.example.com/render.webp',
+    mimeType: 'video/mp4',
+    width: 1920,
+    height: 1080,
+    sizeBytes: 1024,
+    source: 'saved_job_output',
+    sourceJobId: 'job_123',
+    sourceOutputId: 'out_123',
+    metadata: { label: 'Render' },
+  });
+
+  assert.equal(insert.source, 'saved_job_output');
+  assert.equal(insert.sourceJobId, 'job_123');
+  assert.equal(insert.sourceOutputId, 'out_123');
+  assert.equal(insert.status, 'ready');
+  assert.equal(insert.metadata.label, 'Render');
+});
+
+test('job detail route exposes PATCH for persistent hide', () => {
+  const source = fs.readFileSync(
+    path.join(process.cwd(), 'frontend/app/api/jobs/[jobId]/route.ts'),
+    'utf8'
+  );
+
+  assert.match(source, /export\s+async\s+function\s+PATCH/);
+  assert.match(source, /hidden\s*=\s*\$|SET\s+hidden\s*=/i);
+});

--- a/tests/upscale-marketing-content.test.ts
+++ b/tests/upscale-marketing-content.test.ts
@@ -93,8 +93,8 @@ test('upscale landing hero uses app screenshots with default preview media in li
 
   assert.match(source, /upscale-hero-app-light\.webp/);
   assert.match(source, /upscale-hero-app-dark\.webp/);
-  assert.match(source, /role="img"/);
-  assert.match(source, /aria-label=\{imageAlt\}/);
+  assert.match(source, /<MarketingHeroImage/);
+  assert.match(source, /alt=\{imageAlt\}/);
   assert.doesNotMatch(source, /SOURCE_IMAGE_URL|OUTPUT_IMAGE_URL/);
   assert.doesNotMatch(source, /hero\.studioLabel|hero\.stackLabel/);
   assert.doesNotMatch(source, /<HeroVisual imageAlt=\{content\.meta\.imageAlt\} hero=/);


### PR DESCRIPTION
## Summary

Refactors media workspace handling around a clearer scalable model:

- Jobs remain the generation/history surface.
- `job_outputs` becomes the canonical source for generated media outputs.
- `media_assets` becomes the canonical Library source for explicitly reusable assets.
- `user_assets` remains available as a compatibility API and legacy mirror.

## What changed

- Added `job_outputs` and `media_assets` schema support plus Supabase migration/backfill.
- Added server-side `media-library` service for listing Library assets, recent outputs, saving outputs, ensuring reusable assets, and soft-deleting Library assets.
- Added internal APIs under `/api/media-library/*`.
- Updated `/api/jobs` and `/api/jobs/:jobId` to enrich legacy job payloads from `job_outputs` when available and fallback/backfill from legacy columns.
- Updated generation/upload write paths so successful outputs are recorded in `job_outputs`; `character`, `angle`, and `upscale` also auto-save reusable assets.
- Updated Library/composer picker logic so saved Library assets and recent outputs are distinct.
- Made `hideJob` persistent via `PATCH /api/jobs/:jobId`.

## Validation

- `pnpm --prefix frontend exec tsc --noEmit --pretty false`
- `pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/media-library-contract.test.ts tests/image-render-mapping.test.ts tests/job-groups-image-thumbs.test.ts tests/jobs-rail-thumb.test.ts`
- `pnpm --prefix frontend run build`
- Local smoke check: `/app` loads, `/app/library` shows expected auth gate without session, and media-library APIs return `401` without auth.

## Staging QA needed

- Apply the migration and verify `job_outputs` / `media_assets` backfill counts.
- With an authenticated account, test video/image/audio generation output visibility in Jobs/Dashboard versus Library.
- Test `Save to Library`, `Recent Outputs`, Library deletion, and persistent hide after reload.
- Test auto-save for character, angle, and upscale outputs.