### PR TITLE
[codex] Use ESLint CLI for frontend linting

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "postbuild": "next-sitemap",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint app pages components lib src middleware.ts --ext .js,.jsx,.ts,.tsx",
     "lint:exposure": "node ../scripts/check-public-exposure.mjs",
     "seo:check": "node ../scripts/seo-guard.mjs && node ../scripts/internal-link-guard.mjs && node ../scripts/public-media-origin-guard.mjs",
     "media:guard": "node ../scripts/public-media-origin-guard.mjs",


### PR DESCRIPTION
## Summary
- Replace deprecated `next lint` script with the ESLint CLI.
- Keep the lint scope aligned with the existing Next app surface: `app`, `pages`, `components`, `lib`, `src`, and `middleware.ts`.

## Validation
- `pnpm --dir frontend run lint`
- `npm --prefix frontend run build`
- `rg "next lint" frontend package.json .github scripts` returns no matches
