### PR TITLE
[codex] Extract workspace asset selection helpers

### DIFF
--- a/frontend/app/(core)/(workspace)/app/AGENTS.md
+++ b/frontend/app/(core)/(workspace)/app/AGENTS.md
@@ -6,7 +6,7 @@ This route is the main signed-in video generation workspace.
 
 - `AppClient.tsx`: top-level state orchestration while the workspace is being split.
 - `_components`: route-local chrome, panels, skeletons, modals, and presentational UI.
-- `_lib`: route-local pure helpers for previews, render grouping, video settings hydration, workspace boot hydration, storage, copy fallback, client constants, asset normalization, payload builders, input normalization, and workflow mapping.
+- `_lib`: route-local pure helpers for previews, render grouping, video settings hydration, workspace boot hydration, storage, copy fallback, client constants, asset normalization, asset selection, payload builders, input normalization, and workflow mapping.
 - Tool-specific workspaces should stay in their own route folders unless code is clearly shared.
 
 ## Refactor Rules
@@ -16,6 +16,7 @@ This route is the main signed-in video generation workspace.
 - Keep render grouping and preview tile mapping in `_lib`; `AppClient.tsx` should decide state transitions, not rebuild group summary objects inline.
 - Keep video settings snapshot parsing and job media patch mapping in `_lib`; `AppClient.tsx` should wire those results into React state.
 - Keep workspace request parsing and boot hydration decisions in `_lib`; `AppClient.tsx` should apply the resolved state.
+- Keep asset-library selection, reference slot insertion, and Kling library asset mapping in `_lib`; `AppClient.tsx` should handle network calls and React state wiring.
 - Keep generation, polling, wallet, preflight, and upload behavior unchanged unless the task explicitly targets those flows.
 - Keep browser storage keys and pending-render serialization backward compatible.
 - Do not introduce a global state library until repeated state sharing across workspace surfaces justifies it.

--- a/frontend/app/(core)/(workspace)/app/AppClient.tsx
+++ b/frontend/app/(core)/(workspace)/app/AppClient.tsx
@@ -109,15 +109,25 @@ import {
   buildAssetLibraryCacheKey,
   buildAssetLibraryUrl,
   buildComposerAttachments,
+  buildKlingLibraryAsset,
   buildReferenceAudioFieldIds,
+  buildReferenceAssetFromLibraryAsset,
+  getAssetLibrarySourceForField,
   getPrimaryAssetFieldLabel,
   getReferenceInputStatus,
+  getLibraryAssetFieldMismatchMessage,
   hasInputAssetInSlots,
+  insertKlingLibraryAsset,
+  insertReferenceAsset,
+  mergeMirroredLibraryAsset,
   normalizeAssetLibraryPayload,
   PRIMARY_IMAGE_SLOT_IDS,
   PRIMARY_VIDEO_SLOT_IDS,
+  removeReferenceAsset,
   revokeAssetPreview,
   revokeKlingAssetPreview,
+  shouldMirrorCharacterImageAsset,
+  shouldMirrorVideoLibraryAsset,
   type AssetLibraryKind,
   type AssetLibrarySource,
   type AssetPickerTarget,
@@ -1326,7 +1336,7 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
         showNotice(blockedMessage);
         return;
       }
-      const nextSource: AssetLibrarySource = field.type === 'video' ? 'recent' : 'all';
+      const nextSource = getAssetLibrarySourceForField(field);
       if (nextSource !== assetLibrarySource) {
         setAssetLibrarySource(nextSource);
         setAssetLibrary([]);
@@ -1358,12 +1368,9 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
         showNotice(blockedMessage);
         return;
       }
-      if (field.type === 'video' && asset.kind !== 'video') {
-        showNotice('This slot requires a video source. Pick a video from the video library or import an MP4/MOV clip.');
-        return;
-      }
-      if (field.type === 'image' && asset.kind !== 'image') {
-        showNotice('This slot requires an image source. Pick an image from the library or import one.');
+      const mismatchMessage = getLibraryAssetFieldMismatchMessage(field, asset);
+      if (mismatchMessage) {
+        showNotice(mismatchMessage);
         return;
       }
 
@@ -1371,13 +1378,7 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
 
       if (field.type === 'video' && asset.kind === 'video') {
         try {
-          const host = new URL(asset.url).host.toLowerCase();
-          const shouldMirrorVideo =
-            asset.source === 'generated' ||
-            asset.source === 'recent' ||
-            host === 'fal.media' ||
-            host.endsWith('.fal.media');
-          if (shouldMirrorVideo) {
+          if (shouldMirrorVideoLibraryAsset(asset)) {
             const mirrored = await saveAssetToLibrary({
               url: asset.url,
               label:
@@ -1389,16 +1390,7 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
               jobId: asset.jobId ?? null,
               sourceOutputId: asset.sourceOutputId ?? null,
             });
-            resolvedAsset = {
-              ...asset,
-              id: mirrored.id,
-              url: mirrored.url,
-              width: mirrored.width ?? asset.width,
-              height: mirrored.height ?? asset.height,
-              size: mirrored.size ?? asset.size,
-              mime: mirrored.mime ?? asset.mime,
-              canDelete: true,
-            };
+            resolvedAsset = mergeMirroredLibraryAsset(asset, mirrored);
             setAssetLibrary((previous) =>
               previous.map((entry) =>
                 entry.id === asset.id || entry.url === asset.url ? resolvedAsset : entry
@@ -1412,14 +1404,9 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
         }
       }
 
-      if (
-        field.type === 'image' &&
-        asset.kind === 'image' &&
-        asset.source === 'character'
-      ) {
+      if (field.type === 'image' && asset.kind === 'image') {
         try {
-          const host = new URL(asset.url).host.toLowerCase();
-          if (host === 'fal.media' || host.endsWith('.fal.media')) {
+          if (shouldMirrorCharacterImageAsset(asset)) {
             const mirrored = await saveImageToLibrary({
               url: asset.url,
               label:
@@ -1428,16 +1415,7 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
                 'Image',
               source: asset.source,
             });
-            resolvedAsset = {
-              ...asset,
-              id: mirrored.id,
-              url: mirrored.url,
-              width: mirrored.width ?? asset.width,
-              height: mirrored.height ?? asset.height,
-              size: mirrored.size ?? asset.size,
-              mime: mirrored.mime ?? asset.mime,
-              canDelete: true,
-            };
+            resolvedAsset = mergeMirroredLibraryAsset(asset, mirrored);
             setAssetLibrary((previous) =>
               previous.map((entry) =>
                 entry.id === asset.id || entry.url === asset.url ? resolvedAsset : entry
@@ -1451,57 +1429,13 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
         }
       }
 
-      const newAsset: ReferenceAsset = {
-        id: resolvedAsset.id || `library_${Date.now().toString(36)}`,
-        fieldId: field.id,
-        previewUrl: resolvedAsset.url,
-        kind: field.type === 'video' ? 'video' : field.type === 'audio' ? 'audio' : 'image',
-        name:
-          resolvedAsset.url.split('/').pop() ??
-          (field.type === 'video' ? 'Video' : field.type === 'audio' ? 'Audio' : 'Image'),
-        size: resolvedAsset.size ?? 0,
-        type:
-          resolvedAsset.mime ??
-          (field.type === 'video' ? 'video/*' : field.type === 'audio' ? 'audio/*' : 'image/*'),
-        url: resolvedAsset.url,
-        width: resolvedAsset.width ?? null,
-        height: resolvedAsset.height ?? null,
-        assetId: resolvedAsset.id,
-        status: 'ready' as const,
-      };
+      const newAsset = buildReferenceAssetFromLibraryAsset(field, resolvedAsset);
 
       setInputAssets((previous) => {
-        const maxCount = field.maxCount ?? 0;
-        const current = previous[field.id] ? [...previous[field.id]] : [];
-
-        if (maxCount > 0 && current.length < maxCount) {
-          while (current.length < maxCount) {
-            current.push(null);
-          }
-        }
-
-        let targetIndex = typeof slotIndex === 'number' ? slotIndex : -1;
-        if (maxCount > 0 && targetIndex >= maxCount) {
-          targetIndex = -1;
-        }
-        if (targetIndex < 0) {
-          targetIndex = current.findIndex((entry) => entry === null);
-        }
-        if (targetIndex < 0) {
-          if (maxCount > 0 && current.length >= maxCount) {
-            showNotice(`Maximum ${field.label ?? 'reference image'} count reached for this engine.`);
-            return previous;
-          }
-          current.push(newAsset);
-        } else {
-          const existing = current[targetIndex];
-          if (existing) {
-            revokeAssetPreview(existing);
-          }
-          current[targetIndex] = newAsset;
-        }
-
-        return { ...previous, [field.id]: current };
+        return insertReferenceAsset(previous, field, newAsset, slotIndex, {
+          release: revokeAssetPreview,
+          onMaxReached: () => showNotice(`Maximum ${field.label ?? 'reference image'} count reached for this engine.`),
+        });
       });
 
       setAssetPickerTarget(null);
@@ -1511,36 +1445,9 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
 
   const handleSelectKlingLibraryAsset = useCallback(
     (target: Extract<AssetPickerTarget, { kind: 'kling' }>, asset: UserAsset) => {
-      const newAsset: KlingElementAsset = {
-        id: asset.id || `library_${Date.now().toString(36)}`,
-        previewUrl: asset.url,
-        kind: 'image',
-        name: asset.url.split('/').pop() ?? 'Image',
-        status: 'ready',
-        url: asset.url,
-      };
-
+      const newAsset = buildKlingLibraryAsset(asset);
       setKlingElements((previous) =>
-        previous.map((element) => {
-          if (element.id !== target.elementId) return element;
-
-          if (target.slot === 'frontal') {
-            revokeKlingAssetPreview(element.frontal);
-            return { ...element, frontal: newAsset };
-          }
-
-          const references = [...element.references];
-          let targetIndex = typeof target.slotIndex === 'number' ? target.slotIndex : references.findIndex((entry) => entry === null);
-          if (targetIndex < 0) {
-            targetIndex = references.length > 0 ? references.length - 1 : 0;
-          }
-          if (targetIndex >= references.length) {
-            return element;
-          }
-          revokeKlingAssetPreview(references[targetIndex]);
-          references[targetIndex] = newAsset;
-          return { ...element, references };
-        })
+        insertKlingLibraryAsset(previous, target, newAsset, revokeKlingAssetPreview)
       );
 
       setAssetPickerTarget(null);
@@ -1573,37 +1480,10 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
       };
 
       setInputAssets((previous) => {
-        const maxCount = field.maxCount ?? 0;
-        const current = previous[field.id] ? [...previous[field.id]] : [];
-
-        if (maxCount > 0 && current.length < maxCount) {
-          while (current.length < maxCount) {
-            current.push(null);
-          }
-        }
-
-        let targetIndex = typeof slotIndex === 'number' ? slotIndex : -1;
-        if (maxCount > 0 && targetIndex >= maxCount) {
-          targetIndex = -1;
-        }
-        if (targetIndex < 0) {
-          targetIndex = current.findIndex((asset) => asset === null);
-        }
-        if (targetIndex < 0) {
-          if (maxCount > 0 && current.length >= maxCount) {
-            revokeAssetPreview(baseAsset);
-            return previous;
-          }
-          current.push(baseAsset);
-        } else {
-          const existing = current[targetIndex];
-          if (existing) {
-            revokeAssetPreview(existing);
-          }
-          current[targetIndex] = baseAsset;
-        }
-
-        return { ...previous, [field.id]: current };
+        return insertReferenceAsset(previous, field, baseAsset, slotIndex, {
+          release: revokeAssetPreview,
+          onMaxReached: () => revokeAssetPreview(baseAsset),
+        });
       });
 
       const upload = async () => {
@@ -1698,31 +1578,7 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
 
   const handleAssetRemove = useCallback((field: EngineInputField, index: number) => {
     setInputAssets((previous) => {
-      const current = previous[field.id];
-      if (index < 0 || index >= current.length) return previous;
-      const nextList = [...current];
-      const toRelease = nextList[index];
-      if (toRelease) {
-        revokeAssetPreview(toRelease);
-      }
-
-      const maxCount = field.maxCount ?? 0;
-      if (maxCount > 0) {
-        nextList[index] = null;
-      } else {
-        nextList.splice(index, 1);
-      }
-
-      const nextState = { ...previous };
-      const hasValues = nextList.some((asset) => asset !== null);
-
-      if (hasValues || (maxCount > 0 && nextList.length)) {
-        nextState[field.id] = nextList;
-      } else {
-        delete nextState[field.id];
-      }
-
-      return nextState;
+      return removeReferenceAsset(previous, field, index, revokeAssetPreview);
     });
   }, []);
 

--- a/frontend/app/(core)/(workspace)/app/_lib/workspace-assets.ts
+++ b/frontend/app/(core)/(workspace)/app/_lib/workspace-assets.ts
@@ -1,5 +1,5 @@
 import type { ComposerAttachment, AssetFieldConfig } from '@/components/Composer';
-import type { KlingElementAsset } from '@/components/KlingElementsBuilder';
+import type { KlingElementAsset, KlingElementState } from '@/components/KlingElementsBuilder';
 import type { EngineInputField } from '@/types/engines';
 
 export type ReferenceAsset = {
@@ -100,6 +100,191 @@ export function normalizeAssetLibraryPayload(
   return filteredAssets.filter(
     (asset, index, list) => list.findIndex((entry) => entry.url === asset.url) === index
   );
+}
+
+export function getAssetLibrarySourceForField(field: EngineInputField): AssetLibrarySource {
+  return field.type === 'video' ? 'recent' : 'all';
+}
+
+export function getLibraryAssetFieldMismatchMessage(field: EngineInputField, asset: UserAsset): string | null {
+  if (field.type === 'video' && asset.kind !== 'video') {
+    return 'This slot requires a video source. Pick a video from the video library or import an MP4/MOV clip.';
+  }
+  if (field.type === 'image' && asset.kind !== 'image') {
+    return 'This slot requires an image source. Pick an image from the library or import one.';
+  }
+  return null;
+}
+
+export function shouldMirrorVideoLibraryAsset(asset: UserAsset): boolean {
+  const host = new URL(asset.url).host.toLowerCase();
+  return (
+    asset.source === 'generated' ||
+    asset.source === 'recent' ||
+    host === 'fal.media' ||
+    host.endsWith('.fal.media')
+  );
+}
+
+export function shouldMirrorCharacterImageAsset(asset: UserAsset): boolean {
+  if (asset.source !== 'character') return false;
+  const host = new URL(asset.url).host.toLowerCase();
+  return host === 'fal.media' || host.endsWith('.fal.media');
+}
+
+export function mergeMirroredLibraryAsset(
+  asset: UserAsset,
+  mirrored: {
+    id: string;
+    url: string;
+    width?: number | null;
+    height?: number | null;
+    size?: number | null;
+    mime?: string | null;
+  }
+): UserAsset {
+  return {
+    ...asset,
+    id: mirrored.id,
+    url: mirrored.url,
+    width: mirrored.width ?? asset.width,
+    height: mirrored.height ?? asset.height,
+    size: mirrored.size ?? asset.size,
+    mime: mirrored.mime ?? asset.mime,
+    canDelete: true,
+  };
+}
+
+export function buildReferenceAssetFromLibraryAsset(field: EngineInputField, asset: UserAsset): ReferenceAsset {
+  return {
+    id: asset.id || `library_${Date.now().toString(36)}`,
+    fieldId: field.id,
+    previewUrl: asset.url,
+    kind: field.type === 'video' ? 'video' : field.type === 'audio' ? 'audio' : 'image',
+    name: asset.url.split('/').pop() ?? (field.type === 'video' ? 'Video' : field.type === 'audio' ? 'Audio' : 'Image'),
+    size: asset.size ?? 0,
+    type: asset.mime ?? (field.type === 'video' ? 'video/*' : field.type === 'audio' ? 'audio/*' : 'image/*'),
+    url: asset.url,
+    width: asset.width ?? null,
+    height: asset.height ?? null,
+    assetId: asset.id,
+    status: 'ready',
+  };
+}
+
+export function insertReferenceAsset(
+  previous: Record<string, (ReferenceAsset | null)[]>,
+  field: EngineInputField,
+  asset: ReferenceAsset,
+  slotIndex?: number,
+  options?: {
+    release?: (asset: ReferenceAsset) => void;
+    onMaxReached?: () => void;
+  }
+): Record<string, (ReferenceAsset | null)[]> {
+  const maxCount = field.maxCount ?? 0;
+  const current = previous[field.id] ? [...previous[field.id]] : [];
+
+  if (maxCount > 0 && current.length < maxCount) {
+    while (current.length < maxCount) {
+      current.push(null);
+    }
+  }
+
+  let targetIndex = typeof slotIndex === 'number' ? slotIndex : -1;
+  if (maxCount > 0 && targetIndex >= maxCount) {
+    targetIndex = -1;
+  }
+  if (targetIndex < 0) {
+    targetIndex = current.findIndex((entry) => entry === null);
+  }
+  if (targetIndex < 0) {
+    if (maxCount > 0 && current.length >= maxCount) {
+      options?.onMaxReached?.();
+      return previous;
+    }
+    current.push(asset);
+  } else {
+    const existing = current[targetIndex];
+    if (existing) {
+      options?.release?.(existing);
+    }
+    current[targetIndex] = asset;
+  }
+
+  return { ...previous, [field.id]: current };
+}
+
+export function removeReferenceAsset(
+  previous: Record<string, (ReferenceAsset | null)[]>,
+  field: EngineInputField,
+  index: number,
+  release?: (asset: ReferenceAsset) => void
+): Record<string, (ReferenceAsset | null)[]> {
+  const current = previous[field.id];
+  if (!current || index < 0 || index >= current.length) return previous;
+  const nextList = [...current];
+  const toRelease = nextList[index];
+  if (toRelease) {
+    release?.(toRelease);
+  }
+
+  const maxCount = field.maxCount ?? 0;
+  if (maxCount > 0) {
+    nextList[index] = null;
+  } else {
+    nextList.splice(index, 1);
+  }
+
+  const nextState = { ...previous };
+  const hasValues = nextList.some((asset) => asset !== null);
+
+  if (hasValues || (maxCount > 0 && nextList.length)) {
+    nextState[field.id] = nextList;
+  } else {
+    delete nextState[field.id];
+  }
+
+  return nextState;
+}
+
+export function buildKlingLibraryAsset(asset: UserAsset): KlingElementAsset {
+  return {
+    id: asset.id || `library_${Date.now().toString(36)}`,
+    previewUrl: asset.url,
+    kind: 'image',
+    name: asset.url.split('/').pop() ?? 'Image',
+    status: 'ready',
+    url: asset.url,
+  };
+}
+
+export function insertKlingLibraryAsset(
+  elements: KlingElementState[],
+  target: Extract<AssetPickerTarget, { kind: 'kling' }>,
+  asset: KlingElementAsset,
+  release?: (asset: KlingElementAsset | null | undefined) => void
+): KlingElementState[] {
+  return elements.map((element) => {
+    if (element.id !== target.elementId) return element;
+
+    if (target.slot === 'frontal') {
+      release?.(element.frontal);
+      return { ...element, frontal: asset };
+    }
+
+    const references = [...element.references];
+    let targetIndex = typeof target.slotIndex === 'number' ? target.slotIndex : references.findIndex((entry) => entry === null);
+    if (targetIndex < 0) {
+      targetIndex = references.length > 0 ? references.length - 1 : 0;
+    }
+    if (targetIndex >= references.length) {
+      return element;
+    }
+    release?.(references[targetIndex]);
+    references[targetIndex] = asset;
+    return { ...element, references };
+  });
 }
 
 export function revokeAssetPreview(asset: ReferenceAsset | null | undefined) {

--- a/tests/workspace-assets.test.ts
+++ b/tests/workspace-assets.test.ts
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type { KlingElementState } from '../frontend/components/KlingElementsBuilder';
+import type { EngineInputField } from '../frontend/types/engines';
+import {
+  buildKlingLibraryAsset,
+  buildReferenceAssetFromLibraryAsset,
+  getAssetLibrarySourceForField,
+  getLibraryAssetFieldMismatchMessage,
+  insertKlingLibraryAsset,
+  insertReferenceAsset,
+  removeReferenceAsset,
+  shouldMirrorCharacterImageAsset,
+  shouldMirrorVideoLibraryAsset,
+  type ReferenceAsset,
+  type UserAsset,
+} from '../frontend/app/(core)/(workspace)/app/_lib/workspace-assets';
+
+const imageField: EngineInputField = { id: 'image_url', type: 'image', label: 'Image', maxCount: 2 };
+const videoField: EngineInputField = { id: 'video_url', type: 'video', label: 'Video', maxCount: 1 };
+
+function userAsset(patch: Partial<UserAsset> = {}): UserAsset {
+  return {
+    id: 'asset_1',
+    url: 'https://cdn.example.com/source.jpg',
+    kind: 'image',
+    width: 1280,
+    height: 720,
+    size: 1234,
+    mime: 'image/jpeg',
+    source: 'upload',
+    canDelete: true,
+    ...patch,
+  };
+}
+
+test('asset library helpers choose source and validate field kind', () => {
+  assert.equal(getAssetLibrarySourceForField(imageField), 'all');
+  assert.equal(getAssetLibrarySourceForField(videoField), 'recent');
+  assert.equal(getLibraryAssetFieldMismatchMessage(imageField, userAsset({ kind: 'video' })), 'This slot requires an image source. Pick an image from the library or import one.');
+  assert.equal(getLibraryAssetFieldMismatchMessage(videoField, userAsset({ kind: 'image' })), 'This slot requires a video source. Pick a video from the video library or import an MP4/MOV clip.');
+  assert.equal(getLibraryAssetFieldMismatchMessage(imageField, userAsset()), null);
+});
+
+test('asset library mirroring policy detects generated Fal media', () => {
+  assert.equal(shouldMirrorVideoLibraryAsset(userAsset({ kind: 'video', source: 'recent', url: 'https://example.com/a.mp4' })), true);
+  assert.equal(shouldMirrorVideoLibraryAsset(userAsset({ kind: 'video', source: 'upload', url: 'https://fal.media/a.mp4' })), true);
+  assert.equal(shouldMirrorVideoLibraryAsset(userAsset({ kind: 'video', source: 'upload', url: 'https://cdn.example.com/a.mp4' })), false);
+  assert.equal(shouldMirrorCharacterImageAsset(userAsset({ source: 'character', url: 'https://foo.fal.media/a.jpg' })), true);
+  assert.equal(shouldMirrorCharacterImageAsset(userAsset({ source: 'upload', url: 'https://foo.fal.media/a.jpg' })), false);
+});
+
+test('reference asset insertion fills slots, replaces assets, and preserves max count', () => {
+  const first = buildReferenceAssetFromLibraryAsset(imageField, userAsset({ id: 'asset_first' }));
+  const second = buildReferenceAssetFromLibraryAsset(imageField, userAsset({ id: 'asset_second', url: 'https://cdn.example.com/second.jpg' }));
+  const replacement = buildReferenceAssetFromLibraryAsset(imageField, userAsset({ id: 'asset_replacement', url: 'https://cdn.example.com/replacement.jpg' }));
+  const released: string[] = [];
+
+  let state: Record<string, (ReferenceAsset | null)[]> = {};
+  state = insertReferenceAsset(state, imageField, first, undefined, { release: (asset) => released.push(asset.id) });
+  state = insertReferenceAsset(state, imageField, second, undefined, { release: (asset) => released.push(asset.id) });
+  state = insertReferenceAsset(state, imageField, replacement, 0, { release: (asset) => released.push(asset.id) });
+
+  assert.deepEqual(state.image_url.map((entry) => entry?.id), ['asset_replacement', 'asset_second']);
+  assert.deepEqual(released, ['asset_first']);
+
+  let maxReached = false;
+  const unchanged = insertReferenceAsset(state, imageField, first, undefined, { onMaxReached: () => { maxReached = true; } });
+  assert.equal(unchanged, state);
+  assert.equal(maxReached, true);
+
+  state = removeReferenceAsset(state, imageField, 1, (asset) => released.push(asset.id));
+  assert.deepEqual(state.image_url.map((entry) => entry?.id ?? null), ['asset_replacement', null]);
+  assert.deepEqual(released, ['asset_first', 'asset_second']);
+});
+
+test('kling library insertion targets frontal and reference slots', () => {
+  const element: KlingElementState = {
+    id: 'element_1',
+    frontal: null,
+    references: [null, null, null],
+    video: null,
+  };
+  const first = buildKlingLibraryAsset(userAsset({ id: 'kling_first' }));
+  const second = buildKlingLibraryAsset(userAsset({ id: 'kling_second', url: 'https://cdn.example.com/second.jpg' }));
+  const released: string[] = [];
+
+  let elements = insertKlingLibraryAsset(
+    [element],
+    { kind: 'kling', elementId: 'element_1', slot: 'frontal' },
+    first,
+    (asset) => {
+      if (asset) released.push(asset.id);
+    }
+  );
+  elements = insertKlingLibraryAsset(
+    elements,
+    { kind: 'kling', elementId: 'element_1', slot: 'reference', slotIndex: 0 },
+    second,
+    (asset) => {
+      if (asset) released.push(asset.id);
+    }
+  );
+
+  assert.equal(elements[0].frontal?.id, 'kling_first');
+  assert.equal(elements[0].references[0]?.id, 'kling_second');
+  assert.deepEqual(released, []);
+});


### PR DESCRIPTION
## Summary
- Extract asset library source selection, field validation, mirroring policy, reference slot insertion/removal, and Kling library asset mapping into `workspace-assets` helpers.
- Keep `AppClient.tsx` focused on network calls and React state wiring for the asset picker flows.
- Add targeted workspace asset helper coverage and update the route guide for future Codex passes.

## Test Plan
- `npm --prefix frontend run lint`
- `cd frontend && ./node_modules/.bin/tsc --noEmit`
- `npm --prefix frontend run build`
- `pnpm run test:validate`