### PR TITLE
[codex] Extract workspace generation request helpers

### DIFF
--- a/frontend/app/(core)/(workspace)/app/AGENTS.md
+++ b/frontend/app/(core)/(workspace)/app/AGENTS.md
@@ -6,7 +6,7 @@ This route is the main signed-in video generation workspace.
 
 - `AppClient.tsx`: top-level state orchestration while the workspace is being split.
 - `_components`: route-local chrome, panels, skeletons, modals, and presentational UI.
-- `_lib`: route-local pure helpers for previews, render grouping, render status reconciliation, generation input preparation, video settings hydration, workspace boot hydration, storage, copy fallback, client constants, asset normalization, asset selection, payload builders, input normalization, and workflow mapping.
+- `_lib`: route-local pure helpers for previews, render grouping, render status reconciliation, generation input preparation, generation guards and payloads, video settings hydration, workspace boot hydration, storage, copy fallback, client constants, asset normalization, asset selection, payload builders, input normalization, and workflow mapping.
 - Tool-specific workspaces should stay in their own route folders unless code is clearly shared.
 
 ## Refactor Rules
@@ -15,7 +15,8 @@ This route is the main signed-in video generation workspace.
 - Keep schema summarization, asset-library normalization, and copy merging in `_lib`; `AppClient.tsx` should consume those results instead of rebuilding them inline.
 - Keep render grouping and preview tile mapping in `_lib`; `AppClient.tsx` should decide state transitions, not rebuild group summary objects inline.
 - Keep job-to-render conversion, status polling projections, and recent-job reconciliation in `_lib`; `AppClient.tsx` should own timers and network calls.
-- Keep generation attachment ordering, derived input URLs, Kling element payloads, and multi-prompt payloads in `_lib`; `AppClient.tsx` should keep workflow guards and the `runGenerate` call.
+- Keep generation attachment ordering, derived input URLs, Kling element payloads, and multi-prompt payloads in `_lib`; `AppClient.tsx` should consume prepared inputs instead of deriving attachment URLs inline.
+- Keep generation validation guards and `runGenerate` payload assembly in `_lib`; `AppClient.tsx` should decide when to show errors and when to call the network.
 - Keep video settings snapshot parsing and job media patch mapping in `_lib`; `AppClient.tsx` should wire those results into React state.
 - Keep workspace request parsing and boot hydration decisions in `_lib`; `AppClient.tsx` should apply the resolved state.
 - Keep asset-library selection, reference slot insertion, and Kling library asset mapping in `_lib`; `AppClient.tsx` should handle network calls and React state wiring.

--- a/frontend/app/(core)/(workspace)/app/AppClient.tsx
+++ b/frontend/app/(core)/(workspace)/app/AppClient.tsx
@@ -44,14 +44,8 @@ import { Button, ButtonLink } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import type { AssetLibraryModalProps } from '@/components/library/AssetLibraryModal';
 import {
-  getLumaRay2DurationInfo,
-  getLumaRay2ResolutionInfo,
   isLumaRay2EngineId,
-  isLumaRay2AspectRatio,
   isLumaRay2GenerateMode,
-  toLumaRay2DurationLabel,
-  LUMA_RAY2_ERROR_UNSUPPORTED,
-  type LumaRay2DurationLabel,
 } from '@/lib/luma-ray2';
 import { useI18n } from '@/lib/i18n/I18nProvider';
 import { isPlaceholderMediaUrl } from '@/lib/media';
@@ -91,6 +85,13 @@ import {
   type FormState,
 } from './_lib/workspace-form-state';
 import { prepareGenerationInputs } from './_lib/workspace-generation-inputs';
+import {
+  getGenerationIterationGuardMessage,
+  getLumaRay2GenerationContext,
+  getStartRenderValidationMessage,
+  supportsNegativePromptInput,
+} from './_lib/workspace-generation-guards';
+import { buildWorkspaceGeneratePayload } from './_lib/workspace-generation-payload';
 import {
   buildComposerModeToggles,
   coerceFormState,
@@ -2647,79 +2648,34 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
       return;
     }
     setPreflightError(undefined);
-    if (audioWorkflowUnsupported) {
-      showComposerError(workflowCopy.audioUnsupported);
-      return;
-    }
     const trimmedPrompt = effectivePrompt.trim();
     const trimmedNegativePrompt = negativePrompt.trim();
-    const supportsNegativePrompt = Boolean(inputSchemaSummary.negativePromptField);
-    const isLumaRay2 = isLumaRay2EngineId(selectedEngine.id);
-    const isLumaRay2GenerateWorkflow = isLumaRay2 && isLumaRay2GenerateMode(submissionMode);
-    const isLumaRay2ReframeWorkflow = isLumaRay2 && submissionMode === 'reframe';
-    const lumaDuration = isLumaRay2
-      ? getLumaRay2DurationInfo(form.durationOption ?? form.durationSec)
-      : null;
-    const lumaResolution = isLumaRay2 ? getLumaRay2ResolutionInfo(form.resolution) : null;
-    const lumaAspectOk =
-      !isLumaRay2 || isLumaRay2AspectRatio(form.aspectRatio, { includeSquare: isLumaRay2ReframeWorkflow });
-
-    if (multiPromptActive && multiPromptInvalid) {
-      showComposerError(multiPromptError ?? 'Multi-prompt requires a prompt per scene and a valid total duration.');
-      return;
-    }
-
-    if (promptCharLimitExceeded && typeof promptMaxChars === 'number') {
-      const overflow = prompt.length - promptMaxChars;
-      showComposerError(
-        `Prompt is ${overflow} character${overflow === 1 ? '' : 's'} over the ${promptMaxChars}-character limit for ${selectedEngine.label}.`
-      );
-      return;
-    }
-
-    if (inputSchemaSummary.promptRequired && !trimmedPrompt) {
-      showComposerError('A prompt is required for this engine and mode.');
-      return;
-    }
-
-    if (
-      supportsNegativePrompt &&
-      inputSchemaSummary.negativePromptRequired &&
-      !trimmedNegativePrompt
-    ) {
-      const label = inputSchemaSummary.negativePromptField?.label ?? 'Negative prompt';
-      showComposerError(`${label} is required before generating.`);
-      return;
-    }
-
-    const missingAssetField = inputSchemaSummary.assetFields.find(({ field, required }) => {
-      if (!required) return false;
-      const minCount = field.minCount ?? 1;
-      const current = (inputAssets[field.id]?.filter((asset) => asset !== null).length) ?? 0;
-      return current < minCount;
+    const supportsNegativePrompt = supportsNegativePromptInput(inputSchemaSummary);
+    const lumaContext = getLumaRay2GenerationContext({
+      selectedEngineId: selectedEngine.id,
+      submissionMode,
+      form,
     });
-
-    if (missingAssetField) {
-      showComposerError(`${missingAssetField.field.label} is required before generating.`);
-      return;
-    }
-
-    const missingGenericField = extraInputFields.find(({ field, required }) => {
-      if (!required) return false;
-      const value = normalizeExtraInputValue(field, form.extraInputValues[field.id] ?? field.default);
-      return value === undefined;
+    const validationMessage = getStartRenderValidationMessage({
+      audioWorkflowUnsupported,
+      audioUnsupportedMessage: workflowCopy.audioUnsupported,
+      multiPromptActive,
+      multiPromptInvalid,
+      multiPromptError,
+      promptLength: prompt.length,
+      promptCharLimitExceeded,
+      promptMaxChars,
+      selectedEngineLabel: selectedEngine.label,
+      trimmedPrompt,
+      trimmedNegativePrompt,
+      inputSchemaSummary,
+      inputAssets,
+      extraInputFields,
+      form,
+      lumaContext,
     });
-
-    if (missingGenericField) {
-      showComposerError(`${missingGenericField.field.label} is required before generating.`);
-      return;
-    }
-
-    if (
-      (isLumaRay2GenerateWorkflow && (!lumaDuration || !lumaResolution || !lumaAspectOk)) ||
-      (isLumaRay2ReframeWorkflow && !lumaAspectOk)
-    ) {
-      showComposerError(LUMA_RAY2_ERROR_UNSUPPORTED);
+    if (validationMessage) {
+      showComposerError(validationMessage);
       return;
     }
 
@@ -2839,74 +2795,26 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
     } = generationInputs;
 
     const runIteration = async (iterationIndex: number) => {
-      const isImageDrivenMode = submissionMode === 'i2v' || submissionMode === 'i2i';
-      const isReferenceImageMode = submissionMode === 'ref2v';
-      const isFirstLastMode = submissionMode === 'fl2v';
-      const firstFrameAttachment = isFirstLastMode
-        ? (inputsPayload?.find((attachment) => attachment.slotId === 'first_frame_url') ?? primaryAttachment)
-        : null;
-      const lastFrameAttachment = isFirstLastMode
-        ? inputsPayload?.find((attachment) => attachment.slotId === 'last_frame_url')
-        : null;
-
-      if (allowsUnifiedVeoFirstLast && hasLastFrameInput && !primaryImageUrl) {
-        showComposerError('Add a start image before using Last frame with Veo.');
-        return;
-      }
-      if (isImageDrivenMode && !primaryImageUrl) {
-        const guardMessage = selectedEngine.id.startsWith('sora-2')
-          ? 'Ajoutez une image (URL ou fichier) pour lancer Image → Video avec Sora.'
-          : `Add at least one ${primaryAssetFieldLabel.toLowerCase()} (URL or upload) before running this mode.`;
+      const guardMessage = getGenerationIterationGuardMessage({
+        selectedEngineId: selectedEngine.id,
+        submissionMode,
+        allowsUnifiedVeoFirstLast,
+        hasLastFrameInput,
+        isUnifiedSeedance,
+        primaryImageUrl,
+        primaryAudioUrl,
+        primaryAssetFieldLabel,
+        referenceImageUrls,
+        referenceVideoUrls,
+        referenceAudioUrls,
+        inputsPayload,
+        primaryAttachment,
+        addReferenceMediaBeforeAudioMessage: workflowCopy.addReferenceMediaBeforeAudio,
+        extendOrRetakeSourceVideoMessage: workflowCopy.addSourceVideo(getLocalizedModeLabel(submissionMode, uiLocale)),
+      });
+      if (guardMessage) {
         showComposerError(guardMessage);
         return;
-      }
-      if (isReferenceImageMode) {
-        if (isUnifiedSeedance) {
-          if (referenceImageUrls.length === 0 && referenceVideoUrls.length === 0) {
-            showComposerError(
-              referenceAudioUrls.length > 0
-                ? workflowCopy.addReferenceMediaBeforeAudio
-                : 'Add at least one reference image or reference video before running Seedance Reference → Video.'
-            );
-            return;
-          }
-        } else if (referenceImageUrls.length === 0) {
-          showComposerError(
-            selectedEngine.id === 'happy-horse-1-0'
-              ? 'Add 1–9 reference images before running Happy Horse R2V.'
-              : 'Add 1–4 reference images before running Reference → Video.'
-          );
-          return;
-        }
-      }
-      const isVideoDrivenMode = submissionMode === 'r2v';
-      if (isVideoDrivenMode && referenceVideoUrls.length === 0) {
-        showComposerError('Add 1–3 reference videos (MP4/MOV) before running Reference → Video.');
-        return;
-      }
-      const isAudioDrivenMode = submissionMode === 'a2v';
-      if (isAudioDrivenMode && !primaryAudioUrl) {
-        showComposerError('Add an audio file before running Audio → Video.');
-        return;
-      }
-      const isExtendOrRetakeMode = submissionMode === 'extend' || submissionMode === 'retake';
-      if (isExtendOrRetakeMode && referenceVideoUrls.length === 0) {
-        showComposerError(workflowCopy.addSourceVideo(getLocalizedModeLabel(submissionMode, uiLocale)));
-        return;
-      }
-      if (isFirstLastMode) {
-        if (!firstFrameAttachment || !lastFrameAttachment) {
-          showComposerError('Upload both a start image and last frame before generating with Veo.');
-          return;
-        }
-        const sameSource =
-          firstFrameAttachment.assetId && lastFrameAttachment.assetId
-            ? firstFrameAttachment.assetId === lastFrameAttachment.assetId
-            : firstFrameAttachment.url === lastFrameAttachment.url;
-        if (sameSource) {
-          showComposerError('First and last frames must be two different images for this engine.');
-          return;
-        }
       }
 
       const localKey = `local_${batchId}_${iterationIndex + 1}`;
@@ -3034,84 +2942,43 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
       startProgressTracking();
 
       try {
-        const shouldSendAspectRatio = !capability || (capability.aspectRatio?.length ?? 0) > 0;
-        const resolvedDurationSeconds = isLumaRay2GenerateWorkflow && lumaDuration ? lumaDuration.seconds : effectiveDurationSec;
-        const durationOptionLabel: LumaRay2DurationLabel | undefined =
-          typeof form.durationOption === 'string'
-            ? (['5s', '9s'].includes(form.durationOption) ? (form.durationOption as LumaRay2DurationLabel) : undefined)
-            : undefined;
-        const resolvedDurationLabel =
-          isLumaRay2GenerateWorkflow && lumaDuration
-            ? lumaDuration.label
-            : toLumaRay2DurationLabel(effectiveDurationSec, durationOptionLabel) ??
-              durationOptionLabel ??
-              effectiveDurationSec;
-        const shouldSendDuration = !capability || Boolean(capability.duration || capability.frames);
-        const shouldSendResolution = !capability || (capability.resolution?.length ?? 0) > 0;
-        const resolvedResolution = isLumaRay2GenerateWorkflow && lumaResolution ? lumaResolution.value : form.resolution;
-        const shouldSendFps =
-          !capability ||
-          (Array.isArray(capability.fps) ? capability.fps.length > 0 : typeof capability.fps === 'number');
-        const seedNumber =
-          typeof form.seed === 'number' && Number.isFinite(form.seed) ? Math.trunc(form.seed) : undefined;
-        const cameraFixed =
-          typeof form.cameraFixed === 'boolean' ? form.cameraFixed : undefined;
-        const safetyChecker =
-          typeof form.safetyChecker === 'boolean' ? form.safetyChecker : undefined;
-
-        const generatePayload: Parameters<typeof runGenerate>[0] = {
-          engineId: selectedEngine.id,
-          prompt: trimmedPrompt,
-          mode: submissionMode,
-          durationSec: resolvedDurationSeconds,
-          membershipTier: memberTier,
-          payment: { mode: paymentMode },
-          cfgScale: typeof cfgScale === 'number' ? cfgScale : undefined,
-          ...(selectedEngine.id.startsWith('sora-2')
-            ? { variant: selectedEngine.id === 'sora-2-pro' ? 'sora2pro' : 'sora2' }
-            : {}),
-          ...(shouldSendDuration ? { durationOption: resolvedDurationLabel } : {}),
-          ...(form.numFrames != null ? { numFrames: form.numFrames } : {}),
-          ...(shouldSendResolution ? { resolution: resolvedResolution } : {}),
-          ...(shouldSendFps ? { fps: form.fps } : {}),
-          ...(shouldSendAspectRatio ? { aspectRatio: form.aspectRatio } : {}),
-          ...(supportsNegativePrompt && trimmedNegativePrompt ? { negativePrompt: trimmedNegativePrompt } : {}),
-          ...(supportsAudioToggle ? { audio: form.audio } : {}),
-          ...(inputsPayload ? { inputs: inputsPayload } : {}),
-          ...(primaryImageUrl ? { imageUrl: primaryImageUrl } : {}),
-          ...(primaryAudioUrl ? { audioUrl: primaryAudioUrl } : {}),
-          ...(referenceImageUrls.length ? { referenceImages: referenceImageUrls } : {}),
-          ...(endImageUrl ? { endImageUrl } : {}),
-          ...(Object.keys(extraInputValues).length ? { extraInputValues } : {}),
-          ...(multiPromptPayload && multiPromptPayload.length ? { multiPrompt: multiPromptPayload } : {}),
-          ...(supportsKlingV3Controls
-            ? {
-                shotType: activeMode === 'i2v' ? 'customize' : shotType,
-                ...(supportsKlingV3VoiceControl && voiceIds.length ? { voiceIds } : {}),
-                ...(voiceControlEnabled ? { voiceControl: true } : {}),
-                ...(klingElementsPayload ? { elements: klingElementsPayload } : {}),
-              }
-            : {}),
-          ...(isSeedance
-            ? {
-                ...(typeof seedNumber === 'number' ? { seed: seedNumber } : {}),
-                ...(typeof cameraFixed === 'boolean' ? { cameraFixed } : {}),
-                ...(typeof safetyChecker === 'boolean' ? { safetyChecker } : {}),
-              }
-            : {}),
-          idempotencyKey: id,
+        const { payload: generatePayload, resolvedDurationSeconds } = buildWorkspaceGeneratePayload({
+          selectedEngineId: selectedEngine.id,
+          activeMode,
+          submissionMode,
+          form,
+          trimmedPrompt,
+          trimmedNegativePrompt,
+          effectiveDurationSec,
+          memberTier,
+          paymentMode,
+          cfgScale,
+          capability,
+          supportsNegativePrompt,
+          supportsAudioToggle,
+          isSeedance,
+          supportsKlingV3Controls,
+          supportsKlingV3VoiceControl,
+          voiceIds,
+          voiceControlEnabled,
+          shotType,
+          localKey,
           batchId,
-          groupId: batchId,
           iterationIndex,
           iterationCount,
-          localKey,
-          message: friendlyMessage,
+          friendlyMessage,
           etaSeconds,
           etaLabel,
-          visibility: 'private',
-          indexable: false,
-          ...(isLumaRay2GenerateWorkflow ? { loop: Boolean(form.loop) } : {}),
-        };
+          lumaContext,
+          inputsPayload,
+          primaryImageUrl,
+          primaryAudioUrl,
+          referenceImageUrls,
+          endImageUrl,
+          extraInputValues,
+          multiPromptPayload,
+          klingElementsPayload,
+        });
 
         emitClientMetric('generation_started', {
           local_key: localKey,

--- a/frontend/app/(core)/(workspace)/app/_lib/workspace-generation-guards.ts
+++ b/frontend/app/(core)/(workspace)/app/_lib/workspace-generation-guards.ts
@@ -1,0 +1,224 @@
+import {
+  getLumaRay2DurationInfo,
+  getLumaRay2ResolutionInfo,
+  isLumaRay2AspectRatio,
+  isLumaRay2EngineId,
+  isLumaRay2GenerateMode,
+  LUMA_RAY2_ERROR_UNSUPPORTED,
+} from '@/lib/luma-ray2';
+import type { Mode } from '@/types/engines';
+import type { GenerationAttachmentPayload } from './workspace-generation-inputs';
+import { normalizeExtraInputValue, type FormState } from './workspace-form-state';
+import type { WorkspaceInputFieldEntry, WorkspaceInputSchemaSummary } from './workspace-input-schema';
+import type { ReferenceAsset } from './workspace-assets';
+
+export type LumaRay2GenerationContext = {
+  isLumaRay2: boolean;
+  isLumaRay2GenerateWorkflow: boolean;
+  isLumaRay2ReframeWorkflow: boolean;
+  lumaDuration: ReturnType<typeof getLumaRay2DurationInfo> | null;
+  lumaResolution: ReturnType<typeof getLumaRay2ResolutionInfo> | null;
+  lumaAspectOk: boolean;
+};
+
+export type GetLumaRay2GenerationContextOptions = {
+  selectedEngineId: string;
+  submissionMode: string;
+  form: Pick<FormState, 'durationOption' | 'durationSec' | 'resolution' | 'aspectRatio'>;
+};
+
+export type StartRenderValidationOptions = {
+  audioWorkflowUnsupported: boolean;
+  audioUnsupportedMessage: string;
+  multiPromptActive: boolean;
+  multiPromptInvalid: boolean;
+  multiPromptError?: string | null;
+  promptLength: number;
+  promptCharLimitExceeded: boolean;
+  promptMaxChars?: number | null;
+  selectedEngineLabel: string;
+  trimmedPrompt: string;
+  trimmedNegativePrompt: string;
+  inputSchemaSummary: Pick<
+    WorkspaceInputSchemaSummary,
+    | 'promptRequired'
+    | 'negativePromptField'
+    | 'negativePromptRequired'
+    | 'assetFields'
+  >;
+  inputAssets: Record<string, (ReferenceAsset | null)[]>;
+  extraInputFields: WorkspaceInputFieldEntry[];
+  form: Pick<FormState, 'extraInputValues'>;
+  lumaContext: LumaRay2GenerationContext;
+};
+
+export type GenerationIterationGuardOptions = {
+  selectedEngineId: string;
+  submissionMode: Mode | string;
+  allowsUnifiedVeoFirstLast: boolean;
+  hasLastFrameInput: boolean;
+  isUnifiedSeedance: boolean;
+  primaryImageUrl?: string;
+  primaryAudioUrl?: string;
+  primaryAssetFieldLabel: string;
+  referenceImageUrls: string[];
+  referenceVideoUrls: string[];
+  referenceAudioUrls: string[];
+  inputsPayload?: GenerationAttachmentPayload[];
+  primaryAttachment: GenerationAttachmentPayload | null;
+  addReferenceMediaBeforeAudioMessage?: string;
+  extendOrRetakeSourceVideoMessage: string;
+};
+
+export function getLumaRay2GenerationContext({
+  selectedEngineId,
+  submissionMode,
+  form,
+}: GetLumaRay2GenerationContextOptions): LumaRay2GenerationContext {
+  const isLumaRay2 = isLumaRay2EngineId(selectedEngineId);
+  const isLumaRay2GenerateWorkflow = isLumaRay2 && isLumaRay2GenerateMode(submissionMode);
+  const isLumaRay2ReframeWorkflow = isLumaRay2 && submissionMode === 'reframe';
+  const lumaDuration = isLumaRay2 ? getLumaRay2DurationInfo(form.durationOption ?? form.durationSec) : null;
+  const lumaResolution = isLumaRay2 ? getLumaRay2ResolutionInfo(form.resolution) : null;
+  const lumaAspectOk =
+    !isLumaRay2 || isLumaRay2AspectRatio(form.aspectRatio, { includeSquare: isLumaRay2ReframeWorkflow });
+
+  return {
+    isLumaRay2,
+    isLumaRay2GenerateWorkflow,
+    isLumaRay2ReframeWorkflow,
+    lumaDuration,
+    lumaResolution,
+    lumaAspectOk,
+  };
+}
+
+export function supportsNegativePromptInput(
+  inputSchemaSummary: Pick<WorkspaceInputSchemaSummary, 'negativePromptField'>
+): boolean {
+  return Boolean(inputSchemaSummary.negativePromptField);
+}
+
+export function getStartRenderValidationMessage(options: StartRenderValidationOptions): string | null {
+  if (options.audioWorkflowUnsupported) {
+    return options.audioUnsupportedMessage;
+  }
+
+  if (options.multiPromptActive && options.multiPromptInvalid) {
+    return options.multiPromptError ?? 'Multi-prompt requires a prompt per scene and a valid total duration.';
+  }
+
+  if (options.promptCharLimitExceeded && typeof options.promptMaxChars === 'number') {
+    const overflow = options.promptLength - options.promptMaxChars;
+    return `Prompt is ${overflow} character${overflow === 1 ? '' : 's'} over the ${options.promptMaxChars}-character limit for ${options.selectedEngineLabel}.`;
+  }
+
+  if (options.inputSchemaSummary.promptRequired && !options.trimmedPrompt) {
+    return 'A prompt is required for this engine and mode.';
+  }
+
+  const supportsNegativePrompt = supportsNegativePromptInput(options.inputSchemaSummary);
+  if (
+    supportsNegativePrompt &&
+    options.inputSchemaSummary.negativePromptRequired &&
+    !options.trimmedNegativePrompt
+  ) {
+    const label = options.inputSchemaSummary.negativePromptField?.label ?? 'Negative prompt';
+    return `${label} is required before generating.`;
+  }
+
+  const missingAssetField = options.inputSchemaSummary.assetFields.find(({ field, required }) => {
+    if (!required) return false;
+    const minCount = field.minCount ?? 1;
+    const current = options.inputAssets[field.id]?.filter((asset) => asset !== null).length ?? 0;
+    return current < minCount;
+  });
+  if (missingAssetField) {
+    return `${missingAssetField.field.label} is required before generating.`;
+  }
+
+  const missingGenericField = options.extraInputFields.find(({ field, required }) => {
+    if (!required) return false;
+    const value = normalizeExtraInputValue(field, options.form.extraInputValues[field.id] ?? field.default);
+    return value === undefined;
+  });
+  if (missingGenericField) {
+    return `${missingGenericField.field.label} is required before generating.`;
+  }
+
+  if (
+    (options.lumaContext.isLumaRay2GenerateWorkflow &&
+      (!options.lumaContext.lumaDuration || !options.lumaContext.lumaResolution || !options.lumaContext.lumaAspectOk)) ||
+    (options.lumaContext.isLumaRay2ReframeWorkflow && !options.lumaContext.lumaAspectOk)
+  ) {
+    return LUMA_RAY2_ERROR_UNSUPPORTED;
+  }
+
+  return null;
+}
+
+export function getGenerationIterationGuardMessage(options: GenerationIterationGuardOptions): string | null {
+  const isImageDrivenMode = options.submissionMode === 'i2v' || options.submissionMode === 'i2i';
+  const isReferenceImageMode = options.submissionMode === 'ref2v';
+  const isFirstLastMode = options.submissionMode === 'fl2v';
+  const firstFrameAttachment = isFirstLastMode
+    ? options.inputsPayload?.find((attachment) => attachment.slotId === 'first_frame_url') ?? options.primaryAttachment
+    : null;
+  const lastFrameAttachment = isFirstLastMode
+    ? options.inputsPayload?.find((attachment) => attachment.slotId === 'last_frame_url') ?? null
+    : null;
+
+  if (options.allowsUnifiedVeoFirstLast && options.hasLastFrameInput && !options.primaryImageUrl) {
+    return 'Add a start image before using Last frame with Veo.';
+  }
+
+  if (isImageDrivenMode && !options.primaryImageUrl) {
+    return options.selectedEngineId.startsWith('sora-2')
+      ? 'Ajoutez une image (URL ou fichier) pour lancer Image → Video avec Sora.'
+      : `Add at least one ${options.primaryAssetFieldLabel.toLowerCase()} (URL or upload) before running this mode.`;
+  }
+
+  if (isReferenceImageMode) {
+    if (options.isUnifiedSeedance) {
+      if (options.referenceImageUrls.length === 0 && options.referenceVideoUrls.length === 0) {
+        return options.referenceAudioUrls.length > 0
+          ? options.addReferenceMediaBeforeAudioMessage ?? 'Add reference media before adding audio.'
+          : 'Add at least one reference image or reference video before running Seedance Reference → Video.';
+      }
+    } else if (options.referenceImageUrls.length === 0) {
+      return options.selectedEngineId === 'happy-horse-1-0'
+        ? 'Add 1–9 reference images before running Happy Horse R2V.'
+        : 'Add 1–4 reference images before running Reference → Video.';
+    }
+  }
+
+  if (options.submissionMode === 'r2v' && options.referenceVideoUrls.length === 0) {
+    return 'Add 1–3 reference videos (MP4/MOV) before running Reference → Video.';
+  }
+
+  if (options.submissionMode === 'a2v' && !options.primaryAudioUrl) {
+    return 'Add an audio file before running Audio → Video.';
+  }
+
+  if (
+    (options.submissionMode === 'extend' || options.submissionMode === 'retake') &&
+    options.referenceVideoUrls.length === 0
+  ) {
+    return options.extendOrRetakeSourceVideoMessage;
+  }
+
+  if (isFirstLastMode) {
+    if (!firstFrameAttachment || !lastFrameAttachment) {
+      return 'Upload both a start image and last frame before generating with Veo.';
+    }
+    const sameSource =
+      firstFrameAttachment.assetId && lastFrameAttachment.assetId
+        ? firstFrameAttachment.assetId === lastFrameAttachment.assetId
+        : firstFrameAttachment.url === lastFrameAttachment.url;
+    if (sameSource) {
+      return 'First and last frames must be two different images for this engine.';
+    }
+  }
+
+  return null;
+}

--- a/frontend/app/(core)/(workspace)/app/_lib/workspace-generation-payload.ts
+++ b/frontend/app/(core)/(workspace)/app/_lib/workspace-generation-payload.ts
@@ -1,0 +1,156 @@
+import type { runGenerate } from '@/lib/api';
+import { toLumaRay2DurationLabel, type LumaRay2DurationLabel } from '@/lib/luma-ray2';
+import type { EngineModeUiCaps, Mode } from '@/types/engines';
+import type {
+  GenerationAttachmentPayload,
+  GenerationKlingElementPayload,
+} from './workspace-generation-inputs';
+import type { FormState } from './workspace-form-state';
+import type { LumaRay2GenerationContext } from './workspace-generation-guards';
+
+export type WorkspaceGeneratePayload = Parameters<typeof runGenerate>[0] & {
+  imageUrl?: string;
+  referenceImages?: string[];
+};
+
+export type WorkspaceGeneratePayloadBuildResult = {
+  payload: WorkspaceGeneratePayload;
+  resolvedDurationSeconds: number;
+};
+
+export type BuildWorkspaceGeneratePayloadOptions = {
+  selectedEngineId: string;
+  activeMode: Mode;
+  submissionMode: Mode | string;
+  form: FormState;
+  trimmedPrompt: string;
+  trimmedNegativePrompt: string;
+  effectiveDurationSec: number;
+  memberTier?: string;
+  paymentMode: 'wallet' | 'platform';
+  cfgScale?: number | null;
+  capability?: EngineModeUiCaps | null;
+  supportsNegativePrompt: boolean;
+  supportsAudioToggle: boolean;
+  isSeedance: boolean;
+  supportsKlingV3Controls: boolean;
+  supportsKlingV3VoiceControl: boolean;
+  voiceIds: string[];
+  voiceControlEnabled: boolean;
+  shotType: 'customize' | 'intelligent';
+  localKey: string;
+  batchId: string;
+  iterationIndex: number;
+  iterationCount: number;
+  friendlyMessage: string;
+  etaSeconds?: number | null;
+  etaLabel?: string | null;
+  lumaContext: Pick<LumaRay2GenerationContext, 'isLumaRay2GenerateWorkflow' | 'lumaDuration' | 'lumaResolution'>;
+  inputsPayload?: GenerationAttachmentPayload[];
+  primaryImageUrl?: string;
+  primaryAudioUrl?: string;
+  referenceImageUrls: string[];
+  endImageUrl?: string;
+  extraInputValues: Record<string, unknown>;
+  multiPromptPayload?: Array<{ prompt: string; duration: number }>;
+  klingElementsPayload?: GenerationKlingElementPayload[];
+};
+
+export function buildWorkspaceGeneratePayload(
+  options: BuildWorkspaceGeneratePayloadOptions
+): WorkspaceGeneratePayloadBuildResult {
+  const shouldSendAspectRatio =
+    !options.capability || (options.capability.aspectRatio?.length ?? 0) > 0;
+  const resolvedDurationSeconds =
+    options.lumaContext.isLumaRay2GenerateWorkflow && options.lumaContext.lumaDuration
+      ? options.lumaContext.lumaDuration.seconds
+      : options.effectiveDurationSec;
+  const durationOptionLabel: LumaRay2DurationLabel | undefined =
+    typeof options.form.durationOption === 'string'
+      ? (['5s', '9s'].includes(options.form.durationOption)
+          ? (options.form.durationOption as LumaRay2DurationLabel)
+          : undefined)
+      : undefined;
+  const resolvedDurationLabel =
+    options.lumaContext.isLumaRay2GenerateWorkflow && options.lumaContext.lumaDuration
+      ? options.lumaContext.lumaDuration.label
+      : toLumaRay2DurationLabel(options.effectiveDurationSec, durationOptionLabel) ??
+        durationOptionLabel ??
+        options.effectiveDurationSec;
+  const shouldSendDuration = !options.capability || Boolean(options.capability.duration || options.capability.frames);
+  const shouldSendResolution = !options.capability || (options.capability.resolution?.length ?? 0) > 0;
+  const resolvedResolution =
+    options.lumaContext.isLumaRay2GenerateWorkflow && options.lumaContext.lumaResolution
+      ? options.lumaContext.lumaResolution.value
+      : options.form.resolution;
+  const shouldSendFps =
+    !options.capability ||
+    (Array.isArray(options.capability.fps) ? options.capability.fps.length > 0 : typeof options.capability.fps === 'number');
+  const seedNumber =
+    typeof options.form.seed === 'number' && Number.isFinite(options.form.seed)
+      ? Math.trunc(options.form.seed)
+      : undefined;
+  const cameraFixed = typeof options.form.cameraFixed === 'boolean' ? options.form.cameraFixed : undefined;
+  const safetyChecker = typeof options.form.safetyChecker === 'boolean' ? options.form.safetyChecker : undefined;
+
+  const payload: WorkspaceGeneratePayload = {
+    engineId: options.selectedEngineId,
+    prompt: options.trimmedPrompt,
+    mode: options.submissionMode,
+    durationSec: resolvedDurationSeconds,
+    membershipTier: options.memberTier,
+    payment: { mode: options.paymentMode },
+    cfgScale: typeof options.cfgScale === 'number' ? options.cfgScale : undefined,
+    ...(options.selectedEngineId.startsWith('sora-2')
+      ? { variant: options.selectedEngineId === 'sora-2-pro' ? 'sora2pro' : 'sora2' }
+      : {}),
+    ...(shouldSendDuration ? { durationOption: resolvedDurationLabel } : {}),
+    ...(options.form.numFrames != null ? { numFrames: options.form.numFrames } : {}),
+    ...(shouldSendResolution ? { resolution: resolvedResolution } : {}),
+    ...(shouldSendFps ? { fps: options.form.fps } : {}),
+    ...(shouldSendAspectRatio ? { aspectRatio: options.form.aspectRatio } : {}),
+    ...(options.supportsNegativePrompt && options.trimmedNegativePrompt
+      ? { negativePrompt: options.trimmedNegativePrompt }
+      : {}),
+    ...(options.supportsAudioToggle ? { audio: options.form.audio } : {}),
+    ...(options.inputsPayload ? { inputs: options.inputsPayload } : {}),
+    ...(options.primaryImageUrl ? { imageUrl: options.primaryImageUrl } : {}),
+    ...(options.primaryAudioUrl ? { audioUrl: options.primaryAudioUrl } : {}),
+    ...(options.referenceImageUrls.length ? { referenceImages: options.referenceImageUrls } : {}),
+    ...(options.endImageUrl ? { endImageUrl: options.endImageUrl } : {}),
+    ...(Object.keys(options.extraInputValues).length ? { extraInputValues: options.extraInputValues } : {}),
+    ...(options.multiPromptPayload && options.multiPromptPayload.length ? { multiPrompt: options.multiPromptPayload } : {}),
+    ...(options.supportsKlingV3Controls
+      ? {
+          shotType: options.activeMode === 'i2v' ? 'customize' : options.shotType,
+          ...(options.supportsKlingV3VoiceControl && options.voiceIds.length ? { voiceIds: options.voiceIds } : {}),
+          ...(options.voiceControlEnabled ? { voiceControl: true } : {}),
+          ...(options.klingElementsPayload ? { elements: options.klingElementsPayload } : {}),
+        }
+      : {}),
+    ...(options.isSeedance
+      ? {
+          ...(typeof seedNumber === 'number' ? { seed: seedNumber } : {}),
+          ...(typeof cameraFixed === 'boolean' ? { cameraFixed } : {}),
+          ...(typeof safetyChecker === 'boolean' ? { safetyChecker } : {}),
+        }
+      : {}),
+    idempotencyKey: options.localKey,
+    batchId: options.batchId,
+    groupId: options.batchId,
+    iterationIndex: options.iterationIndex,
+    iterationCount: options.iterationCount,
+    localKey: options.localKey,
+    message: options.friendlyMessage,
+    etaSeconds: options.etaSeconds,
+    etaLabel: options.etaLabel,
+    visibility: 'private',
+    indexable: false,
+    ...(options.lumaContext.isLumaRay2GenerateWorkflow ? { loop: Boolean(options.form.loop) } : {}),
+  };
+
+  return {
+    payload,
+    resolvedDurationSeconds,
+  };
+}

--- a/tests/workspace-generation-request-helpers.test.ts
+++ b/tests/workspace-generation-request-helpers.test.ts
@@ -1,0 +1,281 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { LUMA_RAY2_ERROR_UNSUPPORTED } from '../frontend/src/lib/luma-ray2';
+import type { EngineInputField, EngineModeUiCaps } from '../frontend/types/engines';
+import {
+  buildWorkspaceGeneratePayload,
+} from '../frontend/app/(core)/(workspace)/app/_lib/workspace-generation-payload';
+import {
+  getGenerationIterationGuardMessage,
+  getLumaRay2GenerationContext,
+  getStartRenderValidationMessage,
+} from '../frontend/app/(core)/(workspace)/app/_lib/workspace-generation-guards';
+import type { FormState } from '../frontend/app/(core)/(workspace)/app/_lib/workspace-form-state';
+import type { GenerationAttachmentPayload } from '../frontend/app/(core)/(workspace)/app/_lib/workspace-generation-inputs';
+import type { WorkspaceInputSchemaSummary } from '../frontend/app/(core)/(workspace)/app/_lib/workspace-input-schema';
+import type { ReferenceAsset } from '../frontend/app/(core)/(workspace)/app/_lib/workspace-assets';
+
+const textField = (id: string, label: string): EngineInputField => ({ id, label, type: 'text' });
+const imageField = (id: string, label: string, minCount?: number): EngineInputField => ({
+  id,
+  label,
+  type: 'image',
+  minCount,
+});
+
+function baseForm(overrides: Partial<FormState> = {}): FormState {
+  return {
+    engineId: 'seedance-2-0',
+    mode: 't2v',
+    durationSec: 5,
+    durationOption: '5s',
+    resolution: '720p',
+    aspectRatio: '16:9',
+    fps: 24,
+    iterations: 1,
+    audio: false,
+    extraInputValues: {},
+    ...overrides,
+  };
+}
+
+function baseSchemaSummary(overrides: Partial<WorkspaceInputSchemaSummary> = {}): WorkspaceInputSchemaSummary {
+  return {
+    assetFields: [],
+    promotedFields: [],
+    secondaryFields: [],
+    promptRequired: false,
+    negativePromptRequired: false,
+    ...overrides,
+  };
+}
+
+function readyAsset(overrides: Partial<ReferenceAsset> = {}): ReferenceAsset {
+  return {
+    id: 'asset-1',
+    name: 'reference.png',
+    kind: 'image',
+    type: 'image/png',
+    size: 1234,
+    previewUrl: 'https://cdn.example.com/reference.png',
+    url: 'https://cdn.example.com/reference.png',
+    status: 'ready',
+    ...overrides,
+  };
+}
+
+test('start render validation reports required negative prompts', () => {
+  const message = getStartRenderValidationMessage({
+    audioWorkflowUnsupported: false,
+    audioUnsupportedMessage: 'Audio workflow is unsupported.',
+    multiPromptActive: false,
+    multiPromptInvalid: false,
+    multiPromptError: null,
+    promptLength: 10,
+    promptCharLimitExceeded: false,
+    promptMaxChars: undefined,
+    selectedEngineLabel: 'Seedance',
+    trimmedPrompt: 'a prompt',
+    trimmedNegativePrompt: '',
+    inputSchemaSummary: baseSchemaSummary({
+      negativePromptField: textField('negative_prompt', 'Safety & people / likeness.'),
+      negativePromptRequired: true,
+    }),
+    inputAssets: {},
+    extraInputFields: [],
+    form: baseForm(),
+    lumaContext: getLumaRay2GenerationContext({
+      selectedEngineId: 'seedance-2-0',
+      submissionMode: 't2v',
+      form: baseForm(),
+    }),
+  });
+
+  assert.equal(message, 'Safety & people / likeness. is required before generating.');
+});
+
+test('start render validation checks asset minimums and Luma Ray 2 limits', () => {
+  const missingAssetMessage = getStartRenderValidationMessage({
+    audioWorkflowUnsupported: false,
+    audioUnsupportedMessage: 'Audio workflow is unsupported.',
+    multiPromptActive: false,
+    multiPromptInvalid: false,
+    multiPromptError: null,
+    promptLength: 10,
+    promptCharLimitExceeded: false,
+    promptMaxChars: undefined,
+    selectedEngineLabel: 'Seedance',
+    trimmedPrompt: 'a prompt',
+    trimmedNegativePrompt: '',
+    inputSchemaSummary: baseSchemaSummary({
+      assetFields: [{ field: imageField('image_urls', 'Reference images', 2), required: true }],
+    }),
+    inputAssets: { image_urls: [readyAsset()] },
+    extraInputFields: [],
+    form: baseForm(),
+    lumaContext: getLumaRay2GenerationContext({
+      selectedEngineId: 'seedance-2-0',
+      submissionMode: 'ref2v',
+      form: baseForm({ mode: 'ref2v' }),
+    }),
+  });
+
+  assert.equal(missingAssetMessage, 'Reference images is required before generating.');
+
+  const lumaMessage = getStartRenderValidationMessage({
+    audioWorkflowUnsupported: false,
+    audioUnsupportedMessage: 'Audio workflow is unsupported.',
+    multiPromptActive: false,
+    multiPromptInvalid: false,
+    multiPromptError: null,
+    promptLength: 10,
+    promptCharLimitExceeded: false,
+    promptMaxChars: undefined,
+    selectedEngineLabel: 'Luma Ray 2',
+    trimmedPrompt: 'a prompt',
+    trimmedNegativePrompt: '',
+    inputSchemaSummary: baseSchemaSummary({ promptRequired: true }),
+    inputAssets: {},
+    extraInputFields: [],
+    form: baseForm({ engineId: 'lumaRay2', durationOption: '12s' }),
+    lumaContext: getLumaRay2GenerationContext({
+      selectedEngineId: 'lumaRay2',
+      submissionMode: 't2v',
+      form: baseForm({ engineId: 'lumaRay2', durationOption: '12s' }),
+    }),
+  });
+
+  assert.equal(lumaMessage, LUMA_RAY2_ERROR_UNSUPPORTED);
+});
+
+test('iteration guard preserves mode-specific media requirements', () => {
+  assert.equal(
+    getGenerationIterationGuardMessage({
+      selectedEngineId: 'seedance-2-0',
+      submissionMode: 'ref2v',
+      allowsUnifiedVeoFirstLast: false,
+      hasLastFrameInput: false,
+      isUnifiedSeedance: true,
+      primaryImageUrl: undefined,
+      primaryAudioUrl: undefined,
+      primaryAssetFieldLabel: 'Image',
+      referenceImageUrls: [],
+      referenceVideoUrls: [],
+      referenceAudioUrls: ['https://cdn.example.com/audio.wav'],
+      inputsPayload: [],
+      primaryAttachment: null,
+      extendOrRetakeSourceVideoMessage: 'Add a source video before running this mode.',
+    }),
+    'Add reference media before adding audio.'
+  );
+
+  const firstFrame: GenerationAttachmentPayload = {
+    name: 'first.png',
+    type: 'image/png',
+    size: 1,
+    kind: 'image',
+    slotId: 'first_frame_url',
+    url: 'https://cdn.example.com/same.png',
+    assetId: 'same',
+  };
+  const lastFrame: GenerationAttachmentPayload = {
+    ...firstFrame,
+    name: 'last.png',
+    slotId: 'last_frame_url',
+  };
+
+  assert.equal(
+    getGenerationIterationGuardMessage({
+      selectedEngineId: 'veo-3-1',
+      submissionMode: 'fl2v',
+      allowsUnifiedVeoFirstLast: false,
+      hasLastFrameInput: true,
+      isUnifiedSeedance: false,
+      primaryImageUrl: firstFrame.url,
+      primaryAudioUrl: undefined,
+      primaryAssetFieldLabel: 'Start image',
+      referenceImageUrls: [],
+      referenceVideoUrls: [],
+      referenceAudioUrls: [],
+      inputsPayload: [firstFrame, lastFrame],
+      primaryAttachment: firstFrame,
+      extendOrRetakeSourceVideoMessage: 'Add a source video before running this mode.',
+    }),
+    'First and last frames must be two different images for this engine.'
+  );
+});
+
+test('workspace generate payload resolves provider-specific options', () => {
+  const form = baseForm({
+    engineId: 'lumaRay2',
+    durationSec: 9,
+    durationOption: '9s',
+    resolution: '1080p',
+    loop: true,
+    audio: true,
+    seed: 42.8,
+    cameraFixed: false,
+    safetyChecker: true,
+  });
+  const capability: EngineModeUiCaps = {
+    modes: ['t2v'],
+    duration: { options: ['5s', '9s'] },
+    resolution: ['540p', '720p', '1080p'],
+    aspectRatio: ['16:9'],
+    fps: [24],
+    audioToggle: true,
+  };
+
+  const result = buildWorkspaceGeneratePayload({
+    selectedEngineId: 'lumaRay2',
+    activeMode: 't2v',
+    submissionMode: 't2v',
+    form,
+    trimmedPrompt: 'cinematic prompt',
+    trimmedNegativePrompt: 'blur',
+    effectiveDurationSec: 9,
+    memberTier: 'pro',
+    paymentMode: 'wallet',
+    cfgScale: 7,
+    capability,
+    supportsNegativePrompt: true,
+    supportsAudioToggle: true,
+    isSeedance: false,
+    supportsKlingV3Controls: true,
+    supportsKlingV3VoiceControl: true,
+    voiceIds: ['voice-1'],
+    voiceControlEnabled: true,
+    shotType: 'intelligent',
+    localKey: 'local-1',
+    batchId: 'batch-1',
+    iterationIndex: 0,
+    iterationCount: 2,
+    friendlyMessage: 'Take 1 of 2',
+    etaSeconds: 6,
+    etaLabel: '~6 sec',
+    lumaContext: getLumaRay2GenerationContext({
+      selectedEngineId: 'lumaRay2',
+      submissionMode: 't2v',
+      form,
+    }),
+    inputsPayload: [],
+    primaryImageUrl: 'https://cdn.example.com/start.png',
+    primaryAudioUrl: 'https://cdn.example.com/audio.wav',
+    referenceImageUrls: ['https://cdn.example.com/ref.png'],
+    endImageUrl: 'https://cdn.example.com/end.png',
+    extraInputValues: { style: 'cinematic' },
+    multiPromptPayload: [{ prompt: 'scene one', duration: 5 }],
+    klingElementsPayload: [{ frontalImageUrl: 'https://cdn.example.com/frontal.png' }],
+  });
+
+  assert.equal(result.resolvedDurationSeconds, 9);
+  assert.equal(result.payload.durationOption, '9s');
+  assert.equal(result.payload.resolution, '1080p');
+  assert.equal(result.payload.loop, true);
+  assert.equal(result.payload.shotType, 'intelligent');
+  assert.deepEqual(result.payload.voiceIds, ['voice-1']);
+  assert.equal(result.payload.imageUrl, 'https://cdn.example.com/start.png');
+  assert.deepEqual(result.payload.referenceImages, ['https://cdn.example.com/ref.png']);
+  assert.deepEqual(result.payload.extraInputValues, { style: 'cinematic' });
+});


### PR DESCRIPTION
## Summary
- Extract start-render validation and per-iteration media guards into route-local pure helpers.
- Extract runGenerate payload assembly into a tested workspace helper.
- Update the workspace route guide so future Codex work keeps generation guards and payloads out of AppClient.tsx.

## Test Plan
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/workspace-generation-request-helpers.test.ts tests/workspace-generation-inputs.test.ts
- cd frontend && ./node_modules/.bin/tsc --noEmit
- npm --prefix frontend run lint
- pnpm run test:validate
- npm --prefix frontend run build