### PR TITLE
[codex] Configure Next image quality allowlist

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -71,6 +71,7 @@ const nextConfig = {
   trailingSlash: false,
   transpilePackages: ['@maxvideoai/pricing'],
   images: {
+    qualities: [52, 70, 72, 75, 80],
     remotePatterns: [
       { protocol: 'https', hostname: 'videohub-uploads-us.s3.amazonaws.com' },
       { protocol: 'https', hostname: 'media.maxvideoai.com' },


### PR DESCRIPTION
## Summary
- Configure `images.qualities` in Next.js for the `next/image` quality values used by the app.
- Keeps current image quality choices unchanged while removing the Next 16 compatibility warning.

## Validation
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- Browser reload on `/fr/modeles/seedance-2-0`: `imageQualityWarningCount: 0`

## Notes
- Build still reports the existing Supabase/Edge Runtime warning, unrelated to this config change.
