### PR TITLE
[codex] Extract workspace local render preparation

### DIFF
--- a/frontend/app/(core)/(workspace)/app/AGENTS.md
+++ b/frontend/app/(core)/(workspace)/app/AGENTS.md
@@ -6,7 +6,7 @@ This route is the main signed-in video generation workspace.
 
 - `AppClient.tsx`: top-level state orchestration while the workspace is being split.
 - `_components`: route-local chrome, panels, skeletons, modals, and presentational UI.
-- `_lib`: route-local pure helpers for previews, render grouping, render status reconciliation, generation input preparation, generation guards and payloads, video settings hydration, workspace boot hydration, storage, copy fallback, client constants, asset normalization, asset selection, payload builders, input normalization, and workflow mapping.
+- `_lib`: route-local pure helpers for previews, render grouping, render status reconciliation, generation input preparation, generation guards, local render preparation, generation payloads, video settings hydration, workspace boot hydration, storage, copy fallback, client constants, asset normalization, asset selection, payload builders, input normalization, and workflow mapping.
 - Tool-specific workspaces should stay in their own route folders unless code is clearly shared.
 
 ## Refactor Rules
@@ -17,6 +17,7 @@ This route is the main signed-in video generation workspace.
 - Keep job-to-render conversion, status polling projections, and recent-job reconciliation in `_lib`; `AppClient.tsx` should own timers and network calls.
 - Keep generation attachment ordering, derived input URLs, Kling element payloads, and multi-prompt payloads in `_lib`; `AppClient.tsx` should consume prepared inputs instead of deriving attachment URLs inline.
 - Keep generation validation guards and `runGenerate` payload assembly in `_lib`; `AppClient.tsx` should decide when to show errors and when to call the network.
+- Keep local pending-render and selected-preview preparation in `_lib`; `AppClient.tsx` should apply returned state objects and own timers.
 - Keep video settings snapshot parsing and job media patch mapping in `_lib`; `AppClient.tsx` should wire those results into React state.
 - Keep workspace request parsing and boot hydration decisions in `_lib`; `AppClient.tsx` should apply the resolved state.
 - Keep asset-library selection, reference slot insertion, and Kling library asset mapping in `_lib`; `AppClient.tsx` should handle network calls and React state wiring.

--- a/frontend/app/(core)/(workspace)/app/AppClient.tsx
+++ b/frontend/app/(core)/(workspace)/app/AppClient.tsx
@@ -23,7 +23,6 @@ import type { CompositePreviewDockProps } from '@/components/groups/CompositePre
 import dynamic from 'next/dynamic';
 import { DEFAULT_PROCESSING_COPY } from '@/components/groups/ProcessingOverlay';
 import { CURRENCY_LOCALE } from '@/lib/intl';
-import { getRenderEta } from '@/lib/render-eta';
 import { ENV as CLIENT_ENV } from '@/lib/env';
 import { adaptGroupSummaries, adaptGroupSummary } from '@/lib/video-group-adapter';
 import type { VideoGroup } from '@/types/video-groups';
@@ -92,6 +91,7 @@ import {
   supportsNegativePromptInput,
 } from './_lib/workspace-generation-guards';
 import { buildWorkspaceGeneratePayload } from './_lib/workspace-generation-payload';
+import { prepareLocalGenerationRender } from './_lib/workspace-local-generation-render';
 import {
   buildComposerModeToggles,
   coerceFormState,
@@ -2817,22 +2817,30 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
         return;
       }
 
-      const localKey = `local_${batchId}_${iterationIndex + 1}`;
-      const id = localKey;
-      const ar = form.aspectRatio;
-      const thumb = ar === '9:16'
-        ? '/assets/frames/thumb-9x16.svg'
-        : ar === '1:1'
-          ? '/assets/frames/thumb-1x1.svg'
-          : '/assets/frames/thumb-16x9.svg';
-
-      const { seconds: etaSeconds, label: etaLabel } = getRenderEta(selectedEngine, effectiveDurationSec);
-      const friendlyMessage =
-        iterationCount > 1 ? formatTakeLabel(iterationIndex + 1, iterationCount) : '';
-      const startedAt = Date.now();
-      const minEtaSeconds = Math.min(Math.max(etaSeconds ?? 4, 0), 8);
-      const minDurationMs = Math.max(1200, minEtaSeconds * 1000);
-      const minReadyAt = startedAt + minDurationMs;
+      const localRender = prepareLocalGenerationRender({
+        batchId,
+        iterationIndex,
+        iterationCount,
+        selectedEngine,
+        form,
+        effectiveDurationSec,
+        effectivePrompt,
+        preflight,
+        formatTakeLabel,
+      });
+      const {
+        localKey,
+        id,
+        thumb,
+        etaSeconds,
+        etaLabel,
+        friendlyMessage,
+        startedAt,
+        minDurationMs,
+        minReadyAt,
+        initialRender,
+        selectedPreview: initialSelectedPreview,
+      } = localRender;
 
       let progressMessage = friendlyMessage;
       const totalMs = minDurationMs;
@@ -2881,37 +2889,7 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
         }, timeoutMs);
       };
 
-      const initial: LocalRender = {
-        localKey,
-        batchId,
-        iterationIndex,
-        iterationCount,
-        id,
-        engineId: selectedEngine.id,
-        engineLabel: selectedEngine.label,
-        createdAt: new Date().toISOString(),
-        aspectRatio: form.aspectRatio,
-        durationSec: effectiveDurationSec,
-        prompt: effectivePrompt,
-        progress: 5,
-        message: friendlyMessage,
-        status: 'pending',
-        thumbUrl: thumb,
-        readyVideoUrl: undefined,
-        priceCents: preflight?.pricing?.totalCents ?? undefined,
-        currency: preflight?.pricing?.currency ?? preflight?.currency ?? 'USD',
-        pricingSnapshot: preflight?.pricing,
-        paymentStatus: 'pending_payment',
-        etaSeconds,
-        etaLabel,
-        startedAt,
-        minReadyAt,
-        groupId: batchId,
-        renderIds: undefined,
-        heroRenderId: null,
-      };
-
-      setRenders((prev) => [initial, ...prev]);
+      setRenders((prev) => [initialRender, ...prev]);
       setBatchHeroes((prev) => {
         if (prev[batchId]) return prev;
         return { ...prev, [batchId]: localKey };
@@ -2921,23 +2899,7 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
       if (iterationCount > 1) {
         setViewMode((prev) => (prev === 'quad' ? prev : 'quad'));
       }
-      setSelectedPreview({
-        id,
-        localKey,
-        batchId,
-        iterationIndex,
-        iterationCount,
-        aspectRatio: form.aspectRatio,
-        thumbUrl: thumb,
-        progress: initial.progress,
-        message: friendlyMessage,
-        priceCents: initial.priceCents,
-        currency: initial.currency,
-        etaSeconds,
-        etaLabel,
-        prompt: effectivePrompt,
-        status: initial.status,
-      });
+      setSelectedPreview(initialSelectedPreview);
 
       startProgressTracking();
 

--- a/frontend/app/(core)/(workspace)/app/_lib/workspace-local-generation-render.ts
+++ b/frontend/app/(core)/(workspace)/app/_lib/workspace-local-generation-render.ts
@@ -1,0 +1,116 @@
+import { getRenderEta } from '@/lib/render-eta';
+import type { SelectedVideoPreview } from '@/lib/video-preview-group';
+import type { EngineCaps, PreflightResponse } from '@/types/engines';
+import { resolveRenderThumb, type LocalRender } from './render-persistence';
+import type { FormState } from './workspace-form-state';
+
+export type LocalGenerationRenderPreparation = {
+  localKey: string;
+  id: string;
+  thumb: string;
+  etaSeconds: number;
+  etaLabel: string;
+  friendlyMessage: string;
+  startedAt: number;
+  minDurationMs: number;
+  minReadyAt: number;
+  initialRender: LocalRender;
+  selectedPreview: SelectedVideoPreview;
+};
+
+export type PrepareLocalGenerationRenderOptions = {
+  batchId: string;
+  iterationIndex: number;
+  iterationCount: number;
+  selectedEngine: EngineCaps;
+  form: Pick<FormState, 'aspectRatio'>;
+  effectiveDurationSec: number;
+  effectivePrompt: string;
+  preflight?: PreflightResponse | null;
+  formatTakeLabel: (index: number, total: number) => string;
+  now?: number;
+};
+
+export function prepareLocalGenerationRender({
+  batchId,
+  iterationIndex,
+  iterationCount,
+  selectedEngine,
+  form,
+  effectiveDurationSec,
+  effectivePrompt,
+  preflight,
+  formatTakeLabel,
+  now,
+}: PrepareLocalGenerationRenderOptions): LocalGenerationRenderPreparation {
+  const localKey = `local_${batchId}_${iterationIndex + 1}`;
+  const id = localKey;
+  const thumb = resolveRenderThumb({ aspectRatio: form.aspectRatio });
+  const { seconds: etaSeconds, label: etaLabel } = getRenderEta(selectedEngine, effectiveDurationSec);
+  const friendlyMessage = iterationCount > 1 ? formatTakeLabel(iterationIndex + 1, iterationCount) : '';
+  const startedAt = now ?? Date.now();
+  const minEtaSeconds = Math.min(Math.max(etaSeconds ?? 4, 0), 8);
+  const minDurationMs = Math.max(1200, minEtaSeconds * 1000);
+  const minReadyAt = startedAt + minDurationMs;
+  const currency = preflight?.pricing?.currency ?? preflight?.currency ?? 'USD';
+
+  const initialRender: LocalRender = {
+    localKey,
+    batchId,
+    iterationIndex,
+    iterationCount,
+    id,
+    engineId: selectedEngine.id,
+    engineLabel: selectedEngine.label,
+    createdAt: new Date(startedAt).toISOString(),
+    aspectRatio: form.aspectRatio,
+    durationSec: effectiveDurationSec,
+    prompt: effectivePrompt,
+    progress: 5,
+    message: friendlyMessage,
+    status: 'pending',
+    thumbUrl: thumb,
+    readyVideoUrl: undefined,
+    priceCents: preflight?.pricing?.totalCents ?? undefined,
+    currency,
+    pricingSnapshot: preflight?.pricing,
+    paymentStatus: 'pending_payment',
+    etaSeconds,
+    etaLabel,
+    startedAt,
+    minReadyAt,
+    groupId: batchId,
+    renderIds: undefined,
+    heroRenderId: null,
+  };
+
+  return {
+    localKey,
+    id,
+    thumb,
+    etaSeconds,
+    etaLabel,
+    friendlyMessage,
+    startedAt,
+    minDurationMs,
+    minReadyAt,
+    initialRender,
+    selectedPreview: {
+      id,
+      localKey,
+      batchId,
+      iterationIndex,
+      iterationCount,
+      aspectRatio: form.aspectRatio,
+      thumbUrl: thumb,
+      progress: initialRender.progress,
+      message: friendlyMessage,
+      priceCents: initialRender.priceCents,
+      currency: initialRender.currency,
+      etaSeconds,
+      etaLabel,
+      prompt: effectivePrompt,
+      status: initialRender.status,
+    },
+  };
+}

--- a/tests/workspace-local-generation-render.test.ts
+++ b/tests/workspace-local-generation-render.test.ts
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { prepareLocalGenerationRender } from '../frontend/app/(core)/(workspace)/app/_lib/workspace-local-generation-render';
+import type { FormState } from '../frontend/app/(core)/(workspace)/app/_lib/workspace-form-state';
+import type { EngineCaps, PreflightResponse } from '../frontend/types/engines';
+
+function baseForm(overrides: Partial<FormState> = {}): FormState {
+  return {
+    engineId: 'veo-3-1',
+    mode: 't2v',
+    durationSec: 5,
+    resolution: '720p',
+    aspectRatio: '16:9',
+    fps: 24,
+    iterations: 1,
+    audio: false,
+    extraInputValues: {},
+    ...overrides,
+  };
+}
+
+function engine(overrides: Partial<EngineCaps> = {}): EngineCaps {
+  return {
+    id: 'veo-3-1',
+    label: 'Veo 3.1',
+    latencyTier: 'fast',
+    ...overrides,
+  } as EngineCaps;
+}
+
+test('prepareLocalGenerationRender builds the pending render and selected preview', () => {
+  const now = Date.UTC(2026, 0, 2, 3, 4, 5);
+  const preflight = {
+    currency: 'USD',
+    pricing: {
+      totalCents: 250,
+      currency: 'EUR',
+    },
+  } as PreflightResponse;
+
+  const prepared = prepareLocalGenerationRender({
+    batchId: 'batch-abc',
+    iterationIndex: 0,
+    iterationCount: 2,
+    selectedEngine: engine(),
+    form: baseForm({ aspectRatio: '9:16' }),
+    effectiveDurationSec: 5,
+    effectivePrompt: 'A cinematic prompt',
+    preflight,
+    formatTakeLabel: (index, total) => `Take ${index}/${total}`,
+    now,
+  });
+
+  assert.equal(prepared.localKey, 'local_batch-abc_1');
+  assert.equal(prepared.id, 'local_batch-abc_1');
+  assert.equal(prepared.thumb, '/assets/frames/thumb-9x16.svg');
+  assert.equal(prepared.friendlyMessage, 'Take 1/2');
+  assert.equal(prepared.startedAt, now);
+  assert.equal(prepared.minReadyAt, now + prepared.minDurationMs);
+  assert.equal(prepared.minDurationMs, 8000);
+  assert.equal(prepared.initialRender.createdAt, new Date(now).toISOString());
+  assert.equal(prepared.initialRender.engineId, 'veo-3-1');
+  assert.equal(prepared.initialRender.engineLabel, 'Veo 3.1');
+  assert.equal(prepared.initialRender.priceCents, 250);
+  assert.equal(prepared.initialRender.currency, 'EUR');
+  assert.equal(prepared.initialRender.paymentStatus, 'pending_payment');
+  assert.equal(prepared.initialRender.status, 'pending');
+  assert.equal(prepared.initialRender.groupId, 'batch-abc');
+  assert.equal(prepared.initialRender.heroRenderId, null);
+  assert.deepEqual(prepared.selectedPreview, {
+    id: prepared.id,
+    localKey: prepared.localKey,
+    batchId: 'batch-abc',
+    iterationIndex: 0,
+    iterationCount: 2,
+    aspectRatio: '9:16',
+    thumbUrl: '/assets/frames/thumb-9x16.svg',
+    progress: 5,
+    message: 'Take 1/2',
+    priceCents: 250,
+    currency: 'EUR',
+    etaSeconds: prepared.etaSeconds,
+    etaLabel: prepared.etaLabel,
+    prompt: 'A cinematic prompt',
+    status: 'pending',
+  });
+});
+
+test('prepareLocalGenerationRender falls back to single-render copy and currency', () => {
+  const now = Date.UTC(2026, 0, 2, 3, 4, 5);
+  const prepared = prepareLocalGenerationRender({
+    batchId: 'batch-single',
+    iterationIndex: 0,
+    iterationCount: 1,
+    selectedEngine: engine({ latencyTier: 'standard' }),
+    form: baseForm({ aspectRatio: '1:1' }),
+    effectiveDurationSec: 8,
+    effectivePrompt: 'A square prompt',
+    preflight: { currency: 'GBP' } as PreflightResponse,
+    formatTakeLabel: (index, total) => `Take ${index}/${total}`,
+    now,
+  });
+
+  assert.equal(prepared.friendlyMessage, '');
+  assert.equal(prepared.thumb, '/assets/frames/thumb-1x1.svg');
+  assert.equal(prepared.initialRender.currency, 'GBP');
+  assert.equal(prepared.selectedPreview.message, '');
+});


### PR DESCRIPTION
## Summary
- Extract local pending-render and selected-preview preparation from AppClient startRender.
- Reuse the route-local helper for placeholder thumb, ETA, min-ready timing, pricing, and preview state.
- Update the workspace route guide to keep local render preparation in _lib.

## Test Plan
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/workspace-local-generation-render.test.ts tests/workspace-generation-request-helpers.test.ts tests/workspace-generation-inputs.test.ts
- cd frontend && ./node_modules/.bin/tsc --noEmit
- npm --prefix frontend run lint
- pnpm run test:validate
- npm --prefix frontend run build