### PR TITLE
[codex] Extract workspace generation result helpers

### DIFF
--- a/frontend/app/(core)/(workspace)/app/AGENTS.md
+++ b/frontend/app/(core)/(workspace)/app/AGENTS.md
@@ -6,7 +6,7 @@ This route is the main signed-in video generation workspace.
 
 - `AppClient.tsx`: top-level state orchestration while the workspace is being split.
 - `_components`: route-local chrome, panels, skeletons, modals, and presentational UI.
-- `_lib`: route-local pure helpers for previews, render grouping, render status reconciliation, generation input preparation, generation guards, local render preparation, generation payloads, video settings hydration, workspace boot hydration, storage, copy fallback, client constants, asset normalization, asset selection, payload builders, input normalization, and workflow mapping.
+- `_lib`: route-local pure helpers for previews, render grouping, render status reconciliation, generation input preparation, generation guards, local render preparation, generation payloads and accepted results, video settings hydration, workspace boot hydration, storage, copy fallback, client constants, asset normalization, asset selection, payload builders, input normalization, and workflow mapping.
 - Tool-specific workspaces should stay in their own route folders unless code is clearly shared.
 
 ## Refactor Rules
@@ -18,6 +18,7 @@ This route is the main signed-in video generation workspace.
 - Keep generation attachment ordering, derived input URLs, Kling element payloads, and multi-prompt payloads in `_lib`; `AppClient.tsx` should consume prepared inputs instead of deriving attachment URLs inline.
 - Keep generation validation guards and `runGenerate` payload assembly in `_lib`; `AppClient.tsx` should decide when to show errors and when to call the network.
 - Keep local pending-render and selected-preview preparation in `_lib`; `AppClient.tsx` should apply returned state objects and own timers.
+- Keep accepted `runGenerate` response projection and immediate render/preview patches in `_lib`; `AppClient.tsx` should dispatch events and start polling.
 - Keep video settings snapshot parsing and job media patch mapping in `_lib`; `AppClient.tsx` should wire those results into React state.
 - Keep workspace request parsing and boot hydration decisions in `_lib`; `AppClient.tsx` should apply the resolved state.
 - Keep asset-library selection, reference slot insertion, and Kling library asset mapping in `_lib`; `AppClient.tsx` should handle network calls and React state wiring.

--- a/frontend/app/(core)/(workspace)/app/AppClient.tsx
+++ b/frontend/app/(core)/(workspace)/app/AppClient.tsx
@@ -85,6 +85,11 @@ import {
 } from './_lib/workspace-form-state';
 import { prepareGenerationInputs } from './_lib/workspace-generation-inputs';
 import {
+  applyAcceptedGenerationResultToRender,
+  applyAcceptedGenerationResultToSelectedPreview,
+  projectAcceptedGenerationResult,
+} from './_lib/workspace-generation-result';
+import {
   getGenerationIterationGuardMessage,
   getLumaRay2GenerationContext,
   getStartRenderValidationMessage,
@@ -2958,142 +2963,61 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
 
         const res = await runGenerate(generatePayload, token ? { token } : undefined);
 
-        const resolvedJobId = res.jobId ?? id;
-        const resolvedBatchId = res.batchId ?? batchId;
-        const resolvedGroupId = res.groupId ?? batchId;
-        const resolvedIterationIndex = res.iterationIndex ?? iterationIndex;
-        const resolvedIterationCount = res.iterationCount ?? iterationCount;
-        const resolvedThumb = res.thumbUrl ?? thumb;
-        const resolvedPriceCents =
-          res.pricing?.totalCents ?? preflight?.pricing?.totalCents ?? undefined;
-        const resolvedCurrency =
-          res.pricing?.currency ?? preflight?.pricing?.currency ?? preflight?.currency ?? 'USD';
-        const resolvedEtaSeconds =
-          typeof res.etaSeconds === 'number' ? res.etaSeconds : etaSeconds;
-        const resolvedEtaLabel = res.etaLabel ?? etaLabel;
-        const resolvedMessage = res.message ?? friendlyMessage;
-        const resolvedStatus =
-          res.status ?? (res.videoUrl ? 'completed' : 'pending');
-        const resolvedProgress =
-          typeof res.progress === 'number' ? res.progress : res.videoUrl ? 100 : 5;
-        const resolvedPricingSnapshot = res.pricing ?? preflight?.pricing;
-        const resolvedPaymentStatus = res.paymentStatus ?? 'pending_payment';
-        const resolvedRenderIds = res.renderIds ?? undefined;
-        const resolvedHeroRenderId = res.heroRenderId ?? null;
-        const resolvedVideoUrl = res.videoUrl ?? undefined;
+        const acceptedResult = projectAcceptedGenerationResult({
+          response: res,
+          fallback: {
+            id,
+            batchId,
+            iterationIndex,
+            iterationCount,
+            thumbUrl: thumb,
+            priceCents: preflight?.pricing?.totalCents ?? undefined,
+            currency: preflight?.pricing?.currency ?? preflight?.currency ?? 'USD',
+            pricingSnapshot: preflight?.pricing,
+            etaSeconds,
+            etaLabel,
+            message: friendlyMessage,
+            minReadyAt,
+            aspectRatio: form.aspectRatio,
+            localKey,
+          },
+          now: Date.now(),
+        });
 
         try {
-          if (resolvedJobId.startsWith('job_')) {
-            writeScopedStorage(STORAGE_KEYS.previewJobId, resolvedJobId);
+          if (acceptedResult.jobId.startsWith('job_')) {
+            writeScopedStorage(STORAGE_KEYS.previewJobId, acceptedResult.jobId);
           }
         } catch {
           // ignore storage failures
         }
 
-        const now = Date.now();
-        const gatingActive = Boolean(resolvedVideoUrl) && now < minReadyAt;
-        const clampedProgress = resolvedProgress < 5 ? 5 : resolvedProgress;
-        const gatedProgress = gatingActive ? Math.min(clampedProgress, 95) : clampedProgress;
-
         setRenders((prev) =>
           prev.map((render) =>
             render.localKey === localKey
-              ? (() => {
-                  const nextFailedAt =
-                    resolvedStatus === 'failed' && isRefundedPaymentStatus(resolvedPaymentStatus)
-                      ? render.failedAt ?? now
-                      : undefined;
-                  return {
-                  ...render,
-                  id: resolvedJobId,
-                  jobId: resolvedJobId,
-                  batchId: resolvedBatchId,
-                  groupId: resolvedGroupId,
-                  iterationIndex: resolvedIterationIndex,
-                  iterationCount: resolvedIterationCount,
-                  thumbUrl: resolvedThumb,
-                  message: resolvedMessage,
-                  progress: gatedProgress,
-                  status: gatingActive ? 'pending' : resolvedStatus,
-                  priceCents: resolvedPriceCents,
-                  currency: resolvedCurrency,
-                  pricingSnapshot: resolvedPricingSnapshot,
-                  paymentStatus: resolvedPaymentStatus,
-                  failedAt: nextFailedAt,
-                  etaSeconds: resolvedEtaSeconds,
-                  etaLabel: resolvedEtaLabel,
-                  renderIds: resolvedRenderIds,
-                  heroRenderId: resolvedHeroRenderId,
-                  readyVideoUrl: resolvedVideoUrl ?? render.readyVideoUrl,
-                  videoUrl: gatingActive ? render.videoUrl : resolvedVideoUrl ?? render.videoUrl,
-                  previewVideoUrl: render.previewVideoUrl,
-                  };
-                })()
+              ? applyAcceptedGenerationResultToRender(render, acceptedResult)
               : render
           )
         );
-        progressMessage = resolvedMessage;
-        setSelectedPreview((cur) =>
-          cur && cur.localKey === localKey
-            ? {
-                ...cur,
-                id: resolvedJobId,
-                batchId: resolvedBatchId,
-                iterationIndex: resolvedIterationIndex,
-                iterationCount: resolvedIterationCount,
-                thumbUrl: resolvedThumb,
-                progress: gatedProgress,
-                message: resolvedMessage,
-                priceCents: resolvedPriceCents,
-                currency: resolvedCurrency,
-                etaSeconds: resolvedEtaSeconds,
-                etaLabel: resolvedEtaLabel,
-                videoUrl: gatingActive ? cur.videoUrl : resolvedVideoUrl ?? cur.videoUrl,
-                previewVideoUrl: cur.previewVideoUrl,
-                status: gatingActive ? 'pending' : resolvedStatus,
-              }
-            : cur
-        );
+        progressMessage = acceptedResult.message;
+        setSelectedPreview((cur) => applyAcceptedGenerationResultToSelectedPreview(cur, acceptedResult));
 
-        if (resolvedIterationCount > 1) {
+        if (acceptedResult.iterationCount > 1) {
           setViewMode((prev) => (prev === 'quad' ? prev : 'quad'));
         }
-        setActiveBatchId(resolvedBatchId);
-        setActiveGroupId(resolvedBatchId ?? batchId ?? id);
+        setActiveBatchId(acceptedResult.batchId);
+        setActiveGroupId(acceptedResult.batchId ?? batchId ?? id);
         setBatchHeroes((prev) => {
-          if (prev[resolvedBatchId]) return prev;
-          return { ...prev, [resolvedBatchId]: localKey };
+          if (prev[acceptedResult.batchId]) return prev;
+          return { ...prev, [acceptedResult.batchId]: localKey };
         });
 
-        if (resolvedVideoUrl || resolvedStatus === 'completed') {
+        if (acceptedResult.videoUrl || acceptedResult.status === 'completed') {
           stopProgressTracking();
         }
 
         if (typeof window !== 'undefined') {
-          const detail = {
-            ok: true,
-            jobId: resolvedJobId,
-            status: resolvedStatus ?? 'pending',
-            progress: resolvedProgress,
-            videoUrl: resolvedVideoUrl ?? null,
-            thumbUrl: resolvedThumb ?? null,
-            aspectRatio: form.aspectRatio ?? null,
-            pricing: resolvedPricingSnapshot,
-            finalPriceCents: resolvedPriceCents ?? null,
-            currency: resolvedCurrency,
-            paymentStatus: resolvedPaymentStatus ?? 'platform',
-            batchId: resolvedBatchId ?? null,
-            groupId: resolvedGroupId ?? null,
-            iterationIndex: resolvedIterationIndex ?? null,
-            iterationCount: resolvedIterationCount ?? null,
-            renderIds: resolvedRenderIds ?? null,
-            heroRenderId: resolvedHeroRenderId ?? null,
-            localKey,
-            message: resolvedMessage ?? null,
-            etaSeconds: resolvedEtaSeconds ?? null,
-            etaLabel: resolvedEtaLabel ?? null,
-          };
-          window.dispatchEvent(new CustomEvent('jobs:status', { detail }));
+          window.dispatchEvent(new CustomEvent('jobs:status', { detail: acceptedResult.statusEventDetail }));
         }
 
         void mutateLatestJobs(undefined, { revalidate: true });
@@ -3102,7 +3026,7 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
           window.dispatchEvent(new Event('wallet:invalidate'));
         }
 
-        const jobId = resolvedJobId;
+        const jobId = acceptedResult.jobId;
         const poll = async () => {
           try {
             const status = await getJobStatus(jobId);
@@ -3181,7 +3105,7 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
         };
         window.setTimeout(poll, 1500);
 
-        if (resolvedVideoUrl) {
+        if (acceptedResult.videoUrl) {
           stopProgressTracking();
         }
       } catch (error) {

--- a/frontend/app/(core)/(workspace)/app/_lib/workspace-generation-result.ts
+++ b/frontend/app/(core)/(workspace)/app/_lib/workspace-generation-result.ts
@@ -1,0 +1,235 @@
+import { isRefundedPaymentStatus } from '@/lib/gallery-retention';
+import type { SelectedVideoPreview } from '@/lib/video-preview-group';
+import type { LocalRender } from './render-persistence';
+
+export type AcceptedGenerationResponse = {
+  jobId?: string | null;
+  batchId?: string | null;
+  groupId?: string | null;
+  iterationIndex?: number | null;
+  iterationCount?: number | null;
+  thumbUrl?: string | null;
+  pricing?: LocalRender['pricingSnapshot'] | null;
+  paymentStatus?: string | null;
+  etaSeconds?: number | null;
+  etaLabel?: string | null;
+  message?: string | null;
+  status?: LocalRender['status'] | null;
+  progress?: number | null;
+  renderIds?: string[] | null;
+  heroRenderId?: string | null;
+  videoUrl?: string | null;
+};
+
+export type AcceptedGenerationFallback = {
+  id: string;
+  batchId: string;
+  iterationIndex: number;
+  iterationCount: number;
+  thumbUrl: string;
+  priceCents?: number;
+  currency: string;
+  pricingSnapshot?: LocalRender['pricingSnapshot'];
+  etaSeconds?: number | null;
+  etaLabel?: string | null;
+  message: string;
+  minReadyAt: number;
+  aspectRatio: string;
+  localKey: string;
+};
+
+export type AcceptedGenerationStatusEventDetail = {
+  ok: true;
+  jobId: string;
+  status: LocalRender['status'];
+  progress: number;
+  videoUrl: string | null;
+  thumbUrl: string | null;
+  aspectRatio: string | null;
+  pricing: LocalRender['pricingSnapshot'] | undefined;
+  finalPriceCents: number | null;
+  currency: string;
+  paymentStatus: string;
+  batchId: string | null;
+  groupId: string | null;
+  iterationIndex: number | null;
+  iterationCount: number | null;
+  renderIds: string[] | null;
+  heroRenderId: string | null;
+  localKey: string;
+  message: string | null;
+  etaSeconds: number | null;
+  etaLabel: string | null;
+};
+
+export type AcceptedGenerationProjection = {
+  now: number;
+  localKey: string;
+  jobId: string;
+  batchId: string;
+  groupId: string;
+  iterationIndex: number;
+  iterationCount: number;
+  thumbUrl: string;
+  priceCents?: number;
+  currency: string;
+  etaSeconds?: number | null;
+  etaLabel?: string | null;
+  message: string;
+  status: LocalRender['status'];
+  visibleStatus: LocalRender['status'];
+  progress: number;
+  gatedProgress: number;
+  pricingSnapshot?: LocalRender['pricingSnapshot'];
+  paymentStatus: string;
+  renderIds?: string[];
+  heroRenderId: string | null;
+  videoUrl?: string;
+  gatingActive: boolean;
+  statusEventDetail: AcceptedGenerationStatusEventDetail;
+};
+
+export function projectAcceptedGenerationResult({
+  response,
+  fallback,
+  now,
+}: {
+  response: AcceptedGenerationResponse;
+  fallback: AcceptedGenerationFallback;
+  now: number;
+}): AcceptedGenerationProjection {
+  const jobId = response.jobId ?? fallback.id;
+  const batchId = response.batchId ?? fallback.batchId;
+  const groupId = response.groupId ?? fallback.batchId;
+  const iterationIndex = response.iterationIndex ?? fallback.iterationIndex;
+  const iterationCount = response.iterationCount ?? fallback.iterationCount;
+  const thumbUrl = response.thumbUrl ?? fallback.thumbUrl;
+  const priceCents = response.pricing?.totalCents ?? fallback.priceCents;
+  const currency = response.pricing?.currency ?? fallback.currency;
+  const etaSeconds = typeof response.etaSeconds === 'number' ? response.etaSeconds : fallback.etaSeconds;
+  const etaLabel = response.etaLabel ?? fallback.etaLabel;
+  const message = response.message ?? fallback.message;
+  const status = response.status ?? (response.videoUrl ? 'completed' : 'pending');
+  const progress = typeof response.progress === 'number' ? response.progress : response.videoUrl ? 100 : 5;
+  const pricingSnapshot = response.pricing ?? fallback.pricingSnapshot;
+  const paymentStatus = response.paymentStatus ?? 'pending_payment';
+  const renderIds = response.renderIds ?? undefined;
+  const heroRenderId = response.heroRenderId ?? null;
+  const videoUrl = response.videoUrl ?? undefined;
+  const gatingActive = Boolean(videoUrl) && now < fallback.minReadyAt;
+  const clampedProgress = progress < 5 ? 5 : progress;
+  const gatedProgress = gatingActive ? Math.min(clampedProgress, 95) : clampedProgress;
+  const visibleStatus = gatingActive ? 'pending' : status;
+
+  return {
+    now,
+    localKey: fallback.localKey,
+    jobId,
+    batchId,
+    groupId,
+    iterationIndex,
+    iterationCount,
+    thumbUrl,
+    priceCents,
+    currency,
+    etaSeconds,
+    etaLabel,
+    message,
+    status,
+    visibleStatus,
+    progress,
+    gatedProgress,
+    pricingSnapshot,
+    paymentStatus,
+    renderIds,
+    heroRenderId,
+    videoUrl,
+    gatingActive,
+    statusEventDetail: {
+      ok: true,
+      jobId,
+      status,
+      progress,
+      videoUrl: videoUrl ?? null,
+      thumbUrl: thumbUrl ?? null,
+      aspectRatio: fallback.aspectRatio ?? null,
+      pricing: pricingSnapshot,
+      finalPriceCents: priceCents ?? null,
+      currency,
+      paymentStatus: paymentStatus ?? 'platform',
+      batchId: batchId ?? null,
+      groupId: groupId ?? null,
+      iterationIndex: iterationIndex ?? null,
+      iterationCount: iterationCount ?? null,
+      renderIds: renderIds ?? null,
+      heroRenderId: heroRenderId ?? null,
+      localKey: fallback.localKey,
+      message: message ?? null,
+      etaSeconds: etaSeconds ?? null,
+      etaLabel: etaLabel ?? null,
+    },
+  };
+}
+
+export function applyAcceptedGenerationResultToRender(
+  render: LocalRender,
+  projection: AcceptedGenerationProjection
+): LocalRender {
+  const nextFailedAt =
+    projection.status === 'failed' && isRefundedPaymentStatus(projection.paymentStatus)
+      ? render.failedAt ?? projection.now
+      : undefined;
+
+  return {
+    ...render,
+    id: projection.jobId,
+    jobId: projection.jobId,
+    batchId: projection.batchId,
+    groupId: projection.groupId,
+    iterationIndex: projection.iterationIndex,
+    iterationCount: projection.iterationCount,
+    thumbUrl: projection.thumbUrl,
+    message: projection.message,
+    progress: projection.gatedProgress,
+    status: projection.visibleStatus,
+    priceCents: projection.priceCents,
+    currency: projection.currency,
+    pricingSnapshot: projection.pricingSnapshot,
+    paymentStatus: projection.paymentStatus,
+    failedAt: nextFailedAt,
+    etaSeconds: projection.etaSeconds ?? undefined,
+    etaLabel: projection.etaLabel ?? undefined,
+    renderIds: projection.renderIds,
+    heroRenderId: projection.heroRenderId,
+    readyVideoUrl: projection.videoUrl ?? render.readyVideoUrl,
+    videoUrl: projection.gatingActive ? render.videoUrl : projection.videoUrl ?? render.videoUrl,
+    previewVideoUrl: render.previewVideoUrl,
+  };
+}
+
+export function applyAcceptedGenerationResultToSelectedPreview(
+  current: SelectedVideoPreview | null,
+  projection: AcceptedGenerationProjection
+): SelectedVideoPreview | null {
+  if (!current || current.localKey !== projection.localKey) {
+    return current;
+  }
+
+  return {
+    ...current,
+    id: projection.jobId,
+    batchId: projection.batchId,
+    iterationIndex: projection.iterationIndex,
+    iterationCount: projection.iterationCount,
+    thumbUrl: projection.thumbUrl,
+    progress: projection.gatedProgress,
+    message: projection.message,
+    priceCents: projection.priceCents,
+    currency: projection.currency,
+    etaSeconds: projection.etaSeconds ?? undefined,
+    etaLabel: projection.etaLabel ?? undefined,
+    videoUrl: projection.gatingActive ? current.videoUrl : projection.videoUrl ?? current.videoUrl,
+    previewVideoUrl: current.previewVideoUrl,
+    status: projection.visibleStatus,
+  };
+}

--- a/tests/workspace-generation-result.test.ts
+++ b/tests/workspace-generation-result.test.ts
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  applyAcceptedGenerationResultToRender,
+  applyAcceptedGenerationResultToSelectedPreview,
+  projectAcceptedGenerationResult,
+} from '../frontend/app/(core)/(workspace)/app/_lib/workspace-generation-result';
+import type { LocalRender } from '../frontend/app/(core)/(workspace)/app/_lib/render-persistence';
+import type { SelectedVideoPreview } from '../frontend/lib/video-preview-group';
+
+function pendingRender(overrides: Partial<LocalRender> = {}): LocalRender {
+  return {
+    localKey: 'local_batch_1',
+    batchId: 'batch',
+    iterationIndex: 0,
+    iterationCount: 1,
+    id: 'local_batch_1',
+    engineId: 'seedance-2-0',
+    engineLabel: 'Seedance 2.0',
+    createdAt: '2026-01-02T03:04:05.000Z',
+    aspectRatio: '16:9',
+    durationSec: 5,
+    prompt: 'prompt',
+    progress: 5,
+    message: '',
+    status: 'pending',
+    thumbUrl: '/assets/frames/thumb-16x9.svg',
+    paymentStatus: 'pending_payment',
+    startedAt: 1000,
+    minReadyAt: 5000,
+    ...overrides,
+  };
+}
+
+test('projectAcceptedGenerationResult gates early completed videos while preserving the ready URL', () => {
+  const projection = projectAcceptedGenerationResult({
+    response: {
+      jobId: 'job_123',
+      videoUrl: 'https://cdn.example.com/video.mp4',
+      status: 'completed',
+      progress: 100,
+      pricing: { totalCents: 500, currency: 'EUR' },
+      paymentStatus: 'captured',
+      batchId: 'remote-batch',
+      groupId: 'remote-group',
+      iterationIndex: 2,
+      iterationCount: 4,
+      thumbUrl: 'https://cdn.example.com/thumb.jpg',
+      message: 'Ready',
+      etaSeconds: 2,
+      etaLabel: '2s',
+      renderIds: ['r1', 'r2'],
+      heroRenderId: 'r1',
+    },
+    fallback: {
+      id: 'local_batch_3',
+      batchId: 'batch',
+      iterationIndex: 2,
+      iterationCount: 4,
+      thumbUrl: '/assets/frames/thumb-16x9.svg',
+      priceCents: 300,
+      currency: 'USD',
+      pricingSnapshot: { totalCents: 300, currency: 'USD' },
+      etaSeconds: 8,
+      etaLabel: '8s',
+      message: 'Take 3/4',
+      minReadyAt: 10_000,
+      aspectRatio: '16:9',
+      localKey: 'local_batch_3',
+    },
+    now: 5_000,
+  });
+
+  assert.equal(projection.jobId, 'job_123');
+  assert.equal(projection.gatingActive, true);
+  assert.equal(projection.gatedProgress, 95);
+  assert.equal(projection.status, 'completed');
+  assert.equal(projection.visibleStatus, 'pending');
+  assert.equal(projection.videoUrl, 'https://cdn.example.com/video.mp4');
+  assert.equal(projection.statusEventDetail.progress, 100);
+  assert.equal(projection.statusEventDetail.videoUrl, 'https://cdn.example.com/video.mp4');
+  assert.deepEqual(projection.renderIds, ['r1', 'r2']);
+
+  const render = applyAcceptedGenerationResultToRender(pendingRender({ localKey: 'local_batch_3' }), projection);
+  assert.equal(render.id, 'job_123');
+  assert.equal(render.jobId, 'job_123');
+  assert.equal(render.status, 'pending');
+  assert.equal(render.progress, 95);
+  assert.equal(render.readyVideoUrl, 'https://cdn.example.com/video.mp4');
+  assert.equal(render.videoUrl, undefined);
+  assert.equal(render.thumbUrl, 'https://cdn.example.com/thumb.jpg');
+  assert.equal(render.priceCents, 500);
+  assert.equal(render.currency, 'EUR');
+});
+
+test('accepted generation projection updates selected preview and marks refunded failures', () => {
+  const projection = projectAcceptedGenerationResult({
+    response: {
+      jobId: 'job_failed',
+      status: 'failed',
+      progress: 100,
+      paymentStatus: 'refunded',
+      message: 'Provider failed',
+    },
+    fallback: {
+      id: 'local_batch_1',
+      batchId: 'batch',
+      iterationIndex: 0,
+      iterationCount: 1,
+      thumbUrl: '/assets/frames/thumb-16x9.svg',
+      priceCents: undefined,
+      currency: 'USD',
+      pricingSnapshot: undefined,
+      etaSeconds: 8,
+      etaLabel: '8s',
+      message: '',
+      minReadyAt: 1_000,
+      aspectRatio: '9:16',
+      localKey: 'local_batch_1',
+    },
+    now: 2_000,
+  });
+
+  const render = applyAcceptedGenerationResultToRender(pendingRender(), projection);
+  assert.equal(render.status, 'failed');
+  assert.equal(render.failedAt, 2_000);
+  assert.equal(render.message, 'Provider failed');
+
+  const current: SelectedVideoPreview = {
+    id: 'local_batch_1',
+    localKey: 'local_batch_1',
+    progress: 5,
+    status: 'pending',
+    message: '',
+    thumbUrl: '/assets/frames/thumb-16x9.svg',
+  };
+  const selected = applyAcceptedGenerationResultToSelectedPreview(current, projection);
+  assert.equal(selected?.id, 'job_failed');
+  assert.equal(selected?.status, 'failed');
+  assert.equal(selected?.message, 'Provider failed');
+  assert.equal(selected?.progress, 100);
+  assert.equal(selected?.videoUrl, undefined);
+});


### PR DESCRIPTION
## Summary
- Extract accepted runGenerate response projection from AppClient startRender.
- Add pure helpers for immediate render/selected-preview patches, gated completed videos, jobs:status payloads, and refunded failure timestamps.
- Update the workspace route guide so future work keeps accepted generation result shaping in _lib.

## Test Plan
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/workspace-generation-result.test.ts tests/workspace-local-generation-render.test.ts tests/workspace-generation-request-helpers.test.ts tests/workspace-generation-inputs.test.ts
- cd frontend && ./node_modules/.bin/tsc --noEmit
- npm --prefix frontend run lint
- pnpm run test:validate
- npm --prefix frontend run build