### PR TITLE
[codex] Extract workspace generation input helpers

### DIFF
--- a/frontend/app/(core)/(workspace)/app/AGENTS.md
+++ b/frontend/app/(core)/(workspace)/app/AGENTS.md
@@ -6,7 +6,7 @@ This route is the main signed-in video generation workspace.
 
 - `AppClient.tsx`: top-level state orchestration while the workspace is being split.
 - `_components`: route-local chrome, panels, skeletons, modals, and presentational UI.
-- `_lib`: route-local pure helpers for previews, render grouping, render status reconciliation, video settings hydration, workspace boot hydration, storage, copy fallback, client constants, asset normalization, asset selection, payload builders, input normalization, and workflow mapping.
+- `_lib`: route-local pure helpers for previews, render grouping, render status reconciliation, generation input preparation, video settings hydration, workspace boot hydration, storage, copy fallback, client constants, asset normalization, asset selection, payload builders, input normalization, and workflow mapping.
 - Tool-specific workspaces should stay in their own route folders unless code is clearly shared.
 
 ## Refactor Rules
@@ -15,6 +15,7 @@ This route is the main signed-in video generation workspace.
 - Keep schema summarization, asset-library normalization, and copy merging in `_lib`; `AppClient.tsx` should consume those results instead of rebuilding them inline.
 - Keep render grouping and preview tile mapping in `_lib`; `AppClient.tsx` should decide state transitions, not rebuild group summary objects inline.
 - Keep job-to-render conversion, status polling projections, and recent-job reconciliation in `_lib`; `AppClient.tsx` should own timers and network calls.
+- Keep generation attachment ordering, derived input URLs, Kling element payloads, and multi-prompt payloads in `_lib`; `AppClient.tsx` should keep workflow guards and the `runGenerate` call.
 - Keep video settings snapshot parsing and job media patch mapping in `_lib`; `AppClient.tsx` should wire those results into React state.
 - Keep workspace request parsing and boot hydration decisions in `_lib`; `AppClient.tsx` should apply the resolved state.
 - Keep asset-library selection, reference slot insertion, and Kling library asset mapping in `_lib`; `AppClient.tsx` should handle network calls and React state wiring.

--- a/frontend/app/(core)/(workspace)/app/AppClient.tsx
+++ b/frontend/app/(core)/(workspace)/app/AppClient.tsx
@@ -90,6 +90,7 @@ import {
   normalizeExtraInputValue,
   type FormState,
 } from './_lib/workspace-form-state';
+import { prepareGenerationInputs } from './_lib/workspace-generation-inputs';
 import {
   buildComposerModeToggles,
   coerceFormState,
@@ -2799,205 +2800,43 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
       }
     }
 
-    const schema = selectedEngine?.inputSchema;
-    const fieldIndex = new Map<string, EngineInputField>();
-    if (schema) {
-      [...(schema.required ?? []), ...(schema.optional ?? [])].forEach((field) => {
-        fieldIndex.set(field.id, field);
-      });
-    }
-
-    const orderedAttachments: Array<{ field: EngineInputField; asset: ReferenceAsset }> = [];
-    inputSchemaSummary.assetFields.forEach(({ field }) => {
-      const items = inputAssets[field.id] ?? [];
-      items.forEach((asset) => {
-        if (!asset) return;
-        orderedAttachments.push({ field, asset });
-      });
+    const generationInputs = prepareGenerationInputs({
+      selectedEngineId: selectedEngine.id,
+      activeMode,
+      submissionMode,
+      form,
+      inputSchema: selectedEngine.inputSchema,
+      inputSchemaSummary,
+      extraInputFields,
+      inputAssets,
+      primaryAssetFieldIds,
+      referenceAssetFieldIds,
+      genericImageFieldIds,
+      frameAssetFieldIds,
+      referenceAudioFieldIds,
+      supportsKlingV3Controls,
+      klingElements,
+      multiPromptActive,
+      multiPromptScenes,
     });
-
-    Object.entries(inputAssets).forEach(([fieldId, items]) => {
-      if (orderedAttachments.some((entry) => entry.field.id === fieldId)) return;
-      const field = fieldIndex.get(fieldId);
-      if (!field) return;
-      items.forEach((asset) => {
-        if (!asset) return;
-        orderedAttachments.push({ field, asset });
-      });
-    });
-
-    let inputsPayload: Array<{
-      name: string;
-      type: string;
-      size: number;
-      kind: 'image' | 'video' | 'audio';
-      slotId?: string;
-      label?: string;
-      url: string;
-      width?: number | null;
-      height?: number | null;
-      assetId?: string;
-    }> | undefined;
-
-    if (orderedAttachments.length) {
-      const collected: typeof inputsPayload = [];
-      for (const { field, asset } of orderedAttachments) {
-        if (!asset) continue;
-        if (asset.status === 'uploading') {
-          showComposerError('Please wait for uploads to finish before generating.');
-          return;
-        }
-        if (asset.status === 'error' || !asset.url) {
-          showComposerError('One of your reference files is unavailable. Remove it and try again.');
-          return;
-        }
-        collected.push({
-          name: asset.name,
-          type: asset.type || (asset.kind === 'image' ? 'image/*' : asset.kind === 'audio' ? 'audio/*' : 'video/*'),
-          size: asset.size,
-          kind: asset.kind,
-          slotId: field.id,
-          label: field.label,
-          url: asset.url,
-          width: asset.width,
-          height: asset.height,
-          assetId: asset.assetId,
-        });
-      }
-      if (collected.length) {
-        inputsPayload = collected;
-      }
+    if (!generationInputs.ok) {
+      showComposerError(generationInputs.message);
+      return;
     }
 
-    const referenceSlots = referenceAssetFieldIds.size > 0 ? referenceAssetFieldIds : genericImageFieldIds;
-    const activeReferenceSlots =
-      selectedEngine.id === 'happy-horse-1-0'
-        ? submissionMode === 'v2v'
-          ? new Set(['reference_image_urls'])
-          : submissionMode === 'ref2v'
-            ? new Set(['image_urls'])
-            : referenceSlots
-        : referenceSlots;
-    const primaryAttachment =
-      inputsPayload?.find(
-        (attachment) => typeof attachment.slotId === 'string' && primaryAssetFieldIds.has(attachment.slotId)
-      ) ?? null;
-    const referenceImageUrls = inputsPayload
-      ? inputsPayload
-          .filter((attachment) => {
-            if (attachment.kind !== 'image' || typeof attachment.url !== 'string') return false;
-            const slotId = attachment.slotId;
-            if (slotId && primaryAssetFieldIds.has(slotId)) return false;
-            if (slotId && frameAssetFieldIds.has(slotId)) return false;
-            if (!slotId) return activeReferenceSlots.size === 0;
-            if (activeReferenceSlots.size === 0) {
-              return !primaryAssetFieldIds.has(slotId);
-            }
-            return activeReferenceSlots.has(slotId);
-          })
-          .map((attachment) => attachment.url)
-          .filter((url, index, self) => self.indexOf(url) === index)
-      : [];
-    const referenceVideoUrls = inputsPayload
-      ? inputsPayload
-          .filter((attachment) => attachment.kind === 'video' && typeof attachment.url === 'string')
-          .map((attachment) => attachment.url)
-          .filter((url, index, self) => self.indexOf(url) === index)
-      : [];
-    const referenceAudioUrls = inputsPayload
-      ? inputsPayload
-          .filter(
-            (attachment) =>
-              attachment.kind === 'audio' &&
-              typeof attachment.url === 'string' &&
-              typeof attachment.slotId === 'string' &&
-              referenceAudioFieldIds.has(attachment.slotId)
-          )
-          .map((attachment) => attachment.url)
-          .filter((url, index, self) => self.indexOf(url) === index)
-      : [];
-
-    const primaryImageUrl =
-      primaryAttachment?.url ?? (activeMode === 'i2v' || activeMode === 'i2i' ? referenceImageUrls[0] : undefined);
-    const primaryAudioUrl =
-      inputsPayload?.find(
-        (attachment) =>
-          attachment.kind === 'audio' &&
-          typeof attachment.url === 'string' &&
-          !(typeof attachment.slotId === 'string' && referenceAudioFieldIds.has(attachment.slotId))
-      )?.url ?? undefined;
-    const endImageUrl =
-      inputsPayload?.find((attachment) => attachment.slotId === 'end_image_url' && typeof attachment.url === 'string')
-        ?.url ?? undefined;
-    const extraInputValues = extraInputFields.reduce<Record<string, unknown>>((acc, { field }) => {
-      const normalized = normalizeExtraInputValue(field, form.extraInputValues[field.id] ?? field.default);
-      if (normalized !== undefined) {
-        acc[field.id] = normalized;
-      }
-      return acc;
-    }, {});
-
-    let klingElementsPayload:
-      | Array<{ frontalImageUrl?: string; referenceImageUrls?: string[]; videoUrl?: string }>
-      | undefined;
-    if (supportsKlingV3Controls && form.mode === 'i2v') {
-      let videoCount = 0;
-      const collected: Array<{ frontalImageUrl?: string; referenceImageUrls?: string[]; videoUrl?: string }> = [];
-      for (const element of klingElements) {
-        const frontal = element.frontal;
-        const references = element.references.filter((asset): asset is KlingElementAsset => Boolean(asset));
-        const video = element.video;
-        const hasAnyAsset = Boolean(frontal || references.length || video);
-        if (!hasAnyAsset) {
-          continue;
-        }
-
-        const assetsToCheck = [frontal, ...references, video].filter(Boolean) as KlingElementAsset[];
-        for (const asset of assetsToCheck) {
-          if (asset.status === 'uploading') {
-            showComposerError('Please wait for element uploads to finish before generating.');
-            return;
-          }
-          if (asset.status === 'error' || !asset.url) {
-            showComposerError('One of your element assets failed to upload. Remove it and try again.');
-            return;
-          }
-        }
-
-        const frontalUrl = frontal?.url;
-        const referenceUrls = references
-          .map((asset) => asset.url)
-          .filter((url): url is string => Boolean(url));
-        const videoUrl = video?.url;
-        if (videoUrl) {
-          videoCount += 1;
-        }
-        const hasImageSet = Boolean(frontalUrl && referenceUrls.length > 0);
-        const hasVideoReference = Boolean(videoUrl);
-        if (!hasImageSet && !hasVideoReference) {
-          showComposerError('Each Kling element needs a frontal image plus at least one reference image, or one video reference.');
-          return;
-        }
-        collected.push({
-          frontalImageUrl: frontalUrl,
-          referenceImageUrls: referenceUrls.length ? referenceUrls : undefined,
-          videoUrl,
-        });
-      }
-      if (videoCount > 1) {
-        showComposerError('Only one Kling element can include a video reference.');
-        return;
-      }
-      if (collected.length) {
-        klingElementsPayload = collected;
-      }
-    }
-
-    const multiPromptPayload = multiPromptActive
-      ? multiPromptScenes
-          .filter((scene) => scene.prompt.trim().length)
-          .map((scene) => ({ prompt: scene.prompt.trim(), duration: Math.round(scene.duration || 0) }))
-      : undefined;
+    const {
+      inputsPayload,
+      primaryAttachment,
+      referenceImageUrls,
+      referenceVideoUrls,
+      referenceAudioUrls,
+      primaryImageUrl,
+      primaryAudioUrl,
+      endImageUrl,
+      extraInputValues,
+      klingElementsPayload,
+      multiPromptPayload,
+    } = generationInputs;
 
     const runIteration = async (iterationIndex: number) => {
       const isImageDrivenMode = submissionMode === 'i2v' || submissionMode === 'i2i';

--- a/frontend/app/(core)/(workspace)/app/_lib/workspace-generation-inputs.ts
+++ b/frontend/app/(core)/(workspace)/app/_lib/workspace-generation-inputs.ts
@@ -1,0 +1,304 @@
+import type { MultiPromptScene } from '@/components/Composer';
+import type { KlingElementAsset, KlingElementState } from '@/components/KlingElementsBuilder';
+import type { EngineCaps, Mode } from '@/types/engines';
+import type { ReferenceAsset } from './workspace-assets';
+import { normalizeExtraInputValue, type FormState } from './workspace-form-state';
+import type { WorkspaceInputFieldEntry, WorkspaceInputSchemaSummary } from './workspace-input-schema';
+
+export type GenerationAttachmentPayload = {
+  name: string;
+  type: string;
+  size: number;
+  kind: 'image' | 'video' | 'audio';
+  slotId?: string;
+  label?: string;
+  url: string;
+  width?: number | null;
+  height?: number | null;
+  assetId?: string;
+};
+
+export type GenerationKlingElementPayload = {
+  frontalImageUrl?: string;
+  referenceImageUrls?: string[];
+  videoUrl?: string;
+};
+
+export type GenerationInputPreparationResult =
+  | {
+      ok: true;
+      inputsPayload?: GenerationAttachmentPayload[];
+      primaryAttachment: GenerationAttachmentPayload | null;
+      referenceImageUrls: string[];
+      referenceVideoUrls: string[];
+      referenceAudioUrls: string[];
+      primaryImageUrl?: string;
+      primaryAudioUrl?: string;
+      endImageUrl?: string;
+      extraInputValues: Record<string, unknown>;
+      klingElementsPayload?: GenerationKlingElementPayload[];
+      multiPromptPayload?: Array<{ prompt: string; duration: number }>;
+    }
+  | {
+      ok: false;
+      message: string;
+    };
+
+export type PrepareGenerationInputsOptions = {
+  selectedEngineId: string;
+  activeMode: Mode;
+  submissionMode: string;
+  form: FormState;
+  inputSchema: EngineCaps['inputSchema'] | null | undefined;
+  inputSchemaSummary: Pick<WorkspaceInputSchemaSummary, 'assetFields'>;
+  extraInputFields: WorkspaceInputFieldEntry[];
+  inputAssets: Record<string, (ReferenceAsset | null)[]>;
+  primaryAssetFieldIds: ReadonlySet<string>;
+  referenceAssetFieldIds: ReadonlySet<string>;
+  genericImageFieldIds: ReadonlySet<string>;
+  frameAssetFieldIds: ReadonlySet<string>;
+  referenceAudioFieldIds: ReadonlySet<string>;
+  supportsKlingV3Controls: boolean;
+  klingElements: KlingElementState[];
+  multiPromptActive: boolean;
+  multiPromptScenes: MultiPromptScene[];
+};
+
+function uniqueValues(values: string[]): string[] {
+  return values.filter((value, index, self) => self.indexOf(value) === index);
+}
+
+function buildAttachmentPayload(
+  field: { id: string; label?: string },
+  asset: ReferenceAsset & { url: string }
+): GenerationAttachmentPayload {
+  return {
+    name: asset.name,
+    type: asset.type || (asset.kind === 'image' ? 'image/*' : asset.kind === 'audio' ? 'audio/*' : 'video/*'),
+    size: asset.size,
+    kind: asset.kind,
+    slotId: field.id,
+    label: field.label,
+    url: asset.url,
+    width: asset.width,
+    height: asset.height,
+    assetId: asset.assetId,
+  };
+}
+
+function buildKlingElementsPayload(
+  options: Pick<PrepareGenerationInputsOptions, 'supportsKlingV3Controls' | 'form' | 'klingElements'>
+): GenerationInputPreparationResult {
+  if (!options.supportsKlingV3Controls || options.form.mode !== 'i2v') {
+    return {
+      ok: true,
+      primaryAttachment: null,
+      referenceImageUrls: [],
+      referenceVideoUrls: [],
+      referenceAudioUrls: [],
+      extraInputValues: {},
+    };
+  }
+
+  let videoCount = 0;
+  const collected: GenerationKlingElementPayload[] = [];
+  for (const element of options.klingElements) {
+    const frontal = element.frontal;
+    const references = element.references.filter((asset): asset is KlingElementAsset => Boolean(asset));
+    const video = element.video;
+    const hasAnyAsset = Boolean(frontal || references.length || video);
+    if (!hasAnyAsset) {
+      continue;
+    }
+
+    const assetsToCheck = [frontal, ...references, video].filter(Boolean) as KlingElementAsset[];
+    for (const asset of assetsToCheck) {
+      if (asset.status === 'uploading') {
+        return { ok: false, message: 'Please wait for element uploads to finish before generating.' };
+      }
+      if (asset.status === 'error' || !asset.url) {
+        return { ok: false, message: 'One of your element assets failed to upload. Remove it and try again.' };
+      }
+    }
+
+    const frontalUrl = frontal?.url;
+    const referenceUrls = references.map((asset) => asset.url).filter((url): url is string => Boolean(url));
+    const videoUrl = video?.url;
+    if (videoUrl) {
+      videoCount += 1;
+    }
+    const hasImageSet = Boolean(frontalUrl && referenceUrls.length > 0);
+    const hasVideoReference = Boolean(videoUrl);
+    if (!hasImageSet && !hasVideoReference) {
+      return {
+        ok: false,
+        message: 'Each Kling element needs a frontal image plus at least one reference image, or one video reference.',
+      };
+    }
+    collected.push({
+      frontalImageUrl: frontalUrl,
+      referenceImageUrls: referenceUrls.length ? referenceUrls : undefined,
+      videoUrl,
+    });
+  }
+
+  if (videoCount > 1) {
+    return { ok: false, message: 'Only one Kling element can include a video reference.' };
+  }
+
+  return {
+    ok: true,
+    primaryAttachment: null,
+    referenceImageUrls: [],
+    referenceVideoUrls: [],
+    referenceAudioUrls: [],
+    extraInputValues: {},
+    klingElementsPayload: collected.length ? collected : undefined,
+  };
+}
+
+export function prepareGenerationInputs(options: PrepareGenerationInputsOptions): GenerationInputPreparationResult {
+  const fieldIndex = new Map<string, { id: string; label?: string }>();
+  if (options.inputSchema) {
+    [...(options.inputSchema.required ?? []), ...(options.inputSchema.optional ?? [])].forEach((field) => {
+      fieldIndex.set(field.id, field);
+    });
+  }
+
+  const orderedAttachments: Array<{ field: { id: string; label?: string }; asset: ReferenceAsset }> = [];
+  options.inputSchemaSummary.assetFields.forEach(({ field }) => {
+    const items = options.inputAssets[field.id] ?? [];
+    items.forEach((asset) => {
+      if (!asset) return;
+      orderedAttachments.push({ field, asset });
+    });
+  });
+
+  Object.entries(options.inputAssets).forEach(([fieldId, items]) => {
+    if (orderedAttachments.some((entry) => entry.field.id === fieldId)) return;
+    const field = fieldIndex.get(fieldId);
+    if (!field) return;
+    items.forEach((asset) => {
+      if (!asset) return;
+      orderedAttachments.push({ field, asset });
+    });
+  });
+
+  let inputsPayload: GenerationAttachmentPayload[] | undefined;
+  if (orderedAttachments.length) {
+    const collected: GenerationAttachmentPayload[] = [];
+    for (const { field, asset } of orderedAttachments) {
+      const assetUrl = asset.url;
+      if (asset.status === 'uploading') {
+        return { ok: false, message: 'Please wait for uploads to finish before generating.' };
+      }
+      if (asset.status === 'error' || !assetUrl) {
+        return { ok: false, message: 'One of your reference files is unavailable. Remove it and try again.' };
+      }
+      collected.push(buildAttachmentPayload(field, { ...asset, url: assetUrl }));
+    }
+    if (collected.length) {
+      inputsPayload = collected;
+    }
+  }
+
+  const referenceSlots = options.referenceAssetFieldIds.size > 0
+    ? options.referenceAssetFieldIds
+    : options.genericImageFieldIds;
+  const activeReferenceSlots =
+    options.selectedEngineId === 'happy-horse-1-0'
+      ? options.submissionMode === 'v2v'
+        ? new Set(['reference_image_urls'])
+        : options.submissionMode === 'ref2v'
+          ? new Set(['image_urls'])
+          : referenceSlots
+      : referenceSlots;
+  const primaryAttachment =
+    inputsPayload?.find(
+      (attachment) => typeof attachment.slotId === 'string' && options.primaryAssetFieldIds.has(attachment.slotId)
+    ) ?? null;
+  const referenceImageUrls = inputsPayload
+    ? uniqueValues(
+        inputsPayload
+          .filter((attachment) => {
+            if (attachment.kind !== 'image' || typeof attachment.url !== 'string') return false;
+            const slotId = attachment.slotId;
+            if (slotId && options.primaryAssetFieldIds.has(slotId)) return false;
+            if (slotId && options.frameAssetFieldIds.has(slotId)) return false;
+            if (!slotId) return activeReferenceSlots.size === 0;
+            if (activeReferenceSlots.size === 0) {
+              return !options.primaryAssetFieldIds.has(slotId);
+            }
+            return activeReferenceSlots.has(slotId);
+          })
+          .map((attachment) => attachment.url)
+      )
+    : [];
+  const referenceVideoUrls = inputsPayload
+    ? uniqueValues(
+        inputsPayload
+          .filter((attachment) => attachment.kind === 'video' && typeof attachment.url === 'string')
+          .map((attachment) => attachment.url)
+      )
+    : [];
+  const referenceAudioUrls = inputsPayload
+    ? uniqueValues(
+        inputsPayload
+          .filter(
+            (attachment) =>
+              attachment.kind === 'audio' &&
+              typeof attachment.url === 'string' &&
+              typeof attachment.slotId === 'string' &&
+              options.referenceAudioFieldIds.has(attachment.slotId)
+          )
+          .map((attachment) => attachment.url)
+      )
+    : [];
+
+  const primaryImageUrl =
+    primaryAttachment?.url ??
+    (options.activeMode === 'i2v' || options.activeMode === 'i2i' ? referenceImageUrls[0] : undefined);
+  const primaryAudioUrl =
+    inputsPayload?.find(
+      (attachment) =>
+        attachment.kind === 'audio' &&
+        typeof attachment.url === 'string' &&
+        !(typeof attachment.slotId === 'string' && options.referenceAudioFieldIds.has(attachment.slotId))
+    )?.url ?? undefined;
+  const endImageUrl =
+    inputsPayload?.find((attachment) => attachment.slotId === 'end_image_url' && typeof attachment.url === 'string')
+      ?.url ?? undefined;
+  const extraInputValues = options.extraInputFields.reduce<Record<string, unknown>>((acc, { field }) => {
+    const normalized = normalizeExtraInputValue(field, options.form.extraInputValues[field.id] ?? field.default);
+    if (normalized !== undefined) {
+      acc[field.id] = normalized;
+    }
+    return acc;
+  }, {});
+
+  const klingResult = buildKlingElementsPayload(options);
+  if (!klingResult.ok) {
+    return klingResult;
+  }
+
+  const multiPromptPayload = options.multiPromptActive
+    ? options.multiPromptScenes
+        .filter((scene) => scene.prompt.trim().length)
+        .map((scene) => ({ prompt: scene.prompt.trim(), duration: Math.round(scene.duration || 0) }))
+    : undefined;
+
+  return {
+    ok: true,
+    inputsPayload,
+    primaryAttachment,
+    referenceImageUrls,
+    referenceVideoUrls,
+    referenceAudioUrls,
+    primaryImageUrl,
+    primaryAudioUrl,
+    endImageUrl,
+    extraInputValues,
+    klingElementsPayload: klingResult.klingElementsPayload,
+    multiPromptPayload,
+  };
+}

--- a/tests/workspace-generation-inputs.test.ts
+++ b/tests/workspace-generation-inputs.test.ts
@@ -1,0 +1,290 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type { MultiPromptScene } from '../frontend/components/Composer';
+import type { KlingElementState } from '../frontend/components/KlingElementsBuilder';
+import type { EngineInputField } from '../frontend/types/engines';
+import type { ReferenceAsset } from '../frontend/app/(core)/(workspace)/app/_lib/workspace-assets';
+import type { FormState } from '../frontend/app/(core)/(workspace)/app/_lib/workspace-form-state';
+import {
+  prepareGenerationInputs,
+  type GenerationInputPreparationResult,
+} from '../frontend/app/(core)/(workspace)/app/_lib/workspace-generation-inputs';
+
+function field(id: string, type: EngineInputField['type'], label = id): EngineInputField {
+  return { id, type, label };
+}
+
+function asset(overrides: Partial<ReferenceAsset> = {}): ReferenceAsset {
+  const id = overrides.id ?? 'asset_1';
+  const kind = overrides.kind ?? 'image';
+  return {
+    id,
+    fieldId: overrides.fieldId ?? 'image_url',
+    previewUrl: overrides.previewUrl ?? `https://cdn.example.com/${id}.jpg`,
+    kind,
+    name: overrides.name ?? `${id}.${kind === 'video' ? 'mp4' : kind === 'audio' ? 'mp3' : 'jpg'}`,
+    size: overrides.size ?? 123,
+    type: overrides.type ?? (kind === 'video' ? 'video/mp4' : kind === 'audio' ? 'audio/mpeg' : 'image/jpeg'),
+    url: overrides.url ?? `https://cdn.example.com/${id}.${kind === 'video' ? 'mp4' : kind === 'audio' ? 'mp3' : 'jpg'}`,
+    width: overrides.width ?? null,
+    height: overrides.height ?? null,
+    assetId: overrides.assetId ?? id,
+    status: overrides.status ?? 'ready',
+  };
+}
+
+function baseForm(overrides: Partial<FormState> = {}): FormState {
+  return {
+    engineId: 'seedance-2-0',
+    mode: 'ref2v',
+    durationSec: 5,
+    resolution: '720p',
+    aspectRatio: '16:9',
+    fps: 24,
+    iterations: 1,
+    seedLocked: false,
+    loop: false,
+    audio: false,
+    extraInputValues: {},
+    ...overrides,
+  };
+}
+
+function assertReady(
+  result: GenerationInputPreparationResult
+): asserts result is Extract<GenerationInputPreparationResult, { ok: true }> {
+  assert.equal(result.ok, true, result.ok ? undefined : result.message);
+}
+
+test('prepareGenerationInputs orders attachments and derives generation URL groups', () => {
+  const primary = field('image_url', 'image', 'Primary image');
+  const references = field('image_urls', 'image', 'References');
+  const video = field('reference_video_urls', 'video', 'Reference videos');
+  const referenceAudio = field('reference_audio_urls', 'audio', 'Reference audio');
+  const primaryAudio = field('audio_url', 'audio', 'Voice');
+  const endImage = field('end_image_url', 'image', 'End frame');
+  const style = field('style_strength', 'number', 'Style strength');
+  const imageUrlAsset = asset({ id: 'primary', fieldId: 'image_url', url: 'https://cdn.example.com/primary.jpg' });
+  const referenceOne = asset({ id: 'ref1', fieldId: 'image_urls', url: 'https://cdn.example.com/ref-1.jpg' });
+  const referenceDuplicate = asset({ id: 'ref2', fieldId: 'image_urls', url: 'https://cdn.example.com/ref-1.jpg' });
+  const videoAsset = asset({
+    id: 'video1',
+    fieldId: 'reference_video_urls',
+    kind: 'video',
+    url: 'https://cdn.example.com/ref.mp4',
+  });
+  const referenceAudioAsset = asset({
+    id: 'audio_ref',
+    fieldId: 'reference_audio_urls',
+    kind: 'audio',
+    url: 'https://cdn.example.com/ref.mp3',
+  });
+  const primaryAudioAsset = asset({
+    id: 'audio_primary',
+    fieldId: 'audio_url',
+    kind: 'audio',
+    url: 'https://cdn.example.com/voice.mp3',
+  });
+  const endImageAsset = asset({ id: 'end', fieldId: 'end_image_url', url: 'https://cdn.example.com/end.jpg' });
+
+  const result = prepareGenerationInputs({
+    selectedEngineId: 'seedance-2-0',
+    activeMode: 'ref2v',
+    submissionMode: 'ref2v',
+    form: baseForm({ extraInputValues: { style_strength: '0.72' } }),
+    inputSchema: {
+      required: [primary, references],
+      optional: [video, referenceAudio, primaryAudio, endImage, style],
+    },
+    inputSchemaSummary: {
+      assetFields: [
+        { field: primary, required: true, role: 'primary' },
+        { field: references, required: true, role: 'reference' },
+        { field: video, required: false, role: 'reference' },
+        { field: referenceAudio, required: false, role: 'reference' },
+        { field: primaryAudio, required: false, role: 'generic' },
+        { field: endImage, required: false, role: 'frame' },
+      ],
+    },
+    extraInputFields: [{ field: style, required: false }],
+    inputAssets: {
+      image_url: [imageUrlAsset],
+      image_urls: [referenceOne, referenceDuplicate],
+      reference_video_urls: [videoAsset],
+      reference_audio_urls: [referenceAudioAsset],
+      audio_url: [primaryAudioAsset],
+      end_image_url: [endImageAsset],
+    },
+    primaryAssetFieldIds: new Set(['image_url']),
+    referenceAssetFieldIds: new Set(['image_urls']),
+    genericImageFieldIds: new Set(['image_urls']),
+    frameAssetFieldIds: new Set(['end_image_url']),
+    referenceAudioFieldIds: new Set(['reference_audio_urls']),
+    supportsKlingV3Controls: false,
+    klingElements: [],
+    multiPromptActive: false,
+    multiPromptScenes: [],
+  });
+
+  assertReady(result);
+  assert.equal(result.inputsPayload?.[0]?.slotId, 'image_url');
+  assert.equal(result.inputsPayload?.[1]?.slotId, 'image_urls');
+  assert.equal(result.primaryAttachment?.url, 'https://cdn.example.com/primary.jpg');
+  assert.deepEqual(result.referenceImageUrls, ['https://cdn.example.com/ref-1.jpg']);
+  assert.deepEqual(result.referenceVideoUrls, ['https://cdn.example.com/ref.mp4']);
+  assert.deepEqual(result.referenceAudioUrls, ['https://cdn.example.com/ref.mp3']);
+  assert.equal(result.primaryImageUrl, 'https://cdn.example.com/primary.jpg');
+  assert.equal(result.primaryAudioUrl, 'https://cdn.example.com/voice.mp3');
+  assert.equal(result.endImageUrl, 'https://cdn.example.com/end.jpg');
+  assert.deepEqual(result.extraInputValues, { style_strength: 0.72 });
+});
+
+test('prepareGenerationInputs preserves Happy Horse reference slot routing', () => {
+  const imageUrls = field('image_urls', 'image', 'Happy Horse R2V refs');
+  const referenceImageUrls = field('reference_image_urls', 'image', 'Happy Horse V2V refs');
+  const result = prepareGenerationInputs({
+    selectedEngineId: 'happy-horse-1-0',
+    activeMode: 't2v',
+    submissionMode: 'v2v',
+    form: baseForm({ engineId: 'happy-horse-1-0', mode: 'v2v' }),
+    inputSchema: { required: [], optional: [imageUrls, referenceImageUrls] },
+    inputSchemaSummary: {
+      assetFields: [
+        { field: imageUrls, required: false, role: 'reference' },
+        { field: referenceImageUrls, required: false, role: 'reference' },
+      ],
+    },
+    extraInputFields: [],
+    inputAssets: {
+      image_urls: [asset({ id: 'r2v', fieldId: 'image_urls', url: 'https://cdn.example.com/r2v.jpg' })],
+      reference_image_urls: [
+        asset({ id: 'v2v', fieldId: 'reference_image_urls', url: 'https://cdn.example.com/v2v.jpg' }),
+      ],
+    },
+    primaryAssetFieldIds: new Set(),
+    referenceAssetFieldIds: new Set(['image_urls', 'reference_image_urls']),
+    genericImageFieldIds: new Set(['image_urls', 'reference_image_urls']),
+    frameAssetFieldIds: new Set(),
+    referenceAudioFieldIds: new Set(),
+    supportsKlingV3Controls: false,
+    klingElements: [],
+    multiPromptActive: false,
+    multiPromptScenes: [],
+  });
+
+  assertReady(result);
+  assert.deepEqual(result.referenceImageUrls, ['https://cdn.example.com/v2v.jpg']);
+});
+
+test('prepareGenerationInputs reports unavailable assets before generation', () => {
+  const image = field('image_url', 'image', 'Primary image');
+  const result = prepareGenerationInputs({
+    selectedEngineId: 'seedance-2-0',
+    activeMode: 'i2v',
+    submissionMode: 'i2v',
+    form: baseForm({ mode: 'i2v' }),
+    inputSchema: { required: [image], optional: [] },
+    inputSchemaSummary: { assetFields: [{ field: image, required: true, role: 'primary' }] },
+    extraInputFields: [],
+    inputAssets: { image_url: [asset({ fieldId: 'image_url', status: 'uploading' })] },
+    primaryAssetFieldIds: new Set(['image_url']),
+    referenceAssetFieldIds: new Set(),
+    genericImageFieldIds: new Set(),
+    frameAssetFieldIds: new Set(),
+    referenceAudioFieldIds: new Set(),
+    supportsKlingV3Controls: false,
+    klingElements: [],
+    multiPromptActive: false,
+    multiPromptScenes: [],
+  });
+
+  assert.deepEqual(result, {
+    ok: false,
+    message: 'Please wait for uploads to finish before generating.',
+  });
+});
+
+test('prepareGenerationInputs builds Kling element and multi-prompt payloads', () => {
+  const klingElements: KlingElementState[] = [
+    {
+      id: 'element_1',
+      frontal: {
+        id: 'frontal',
+        previewUrl: 'https://cdn.example.com/frontal.jpg',
+        kind: 'image',
+        name: 'frontal.jpg',
+        status: 'ready',
+        url: 'https://cdn.example.com/frontal.jpg',
+      },
+      references: [
+        {
+          id: 'ref',
+          previewUrl: 'https://cdn.example.com/kling-ref.jpg',
+          kind: 'image',
+          name: 'ref.jpg',
+          status: 'ready',
+          url: 'https://cdn.example.com/kling-ref.jpg',
+        },
+        null,
+      ],
+      video: null,
+    },
+    {
+      id: 'element_2',
+      frontal: null,
+      references: [null],
+      video: {
+        id: 'video',
+        previewUrl: 'https://cdn.example.com/kling-video.mp4',
+        kind: 'video',
+        name: 'video.mp4',
+        status: 'ready',
+        url: 'https://cdn.example.com/kling-video.mp4',
+      },
+    },
+  ];
+  const scenes: MultiPromptScene[] = [
+    { id: 'scene_1', prompt: ' Wide shot ', duration: 4.4 },
+    { id: 'scene_2', prompt: '', duration: 5 },
+    { id: 'scene_3', prompt: 'Close-up', duration: 6.6 },
+  ];
+
+  const result = prepareGenerationInputs({
+    selectedEngineId: 'kling-3',
+    activeMode: 'i2v',
+    submissionMode: 'i2v',
+    form: baseForm({ engineId: 'kling-3', mode: 'i2v' }),
+    inputSchema: { required: [], optional: [] },
+    inputSchemaSummary: { assetFields: [] },
+    extraInputFields: [],
+    inputAssets: {},
+    primaryAssetFieldIds: new Set(),
+    referenceAssetFieldIds: new Set(),
+    genericImageFieldIds: new Set(),
+    frameAssetFieldIds: new Set(),
+    referenceAudioFieldIds: new Set(),
+    supportsKlingV3Controls: true,
+    klingElements,
+    multiPromptActive: true,
+    multiPromptScenes: scenes,
+  });
+
+  assertReady(result);
+  assert.deepEqual(result.klingElementsPayload, [
+    {
+      frontalImageUrl: 'https://cdn.example.com/frontal.jpg',
+      referenceImageUrls: ['https://cdn.example.com/kling-ref.jpg'],
+      videoUrl: undefined,
+    },
+    {
+      frontalImageUrl: undefined,
+      referenceImageUrls: undefined,
+      videoUrl: 'https://cdn.example.com/kling-video.mp4',
+    },
+  ]);
+  assert.deepEqual(result.multiPromptPayload, [
+    { prompt: 'Wide shot', duration: 4 },
+    { prompt: 'Close-up', duration: 7 },
+  ]);
+});


### PR DESCRIPTION
## Summary
- Extract generation attachment ordering, derived input URL groups, extra input normalization, Kling element payloads, and multi-prompt payloads into `workspace-generation-inputs`.
- Keep `AppClient.tsx` responsible for workflow guards, wallet checks, progress state, and the `runGenerate` call.
- Add targeted generation input helper coverage and update the workspace route guide.

## Test Plan
- `pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/workspace-generation-inputs.test.ts`
- `cd frontend && ./node_modules/.bin/tsc --noEmit`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- `pnpm run test:validate`