### PR TITLE
[codex] Extract workspace generation polling helpers

### DIFF
--- a/frontend/app/(core)/(workspace)/app/AGENTS.md
+++ b/frontend/app/(core)/(workspace)/app/AGENTS.md
@@ -6,7 +6,7 @@ This route is the main signed-in video generation workspace.
 
 - `AppClient.tsx`: top-level state orchestration while the workspace is being split.
 - `_components`: route-local chrome, panels, skeletons, modals, and presentational UI.
-- `_lib`: route-local pure helpers for previews, render grouping, render status reconciliation, generation input preparation, generation guards, local render preparation, generation payloads and accepted results, video settings hydration, workspace boot hydration, storage, copy fallback, client constants, asset normalization, asset selection, payload builders, input normalization, and workflow mapping.
+- `_lib`: route-local pure helpers for previews, render grouping, render status reconciliation, generation input preparation, generation guards, local render preparation, generation payloads, accepted results, generation polling projections, video settings hydration, workspace boot hydration, storage, copy fallback, client constants, asset normalization, asset selection, payload builders, input normalization, and workflow mapping.
 - Tool-specific workspaces should stay in their own route folders unless code is clearly shared.
 
 ## Refactor Rules
@@ -19,6 +19,7 @@ This route is the main signed-in video generation workspace.
 - Keep generation validation guards and `runGenerate` payload assembly in `_lib`; `AppClient.tsx` should decide when to show errors and when to call the network.
 - Keep local pending-render and selected-preview preparation in `_lib`; `AppClient.tsx` should apply returned state objects and own timers.
 - Keep accepted `runGenerate` response projection and immediate render/preview patches in `_lib`; `AppClient.tsx` should dispatch events and start polling.
+- Keep generation polling projections and poll-delay decisions in `_lib`; `AppClient.tsx` should own `getJobStatus`, timers, and React setters.
 - Keep video settings snapshot parsing and job media patch mapping in `_lib`; `AppClient.tsx` should wire those results into React state.
 - Keep workspace request parsing and boot hydration decisions in `_lib`; `AppClient.tsx` should apply the resolved state.
 - Keep asset-library selection, reference slot insertion, and Kling library asset mapping in `_lib`; `AppClient.tsx` should handle network calls and React state wiring.

--- a/frontend/app/(core)/(workspace)/app/AppClient.tsx
+++ b/frontend/app/(core)/(workspace)/app/AppClient.tsx
@@ -36,7 +36,7 @@ import { useResultProvider } from '@/hooks/useResultProvider';
 import { GroupedJobCard, type GroupedJobAction } from '@/components/GroupedJobCard';
 import { normalizeGroupSummaries, normalizeGroupSummary } from '@/lib/normalize-group-summary';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
-import { isExpiredRefundedFailedGalleryItem, isRefundedPaymentStatus } from '@/lib/gallery-retention';
+import { isExpiredRefundedFailedGalleryItem } from '@/lib/gallery-retention';
 import { supportsAudioPricingToggle } from '@/lib/pricing-addons';
 import { readLastKnownUserId } from '@/lib/last-known';
 import { Button, ButtonLink } from '@/components/ui/Button';
@@ -47,7 +47,6 @@ import {
   isLumaRay2GenerateMode,
 } from '@/lib/luma-ray2';
 import { useI18n } from '@/lib/i18n/I18nProvider';
-import { isPlaceholderMediaUrl } from '@/lib/media';
 import {
   getSeedanceAssetState,
   getSeedanceFieldBlockKey,
@@ -75,7 +74,6 @@ import {
 import { getCompositePreviewPosterSrc } from './_lib/composite-preview';
 import {
   isAudioWorkspaceRender,
-  resolvePolledThumbUrl,
   serializePendingRenders,
   type LocalRender,
 } from './_lib/render-persistence';
@@ -84,6 +82,11 @@ import {
   type FormState,
 } from './_lib/workspace-form-state';
 import { prepareGenerationInputs } from './_lib/workspace-generation-inputs';
+import {
+  applyGenerationPollToRender,
+  applyGenerationPollToSelectedPreview,
+  projectGenerationPollStatus,
+} from './_lib/workspace-generation-polling';
 import {
   applyAcceptedGenerationResultToRender,
   applyAcceptedGenerationResultToSelectedPreview,
@@ -3034,69 +3037,29 @@ const handleRefreshJob = useCallback(async (jobId: string) => {
               progressMessage = status.message;
             }
             const target = rendersRef.current.find((r) => r.id === jobId);
-            const now = Date.now();
-            const minReadyAtCurrent = target?.minReadyAt ?? 0;
-            const isCompleted = status.status === 'completed' || Boolean(status.videoUrl);
-            if (isCompleted && target && now < minReadyAtCurrent) {
-              window.setTimeout(poll, Math.max(500, minReadyAtCurrent - now));
+            const pollProjection = projectGenerationPollStatus({
+              status,
+              target,
+              jobId,
+              localKey,
+              now: Date.now(),
+            });
+            if (pollProjection.deferUntilReady && pollProjection.nextPollDelayMs !== null) {
+              window.setTimeout(poll, pollProjection.nextPollDelayMs);
               return;
             }
-            const hasVideo = Boolean(status.videoUrl);
-            const hasThumb = Boolean(status.thumbUrl && !isPlaceholderMediaUrl(status.thumbUrl));
             setRenders((prev) =>
               prev.map((r) =>
                 r.id === jobId
-                  ? (() => {
-                      const nextStatus = status.status ?? r.status;
-                      const nextPaymentStatus = status.paymentStatus ?? r.paymentStatus;
-                      const nextFailedAt =
-                        nextStatus === 'failed' && isRefundedPaymentStatus(nextPaymentStatus)
-                          ? r.failedAt ?? now
-                          : undefined;
-                      return {
-                      ...r,
-                      status: nextStatus,
-                      progress: status.progress ?? r.progress,
-                      readyVideoUrl: status.videoUrl ?? r.readyVideoUrl,
-                      videoUrl: status.videoUrl ?? r.videoUrl ?? r.readyVideoUrl,
-                      previewVideoUrl: status.previewVideoUrl ?? r.previewVideoUrl,
-                      thumbUrl: resolvePolledThumbUrl(r.thumbUrl, status.thumbUrl),
-                      priceCents: status.finalPriceCents ?? status.pricing?.totalCents ?? r.priceCents,
-                      currency: status.currency ?? status.pricing?.currency ?? r.currency,
-                      pricingSnapshot: status.pricing ?? r.pricingSnapshot,
-                      paymentStatus: nextPaymentStatus,
-                      failedAt: nextFailedAt,
-                    };
-                  })()
+                  ? applyGenerationPollToRender(r, pollProjection)
                   : r
               )
             );
-            setSelectedPreview((cur) =>
-              cur && (cur.id === jobId || cur.localKey === localKey)
-                ? {
-                    ...cur,
-                    status: status.status ?? cur.status,
-                    id: jobId,
-                    localKey,
-                    progress: status.progress ?? cur.progress,
-                    videoUrl: status.videoUrl ?? target?.readyVideoUrl ?? cur.videoUrl,
-                    previewVideoUrl: status.previewVideoUrl ?? cur.previewVideoUrl,
-                    thumbUrl: resolvePolledThumbUrl(cur.thumbUrl, status.thumbUrl),
-                    priceCents: status.finalPriceCents ?? status.pricing?.totalCents ?? cur.priceCents,
-                    currency: status.currency ?? status.pricing?.currency ?? cur.currency,
-                    etaLabel: cur.etaLabel,
-                    etaSeconds: cur.etaSeconds,
-                  }
-                : cur
-            );
-            const shouldKeepPolling =
-              status.status !== 'failed' &&
-              (status.status !== 'completed' || !hasVideo || !hasThumb);
-            if (shouldKeepPolling) {
-              const delay = status.status === 'completed' && !hasVideo ? 4000 : 2000;
-              window.setTimeout(poll, delay);
+            setSelectedPreview((cur) => applyGenerationPollToSelectedPreview(cur, pollProjection));
+            if (pollProjection.shouldKeepPolling && pollProjection.nextPollDelayMs !== null) {
+              window.setTimeout(poll, pollProjection.nextPollDelayMs);
             }
-            if (status.status === 'failed' || (status.status === 'completed' && hasVideo && hasThumb)) {
+            if (pollProjection.shouldStopProgressTracking) {
               stopProgressTracking();
             }
           } catch {

--- a/frontend/app/(core)/(workspace)/app/_lib/workspace-generation-polling.ts
+++ b/frontend/app/(core)/(workspace)/app/_lib/workspace-generation-polling.ts
@@ -1,0 +1,132 @@
+import { isRefundedPaymentStatus } from '@/lib/gallery-retention';
+import { isPlaceholderMediaUrl } from '@/lib/media';
+import type { SelectedVideoPreview } from '@/lib/video-preview-group';
+import { resolvePolledThumbUrl, type LocalRender } from './render-persistence';
+
+export type GenerationPollStatus = {
+  status?: LocalRender['status'] | null;
+  progress?: number | null;
+  videoUrl?: string | null;
+  previewVideoUrl?: string | null;
+  thumbUrl?: string | null;
+  finalPriceCents?: number | null;
+  currency?: string | null;
+  pricing?: LocalRender['pricingSnapshot'] | null;
+  paymentStatus?: string | null;
+  message?: string | null;
+};
+
+export type GenerationPollProjection = {
+  status: GenerationPollStatus;
+  jobId: string;
+  localKey: string;
+  now: number;
+  targetReadyVideoUrl?: string;
+  deferUntilReady: boolean;
+  shouldApplyState: boolean;
+  shouldKeepPolling: boolean;
+  shouldStopProgressTracking: boolean;
+  nextPollDelayMs: number | null;
+  progressMessage?: string;
+};
+
+export function projectGenerationPollStatus({
+  status,
+  target,
+  jobId,
+  localKey,
+  now,
+}: {
+  status: GenerationPollStatus;
+  target?: LocalRender | null;
+  jobId: string;
+  localKey: string;
+  now: number;
+}): GenerationPollProjection {
+  const isCompleted = status.status === 'completed' || Boolean(status.videoUrl);
+  const minReadyAtCurrent = target?.minReadyAt ?? 0;
+  if (isCompleted && target && now < minReadyAtCurrent) {
+    return {
+      status,
+      jobId,
+      localKey,
+      now,
+      targetReadyVideoUrl: target.readyVideoUrl,
+      deferUntilReady: true,
+      shouldApplyState: false,
+      shouldKeepPolling: true,
+      shouldStopProgressTracking: false,
+      nextPollDelayMs: Math.max(500, minReadyAtCurrent - now),
+      progressMessage: status.message ?? undefined,
+    };
+  }
+
+  const hasVideo = Boolean(status.videoUrl);
+  const hasThumb = Boolean(status.thumbUrl && !isPlaceholderMediaUrl(status.thumbUrl));
+  const shouldKeepPolling = status.status !== 'failed' && (status.status !== 'completed' || !hasVideo || !hasThumb);
+
+  return {
+    status,
+    jobId,
+    localKey,
+    now,
+    targetReadyVideoUrl: target?.readyVideoUrl,
+    deferUntilReady: false,
+    shouldApplyState: true,
+    shouldKeepPolling,
+    shouldStopProgressTracking: status.status === 'failed' || (status.status === 'completed' && hasVideo && hasThumb),
+    nextPollDelayMs: shouldKeepPolling ? (status.status === 'completed' && !hasVideo ? 4000 : 2000) : null,
+    progressMessage: status.message ?? undefined,
+  };
+}
+
+export function applyGenerationPollToRender(
+  render: LocalRender,
+  projection: GenerationPollProjection
+): LocalRender {
+  const nextStatus = projection.status.status ?? render.status;
+  const nextPaymentStatus = projection.status.paymentStatus ?? render.paymentStatus;
+  const nextFailedAt =
+    nextStatus === 'failed' && isRefundedPaymentStatus(nextPaymentStatus)
+      ? render.failedAt ?? projection.now
+      : undefined;
+
+  return {
+    ...render,
+    status: nextStatus,
+    progress: projection.status.progress ?? render.progress,
+    readyVideoUrl: projection.status.videoUrl ?? render.readyVideoUrl,
+    videoUrl: projection.status.videoUrl ?? render.videoUrl ?? render.readyVideoUrl,
+    previewVideoUrl: projection.status.previewVideoUrl ?? render.previewVideoUrl,
+    thumbUrl: resolvePolledThumbUrl(render.thumbUrl, projection.status.thumbUrl),
+    priceCents: projection.status.finalPriceCents ?? projection.status.pricing?.totalCents ?? render.priceCents,
+    currency: projection.status.currency ?? projection.status.pricing?.currency ?? render.currency,
+    pricingSnapshot: projection.status.pricing ?? render.pricingSnapshot,
+    paymentStatus: nextPaymentStatus,
+    failedAt: nextFailedAt,
+  };
+}
+
+export function applyGenerationPollToSelectedPreview(
+  current: SelectedVideoPreview | null,
+  projection: GenerationPollProjection
+): SelectedVideoPreview | null {
+  if (!current || (current.id !== projection.jobId && current.localKey !== projection.localKey)) {
+    return current;
+  }
+
+  return {
+    ...current,
+    status: projection.status.status ?? current.status,
+    id: projection.jobId,
+    localKey: projection.localKey,
+    progress: projection.status.progress ?? current.progress,
+    videoUrl: projection.status.videoUrl ?? projection.targetReadyVideoUrl ?? current.videoUrl,
+    previewVideoUrl: projection.status.previewVideoUrl ?? current.previewVideoUrl,
+    thumbUrl: resolvePolledThumbUrl(current.thumbUrl, projection.status.thumbUrl),
+    priceCents: projection.status.finalPriceCents ?? projection.status.pricing?.totalCents ?? current.priceCents,
+    currency: projection.status.currency ?? projection.status.pricing?.currency ?? current.currency,
+    etaLabel: current.etaLabel,
+    etaSeconds: current.etaSeconds,
+  };
+}

--- a/tests/workspace-gallery-rail-contract.test.ts
+++ b/tests/workspace-gallery-rail-contract.test.ts
@@ -107,11 +107,17 @@ test('video polling waits for a real static thumbnail', () => {
     path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/_lib/workspace-render-status.ts'),
     'utf8'
   );
+  const generationPollingSource = fs.readFileSync(
+    path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/_lib/workspace-generation-polling.ts'),
+    'utf8'
+  );
 
   assert.match(renderPersistenceSource, /export function resolvePolledThumbUrl/);
   assert.match(renderPersistenceSource, /next && !isPlaceholderMediaUrl\(next\)/);
   assert.match(renderStatusSource, /thumbUrl:\s*resolvePolledThumbUrl\(render\.thumbUrl,\s*status\.thumbUrl\)/);
   assert.match(renderStatusSource, /thumbUrl:\s*resolvePolledThumbUrl\(current\.thumbUrl,\s*status\.thumbUrl\)/);
-  assert.match(appSource, /thumbUrl:\s*resolvePolledThumbUrl\(r\.thumbUrl,\s*status\.thumbUrl\)/);
+  assert.match(generationPollingSource, /thumbUrl:\s*resolvePolledThumbUrl\(render\.thumbUrl,\s*projection\.status\.thumbUrl\)/);
+  assert.match(generationPollingSource, /thumbUrl:\s*resolvePolledThumbUrl\(current\.thumbUrl,\s*projection\.status\.thumbUrl\)/);
+  assert.match(appSource, /applyGenerationPollToRender\(r,\s*pollProjection\)/);
   assert.match(appSource, /applyPolledJobStatusToRender\(item,\s*status\)/);
 });

--- a/tests/workspace-generation-polling.test.ts
+++ b/tests/workspace-generation-polling.test.ts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  applyGenerationPollToRender,
+  applyGenerationPollToSelectedPreview,
+  projectGenerationPollStatus,
+} from '../frontend/app/(core)/(workspace)/app/_lib/workspace-generation-polling';
+import type { LocalRender } from '../frontend/app/(core)/(workspace)/app/_lib/render-persistence';
+import type { SelectedVideoPreview } from '../frontend/lib/video-preview-group';
+
+function render(overrides: Partial<LocalRender> = {}): LocalRender {
+  return {
+    localKey: 'local_batch_1',
+    batchId: 'batch',
+    iterationIndex: 0,
+    iterationCount: 1,
+    id: 'job_123',
+    jobId: 'job_123',
+    engineId: 'seedance-2-0',
+    engineLabel: 'Seedance 2.0',
+    createdAt: '2026-01-02T03:04:05.000Z',
+    aspectRatio: '16:9',
+    durationSec: 5,
+    prompt: 'prompt',
+    progress: 5,
+    message: 'Working',
+    status: 'pending',
+    thumbUrl: '/assets/frames/thumb-16x9.svg',
+    paymentStatus: 'pending_payment',
+    startedAt: 1000,
+    minReadyAt: 10_000,
+    ...overrides,
+  };
+}
+
+test('projectGenerationPollStatus defers completed videos until minReadyAt', () => {
+  const target = render({ readyVideoUrl: 'https://cdn.example.com/previous.mp4' });
+  const projection = projectGenerationPollStatus({
+    status: {
+      status: 'completed',
+      progress: 100,
+      videoUrl: 'https://cdn.example.com/final.mp4',
+      thumbUrl: 'https://cdn.example.com/thumb.jpg',
+      message: 'Ready',
+    },
+    target,
+    jobId: 'job_123',
+    localKey: 'local_batch_1',
+    now: 5_000,
+  });
+
+  assert.equal(projection.deferUntilReady, true);
+  assert.equal(projection.nextPollDelayMs, 5_000);
+  assert.equal(projection.shouldApplyState, false);
+  assert.equal(projection.progressMessage, 'Ready');
+});
+
+test('poll projection patches renders and selected preview when media is complete', () => {
+  const target = render();
+  const projection = projectGenerationPollStatus({
+    status: {
+      status: 'completed',
+      progress: 100,
+      videoUrl: 'https://cdn.example.com/final.mp4',
+      previewVideoUrl: 'https://cdn.example.com/preview.mp4',
+      thumbUrl: 'https://cdn.example.com/thumb.jpg',
+      finalPriceCents: 450,
+      currency: 'EUR',
+      pricing: { totalCents: 450, currency: 'EUR' },
+      paymentStatus: 'captured',
+      message: 'Done',
+    },
+    target,
+    jobId: 'job_123',
+    localKey: 'local_batch_1',
+    now: 12_000,
+  });
+
+  assert.equal(projection.deferUntilReady, false);
+  assert.equal(projection.shouldKeepPolling, false);
+  assert.equal(projection.nextPollDelayMs, null);
+  assert.equal(projection.shouldStopProgressTracking, true);
+
+  const nextRender = applyGenerationPollToRender(target, projection);
+  assert.equal(nextRender.status, 'completed');
+  assert.equal(nextRender.progress, 100);
+  assert.equal(nextRender.readyVideoUrl, 'https://cdn.example.com/final.mp4');
+  assert.equal(nextRender.videoUrl, 'https://cdn.example.com/final.mp4');
+  assert.equal(nextRender.previewVideoUrl, 'https://cdn.example.com/preview.mp4');
+  assert.equal(nextRender.thumbUrl, 'https://cdn.example.com/thumb.jpg');
+  assert.equal(nextRender.priceCents, 450);
+  assert.equal(nextRender.currency, 'EUR');
+  assert.equal(nextRender.paymentStatus, 'captured');
+  assert.equal(nextRender.message, 'Working');
+
+  const selected: SelectedVideoPreview = {
+    id: 'job_123',
+    localKey: 'local_batch_1',
+    progress: 5,
+    status: 'pending',
+    message: 'Working',
+    thumbUrl: '/assets/frames/thumb-16x9.svg',
+  };
+  const nextSelected = applyGenerationPollToSelectedPreview(selected, projection);
+  assert.equal(nextSelected?.status, 'completed');
+  assert.equal(nextSelected?.videoUrl, 'https://cdn.example.com/final.mp4');
+  assert.equal(nextSelected?.thumbUrl, 'https://cdn.example.com/thumb.jpg');
+});
+
+test('poll projection marks refunded failures and stops progress tracking', () => {
+  const target = render();
+  const projection = projectGenerationPollStatus({
+    status: {
+      status: 'failed',
+      progress: 100,
+      videoUrl: null,
+      thumbUrl: null,
+      paymentStatus: 'refunded',
+      message: 'Failed',
+    },
+    target,
+    jobId: 'job_123',
+    localKey: 'local_batch_1',
+    now: 12_000,
+  });
+
+  assert.equal(projection.shouldKeepPolling, false);
+  assert.equal(projection.shouldStopProgressTracking, true);
+
+  const nextRender = applyGenerationPollToRender(target, projection);
+  assert.equal(nextRender.status, 'failed');
+  assert.equal(nextRender.paymentStatus, 'refunded');
+  assert.equal(nextRender.failedAt, 12_000);
+});


### PR DESCRIPTION
## Summary
- Extract workspace generation polling projection and render/preview patching into a route-local helper.
- Keep AppClient responsible for getJobStatus, timers, and React setters while removing inline thumbnail/payment polling logic.
- Update workspace guide and polling contract tests for the new helper boundary.

## Test plan
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/workspace-gallery-rail-contract.test.ts tests/workspace-generation-polling.test.ts
- pnpm run test:validate
- npm --prefix frontend run lint
- npm --prefix frontend run build
- cd frontend && ./node_modules/.bin/tsc --noEmit
- git diff --check