### PR TITLE
[codex] Extract workspace hydration helpers

### DIFF
--- a/frontend/app/(core)/(workspace)/app/AGENTS.md
+++ b/frontend/app/(core)/(workspace)/app/AGENTS.md
@@ -6,7 +6,7 @@ This route is the main signed-in video generation workspace.
 
 - `AppClient.tsx`: top-level state orchestration while the workspace is being split.
 - `_components`: route-local chrome, panels, skeletons, modals, and presentational UI.
-- `_lib`: route-local pure helpers for previews, render grouping, video settings hydration, storage, copy fallback, client constants, asset normalization, payload builders, input normalization, and workflow mapping.
+- `_lib`: route-local pure helpers for previews, render grouping, video settings hydration, workspace boot hydration, storage, copy fallback, client constants, asset normalization, payload builders, input normalization, and workflow mapping.
 - Tool-specific workspaces should stay in their own route folders unless code is clearly shared.
 
 ## Refactor Rules
@@ -15,6 +15,7 @@ This route is the main signed-in video generation workspace.
 - Keep schema summarization, asset-library normalization, and copy merging in `_lib`; `AppClient.tsx` should consume those results instead of rebuilding them inline.
 - Keep render grouping and preview tile mapping in `_lib`; `AppClient.tsx` should decide state transitions, not rebuild group summary objects inline.
 - Keep video settings snapshot parsing and job media patch mapping in `_lib`; `AppClient.tsx` should wire those results into React state.
+- Keep workspace request parsing and boot hydration decisions in `_lib`; `AppClient.tsx` should apply the resolved state.
 - Keep generation, polling, wallet, preflight, and upload behavior unchanged unless the task explicitly targets those flows.
 - Keep browser storage keys and pending-render serialization backward compatible.
 - Do not introduce a global state library until repeated state sharing across workspace surfaces justifies it.

--- a/frontend/app/(core)/(workspace)/app/AppClient.tsx
+++ b/frontend/app/(core)/(workspace)/app/AppClient.tsx
@@ -8,7 +8,6 @@ import { authFetch } from '@/lib/authFetch';
 import { prepareImageFileForUpload } from '@/lib/client-image-upload';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import type { EngineCaps, EngineInputField, Mode, PreflightRequest, PreflightResponse } from '@/types/engines';
-import { LOGIN_LAST_TARGET_KEY, LOGIN_SKIP_ONBOARDING_KEY } from '@/lib/auth-storage';
 import { SettingsControls } from '@/components/SettingsControls';
 import { CoreSettingsBar } from '@/components/CoreSettingsBar';
 import { EngineSettingsBar } from '@/components/EngineSettingsBar';
@@ -83,7 +82,6 @@ import {
 } from './_components/WorkspaceBootSkeletons';
 import { getCompositePreviewPosterSrc } from './_lib/composite-preview';
 import {
-  deserializePendingRenders,
   isAudioWorkspaceRender,
   resolvePolledThumbUrl,
   resolveRenderThumb,
@@ -92,7 +90,6 @@ import {
 } from './_lib/render-persistence';
 import {
   normalizeExtraInputValue,
-  parseStoredForm,
   type FormState,
 } from './_lib/workspace-form-state';
 import {
@@ -105,9 +102,7 @@ import {
   getEngineModeOptions,
   getModeCaps,
   getPreferredEngineMode,
-  isModeValue,
   matchesEngineToken,
-  normalizeEngineToken,
 } from './_lib/workspace-engine-helpers';
 import {
   buildAssetFieldIdSet,
@@ -151,13 +146,20 @@ import {
   normalizeSharedVideoPayload,
 } from './_lib/workspace-input-helpers';
 import {
-  buildWorkspaceStorageKey,
   readScopedWorkspaceStorage,
   readWorkspaceStorage,
   STORAGE_KEYS,
   writeScopedWorkspaceStorage,
   writeWorkspaceStorage,
 } from './_lib/workspace-storage';
+import {
+  buildInitialWorkspaceFormState,
+  buildPendingRenderHydrationState,
+  consumeWorkspaceOnboardingSkipIntent,
+  parseStoredMultiPromptScenes,
+  readStoredWorkspaceForm,
+  resolveWorkspaceRequestParams,
+} from './_lib/workspace-hydration';
 import {
   buildComposerPromotedActions,
   summarizeWorkspaceInputSchema,
@@ -322,10 +324,6 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
   const [topUpError, setTopUpError] = useState<string | null>(null);
 
   const storageScope = useMemo(() => userId ?? 'anon', [userId]);
-  const storageKey = useCallback(
-    (base: string, scope: string = storageScope) => buildWorkspaceStorageKey(base, scope),
-    [storageScope]
-  );
   const readScopedStorage = useCallback(
     (base: string): string | null => {
       return readScopedWorkspaceStorage(base, storageScope);
@@ -350,114 +348,57 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
     },
     [storageScope]
   );
-const fromVideoId = useMemo(() => searchParams?.get('from') ?? null, [searchParams]);
-const requestedJobId = useMemo(() => {
-  const value = searchParams?.get('job');
-  if (!value) return null;
-  const trimmed = value.trim();
-  return trimmed.length ? trimmed : null;
-}, [searchParams]);
-const requestedEngineId = useMemo(() => {
-  const value = searchParams?.get('engine');
-  if (!value) return null;
-  const trimmed = value.trim();
-  return trimmed.length ? trimmed : null;
-}, [searchParams]);
-const requestedMode = useMemo<Mode | null>(() => {
-  const value = searchParams?.get('mode');
-  if (!value) return null;
-  const trimmed = value.trim().toLowerCase();
-  return isModeValue(trimmed) ? trimmed : null;
-}, [searchParams]);
-const resolvedRequestedEngineId = useMemo(() => {
-  if (!requestedEngineId) return null;
-  const normalized = requestedEngineId.trim().toLowerCase();
-  if (normalized === 'pika-image-to-video') {
-    return 'pika-text-to-video';
-  }
-  return requestedEngineId;
-}, [requestedEngineId]);
-const requestedEngineToken = useMemo(
-  () => normalizeEngineToken(resolvedRequestedEngineId),
-  [resolvedRequestedEngineId]
-);
-const searchString = useMemo(() => searchParams?.toString() ?? '', [searchParams]);
-const loginRedirectTarget = useMemo(() => {
-  const base = pathname ?? '/app';
-  return searchString ? `${base}?${searchString}` : base;
-}, [pathname, searchString]);
-const skipOnboardingRef = useRef<boolean>(false);
-const hydratedJobRef = useRef<string | null>(null);
-const preserveStoredDraftRef = useRef<boolean>(false);
-const requestedEngineOverrideIdRef = useRef<string | null>(null);
-const requestedEngineOverrideTokenRef = useRef<string | null>(null);
-const requestedModeOverrideRef = useRef<Mode | null>(null);
+  const workspaceRequest = useMemo(
+    () => resolveWorkspaceRequestParams(searchParams, pathname),
+    [pathname, searchParams]
+  );
+  const {
+    fromVideoId,
+    requestedJobId,
+    resolvedRequestedEngineId,
+    requestedEngineToken,
+    requestedMode,
+    searchString,
+    loginRedirectTarget,
+  } = workspaceRequest;
+  const skipOnboardingRef = useRef<boolean>(false);
+  const hydratedJobRef = useRef<string | null>(null);
+  const preserveStoredDraftRef = useRef<boolean>(false);
+  const requestedEngineOverrideIdRef = useRef<string | null>(null);
+  const requestedEngineOverrideTokenRef = useRef<string | null>(null);
+  const requestedModeOverrideRef = useRef<Mode | null>(null);
 
-useEffect(() => {
-  if (!resolvedRequestedEngineId) return;
-  requestedEngineOverrideIdRef.current = resolvedRequestedEngineId;
-  requestedEngineOverrideTokenRef.current = requestedEngineToken;
-  requestedModeOverrideRef.current = requestedMode;
-}, [resolvedRequestedEngineId, requestedEngineToken, requestedMode]);
+  useEffect(() => {
+    if (!resolvedRequestedEngineId) return;
+    requestedEngineOverrideIdRef.current = resolvedRequestedEngineId;
+    requestedEngineOverrideTokenRef.current = requestedEngineToken;
+    requestedModeOverrideRef.current = requestedMode;
+  }, [resolvedRequestedEngineId, requestedEngineToken, requestedMode]);
 
-const effectiveRequestedEngineId = resolvedRequestedEngineId ?? requestedEngineOverrideIdRef.current;
-const effectiveRequestedEngineToken = requestedEngineToken ?? requestedEngineOverrideTokenRef.current;
-const effectiveRequestedMode = requestedMode ?? requestedModeOverrideRef.current;
+  const effectiveRequestedEngineId = resolvedRequestedEngineId ?? requestedEngineOverrideIdRef.current;
+  const effectiveRequestedEngineToken = requestedEngineToken ?? requestedEngineOverrideTokenRef.current;
+  const effectiveRequestedMode = requestedMode ?? requestedModeOverrideRef.current;
 
-useEffect(() => {
-  if (typeof window === 'undefined') return;
-  let skipFlag = window.sessionStorage.getItem(LOGIN_SKIP_ONBOARDING_KEY);
-  if (!skipFlag) {
-    skipFlag = window.localStorage.getItem(LOGIN_SKIP_ONBOARDING_KEY);
-    if (skipFlag) {
-      window.localStorage.removeItem(LOGIN_SKIP_ONBOARDING_KEY);
-      window.sessionStorage.setItem(LOGIN_SKIP_ONBOARDING_KEY, skipFlag);
-    }
-  }
-  if (skipFlag === 'true') {
-    skipOnboardingRef.current = true;
-    if (process.env.NODE_ENV !== 'production') {
-      console.log('[app] skip onboarding via flag');
-    }
-    window.sessionStorage.removeItem(LOGIN_SKIP_ONBOARDING_KEY);
-    window.localStorage.removeItem(LOGIN_SKIP_ONBOARDING_KEY);
-  }
-  let lastTarget =
-    window.sessionStorage.getItem(LOGIN_LAST_TARGET_KEY) ??
-    null;
-  if (!lastTarget) {
-    lastTarget = window.localStorage.getItem(LOGIN_LAST_TARGET_KEY);
-    if (lastTarget) {
-      window.localStorage.removeItem(LOGIN_LAST_TARGET_KEY);
-      window.sessionStorage.setItem(LOGIN_LAST_TARGET_KEY, lastTarget);
-    }
-  }
-  if (lastTarget) {
-    const normalized = lastTarget.trim();
-    const shouldSkip =
-      normalized.startsWith('/generate') ||
-      normalized.startsWith('/app') ||
-      normalized.includes('from=') ||
-      normalized.includes('engine=');
-    if (shouldSkip) {
+  useEffect(() => {
+    const skipIntent = consumeWorkspaceOnboardingSkipIntent(fromVideoId);
+    if (skipIntent.shouldSkip) {
       skipOnboardingRef.current = true;
     }
     if (process.env.NODE_ENV !== 'production') {
-      console.log('[app] read last target', { lastTarget, shouldSkip });
+      if (skipIntent.skippedViaFlag) {
+        console.log('[app] skip onboarding via flag');
+      }
+      if (skipIntent.lastTarget) {
+        console.log('[app] read last target', {
+          lastTarget: skipIntent.lastTarget,
+          shouldSkip: skipIntent.lastTargetShouldSkip,
+        });
+      }
+      if (skipIntent.fromVideoId) {
+        console.log('[app] skip onboarding due to fromVideoId', { fromVideoId: skipIntent.fromVideoId });
+      }
     }
-    window.sessionStorage.removeItem(LOGIN_LAST_TARGET_KEY);
-    window.localStorage.removeItem(LOGIN_LAST_TARGET_KEY);
-  }
-}, []);
-
-useEffect(() => {
-  if (fromVideoId) {
-    skipOnboardingRef.current = true;
-    if (process.env.NODE_ENV !== 'production') {
-      console.log('[app] skip onboarding due to fromVideoId', { fromVideoId });
-    }
-  }
-}, [fromVideoId]);
+  }, [fromVideoId]);
   const [renders, setRenders] = useState<LocalRender[]>([]);
   const [sharedPrompt, setSharedPrompt] = useState<string | null>(null);
   const [sharedVideoSettings, setSharedVideoSettings] = useState<SharedVideoPreview | null>(null);
@@ -644,27 +585,9 @@ useEffect(() => {
 
       const storedMultiPromptEnabled = readStorage(STORAGE_KEYS.multiPromptEnabled);
       setMultiPromptEnabled(storedMultiPromptEnabled === 'true');
-      const storedMultiPromptScenes = readStorage(STORAGE_KEYS.multiPromptScenes);
-      if (storedMultiPromptScenes) {
-        try {
-          const parsed = JSON.parse(storedMultiPromptScenes) as MultiPromptScene[];
-          if (Array.isArray(parsed) && parsed.length) {
-            const sanitized = parsed
-              .map((scene) => ({
-                id: typeof scene.id === 'string' ? scene.id : createLocalId('scene'),
-                prompt: typeof scene.prompt === 'string' ? scene.prompt : '',
-                duration:
-                  typeof scene.duration === 'number' && Number.isFinite(scene.duration)
-                    ? Math.round(scene.duration)
-                    : 5,
-              }))
-              .filter((scene) => scene.prompt.length || scene.duration);
-            setMultiPromptScenes(sanitized.length ? sanitized : [createMultiPromptScene()]);
-          }
-        } catch {
-          setMultiPromptScenes([createMultiPromptScene()]);
-        }
-      }
+      setMultiPromptScenes(
+        parseStoredMultiPromptScenes(readStorage(STORAGE_KEYS.multiPromptScenes), createLocalId, createMultiPromptScene)
+      );
 
       const storedShotType = readStorage(STORAGE_KEYS.shotType);
       if (storedShotType === 'customize' || storedShotType === 'intelligent') {
@@ -676,171 +599,31 @@ useEffect(() => {
       }
 
       const formValue = readStorage(STORAGE_KEYS.form);
-      const storedFormRaw = (() => {
-        try {
-          const scoped = window.localStorage.getItem(storageKey(STORAGE_KEYS.form));
-          const base = window.localStorage.getItem(STORAGE_KEYS.form);
-          const scopedParsed = scoped ? parseStoredForm(scoped) : null;
-          const baseParsed = base ? parseStoredForm(base) : null;
-          if (storageScope === 'anon') {
-            return baseParsed ?? scopedParsed ?? (formValue ? parseStoredForm(formValue) : null);
-          }
-          if (scopedParsed && baseParsed) {
-            const scopedAt = typeof scopedParsed.updatedAt === 'number' ? scopedParsed.updatedAt : 0;
-            const baseAt = typeof baseParsed.updatedAt === 'number' ? baseParsed.updatedAt : 0;
-            return baseAt > scopedAt ? baseParsed : scopedParsed;
-          }
-          return scopedParsed ?? baseParsed ?? (formValue ? parseStoredForm(formValue) : null);
-        } catch {
-          return formValue ? parseStoredForm(formValue) : null;
-        }
-      })();
-      let nextForm: FormState | null = null;
-      preserveStoredDraftRef.current = Boolean(effectiveRequestedEngineId && storedFormRaw);
-
-      if (storedFormRaw) {
-        const storedToken = normalizeEngineToken(storedFormRaw.engineId);
-        const engine =
-          engines.find((entry) => entry.id === storedFormRaw.engineId) ??
-          (storedToken ? engines.find((entry) => matchesEngineToken(entry, storedToken)) : null) ??
-          engines[0] ??
-          null;
-        if (engine) {
-          const mode = getPreferredEngineMode(engine, storedFormRaw.mode);
-          const base = coerceFormState(engine, mode, null);
-          const candidate: FormState = {
-            ...base,
-            engineId: engine.id,
-            mode,
-            durationSec:
-              typeof storedFormRaw.durationSec === 'number' && Number.isFinite(storedFormRaw.durationSec)
-                ? storedFormRaw.durationSec
-                : base.durationSec,
-            durationOption:
-              typeof storedFormRaw.durationOption === 'number' || typeof storedFormRaw.durationOption === 'string'
-                ? storedFormRaw.durationOption
-                : base.durationOption,
-            numFrames:
-              typeof storedFormRaw.numFrames === 'number' && Number.isFinite(storedFormRaw.numFrames)
-                ? storedFormRaw.numFrames
-                : base.numFrames,
-            resolution: typeof storedFormRaw.resolution === 'string' ? storedFormRaw.resolution : base.resolution,
-            aspectRatio: typeof storedFormRaw.aspectRatio === 'string' ? storedFormRaw.aspectRatio : base.aspectRatio,
-            fps: typeof storedFormRaw.fps === 'number' && Number.isFinite(storedFormRaw.fps) ? storedFormRaw.fps : base.fps,
-            iterations:
-              typeof storedFormRaw.iterations === 'number' && Number.isFinite(storedFormRaw.iterations)
-                ? storedFormRaw.iterations
-                : base.iterations,
-            seedLocked: typeof storedFormRaw.seedLocked === 'boolean' ? storedFormRaw.seedLocked : base.seedLocked,
-            loop: typeof storedFormRaw.loop === 'boolean' ? storedFormRaw.loop : base.loop,
-            audio: typeof storedFormRaw.audio === 'boolean' ? storedFormRaw.audio : base.audio,
-            seed: typeof storedFormRaw.seed === 'number' ? storedFormRaw.seed : base.seed,
-            cameraFixed:
-              typeof storedFormRaw.cameraFixed === 'boolean' ? storedFormRaw.cameraFixed : base.cameraFixed,
-            safetyChecker:
-              typeof storedFormRaw.safetyChecker === 'boolean'
-                ? storedFormRaw.safetyChecker
-                : base.safetyChecker,
-            extraInputValues: storedFormRaw.extraInputValues ?? base.extraInputValues,
-          };
-          nextForm = coerceFormState(engine, mode, candidate);
-        }
+      const initialForm = buildInitialWorkspaceFormState({
+        engines,
+        storedFormRaw: readStoredWorkspaceForm(storageScope, formValue),
+        effectiveRequestedEngineId,
+        effectiveRequestedEngineToken,
+        effectiveRequestedMode,
+      });
+      preserveStoredDraftRef.current = initialForm.preserveStoredDraft;
+      hasStoredFormRef.current = initialForm.hasStoredForm;
+      if (initialForm.form) {
+        setForm(initialForm.form);
       }
-      hasStoredFormRef.current = Boolean(nextForm);
-
-      if (effectiveRequestedEngineId) {
-        const requestedEngine =
-          engines.find((entry) => entry.id === effectiveRequestedEngineId) ??
-          (effectiveRequestedEngineToken
-            ? engines.find((entry) => matchesEngineToken(entry, effectiveRequestedEngineToken))
-            : null) ??
-          null;
-        if (requestedEngine) {
-          const preferredMode = getPreferredEngineMode(requestedEngine, effectiveRequestedMode ?? nextForm?.mode ?? null);
-          const normalizedPrevious = nextForm
-            ? { ...nextForm, engineId: requestedEngine.id, mode: preferredMode }
-            : null;
-          const base: FormState = normalizedPrevious
-            ? coerceFormState(requestedEngine, preferredMode, normalizedPrevious)
-            : {
-                engineId: requestedEngine.id,
-                mode: preferredMode,
-                durationSec: 4,
-                durationOption: 4,
-                numFrames: undefined,
-                resolution: '720p',
-                aspectRatio: '16:9',
-                fps: 24,
-                iterations: 1,
-                seedLocked: false,
-                audio: true,
-                seed: null,
-                cameraFixed: false,
-                safetyChecker: true,
-                extraInputValues: {},
-              };
-          nextForm = base;
-          hasStoredFormRef.current = hasStoredFormRef.current && preserveStoredDraftRef.current;
-          if (process.env.NODE_ENV !== 'production') {
-            console.log('[generate] engine override from storage hydrate', {
-              from: storedFormRaw?.engineId ?? null,
-              to: nextForm.engineId,
-              preserveStoredDraft: preserveStoredDraftRef.current,
-            });
-          }
-          const shouldPersistRequestedEngine =
-            !storedFormRaw ||
-            storedFormRaw.engineId !== nextForm.engineId ||
-            storedFormRaw.mode !== nextForm.mode;
-          if (!preserveStoredDraftRef.current || shouldPersistRequestedEngine) {
-            queueMicrotask(() => {
-              try {
-                writeStorage(STORAGE_KEYS.form, JSON.stringify(nextForm));
-              } catch {
-                // noop
-              }
-            });
-          }
-        } else if (!storedFormRaw) {
-          const preferredMode: Mode = effectiveRequestedMode ?? 't2v';
-          const base: FormState = {
-            engineId: effectiveRequestedEngineId,
-            mode: preferredMode,
-            durationSec: 4,
-            durationOption: 4,
-            numFrames: undefined,
-            resolution: '720p',
-            aspectRatio: '16:9',
-            fps: 24,
-            iterations: 1,
-            seedLocked: false,
-            audio: true,
-            seed: null,
-            cameraFixed: false,
-            safetyChecker: true,
-            extraInputValues: {},
-          };
-          nextForm = base;
-          if (process.env.NODE_ENV !== 'production') {
-            console.log('[generate] engine override from storage hydrate', {
-              from: null,
-              to: nextForm.engineId,
-            });
-          }
-          queueMicrotask(() => {
-            try {
-              writeStorage(STORAGE_KEYS.form, JSON.stringify(nextForm));
-            } catch {
-              // noop
-            }
-          });
-        }
+      if (initialForm.debugEngineOverride && process.env.NODE_ENV !== 'production') {
+        console.log('[generate] engine override from storage hydrate', initialForm.debugEngineOverride);
       }
-      if (!nextForm) {
-        const engine = engines[0];
-        nextForm = coerceFormState(engine, getPreferredEngineMode(engine, effectiveRequestedMode), null);
+      if (initialForm.formToPersist) {
+        const formToPersist = initialForm.formToPersist;
+        queueMicrotask(() => {
+          try {
+            writeStorage(STORAGE_KEYS.form, JSON.stringify(formToPersist));
+          } catch {
+            // noop
+          }
+        });
       }
-      setForm(nextForm);
 
       const storedTier = readStorage(STORAGE_KEYS.memberTier);
       if (storedTier === 'Member' || storedTier === 'Plus' || storedTier === 'Pro') {
@@ -848,24 +631,14 @@ useEffect(() => {
       }
 
       const pendingValue = readScopedStorage(STORAGE_KEYS.pendingRenders);
-      const pendingRenders = deserializePendingRenders(pendingValue);
-      if (pendingRenders.length) {
-        setRenders(pendingRenders);
-        setBatchHeroes(() => {
-          const next: Record<string, string> = {};
-          pendingRenders.forEach((render) => {
-            if (render.batchId && render.localKey && !next[render.batchId]) {
-              next[render.batchId] = render.localKey;
-            }
-          });
-          return next;
-        });
-        const first = pendingRenders[0];
-        const batchId = first.batchId ?? first.groupId ?? first.localKey ?? null;
-        setActiveBatchId(batchId);
-        setActiveGroupId(first.groupId ?? batchId);
+      const pendingHydration = buildPendingRenderHydrationState(pendingValue);
+      if (pendingHydration.pendingRenders.length) {
+        setRenders(pendingHydration.pendingRenders);
+        setBatchHeroes(pendingHydration.batchHeroes);
+        setActiveBatchId(pendingHydration.activeBatchId);
+        setActiveGroupId(pendingHydration.activeGroupId);
       }
-      persistedRendersRef.current = serializePendingRenders(pendingRenders);
+      persistedRendersRef.current = pendingHydration.serialized;
     } catch {
       setRenders([]);
       setBatchHeroes({});
@@ -878,7 +651,6 @@ useEffect(() => {
     engines,
     readScopedStorage,
     readStorage,
-    storageKey,
     writeStorage,
     setMemberTier,
     storageScope,

--- a/frontend/app/(core)/(workspace)/app/_lib/workspace-form-state.ts
+++ b/frontend/app/(core)/(workspace)/app/_lib/workspace-form-state.ts
@@ -19,7 +19,7 @@ export interface FormState {
   extraInputValues: Record<string, unknown>;
 }
 
-type StoredFormState = Partial<FormState> & { engineId: string; mode: Mode; updatedAt?: number };
+export type StoredFormState = Partial<FormState> & { engineId: string; mode: Mode; updatedAt?: number };
 
 export function coerceStoredExtraInputValues(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;

--- a/frontend/app/(core)/(workspace)/app/_lib/workspace-hydration.ts
+++ b/frontend/app/(core)/(workspace)/app/_lib/workspace-hydration.ts
@@ -1,0 +1,333 @@
+import type { MultiPromptScene } from '@/components/Composer';
+import { LOGIN_LAST_TARGET_KEY, LOGIN_SKIP_ONBOARDING_KEY } from '@/lib/auth-storage';
+import type { EngineCaps, Mode } from '@/types/engines';
+import { deserializePendingRenders, serializePendingRenders, type LocalRender } from './render-persistence';
+import { parseStoredForm, type FormState, type StoredFormState } from './workspace-form-state';
+import {
+  coerceFormState,
+  getPreferredEngineMode,
+  isModeValue,
+  matchesEngineToken,
+  normalizeEngineToken,
+} from './workspace-engine-helpers';
+import { buildWorkspaceStorageKey, STORAGE_KEYS } from './workspace-storage';
+
+type SearchParamsLike = Pick<URLSearchParams, 'get' | 'toString'> | null | undefined;
+
+export type WorkspaceRequestParams = {
+  fromVideoId: string | null;
+  requestedJobId: string | null;
+  requestedEngineId: string | null;
+  requestedMode: Mode | null;
+  resolvedRequestedEngineId: string | null;
+  requestedEngineToken: string;
+  searchString: string;
+  loginRedirectTarget: string;
+};
+
+export type WorkspaceOnboardingSkipIntent = {
+  shouldSkip: boolean;
+  skippedViaFlag: boolean;
+  fromVideoId: string | null;
+  lastTarget: string | null;
+  lastTargetShouldSkip: boolean;
+};
+
+export type InitialWorkspaceFormResult = {
+  form: FormState | null;
+  preserveStoredDraft: boolean;
+  hasStoredForm: boolean;
+  formToPersist: FormState | null;
+  debugEngineOverride: {
+    from: string | null;
+    to: string;
+    preserveStoredDraft?: boolean;
+  } | null;
+};
+
+export type PendingRenderHydrationState = {
+  pendingRenders: LocalRender[];
+  batchHeroes: Record<string, string>;
+  activeBatchId: string | null;
+  activeGroupId: string | null;
+  serialized: string | null;
+};
+
+function readTrimmedParam(searchParams: SearchParamsLike, key: string): string | null {
+  const value = searchParams?.get(key);
+  if (!value) return null;
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : null;
+}
+
+export function resolveWorkspaceRequestParams(
+  searchParams: SearchParamsLike,
+  pathname: string | null | undefined
+): WorkspaceRequestParams {
+  const fromVideoId = searchParams?.get('from') ?? null;
+  const requestedJobId = readTrimmedParam(searchParams, 'job');
+  const requestedEngineId = readTrimmedParam(searchParams, 'engine');
+  const requestedModeRaw = readTrimmedParam(searchParams, 'mode')?.toLowerCase() ?? null;
+  const requestedMode = isModeValue(requestedModeRaw) ? requestedModeRaw : null;
+  const resolvedRequestedEngineId =
+    requestedEngineId?.trim().toLowerCase() === 'pika-image-to-video' ? 'pika-text-to-video' : requestedEngineId;
+  const requestedEngineToken = normalizeEngineToken(resolvedRequestedEngineId);
+  const searchString = searchParams?.toString() ?? '';
+  const base = pathname ?? '/app';
+
+  return {
+    fromVideoId,
+    requestedJobId,
+    requestedEngineId,
+    requestedMode,
+    resolvedRequestedEngineId,
+    requestedEngineToken,
+    searchString,
+    loginRedirectTarget: searchString ? `${base}?${searchString}` : base,
+  };
+}
+
+function consumeMigratedStorageValue(key: string): string | null {
+  if (typeof window === 'undefined') return null;
+  let value = window.sessionStorage.getItem(key);
+  if (!value) {
+    value = window.localStorage.getItem(key);
+    if (value) {
+      window.localStorage.removeItem(key);
+      window.sessionStorage.setItem(key, value);
+    }
+  }
+  return value;
+}
+
+export function consumeWorkspaceOnboardingSkipIntent(fromVideoId: string | null): WorkspaceOnboardingSkipIntent {
+  if (typeof window === 'undefined') {
+    return {
+      shouldSkip: Boolean(fromVideoId),
+      skippedViaFlag: false,
+      fromVideoId,
+      lastTarget: null,
+      lastTargetShouldSkip: false,
+    };
+  }
+
+  const skipFlag = consumeMigratedStorageValue(LOGIN_SKIP_ONBOARDING_KEY);
+  const skippedViaFlag = skipFlag === 'true';
+  window.sessionStorage.removeItem(LOGIN_SKIP_ONBOARDING_KEY);
+  window.localStorage.removeItem(LOGIN_SKIP_ONBOARDING_KEY);
+
+  const lastTarget = consumeMigratedStorageValue(LOGIN_LAST_TARGET_KEY);
+  const normalizedLastTarget = lastTarget?.trim() ?? '';
+  const lastTargetShouldSkip = Boolean(
+    normalizedLastTarget &&
+      (normalizedLastTarget.startsWith('/generate') ||
+        normalizedLastTarget.startsWith('/app') ||
+        normalizedLastTarget.includes('from=') ||
+        normalizedLastTarget.includes('engine='))
+  );
+  window.sessionStorage.removeItem(LOGIN_LAST_TARGET_KEY);
+  window.localStorage.removeItem(LOGIN_LAST_TARGET_KEY);
+
+  return {
+    shouldSkip: skippedViaFlag || lastTargetShouldSkip || Boolean(fromVideoId),
+    skippedViaFlag,
+    fromVideoId,
+    lastTarget,
+    lastTargetShouldSkip,
+  };
+}
+
+export function parseStoredMultiPromptScenes(
+  value: string | null,
+  createLocalId: (prefix: string) => string,
+  createFallbackScene: () => MultiPromptScene
+): MultiPromptScene[] {
+  if (!value) return [createFallbackScene()];
+  try {
+    const parsed = JSON.parse(value) as MultiPromptScene[];
+    if (!Array.isArray(parsed) || !parsed.length) return [createFallbackScene()];
+    const sanitized = parsed
+      .map((scene) => ({
+        id: typeof scene.id === 'string' ? scene.id : createLocalId('scene'),
+        prompt: typeof scene.prompt === 'string' ? scene.prompt : '',
+        duration: typeof scene.duration === 'number' && Number.isFinite(scene.duration) ? Math.round(scene.duration) : 5,
+      }))
+      .filter((scene) => scene.prompt.length || scene.duration);
+    return sanitized.length ? sanitized : [createFallbackScene()];
+  } catch {
+    return [createFallbackScene()];
+  }
+}
+
+export function readStoredWorkspaceForm(storageScope: string, formValue: string | null): StoredFormState | null {
+  if (typeof window === 'undefined') return formValue ? parseStoredForm(formValue) : null;
+  try {
+    const scoped = window.localStorage.getItem(buildWorkspaceStorageKey(STORAGE_KEYS.form, storageScope));
+    const base = window.localStorage.getItem(STORAGE_KEYS.form);
+    const scopedParsed = scoped ? parseStoredForm(scoped) : null;
+    const baseParsed = base ? parseStoredForm(base) : null;
+    if (storageScope === 'anon') {
+      return baseParsed ?? scopedParsed ?? (formValue ? parseStoredForm(formValue) : null);
+    }
+    if (scopedParsed && baseParsed) {
+      const scopedAt = typeof scopedParsed.updatedAt === 'number' ? scopedParsed.updatedAt : 0;
+      const baseAt = typeof baseParsed.updatedAt === 'number' ? baseParsed.updatedAt : 0;
+      return baseAt > scopedAt ? baseParsed : scopedParsed;
+    }
+    return scopedParsed ?? baseParsed ?? (formValue ? parseStoredForm(formValue) : null);
+  } catch {
+    return formValue ? parseStoredForm(formValue) : null;
+  }
+}
+
+function buildRequestedEngineFallbackForm(engineId: string, mode: Mode): FormState {
+  return {
+    engineId,
+    mode,
+    durationSec: 4,
+    durationOption: 4,
+    numFrames: undefined,
+    resolution: '720p',
+    aspectRatio: '16:9',
+    fps: 24,
+    iterations: 1,
+    seedLocked: false,
+    audio: true,
+    seed: null,
+    cameraFixed: false,
+    safetyChecker: true,
+    extraInputValues: {},
+  };
+}
+
+function findEngineByIdOrToken(engines: EngineCaps[], engineId: string | null, token?: string | null): EngineCaps | null {
+  if (!engineId && !token) return null;
+  return (
+    (engineId ? engines.find((entry) => entry.id === engineId) : null) ??
+    (token ? engines.find((entry) => matchesEngineToken(entry, token)) : null) ??
+    null
+  );
+}
+
+export function buildInitialWorkspaceFormState({
+  engines,
+  storedFormRaw,
+  effectiveRequestedEngineId,
+  effectiveRequestedEngineToken,
+  effectiveRequestedMode,
+}: {
+  engines: EngineCaps[];
+  storedFormRaw: StoredFormState | null;
+  effectiveRequestedEngineId: string | null;
+  effectiveRequestedEngineToken: string;
+  effectiveRequestedMode: Mode | null;
+}): InitialWorkspaceFormResult {
+  let nextForm: FormState | null = null;
+  let formToPersist: FormState | null = null;
+  let debugEngineOverride: InitialWorkspaceFormResult['debugEngineOverride'] = null;
+  const preserveStoredDraft = Boolean(effectiveRequestedEngineId && storedFormRaw);
+
+  if (storedFormRaw) {
+    const storedToken = normalizeEngineToken(storedFormRaw.engineId);
+    const engine = findEngineByIdOrToken(engines, storedFormRaw.engineId, storedToken) ?? engines[0] ?? null;
+    if (engine) {
+      const mode = getPreferredEngineMode(engine, storedFormRaw.mode);
+      const base = coerceFormState(engine, mode, null);
+      const candidate: FormState = {
+        ...base,
+        engineId: engine.id,
+        mode,
+        durationSec:
+          typeof storedFormRaw.durationSec === 'number' && Number.isFinite(storedFormRaw.durationSec)
+            ? storedFormRaw.durationSec
+            : base.durationSec,
+        durationOption:
+          typeof storedFormRaw.durationOption === 'number' || typeof storedFormRaw.durationOption === 'string'
+            ? storedFormRaw.durationOption
+            : base.durationOption,
+        numFrames:
+          typeof storedFormRaw.numFrames === 'number' && Number.isFinite(storedFormRaw.numFrames)
+            ? storedFormRaw.numFrames
+            : base.numFrames,
+        resolution: typeof storedFormRaw.resolution === 'string' ? storedFormRaw.resolution : base.resolution,
+        aspectRatio: typeof storedFormRaw.aspectRatio === 'string' ? storedFormRaw.aspectRatio : base.aspectRatio,
+        fps: typeof storedFormRaw.fps === 'number' && Number.isFinite(storedFormRaw.fps) ? storedFormRaw.fps : base.fps,
+        iterations:
+          typeof storedFormRaw.iterations === 'number' && Number.isFinite(storedFormRaw.iterations)
+            ? storedFormRaw.iterations
+            : base.iterations,
+        seedLocked: typeof storedFormRaw.seedLocked === 'boolean' ? storedFormRaw.seedLocked : base.seedLocked,
+        loop: typeof storedFormRaw.loop === 'boolean' ? storedFormRaw.loop : base.loop,
+        audio: typeof storedFormRaw.audio === 'boolean' ? storedFormRaw.audio : base.audio,
+        seed: typeof storedFormRaw.seed === 'number' ? storedFormRaw.seed : base.seed,
+        cameraFixed: typeof storedFormRaw.cameraFixed === 'boolean' ? storedFormRaw.cameraFixed : base.cameraFixed,
+        safetyChecker:
+          typeof storedFormRaw.safetyChecker === 'boolean' ? storedFormRaw.safetyChecker : base.safetyChecker,
+        extraInputValues: storedFormRaw.extraInputValues ?? base.extraInputValues,
+      };
+      nextForm = coerceFormState(engine, mode, candidate);
+    }
+  }
+
+  const hadStoredForm = Boolean(nextForm);
+
+  if (effectiveRequestedEngineId) {
+    const requestedEngine = findEngineByIdOrToken(engines, effectiveRequestedEngineId, effectiveRequestedEngineToken);
+    if (requestedEngine) {
+      const preferredMode = getPreferredEngineMode(requestedEngine, effectiveRequestedMode ?? nextForm?.mode ?? null);
+      const normalizedPrevious = nextForm ? { ...nextForm, engineId: requestedEngine.id, mode: preferredMode } : null;
+      nextForm = normalizedPrevious
+        ? coerceFormState(requestedEngine, preferredMode, normalizedPrevious)
+        : buildRequestedEngineFallbackForm(requestedEngine.id, preferredMode);
+      debugEngineOverride = {
+        from: storedFormRaw?.engineId ?? null,
+        to: nextForm.engineId,
+        preserveStoredDraft,
+      };
+      const shouldPersistRequestedEngine =
+        !storedFormRaw || storedFormRaw.engineId !== nextForm.engineId || storedFormRaw.mode !== nextForm.mode;
+      if (!preserveStoredDraft || shouldPersistRequestedEngine) {
+        formToPersist = nextForm;
+      }
+    } else if (!storedFormRaw) {
+      const preferredMode: Mode = effectiveRequestedMode ?? 't2v';
+      nextForm = buildRequestedEngineFallbackForm(effectiveRequestedEngineId, preferredMode);
+      formToPersist = nextForm;
+      debugEngineOverride = {
+        from: null,
+        to: nextForm.engineId,
+      };
+    }
+  }
+
+  if (!nextForm && engines[0]) {
+    nextForm = coerceFormState(engines[0], getPreferredEngineMode(engines[0], effectiveRequestedMode), null);
+  }
+
+  return {
+    form: nextForm,
+    preserveStoredDraft,
+    hasStoredForm: hadStoredForm && (!effectiveRequestedEngineId || preserveStoredDraft),
+    formToPersist,
+    debugEngineOverride,
+  };
+}
+
+export function buildPendingRenderHydrationState(value: string | null): PendingRenderHydrationState {
+  const pendingRenders = deserializePendingRenders(value);
+  const batchHeroes: Record<string, string> = {};
+  pendingRenders.forEach((render) => {
+    if (render.batchId && render.localKey && !batchHeroes[render.batchId]) {
+      batchHeroes[render.batchId] = render.localKey;
+    }
+  });
+  const first = pendingRenders[0];
+  const batchId = first ? first.batchId ?? first.groupId ?? first.localKey ?? null : null;
+  return {
+    pendingRenders,
+    batchHeroes,
+    activeBatchId: batchId,
+    activeGroupId: first ? first.groupId ?? batchId : null,
+    serialized: serializePendingRenders(pendingRenders),
+  };
+}

--- a/tests/workspace-hydration.test.ts
+++ b/tests/workspace-hydration.test.ts
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type { EngineCaps } from '../frontend/types/engines';
+import { serializePendingRenders, type LocalRender } from '../frontend/app/(core)/(workspace)/app/_lib/render-persistence';
+import {
+  buildInitialWorkspaceFormState,
+  buildPendingRenderHydrationState,
+  parseStoredMultiPromptScenes,
+  resolveWorkspaceRequestParams,
+} from '../frontend/app/(core)/(workspace)/app/_lib/workspace-hydration';
+import type { StoredFormState } from '../frontend/app/(core)/(workspace)/app/_lib/workspace-form-state';
+
+function makeEngine(id: string, overrides: Partial<EngineCaps> = {}): EngineCaps {
+  return {
+    id,
+    label: id,
+    provider: 'test',
+    status: 'live',
+    latencyTier: 'standard',
+    modes: ['t2v'],
+    maxDurationSec: 12,
+    resolutions: ['720p', '1080p'],
+    aspectRatios: ['16:9', '1:1'],
+    fps: [24, 30],
+    audio: true,
+    upscale4k: false,
+    extend: false,
+    motionControls: false,
+    keyframes: false,
+    params: {},
+    inputLimits: {},
+    updatedAt: '2026-05-06T00:00:00.000Z',
+    ttlSec: 60,
+    availability: 'available',
+    ...overrides,
+  } as EngineCaps;
+}
+
+test('workspace request params normalize aliases and preserve redirect target', () => {
+  const params = new URLSearchParams('engine=pika-image-to-video&mode=i2v&job=%20job_123%20&from=vid_1');
+  const result = resolveWorkspaceRequestParams(params, '/app');
+
+  assert.equal(result.fromVideoId, 'vid_1');
+  assert.equal(result.requestedJobId, 'job_123');
+  assert.equal(result.resolvedRequestedEngineId, 'pika-text-to-video');
+  assert.equal(result.requestedEngineToken, 'pikatexttovideo');
+  assert.equal(result.requestedMode, 'i2v');
+  assert.equal(result.loginRedirectTarget, '/app?engine=pika-image-to-video&mode=i2v&job=+job_123+&from=vid_1');
+});
+
+test('stored multi-prompt scenes are sanitized with stable fallback', () => {
+  const scenes = parseStoredMultiPromptScenes(
+    JSON.stringify([
+      { prompt: 'Opening shot', duration: 4.6 },
+      { id: 'scene_existing', prompt: '', duration: 0 },
+    ]),
+    (prefix) => `${prefix}_generated`,
+    () => ({ id: 'fallback', prompt: '', duration: 5 })
+  );
+
+  assert.deepEqual(scenes, [{ id: 'scene_generated', prompt: 'Opening shot', duration: 5 }]);
+  assert.deepEqual(
+    parseStoredMultiPromptScenes('not json', () => 'unused', () => ({ id: 'fallback', prompt: '', duration: 5 })),
+    [{ id: 'fallback', prompt: '', duration: 5 }]
+  );
+});
+
+test('initial workspace form applies requested engine while preserving stored draft metadata', () => {
+  const stored: StoredFormState = {
+    engineId: 'seedance-2-0',
+    mode: 't2v',
+    durationSec: 9,
+    resolution: '1080p',
+    aspectRatio: '1:1',
+    fps: 30,
+    iterations: 2,
+    audio: false,
+    extraInputValues: { camera: 'locked' },
+  };
+  const result = buildInitialWorkspaceFormState({
+    engines: [
+      makeEngine('seedance-2-0'),
+      makeEngine('kling-3-pro', { modes: ['i2v', 't2v'], providerMeta: { modelSlug: 'kling-3-pro' } }),
+    ],
+    storedFormRaw: stored,
+    effectiveRequestedEngineId: 'kling-3-pro',
+    effectiveRequestedEngineToken: '',
+    effectiveRequestedMode: 'i2v',
+  });
+
+  assert.equal(result.preserveStoredDraft, true);
+  assert.equal(result.hasStoredForm, true);
+  assert.equal(result.form?.engineId, 'kling-3-pro');
+  assert.equal(result.form?.mode, 'i2v');
+  assert.equal(result.form?.durationSec, 9);
+  assert.equal(result.formToPersist?.engineId, 'kling-3-pro');
+  assert.deepEqual(result.debugEngineOverride, {
+    from: 'seedance-2-0',
+    to: 'kling-3-pro',
+    preserveStoredDraft: true,
+  });
+});
+
+test('pending render hydration derives active group and batch hero state', () => {
+  const render: LocalRender = {
+    localKey: 'local_1',
+    batchId: 'batch_1',
+    iterationIndex: 0,
+    iterationCount: 2,
+    id: 'job_1',
+    jobId: 'job_1',
+    engineId: 'seedance-2-0',
+    engineLabel: 'Seedance 2.0',
+    createdAt: '2026-05-06T00:00:00.000Z',
+    aspectRatio: '16:9',
+    durationSec: 5,
+    prompt: 'Test',
+    progress: 40,
+    message: 'Pending',
+    status: 'pending',
+    startedAt: 1,
+    minReadyAt: 1,
+    groupId: 'group_1',
+  };
+  const state = buildPendingRenderHydrationState(serializePendingRenders([render]));
+
+  assert.equal(state.pendingRenders.length, 1);
+  assert.deepEqual(state.batchHeroes, { batch_1: 'local_1' });
+  assert.equal(state.activeBatchId, 'batch_1');
+  assert.equal(state.activeGroupId, 'group_1');
+  assert.equal(typeof state.serialized, 'string');
+});


### PR DESCRIPTION
## Summary
- Extract workspace URL request parsing, post-login onboarding skip detection, stored multi-prompt parsing, initial form selection, and pending render hydration into `_lib/workspace-hydration.ts`.
- Keep `AppClient.tsx` focused on applying the resolved boot state into React state.
- Add targeted hydration tests and update the route guide for the new helper boundary.

## Test Plan
- `npm --prefix frontend run lint`
- `./node_modules/.bin/tsc --noEmit` from `frontend/`
- `npm --prefix frontend run build`
- `pnpm run test:validate`