### PR TITLE
[codex] Fix Supabase Edge middleware warning

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -6,7 +6,6 @@ import { routing } from '@/i18n/routing';
 import { defaultLocale, localePathnames, locales, type AppLocale } from '@/i18n/locales';
 import { LOCALE_COOKIE } from '@/lib/i18n/constants';
 import localizedSlugConfig from '@/config/localized-slugs.json';
-import { updateSession } from '@/lib/supabase-ssr';
 import { LOGOUT_INTENT_COOKIE } from '@/lib/logout-intent-cookie';
 import { isSeoWatchVideoPath } from '@/lib/video-seo';
 import { canVisitorBrowseWorkspacePath } from '@/lib/visitor-access';
@@ -480,6 +479,7 @@ export async function middleware(req: NextRequest) {
     return finalizeResponse(response, hasLogoutIntentCookie, trackingNoindex, appNoindex);
   }
 
+  const { updateSession } = await import('@/lib/supabase-ssr');
   const { userId } = await updateSession(req, response);
 
   if (isAdminRoute) {


### PR DESCRIPTION
## Summary
- Load the Supabase session helper dynamically only after middleware confirms a route is protected.
- Removes the Supabase/Edge Runtime build warning without moving all middleware traffic to Node.js runtime.

## Validation
- `npm --prefix frontend run build`
- `npm --prefix frontend run lint`
- Local smoke: `HEAD /fr/modeles/seedance-2-0` returns 200
- Local smoke: `HEAD /app` returns 200 with `X-Robots-Tag: noindex`
- Browser reload on `/fr/modeles/seedance-2-0`: `imageQualityWarningCount: 0`, `supabaseEdgeWarningCount: 0`
