### PR TITLE
[codex] Extract workspace render status helpers

### DIFF
--- a/frontend/app/(core)/(workspace)/app/AGENTS.md
+++ b/frontend/app/(core)/(workspace)/app/AGENTS.md
@@ -6,7 +6,7 @@ This route is the main signed-in video generation workspace.
 
 - `AppClient.tsx`: top-level state orchestration while the workspace is being split.
 - `_components`: route-local chrome, panels, skeletons, modals, and presentational UI.
-- `_lib`: route-local pure helpers for previews, render grouping, video settings hydration, workspace boot hydration, storage, copy fallback, client constants, asset normalization, asset selection, payload builders, input normalization, and workflow mapping.
+- `_lib`: route-local pure helpers for previews, render grouping, render status reconciliation, video settings hydration, workspace boot hydration, storage, copy fallback, client constants, asset normalization, asset selection, payload builders, input normalization, and workflow mapping.
 - Tool-specific workspaces should stay in their own route folders unless code is clearly shared.
 
 ## Refactor Rules
@@ -14,6 +14,7 @@ This route is the main signed-in video generation workspace.
 - Extract stable UI and pure helpers before moving generation state.
 - Keep schema summarization, asset-library normalization, and copy merging in `_lib`; `AppClient.tsx` should consume those results instead of rebuilding them inline.
 - Keep render grouping and preview tile mapping in `_lib`; `AppClient.tsx` should decide state transitions, not rebuild group summary objects inline.
+- Keep job-to-render conversion, status polling projections, and recent-job reconciliation in `_lib`; `AppClient.tsx` should own timers and network calls.
 - Keep video settings snapshot parsing and job media patch mapping in `_lib`; `AppClient.tsx` should wire those results into React state.
 - Keep workspace request parsing and boot hydration decisions in `_lib`; `AppClient.tsx` should apply the resolved state.
 - Keep asset-library selection, reference slot insertion, and Kling library asset mapping in `_lib`; `AppClient.tsx` should handle network calls and React state wiring.

--- a/frontend/app/(core)/(workspace)/app/AppClient.tsx
+++ b/frontend/app/(core)/(workspace)/app/AppClient.tsx
@@ -36,7 +36,6 @@ import {
 import { useResultProvider } from '@/hooks/useResultProvider';
 import { GroupedJobCard, type GroupedJobAction } from '@/components/GroupedJobCard';
 import { normalizeGroupSummaries, normalizeGroupSummary } from '@/lib/normalize-group-summary';
-import type { Job } from '@/types/jobs';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { isExpiredRefundedFailedGalleryItem, isRefundedPaymentStatus } from '@/lib/gallery-retention';
 import { supportsAudioPricingToggle } from '@/lib/pricing-addons';
@@ -84,7 +83,6 @@ import { getCompositePreviewPosterSrc } from './_lib/composite-preview';
 import {
   isAudioWorkspaceRender,
   resolvePolledThumbUrl,
-  resolveRenderThumb,
   serializePendingRenders,
   type LocalRender,
 } from './_lib/render-persistence';
@@ -189,6 +187,14 @@ import {
   isGenerationGroupLoading,
   pruneBatchHeroes,
 } from './_lib/workspace-render-groups';
+import {
+  applyPolledJobStatusToRender,
+  applyPolledJobStatusToSelectedPreview,
+  buildRecentJobIdSet,
+  getRendersNeedingStatusRefresh,
+  mergeRecentJobsIntoLocalRenders,
+  shouldRemoveCompletedSyncedRender,
+} from './_lib/workspace-render-status';
 import {
   createUploadFailure,
   getUploadFailureMessage,
@@ -445,103 +451,6 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
   const persistedRendersRef = useRef<string | null>(null);
   const pendingPollRef = useRef<number | null>(null);
   const statusErrorCountsRef = useRef<Map<string, { unauthorized: number }>>(new Map());
-  const convertJobToLocalRender = useCallback(
-    (job: Job): LocalRender => {
-      const baseLocalKey = job.localKey ?? job.jobId;
-      const localKey = baseLocalKey ?? `job_${job.jobId}`;
-      const batchId = job.batchId ?? job.groupId ?? localKey;
-      const renderIds = Array.isArray(job.renderIds)
-        ? job.renderIds.filter((value): value is string => typeof value === 'string' && value.length > 0)
-        : undefined;
-      const normalizedStatus = (() => {
-        const raw = (job.status ?? '').toLowerCase();
-        if (raw === 'failed') return 'failed' as const;
-        if (raw === 'completed') return 'completed' as const;
-        if (job.videoUrl) return 'completed' as const;
-        return 'pending' as const;
-      })();
-      const normalizedProgress = (() => {
-        if (typeof job.progress === 'number' && Number.isFinite(job.progress)) {
-          return Math.max(0, Math.min(100, Math.round(job.progress)));
-        }
-        if (normalizedStatus === 'completed' || job.videoUrl) return 100;
-        if (normalizedStatus === 'failed') return 100;
-        return 0;
-      })();
-      const createdAt = typeof job.createdAt === 'string' && job.createdAt.length ? job.createdAt : new Date().toISOString();
-      const parsedCreated = Number.isFinite(Date.parse(createdAt)) ? Date.parse(createdAt) : Date.now();
-      const priceCents = typeof job.finalPriceCents === 'number' ? job.finalPriceCents : job.pricingSnapshot?.totalCents;
-      const currency = job.currency ?? job.pricingSnapshot?.currency ?? undefined;
-      const engineId =
-        job.engineId ?? (job.engineLabel ? engineIdByLabel.get(job.engineLabel.toLowerCase()) ?? undefined : undefined) ?? 'unknown-engine';
-      const pendingMessage = (() => {
-        if (engineId.startsWith('sora-2')) {
-          return 'Sora 2 renders take a little longer—hang tight while we finish up the magic.';
-        }
-        return 'Render pending.';
-      })();
-
-      const message =
-        job.message ??
-        (normalizedStatus === 'completed'
-          ? 'Render completed.'
-          : normalizedStatus === 'failed'
-            ? 'The service reported a failure without details. Try again. If it fails repeatedly, contact support with your request ID.'
-            : pendingMessage);
-      const jobThumb = job.thumbUrl && !isPlaceholderMediaUrl(job.thumbUrl) ? job.thumbUrl : null;
-      const thumbUrl =
-        jobThumb ??
-        job.previewFrame ??
-        resolveRenderThumb({ thumbUrl: job.thumbUrl, aspectRatio: job.aspectRatio ?? null });
-
-      return {
-        localKey,
-        batchId,
-        iterationIndex:
-          typeof job.iterationIndex === 'number' && Number.isFinite(job.iterationIndex)
-            ? Math.max(0, Math.trunc(job.iterationIndex))
-            : 0,
-        iterationCount: Math.max(
-          1,
-          typeof job.iterationCount === 'number' && Number.isFinite(job.iterationCount)
-            ? Math.trunc(job.iterationCount)
-            : renderIds?.length ?? 1
-        ),
-        id: job.jobId,
-        jobId: job.jobId,
-        engineId,
-        engineLabel: job.engineLabel ?? 'Unknown engine',
-        createdAt,
-        aspectRatio: job.aspectRatio ?? '16:9',
-        durationSec: job.durationSec,
-        prompt: job.prompt ?? '',
-        progress: normalizedProgress,
-        message,
-      status: normalizedStatus,
-      videoUrl: job.videoUrl ?? undefined,
-      previewVideoUrl: job.previewVideoUrl ?? undefined,
-      readyVideoUrl: job.videoUrl ?? undefined,
-      thumbUrl,
-      hasAudio: typeof job.hasAudio === 'boolean' ? job.hasAudio : undefined,
-      priceCents: priceCents ?? undefined,
-        currency,
-        pricingSnapshot: job.pricingSnapshot,
-        paymentStatus: job.paymentStatus ?? 'platform',
-        failedAt:
-          normalizedStatus === 'failed' && isRefundedPaymentStatus(job.paymentStatus ?? null)
-            ? parsedCreated
-            : undefined,
-        etaSeconds: job.etaSeconds ?? undefined,
-        etaLabel: job.etaLabel ?? undefined,
-        startedAt: parsedCreated,
-        minReadyAt: parsedCreated,
-        groupId: job.groupId ?? job.batchId ?? null,
-        renderIds,
-        heroRenderId: job.heroRenderId ?? null,
-      };
-    },
-    [engineIdByLabel]
-  );
   const hydratedScopeRef = useRef<string | null>(null);
   const hasStoredFormRef = useRef<boolean>(false);
 
@@ -685,14 +594,7 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    const jobsNeedingRefresh = renders.filter((render) => {
-      if (typeof render.jobId !== 'string' || render.jobId.length === 0) return false;
-      if (render.status === 'failed') return false;
-      const hasVideo = Boolean(render.videoUrl);
-      const hasThumb = Boolean(render.thumbUrl && !isPlaceholderMediaUrl(render.thumbUrl));
-      if ((render.status ?? 'pending') !== 'completed') return true;
-      return !hasVideo || !hasThumb;
-    });
+    const jobsNeedingRefresh = getRendersNeedingStatusRefresh(renders);
     if (!jobsNeedingRefresh.length) {
       if (pendingPollRef.current !== null) {
         window.clearInterval(pendingPollRef.current);
@@ -712,42 +614,11 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
             if (cancelled) return;
             setRenders((prev) =>
               prev.map((item) =>
-                item.jobId === render.jobId
-                  ? {
-                      ...item,
-                      status: status.status ?? item.status,
-                      progress: status.progress ?? item.progress,
-                      readyVideoUrl: status.videoUrl ?? item.readyVideoUrl,
-                      videoUrl: status.videoUrl ?? item.videoUrl ?? item.readyVideoUrl,
-                      previewVideoUrl: status.previewVideoUrl ?? item.previewVideoUrl,
-                      thumbUrl: resolvePolledThumbUrl(item.thumbUrl, status.thumbUrl),
-                      aspectRatio: status.aspectRatio ?? item.aspectRatio,
-                      priceCents: status.finalPriceCents ?? status.pricing?.totalCents ?? item.priceCents,
-                      currency: status.currency ?? status.pricing?.currency ?? item.currency,
-                      pricingSnapshot: status.pricing ?? item.pricingSnapshot,
-                      paymentStatus: status.paymentStatus ?? item.paymentStatus,
-                      message: status.message ?? item.message,
-                    }
-                  : item
+                item.jobId === render.jobId ? applyPolledJobStatusToRender(item, status) : item
               )
             );
             setSelectedPreview((cur) =>
-              cur && (cur.id === render.jobId || cur.localKey === render.localKey)
-                ? {
-                    ...cur,
-                    id: render.jobId,
-                    localKey: render.localKey,
-                    status: status.status ?? cur.status,
-                    progress: status.progress ?? cur.progress,
-                    videoUrl: status.videoUrl ?? cur.videoUrl,
-                    previewVideoUrl: status.previewVideoUrl ?? cur.previewVideoUrl,
-                    thumbUrl: resolvePolledThumbUrl(cur.thumbUrl, status.thumbUrl),
-                    aspectRatio: status.aspectRatio ?? cur.aspectRatio,
-                    priceCents: status.finalPriceCents ?? status.pricing?.totalCents ?? cur.priceCents,
-                    currency: status.currency ?? status.pricing?.currency ?? cur.currency,
-                    message: status.message ?? cur.message,
-                  }
-                : cur
+              applyPolledJobStatusToSelectedPreview(cur, render, status)
             );
           } catch (error) {
             const statusCode = typeof error === 'object' && error ? (error as { status?: unknown }).status : undefined;
@@ -797,66 +668,13 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
 
   useEffect(() => {
     if (!recentJobs.length) return;
-    const heroCandidates: Array<{ batchId: string | null; localKey: string }> = [];
+    let heroCandidates: Array<{ batchId: string | null; localKey: string }> = [];
 
     setRenders((previous) => {
       if (!recentJobs.length) return previous;
-
-      const next = [...previous];
-      const byLocalKey = new Map<string, number>();
-      const byJobId = new Map<string, number>();
-      previous.forEach((render, index) => {
-        if (render.localKey) {
-          byLocalKey.set(render.localKey, index);
-        }
-        if (render.jobId) {
-          byJobId.set(render.jobId, index);
-        }
-      });
-
-      let changed = false;
-
-      recentJobs.forEach((job) => {
-        if (!job.jobId) return;
-        const converted = convertJobToLocalRender(job);
-        const jobIdIndex = converted.jobId ? byJobId.get(converted.jobId) : undefined;
-        const localKeyIndex = byLocalKey.get(converted.localKey);
-        const targetIndex = jobIdIndex ?? localKeyIndex;
-
-        if (targetIndex !== undefined) {
-          const existing = next[targetIndex];
-          const merged: LocalRender = {
-            ...converted,
-            localKey: existing.localKey ?? converted.localKey,
-            batchId: existing.batchId ?? converted.batchId,
-          };
-          next[targetIndex] = merged;
-          if (merged.localKey) {
-            byLocalKey.set(merged.localKey, targetIndex);
-          }
-          if (merged.jobId) {
-            byJobId.set(merged.jobId, targetIndex);
-          }
-          heroCandidates.push({ batchId: merged.batchId ?? null, localKey: merged.localKey });
-          changed = true;
-        } else {
-          const merged: LocalRender = converted;
-          next.push(merged);
-          if (merged.localKey) {
-            byLocalKey.set(merged.localKey, next.length - 1);
-          }
-          if (merged.jobId) {
-            byJobId.set(merged.jobId, next.length - 1);
-          }
-          heroCandidates.push({ batchId: merged.batchId ?? null, localKey: merged.localKey });
-          changed = true;
-        }
-      });
-
-      if (!changed) return previous;
-
-      next.sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt));
-      return next;
+      const result = mergeRecentJobsIntoLocalRenders(previous, recentJobs, { engineIdByLabel });
+      heroCandidates = result.heroCandidates;
+      return result.renders;
     });
 
     if (heroCandidates.length) {
@@ -873,7 +691,7 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
         return modified ? next : previous;
       });
     }
-  }, [convertJobToLocalRender, recentJobs]);
+  }, [engineIdByLabel, recentJobs]);
 
   useEffect(() => {
     const shouldRemove = (render: LocalRender) =>
@@ -899,23 +717,9 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
 
   useEffect(() => {
     if (!renders.length || !recentJobs.length) return;
-    const recentJobIds = new Set<string>();
-    recentJobs.forEach((job) => {
-      if (typeof job.jobId === 'string' && job.jobId.length > 0) {
-        recentJobIds.add(job.jobId);
-      }
-    });
+    const recentJobIds = buildRecentJobIdSet(recentJobs);
     if (!recentJobIds.size) return;
-    const shouldRemove = (render: LocalRender) => {
-      if (!render.jobId || !recentJobIds.has(render.jobId)) {
-        return false;
-      }
-      if (render.status !== 'completed') {
-        return false;
-      }
-      const hasVideo = Boolean(render.videoUrl ?? render.readyVideoUrl);
-      return hasVideo;
-    };
+    const shouldRemove = (render: LocalRender) => shouldRemoveCompletedSyncedRender(render, recentJobIds);
     const removedRefs = filterLocalRenders(renders, shouldRemove);
     if (!hasRemovedRenderRefs(removedRefs)) {
       return;

--- a/frontend/app/(core)/(workspace)/app/_lib/workspace-render-status.ts
+++ b/frontend/app/(core)/(workspace)/app/_lib/workspace-render-status.ts
@@ -1,0 +1,274 @@
+import { isRefundedPaymentStatus } from '@/lib/gallery-retention';
+import { isPlaceholderMediaUrl } from '@/lib/media';
+import type { SelectedVideoPreview } from '@/lib/video-preview-group';
+import type { Job } from '@/types/jobs';
+import type { LocalRender } from './render-persistence';
+import { resolvePolledThumbUrl, resolveRenderThumb } from './render-persistence';
+
+export type RenderHeroCandidate = {
+  batchId: string | null;
+  localKey: string;
+};
+
+export type PolledJobStatus = {
+  status?: LocalRender['status'] | null;
+  progress?: number | null;
+  videoUrl?: string | null;
+  previewVideoUrl?: string | null;
+  thumbUrl?: string | null;
+  aspectRatio?: string | null;
+  finalPriceCents?: number | null;
+  currency?: string | null;
+  pricing?: LocalRender['pricingSnapshot'] | null;
+  paymentStatus?: string | null;
+  message?: string | null;
+};
+
+export type LocalRenderFromJobOptions = {
+  engineIdByLabel?: ReadonlyMap<string, string>;
+  now?: number;
+};
+
+export function convertJobToLocalRender(job: Job, options: LocalRenderFromJobOptions = {}): LocalRender {
+  const now = options.now ?? Date.now();
+  const baseLocalKey = job.localKey ?? job.jobId;
+  const localKey = baseLocalKey ?? `job_${job.jobId}`;
+  const batchId = job.batchId ?? job.groupId ?? localKey;
+  const renderIds = Array.isArray(job.renderIds)
+    ? job.renderIds.filter((value): value is string => typeof value === 'string' && value.length > 0)
+    : undefined;
+  const normalizedStatus = (() => {
+    const raw = (job.status ?? '').toLowerCase();
+    if (raw === 'failed') return 'failed' as const;
+    if (raw === 'completed') return 'completed' as const;
+    if (job.videoUrl) return 'completed' as const;
+    return 'pending' as const;
+  })();
+  const normalizedProgress = (() => {
+    if (typeof job.progress === 'number' && Number.isFinite(job.progress)) {
+      return Math.max(0, Math.min(100, Math.round(job.progress)));
+    }
+    if (normalizedStatus === 'completed' || job.videoUrl) return 100;
+    if (normalizedStatus === 'failed') return 100;
+    return 0;
+  })();
+  const createdAt = typeof job.createdAt === 'string' && job.createdAt.length ? job.createdAt : new Date(now).toISOString();
+  const parsedCreated = Number.isFinite(Date.parse(createdAt)) ? Date.parse(createdAt) : now;
+  const priceCents = typeof job.finalPriceCents === 'number' ? job.finalPriceCents : job.pricingSnapshot?.totalCents;
+  const currency = job.currency ?? job.pricingSnapshot?.currency ?? undefined;
+  const engineId =
+    job.engineId ??
+    (job.engineLabel ? options.engineIdByLabel?.get(job.engineLabel.toLowerCase()) ?? undefined : undefined) ??
+    'unknown-engine';
+  const pendingMessage = (() => {
+    if (engineId.startsWith('sora-2')) {
+      return 'Sora 2 renders take a little longer—hang tight while we finish up the magic.';
+    }
+    return 'Render pending.';
+  })();
+
+  const message =
+    job.message ??
+    (normalizedStatus === 'completed'
+      ? 'Render completed.'
+      : normalizedStatus === 'failed'
+        ? 'The service reported a failure without details. Try again. If it fails repeatedly, contact support with your request ID.'
+        : pendingMessage);
+  const jobThumb = job.thumbUrl && !isPlaceholderMediaUrl(job.thumbUrl) ? job.thumbUrl : null;
+  const thumbUrl =
+    jobThumb ??
+    job.previewFrame ??
+    resolveRenderThumb({ thumbUrl: job.thumbUrl, aspectRatio: job.aspectRatio ?? null });
+
+  return {
+    localKey,
+    batchId,
+    iterationIndex:
+      typeof job.iterationIndex === 'number' && Number.isFinite(job.iterationIndex)
+        ? Math.max(0, Math.trunc(job.iterationIndex))
+        : 0,
+    iterationCount: Math.max(
+      1,
+      typeof job.iterationCount === 'number' && Number.isFinite(job.iterationCount)
+        ? Math.trunc(job.iterationCount)
+        : renderIds?.length ?? 1
+    ),
+    id: job.jobId,
+    jobId: job.jobId,
+    engineId,
+    engineLabel: job.engineLabel ?? 'Unknown engine',
+    createdAt,
+    aspectRatio: job.aspectRatio ?? '16:9',
+    durationSec: job.durationSec,
+    prompt: job.prompt ?? '',
+    progress: normalizedProgress,
+    message,
+    status: normalizedStatus,
+    videoUrl: job.videoUrl ?? undefined,
+    previewVideoUrl: job.previewVideoUrl ?? undefined,
+    readyVideoUrl: job.videoUrl ?? undefined,
+    thumbUrl,
+    hasAudio: typeof job.hasAudio === 'boolean' ? job.hasAudio : undefined,
+    priceCents: priceCents ?? undefined,
+    currency,
+    pricingSnapshot: job.pricingSnapshot,
+    paymentStatus: job.paymentStatus ?? 'platform',
+    failedAt:
+      normalizedStatus === 'failed' && isRefundedPaymentStatus(job.paymentStatus ?? null)
+        ? parsedCreated
+        : undefined,
+    etaSeconds: job.etaSeconds ?? undefined,
+    etaLabel: job.etaLabel ?? undefined,
+    startedAt: parsedCreated,
+    minReadyAt: parsedCreated,
+    groupId: job.groupId ?? job.batchId ?? null,
+    renderIds,
+    heroRenderId: job.heroRenderId ?? null,
+  };
+}
+
+export function getRendersNeedingStatusRefresh(renders: LocalRender[]): LocalRender[] {
+  return renders.filter((render) => {
+    if (typeof render.jobId !== 'string' || render.jobId.length === 0) return false;
+    if (render.status === 'failed') return false;
+    const hasVideo = Boolean(render.videoUrl);
+    const hasThumb = Boolean(render.thumbUrl && !isPlaceholderMediaUrl(render.thumbUrl));
+    if ((render.status ?? 'pending') !== 'completed') return true;
+    return !hasVideo || !hasThumb;
+  });
+}
+
+export function applyPolledJobStatusToRender(render: LocalRender, status: PolledJobStatus): LocalRender {
+  return {
+    ...render,
+    status: status.status ?? render.status,
+    progress: status.progress ?? render.progress,
+    readyVideoUrl: status.videoUrl ?? render.readyVideoUrl,
+    videoUrl: status.videoUrl ?? render.videoUrl ?? render.readyVideoUrl,
+    previewVideoUrl: status.previewVideoUrl ?? render.previewVideoUrl,
+    thumbUrl: resolvePolledThumbUrl(render.thumbUrl, status.thumbUrl),
+    aspectRatio: status.aspectRatio ?? render.aspectRatio,
+    priceCents: status.finalPriceCents ?? status.pricing?.totalCents ?? render.priceCents,
+    currency: status.currency ?? status.pricing?.currency ?? render.currency,
+    pricingSnapshot: status.pricing ?? render.pricingSnapshot,
+    paymentStatus: status.paymentStatus ?? render.paymentStatus,
+    message: status.message ?? render.message,
+  };
+}
+
+export function applyPolledJobStatusToSelectedPreview(
+  current: SelectedVideoPreview | null,
+  render: Pick<LocalRender, 'jobId' | 'localKey'>,
+  status: PolledJobStatus
+): SelectedVideoPreview | null {
+  if (!current || !render.jobId || (current.id !== render.jobId && current.localKey !== render.localKey)) {
+    return current;
+  }
+
+  return {
+    ...current,
+    id: render.jobId,
+    localKey: render.localKey,
+    status: status.status ?? current.status,
+    progress: status.progress ?? current.progress,
+    videoUrl: status.videoUrl ?? current.videoUrl,
+    previewVideoUrl: status.previewVideoUrl ?? current.previewVideoUrl,
+    thumbUrl: resolvePolledThumbUrl(current.thumbUrl, status.thumbUrl),
+    aspectRatio: status.aspectRatio ?? current.aspectRatio,
+    priceCents: status.finalPriceCents ?? status.pricing?.totalCents ?? current.priceCents,
+    currency: status.currency ?? status.pricing?.currency ?? current.currency,
+    message: status.message ?? current.message,
+  };
+}
+
+export type RecentJobsMergeResult = {
+  renders: LocalRender[];
+  heroCandidates: RenderHeroCandidate[];
+  changed: boolean;
+};
+
+export function mergeRecentJobsIntoLocalRenders(
+  previous: LocalRender[],
+  recentJobs: Job[],
+  options: LocalRenderFromJobOptions = {}
+): RecentJobsMergeResult {
+  const next = [...previous];
+  const byLocalKey = new Map<string, number>();
+  const byJobId = new Map<string, number>();
+  const heroCandidates: RenderHeroCandidate[] = [];
+
+  previous.forEach((render, index) => {
+    if (render.localKey) {
+      byLocalKey.set(render.localKey, index);
+    }
+    if (render.jobId) {
+      byJobId.set(render.jobId, index);
+    }
+  });
+
+  let changed = false;
+
+  recentJobs.forEach((job) => {
+    if (!job.jobId) return;
+    const converted = convertJobToLocalRender(job, options);
+    const jobIdIndex = converted.jobId ? byJobId.get(converted.jobId) : undefined;
+    const localKeyIndex = byLocalKey.get(converted.localKey);
+    const targetIndex = jobIdIndex ?? localKeyIndex;
+
+    if (targetIndex !== undefined) {
+      const existing = next[targetIndex];
+      const merged: LocalRender = {
+        ...converted,
+        localKey: existing.localKey ?? converted.localKey,
+        batchId: existing.batchId ?? converted.batchId,
+      };
+      next[targetIndex] = merged;
+      if (merged.localKey) {
+        byLocalKey.set(merged.localKey, targetIndex);
+      }
+      if (merged.jobId) {
+        byJobId.set(merged.jobId, targetIndex);
+      }
+      heroCandidates.push({ batchId: merged.batchId ?? null, localKey: merged.localKey });
+      changed = true;
+      return;
+    }
+
+    next.push(converted);
+    if (converted.localKey) {
+      byLocalKey.set(converted.localKey, next.length - 1);
+    }
+    if (converted.jobId) {
+      byJobId.set(converted.jobId, next.length - 1);
+    }
+    heroCandidates.push({ batchId: converted.batchId ?? null, localKey: converted.localKey });
+    changed = true;
+  });
+
+  if (!changed) {
+    return { renders: previous, heroCandidates, changed: false };
+  }
+
+  next.sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt));
+  return { renders: next, heroCandidates, changed: true };
+}
+
+export function buildRecentJobIdSet(recentJobs: Pick<Job, 'jobId'>[]): Set<string> {
+  const ids = new Set<string>();
+  recentJobs.forEach((job) => {
+    if (typeof job.jobId === 'string' && job.jobId.length > 0) {
+      ids.add(job.jobId);
+    }
+  });
+  return ids;
+}
+
+export function shouldRemoveCompletedSyncedRender(render: LocalRender, recentJobIds: Set<string>): boolean {
+  if (!render.jobId || !recentJobIds.has(render.jobId)) {
+    return false;
+  }
+  if (render.status !== 'completed') {
+    return false;
+  }
+  return Boolean(render.videoUrl ?? render.readyVideoUrl);
+}

--- a/tests/workspace-gallery-rail-contract.test.ts
+++ b/tests/workspace-gallery-rail-contract.test.ts
@@ -103,9 +103,15 @@ test('video polling waits for a real static thumbnail', () => {
     path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/_lib/render-persistence.ts'),
     'utf8'
   );
+  const renderStatusSource = fs.readFileSync(
+    path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/_lib/workspace-render-status.ts'),
+    'utf8'
+  );
 
   assert.match(renderPersistenceSource, /export function resolvePolledThumbUrl/);
   assert.match(renderPersistenceSource, /next && !isPlaceholderMediaUrl\(next\)/);
+  assert.match(renderStatusSource, /thumbUrl:\s*resolvePolledThumbUrl\(render\.thumbUrl,\s*status\.thumbUrl\)/);
+  assert.match(renderStatusSource, /thumbUrl:\s*resolvePolledThumbUrl\(current\.thumbUrl,\s*status\.thumbUrl\)/);
   assert.match(appSource, /thumbUrl:\s*resolvePolledThumbUrl\(r\.thumbUrl,\s*status\.thumbUrl\)/);
-  assert.match(appSource, /thumbUrl:\s*resolvePolledThumbUrl\(item\.thumbUrl,\s*status\.thumbUrl\)/);
+  assert.match(appSource, /applyPolledJobStatusToRender\(item,\s*status\)/);
 });

--- a/tests/workspace-render-status.test.ts
+++ b/tests/workspace-render-status.test.ts
@@ -1,0 +1,197 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type { Job } from '../frontend/types/jobs';
+import type { SelectedVideoPreview } from '../frontend/lib/video-preview-group';
+import type { LocalRender } from '../frontend/app/(core)/(workspace)/app/_lib/render-persistence';
+import {
+  applyPolledJobStatusToRender,
+  applyPolledJobStatusToSelectedPreview,
+  buildRecentJobIdSet,
+  convertJobToLocalRender,
+  getRendersNeedingStatusRefresh,
+  mergeRecentJobsIntoLocalRenders,
+  shouldRemoveCompletedSyncedRender,
+} from '../frontend/app/(core)/(workspace)/app/_lib/workspace-render-status';
+
+const baseTime = Date.parse('2026-05-06T12:00:00.000Z');
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+  return {
+    jobId: 'job_1',
+    engineLabel: 'Seedance 2.0',
+    durationSec: 5,
+    prompt: 'A cinematic product shot',
+    createdAt: '2026-05-06T10:00:00.000Z',
+    aspectRatio: '16:9',
+    ...overrides,
+  };
+}
+
+function makeRender(overrides: Partial<LocalRender> = {}): LocalRender {
+  return {
+    localKey: 'local_1',
+    batchId: 'batch_1',
+    iterationIndex: 0,
+    iterationCount: 1,
+    id: 'job_1',
+    jobId: 'job_1',
+    engineId: 'seedance-2-0',
+    engineLabel: 'Seedance 2.0',
+    createdAt: '2026-05-06T10:00:00.000Z',
+    aspectRatio: '16:9',
+    durationSec: 5,
+    prompt: 'A cinematic product shot',
+    progress: 0,
+    message: 'Render pending.',
+    status: 'pending',
+    startedAt: baseTime,
+    minReadyAt: baseTime,
+    ...overrides,
+  };
+}
+
+test('convertJobToLocalRender normalizes API jobs into local render state', () => {
+  const engineIdByLabel = new Map([['seedance 2.0', 'seedance-2-0']]);
+  const render = convertJobToLocalRender(
+    makeJob({
+      localKey: 'local_existing',
+      batchId: 'batch_existing',
+      status: 'completed',
+      progress: 132,
+      videoUrl: 'https://cdn.example.com/video.mp4',
+      previewVideoUrl: 'https://cdn.example.com/preview.mp4',
+      thumbUrl: '/assets/frames/thumb-16x9.svg',
+      previewFrame: 'https://cdn.example.com/frame.jpg',
+      finalPriceCents: 123,
+      currency: 'eur',
+      renderIds: ['render_1', '', 'render_2'],
+    }),
+    { engineIdByLabel, now: baseTime }
+  );
+
+  assert.equal(render.localKey, 'local_existing');
+  assert.equal(render.batchId, 'batch_existing');
+  assert.equal(render.engineId, 'seedance-2-0');
+  assert.equal(render.status, 'completed');
+  assert.equal(render.progress, 100);
+  assert.equal(render.thumbUrl, 'https://cdn.example.com/frame.jpg');
+  assert.deepEqual(render.renderIds, ['render_1', 'render_2']);
+  assert.equal(render.priceCents, 123);
+  assert.equal(render.currency, 'eur');
+});
+
+test('getRendersNeedingStatusRefresh keeps only incomplete or media-incomplete renders', () => {
+  const pending = makeRender({ jobId: 'pending', status: 'pending' });
+  const completedMissingThumb = makeRender({
+    jobId: 'missing_thumb',
+    status: 'completed',
+    videoUrl: 'https://cdn.example.com/video.mp4',
+    thumbUrl: '/assets/frames/thumb-16x9.svg',
+  });
+  const completedReady = makeRender({
+    jobId: 'ready',
+    status: 'completed',
+    videoUrl: 'https://cdn.example.com/video.mp4',
+    thumbUrl: 'https://cdn.example.com/thumb.jpg',
+  });
+  const failed = makeRender({ jobId: 'failed', status: 'failed' });
+
+  assert.deepEqual(
+    getRendersNeedingStatusRefresh([pending, completedMissingThumb, completedReady, failed]).map((render) => render.jobId),
+    ['pending', 'missing_thumb']
+  );
+});
+
+test('polled status helpers update render and selected preview consistently', () => {
+  const render = makeRender({
+    readyVideoUrl: 'https://cdn.example.com/old.mp4',
+    thumbUrl: 'https://cdn.example.com/old.jpg',
+  });
+  const status = {
+    status: 'completed' as const,
+    progress: 100,
+    videoUrl: 'https://cdn.example.com/new.mp4',
+    previewVideoUrl: 'https://cdn.example.com/preview.mp4',
+    thumbUrl: 'https://cdn.example.com/new.jpg',
+    aspectRatio: '9:16',
+    finalPriceCents: 250,
+    currency: 'eur',
+    paymentStatus: 'paid',
+    message: 'Render completed.',
+  };
+
+  const nextRender = applyPolledJobStatusToRender(render, status);
+  assert.equal(nextRender.videoUrl, 'https://cdn.example.com/new.mp4');
+  assert.equal(nextRender.readyVideoUrl, 'https://cdn.example.com/new.mp4');
+  assert.equal(nextRender.thumbUrl, 'https://cdn.example.com/new.jpg');
+  assert.equal(nextRender.aspectRatio, '9:16');
+  assert.equal(nextRender.priceCents, 250);
+  assert.equal(nextRender.message, 'Render completed.');
+
+  const preview: SelectedVideoPreview = { id: 'job_1', localKey: 'local_1', status: 'pending' };
+  const nextPreview = applyPolledJobStatusToSelectedPreview(preview, render, status);
+  assert.equal(nextPreview?.status, 'completed');
+  assert.equal(nextPreview?.videoUrl, 'https://cdn.example.com/new.mp4');
+  assert.equal(nextPreview?.thumbUrl, 'https://cdn.example.com/new.jpg');
+});
+
+test('mergeRecentJobsIntoLocalRenders preserves local identity and returns hero candidates', () => {
+  const existing = makeRender({
+    localKey: 'local_existing',
+    batchId: 'batch_existing',
+    jobId: 'job_existing',
+    id: 'job_existing',
+    createdAt: '2026-05-06T09:00:00.000Z',
+  });
+  const result = mergeRecentJobsIntoLocalRenders(
+    [existing],
+    [
+      makeJob({
+        jobId: 'job_existing',
+        localKey: 'server_local',
+        batchId: 'server_batch',
+        createdAt: '2026-05-06T11:00:00.000Z',
+        status: 'completed',
+        videoUrl: 'https://cdn.example.com/existing.mp4',
+      }),
+      makeJob({
+        jobId: 'job_new',
+        localKey: 'local_new',
+        batchId: 'batch_new',
+        createdAt: '2026-05-06T10:30:00.000Z',
+      }),
+    ],
+    { now: baseTime }
+  );
+
+  assert.equal(result.changed, true);
+  assert.equal(result.renders[0]?.jobId, 'job_existing');
+  assert.equal(result.renders[0]?.localKey, 'local_existing');
+  assert.equal(result.renders[0]?.batchId, 'batch_existing');
+  assert.equal(result.renders[1]?.jobId, 'job_new');
+  assert.deepEqual(result.heroCandidates, [
+    { batchId: 'batch_existing', localKey: 'local_existing' },
+    { batchId: 'batch_new', localKey: 'local_new' },
+  ]);
+});
+
+test('recent job cleanup helpers identify completed synced renders', () => {
+  const recentJobIds = buildRecentJobIdSet([{ jobId: 'job_1' }, { jobId: '' }]);
+
+  assert.equal(
+    shouldRemoveCompletedSyncedRender(
+      makeRender({ jobId: 'job_1', status: 'completed', videoUrl: 'https://cdn.example.com/video.mp4' }),
+      recentJobIds
+    ),
+    true
+  );
+  assert.equal(shouldRemoveCompletedSyncedRender(makeRender({ jobId: 'job_1', status: 'pending' }), recentJobIds), false);
+  assert.equal(
+    shouldRemoveCompletedSyncedRender(
+      makeRender({ jobId: 'other', status: 'completed', videoUrl: 'https://cdn.example.com/video.mp4' }),
+      recentJobIds
+    ),
+    false
+  );
+});


### PR DESCRIPTION
## Summary
- Extract API job to `LocalRender` conversion, status refresh selection, polled status projection, and recent-job reconciliation into `workspace-render-status` helpers.
- Keep `AppClient.tsx` focused on React effects, timers, and network calls while preserving polling behavior for real thumbnails.
- Add targeted render status helper tests and update the existing rail contract to watch the extracted helper.

## Test Plan
- `pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/workspace-render-status.test.ts`
- `cd frontend && ./node_modules/.bin/tsc --noEmit`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- `pnpm run test:validate`