### PR TITLE
[codex] Extract workspace render state hook

### DIFF
--- a/frontend/app/(core)/(workspace)/app/AGENTS.md
+++ b/frontend/app/(core)/(workspace)/app/AGENTS.md
@@ -6,7 +6,7 @@ This route is the main signed-in video generation workspace.
 
 - `AppClient.tsx`: top-level state orchestration while the workspace is being split.
 - `_components`: route-local chrome, panels, skeletons, modals, and presentational UI.
-- `_hooks`: route-local stateful workflow hooks for bounded client concerns such as asset library, upload orchestration, video settings application, and hydration.
+- `_hooks`: route-local stateful workflow hooks for bounded client concerns such as asset library, upload orchestration, render state and polling, video settings application, and hydration.
 - `_lib`: route-local pure helpers for previews, render grouping, render status reconciliation, generation input preparation, generation guards, local render preparation, generation payloads, accepted results, generation polling projections, video settings hydration, workspace boot hydration, storage, copy fallback, client constants, asset normalization, asset selection, payload builders, input normalization, and workflow mapping.
 - Tool-specific workspaces should stay in their own route folders unless code is clearly shared.
 
@@ -15,7 +15,7 @@ This route is the main signed-in video generation workspace.
 - Extract stable UI and pure helpers before moving generation state.
 - Keep schema summarization, asset-library normalization, and copy merging in `_lib`; `AppClient.tsx` should consume those results instead of rebuilding them inline.
 - Keep render grouping and preview tile mapping in `_lib`; `AppClient.tsx` should decide state transitions, not rebuild group summary objects inline.
-- Keep job-to-render conversion, status polling projections, and recent-job reconciliation in `_lib`; `AppClient.tsx` should own timers and network calls.
+- Keep job-to-render conversion, status polling projections, and recent-job reconciliation in `_lib`; route-local hooks should own render state, timers, and bounded network polling.
 - Keep generation attachment ordering, derived input URLs, Kling element payloads, and multi-prompt payloads in `_lib`; `AppClient.tsx` should consume prepared inputs instead of deriving attachment URLs inline.
 - Keep generation validation guards and `runGenerate` payload assembly in `_lib`; `AppClient.tsx` should decide when to show errors and when to call the network.
 - Keep local pending-render and selected-preview preparation in `_lib`; `AppClient.tsx` should apply returned state objects and own timers.

--- a/frontend/app/(core)/(workspace)/app/AppClient.tsx
+++ b/frontend/app/(core)/(workspace)/app/AppClient.tsx
@@ -23,18 +23,16 @@ import dynamic from 'next/dynamic';
 import { DEFAULT_PROCESSING_COPY } from '@/components/groups/ProcessingOverlay';
 import { CURRENCY_LOCALE } from '@/lib/intl';
 import { ENV as CLIENT_ENV } from '@/lib/env';
-import { adaptGroupSummaries, adaptGroupSummary } from '@/lib/video-group-adapter';
+import { adaptGroupSummary } from '@/lib/video-group-adapter';
 import type { VideoGroup } from '@/types/video-groups';
 import {
   mapSelectedPreviewToGroup,
-  type SelectedVideoPreview,
   type SharedVideoPreview,
 } from '@/lib/video-preview-group';
 import { useResultProvider } from '@/hooks/useResultProvider';
 import { GroupedJobCard, type GroupedJobAction } from '@/components/GroupedJobCard';
-import { normalizeGroupSummaries, normalizeGroupSummary } from '@/lib/normalize-group-summary';
+import { normalizeGroupSummary } from '@/lib/normalize-group-summary';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
-import { isExpiredRefundedFailedGalleryItem } from '@/lib/gallery-retention';
 import { supportsAudioPricingToggle } from '@/lib/pricing-addons';
 import { readLastKnownUserId } from '@/lib/last-known';
 import { Button, ButtonLink } from '@/components/ui/Button';
@@ -70,11 +68,6 @@ import {
   WorkspaceBootPreview,
 } from './_components/WorkspaceBootSkeletons';
 import { getCompositePreviewPosterSrc } from './_lib/composite-preview';
-import {
-  isAudioWorkspaceRender,
-  serializePendingRenders,
-  type LocalRender,
-} from './_lib/render-persistence';
 import {
   normalizeExtraInputValue,
   type FormState,
@@ -151,7 +144,6 @@ import {
 } from './_lib/workspace-storage';
 import {
   buildInitialWorkspaceFormState,
-  buildPendingRenderHydrationState,
   consumeWorkspaceOnboardingSkipIntent,
   parseStoredMultiPromptScenes,
   readStoredWorkspaceForm,
@@ -162,29 +154,12 @@ import {
   summarizeWorkspaceInputSchema,
 } from './_lib/workspace-input-schema';
 import {
-  buildPendingGroupSummaries,
-  buildPendingSummaryMap,
   buildQuadTileFromGroupMember,
   buildQuadTileFromRender,
-  buildRenderGroups,
-  clearRemovedGroupId,
-  clearSelectedPreviewForRemovedRenders,
-  filterLocalRenders,
-  getGenerationSkeletonCount,
-  hasRemovedRenderRefs,
   haveSameGroupOrder,
-  isGenerationGroupLoading,
-  pruneBatchHeroes,
 } from './_lib/workspace-render-groups';
-import {
-  applyPolledJobStatusToRender,
-  applyPolledJobStatusToSelectedPreview,
-  buildRecentJobIdSet,
-  getRendersNeedingStatusRefresh,
-  mergeRecentJobsIntoLocalRenders,
-  shouldRemoveCompletedSyncedRender,
-} from './_lib/workspace-render-status';
 import { useWorkspaceAssets } from './_hooks/useWorkspaceAssets';
+import { useWorkspaceRenderState } from './_hooks/useWorkspaceRenderState';
 import { useWorkspaceVideoSettings } from './_hooks/useWorkspaceVideoSettings';
 
 const AssetLibraryModal = dynamic<AssetLibraryModalProps>(
@@ -388,19 +363,13 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
       }
     }
   }, [fromVideoId]);
-  const [renders, setRenders] = useState<LocalRender[]>([]);
   const [sharedPrompt, setSharedPrompt] = useState<string | null>(null);
   const [sharedVideoSettings, setSharedVideoSettings] = useState<SharedVideoPreview | null>(null);
-  const [selectedPreview, setSelectedPreview] = useState<SelectedVideoPreview | null>(null);
   const [guidedSampleFeed, setGuidedSampleFeed] = useState<GalleryFeedState>({ visibleGroups: [], sampleOnly: false });
   const [previewAutoPlayRequestId, setPreviewAutoPlayRequestId] = useState(0);
-  const [activeBatchId, setActiveBatchId] = useState<string | null>(null);
-  const [batchHeroes, setBatchHeroes] = useState<Record<string, string>>({});
-  const [galleryRetentionTick, setGalleryRetentionTick] = useState(0);
   const [viewerTarget, setViewerTarget] = useState<
     { kind: 'pending'; id: string } | { kind: 'summary'; summary: GroupSummary } | { kind: 'group'; group: VideoGroup } | null
   >(null);
-  const [viewMode, setViewMode] = useState<'single' | 'quad'>('single');
   const [isDesktopLayout, setIsDesktopLayout] = useState<boolean>(() => {
     if (typeof window === 'undefined') return false;
     return window.matchMedia(`(min-width: ${DESKTOP_RAIL_MIN_WIDTH}px)`).matches;
@@ -419,11 +388,41 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
     mediaQuery.addListener(handleChange);
     return () => mediaQuery.removeListener(handleChange);
   }, []);
-  const [activeGroupId, setActiveGroupId] = useState<string | null>(null);
-  const rendersRef = useRef<LocalRender[]>([]);
-  const persistedRendersRef = useRef<string | null>(null);
-  const pendingPollRef = useRef<number | null>(null);
-  const statusErrorCountsRef = useRef<Map<string, { unauthorized: number }>>(new Map());
+  const [compositeOverride, setCompositeOverride] = useState<VideoGroup | null>(null);
+  const [compositeOverrideSummary, setCompositeOverrideSummary] = useState<GroupSummary | null>(null);
+  const {
+    renders,
+    setRenders,
+    rendersRef,
+    selectedPreview,
+    setSelectedPreview,
+    setActiveBatchId,
+    batchHeroes,
+    setBatchHeroes,
+    setActiveGroupId,
+    setViewMode,
+    renderGroups,
+    normalizedPendingGroups,
+    pendingSummaryMap,
+    activeVideoGroup,
+    isGenerationLoading,
+    generationSkeletonCount,
+    hydratePendingRendersFromStorage,
+    resetRenderState,
+  } = useWorkspaceRenderState({
+    recentJobs,
+    engineIdByLabel,
+    provider,
+    storageScope,
+    hydratedForScope,
+    formIterations: form?.iterations,
+    compositeOverride,
+    compositeOverrideSummary,
+    writeScopedStorage,
+  });
+  const isGuidedSamplesActive = guidedSampleFeed.sampleOnly;
+  const guidedSampleGroups = guidedSampleFeed.visibleGroups;
+  const applyVideoSettingsSnapshotRef = useRef<(snapshot: unknown) => void>(() => undefined);
   const hydratedScopeRef = useRef<string | null>(null);
   const hasStoredFormRef = useRef<boolean>(false);
 
@@ -449,13 +448,6 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
   }, [authLoading, authStatus, user?.id]);
 
   useEffect(() => {
-    const intervalId = window.setInterval(() => {
-      setGalleryRetentionTick((current) => current + 1);
-    }, 5_000);
-    return () => window.clearInterval(intervalId);
-  }, []);
-
-  useEffect(() => {
     if (typeof window === 'undefined') return;
     if (!engines.length) return;
     if (requestedJobId) return;
@@ -463,10 +455,7 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
     hydratedScopeRef.current = storageScope;
     setHydratedForScope(null);
 
-    setRenders([]);
-    setBatchHeroes({});
-    setActiveBatchId(null);
-    setActiveGroupId(null);
+    resetRenderState();
 
     try {
       const promptValue = readStorage(STORAGE_KEYS.prompt);
@@ -523,26 +512,18 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
       }
 
       const pendingValue = readScopedStorage(STORAGE_KEYS.pendingRenders);
-      const pendingHydration = buildPendingRenderHydrationState(pendingValue);
-      if (pendingHydration.pendingRenders.length) {
-        setRenders(pendingHydration.pendingRenders);
-        setBatchHeroes(pendingHydration.batchHeroes);
-        setActiveBatchId(pendingHydration.activeBatchId);
-        setActiveGroupId(pendingHydration.activeGroupId);
-      }
-      persistedRendersRef.current = pendingHydration.serialized;
+      hydratePendingRendersFromStorage(pendingValue);
     } catch {
-      setRenders([]);
-      setBatchHeroes({});
-      setActiveBatchId(null);
-      setActiveGroupId(null);
+      resetRenderState();
     } finally {
       setHydratedForScope(storageScope);
     }
   }, [
     engines,
+    hydratePendingRendersFromStorage,
     readScopedStorage,
     readStorage,
+    resetRenderState,
     writeStorage,
     setMemberTier,
     storageScope,
@@ -552,214 +533,6 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
     requestedJobId,
   ]);
 
-  useEffect(() => {
-    rendersRef.current = renders;
-  }, [renders]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    if (hydratedScopeRef.current !== storageScope) return;
-    const serialized = serializePendingRenders(renders);
-    if (serialized === persistedRendersRef.current) return;
-    persistedRendersRef.current = serialized;
-    writeScopedStorage(STORAGE_KEYS.pendingRenders, serialized);
-  }, [renders, storageScope, writeScopedStorage]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const jobsNeedingRefresh = getRendersNeedingStatusRefresh(renders);
-    if (!jobsNeedingRefresh.length) {
-      if (pendingPollRef.current !== null) {
-        window.clearInterval(pendingPollRef.current);
-        pendingPollRef.current = null;
-      }
-      return;
-    }
-    let cancelled = false;
-
-    const poll = async () => {
-      await Promise.all(
-        jobsNeedingRefresh.map(async (render) => {
-          if (!render.jobId) return;
-          try {
-            const status = await getJobStatus(render.jobId);
-            statusErrorCountsRef.current.delete(render.jobId);
-            if (cancelled) return;
-            setRenders((prev) =>
-              prev.map((item) =>
-                item.jobId === render.jobId ? applyPolledJobStatusToRender(item, status) : item
-              )
-            );
-            setSelectedPreview((cur) =>
-              applyPolledJobStatusToSelectedPreview(cur, render, status)
-            );
-          } catch (error) {
-            const statusCode = typeof error === 'object' && error ? (error as { status?: unknown }).status : undefined;
-            if (statusCode === 404) {
-              statusErrorCountsRef.current.delete(render.jobId);
-              if (cancelled) return;
-              setRenders((prev) => prev.filter((item) => item.jobId !== render.jobId));
-              setSelectedPreview((cur) => (cur && cur.id === render.jobId ? null : cur));
-              return;
-            }
-
-            if (statusCode === 401) {
-              const meta = statusErrorCountsRef.current.get(render.jobId) ?? { unauthorized: 0 };
-              meta.unauthorized += 1;
-              statusErrorCountsRef.current.set(render.jobId, meta);
-              if (meta.unauthorized >= 3) {
-                statusErrorCountsRef.current.delete(render.jobId);
-                if (cancelled) return;
-                setRenders((prev) => prev.filter((item) => item.jobId !== render.jobId));
-                setSelectedPreview((cur) => (cur && cur.id === render.jobId ? null : cur));
-              }
-              return;
-            }
-
-            // ignore other transient errors and retry on next tick
-          }
-        })
-      );
-    };
-
-    void poll();
-    if (pendingPollRef.current !== null) {
-      window.clearInterval(pendingPollRef.current);
-    }
-    pendingPollRef.current = window.setInterval(() => {
-      void poll();
-    }, 4000);
-
-    return () => {
-      cancelled = true;
-      if (pendingPollRef.current !== null) {
-        window.clearInterval(pendingPollRef.current);
-        pendingPollRef.current = null;
-      }
-    };
-  }, [renders, setSelectedPreview]);
-
-  useEffect(() => {
-    if (!recentJobs.length) return;
-    let heroCandidates: Array<{ batchId: string | null; localKey: string }> = [];
-
-    setRenders((previous) => {
-      if (!recentJobs.length) return previous;
-      const result = mergeRecentJobsIntoLocalRenders(previous, recentJobs, { engineIdByLabel });
-      heroCandidates = result.heroCandidates;
-      return result.renders;
-    });
-
-    if (heroCandidates.length) {
-      setBatchHeroes((previous) => {
-        const next = { ...previous };
-        let modified = false;
-        heroCandidates.forEach(({ batchId, localKey }) => {
-          if (!batchId || !localKey) return;
-          if (!next[batchId]) {
-            next[batchId] = localKey;
-            modified = true;
-          }
-        });
-        return modified ? next : previous;
-      });
-    }
-  }, [engineIdByLabel, recentJobs]);
-
-  useEffect(() => {
-    const shouldRemove = (render: LocalRender) =>
-      isAudioWorkspaceRender({ jobId: render.jobId, engineId: render.engineId });
-    const removedRefs = filterLocalRenders(renders, shouldRemove);
-    if (!hasRemovedRenderRefs(removedRefs)) {
-      return;
-    }
-
-    setRenders((prev) => {
-      if (prev === renders) return removedRefs.renders;
-      const nextRemoval = filterLocalRenders(prev, shouldRemove);
-      return nextRemoval.changed ? nextRemoval.renders : prev;
-    });
-
-    setBatchHeroes((prev) => pruneBatchHeroes(prev, removedRefs.removedGroupIds));
-    setActiveBatchId((current) => clearRemovedGroupId(current, removedRefs.removedGroupIds));
-    setActiveGroupId((current) => clearRemovedGroupId(current, removedRefs.removedGroupIds));
-    setSelectedPreview((current) =>
-      clearSelectedPreviewForRemovedRenders(current, removedRefs, { clearAudioPreview: true })
-    );
-  }, [renders]);
-
-  useEffect(() => {
-    if (!renders.length || !recentJobs.length) return;
-    const recentJobIds = buildRecentJobIdSet(recentJobs);
-    if (!recentJobIds.size) return;
-    const shouldRemove = (render: LocalRender) => shouldRemoveCompletedSyncedRender(render, recentJobIds);
-    const removedRefs = filterLocalRenders(renders, shouldRemove);
-    if (!hasRemovedRenderRefs(removedRefs)) {
-      return;
-    }
-    setRenders((prev) => {
-      if (prev === renders) return removedRefs.renders;
-      const nextRemoval = filterLocalRenders(prev, shouldRemove);
-      return nextRemoval.changed ? nextRemoval.renders : prev;
-    });
-    setBatchHeroes((prev) => pruneBatchHeroes(prev, removedRefs.removedGroupIds));
-    setActiveBatchId((current) => clearRemovedGroupId(current, removedRefs.removedGroupIds));
-    setActiveGroupId((current) => clearRemovedGroupId(current, removedRefs.removedGroupIds));
-    setSelectedPreview((current) => clearSelectedPreviewForRemovedRenders(current, removedRefs));
-  }, [recentJobs, renders]);
-
-  useEffect(() => {
-    if (!renders.length) return;
-    const now = Date.now();
-    const shouldRemove = (render: LocalRender) => isExpiredRefundedFailedGalleryItem(render, now);
-    const removedRefs = filterLocalRenders(renders, shouldRemove);
-    if (!hasRemovedRenderRefs(removedRefs)) {
-      return;
-    }
-    setRenders((prev) => {
-      if (prev === renders) return removedRefs.renders;
-      const nextRemoval = filterLocalRenders(prev, shouldRemove);
-      return nextRemoval.changed ? nextRemoval.renders : prev;
-    });
-    setBatchHeroes((prev) => pruneBatchHeroes(prev, removedRefs.removedGroupIds));
-    setActiveBatchId((current) => clearRemovedGroupId(current, removedRefs.removedGroupIds));
-    setActiveGroupId((current) => clearRemovedGroupId(current, removedRefs.removedGroupIds));
-    setSelectedPreview((current) => clearSelectedPreviewForRemovedRenders(current, removedRefs));
-  }, [renders, galleryRetentionTick]);
-
-  const renderGroups = useMemo(() => buildRenderGroups(renders), [renders]);
-  const effectiveBatchId = useMemo(() => activeBatchId ?? selectedPreview?.batchId ?? null, [activeBatchId, selectedPreview?.batchId]);
-  useEffect(() => {
-    if (!effectiveBatchId) return;
-    if (batchHeroes[effectiveBatchId]) return;
-    const group = renderGroups.get(effectiveBatchId);
-    if (!group || !group.items.length) return;
-    setBatchHeroes((prev) => {
-      if (prev[effectiveBatchId]) return prev;
-      return { ...prev, [effectiveBatchId]: group.items[0].localKey };
-    });
-  }, [effectiveBatchId, renderGroups, batchHeroes]);
-  useEffect(() => {
-    const currentIterations = form?.iterations ?? 1;
-    if (currentIterations <= 1 && viewMode !== 'single') {
-      setViewMode('single');
-    }
-  }, [form?.iterations, viewMode]);
-  const pendingGroups = useMemo(() => buildPendingGroupSummaries(renderGroups, batchHeroes), [renderGroups, batchHeroes]);
-  const normalizedPendingGroups = useMemo(() => normalizeGroupSummaries(pendingGroups), [pendingGroups]);
-  const pendingSummaryMap = useMemo(() => buildPendingSummaryMap(pendingGroups), [pendingGroups]);
-  const activeVideoGroups = useMemo(() => adaptGroupSummaries(pendingGroups, provider), [pendingGroups, provider]);
-  const [compositeOverride, setCompositeOverride] = useState<VideoGroup | null>(null);
-  const [compositeOverrideSummary, setCompositeOverrideSummary] = useState<GroupSummary | null>(null);
-  const isGuidedSamplesActive = guidedSampleFeed.sampleOnly;
-  const guidedSampleGroups = guidedSampleFeed.visibleGroups;
-  const applyVideoSettingsSnapshotRef = useRef<(snapshot: unknown) => void>(() => undefined);
-  const activeVideoGroup = useMemo<VideoGroup | null>(() => {
-    if (compositeOverride) return null;
-    if (!activeVideoGroups.length) return null;
-    if (!activeGroupId) return activeVideoGroups[0] ?? null;
-    return activeVideoGroups.find((group) => group.id === activeGroupId) ?? activeVideoGroups[0] ?? null;
-  }, [activeVideoGroups, activeGroupId, compositeOverride]);
   const compositeGroup = compositeOverride ?? activeVideoGroup ?? null;
   const selectedPreviewGroup = useMemo(() => mapSelectedPreviewToGroup(selectedPreview, provider), [selectedPreview, provider]);
   const initialPreviewFallbackGroup =
@@ -769,26 +542,6 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
   const displayCompositeGroup = compositeGroup ?? selectedPreviewGroup ?? initialPreviewFallbackGroup;
   const compositePreviewPosterSrc = useMemo(() => getCompositePreviewPosterSrc(displayCompositeGroup), [displayCompositeGroup]);
 
-  useEffect(() => {
-    if (compositeOverrideSummary) {
-      return;
-    }
-    if (!pendingGroups.length) {
-      if (activeGroupId !== null) {
-        setActiveGroupId(null);
-      }
-      return;
-    }
-    if (!activeGroupId || !pendingGroups.some((group) => group.id === activeGroupId)) {
-      setActiveGroupId(pendingGroups[0].id);
-    }
-  }, [pendingGroups, activeGroupId, compositeOverrideSummary]);
-
-  const isGenerationLoading = useMemo(() => isGenerationGroupLoading(pendingGroups), [pendingGroups]);
-  const generationSkeletonCount = useMemo(
-    () => getGenerationSkeletonCount(renders, form?.iterations),
-    [renders, form?.iterations]
-  );
   const viewerGroup = useMemo<VideoGroup | null>(() => {
     if (!viewerTarget) return null;
     if (viewerTarget.kind === 'pending') {
@@ -1140,7 +893,15 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
       currency: latestJobWithMedia.currency ?? latestJobWithMedia.pricingSnapshot?.currency,
       prompt: latestJobWithMedia.prompt ?? undefined,
     });
-  }, [effectiveRequestedEngineId, effectiveRequestedEngineToken, readScopedStorage, recentJobs, renders.length, selectedPreview]);
+  }, [
+    effectiveRequestedEngineId,
+    effectiveRequestedEngineToken,
+    readScopedStorage,
+    recentJobs,
+    renders.length,
+    selectedPreview,
+    setSelectedPreview,
+  ]);
 
   const focusComposer = useCallback(() => {
     if (!composerRef.current) return;
@@ -2297,6 +2058,12 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
     extraInputFields,
     inputAssets,
     setActiveGroupId,
+    setActiveBatchId,
+    setBatchHeroes,
+    setRenders,
+    setSelectedPreview,
+    setViewMode,
+    rendersRef,
     uiLocale,
     workflowCopy,
     capability,
@@ -2479,7 +2246,16 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
           break;
       }
     },
-    [applyVideoSettingsFromTile, focusComposer, hydrateVideoSettingsFromJob, setPrompt, showNotice]
+    [
+      applyVideoSettingsFromTile,
+      focusComposer,
+      hydrateVideoSettingsFromJob,
+      setActiveBatchId,
+      setPrompt,
+      setSelectedPreview,
+      setViewMode,
+      showNotice,
+    ]
   );
 
   const handleCopySharedPrompt = useCallback(() => {
@@ -2631,6 +2407,7 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
       setActiveGroupId,
       setViewMode,
       setActiveBatchId,
+      setBatchHeroes,
       setSelectedPreview,
       setPreviewAutoPlayRequestId,
       provider,

--- a/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceRenderState.ts
+++ b/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceRenderState.ts
@@ -1,0 +1,385 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
+import { getJobStatus } from '@/lib/api';
+import { isExpiredRefundedFailedGalleryItem } from '@/lib/gallery-retention';
+import { normalizeGroupSummaries } from '@/lib/normalize-group-summary';
+import { adaptGroupSummaries } from '@/lib/video-group-adapter';
+import type { SelectedVideoPreview } from '@/lib/video-preview-group';
+import type { GroupSummary } from '@/types/groups';
+import type { Job } from '@/types/jobs';
+import type { ResultProvider, VideoGroup } from '@/types/video-groups';
+import {
+  isAudioWorkspaceRender,
+  serializePendingRenders,
+  type LocalRender,
+} from '../_lib/render-persistence';
+import { buildPendingRenderHydrationState } from '../_lib/workspace-hydration';
+import {
+  buildPendingGroupSummaries,
+  buildPendingSummaryMap,
+  buildRenderGroups,
+  clearRemovedGroupId,
+  clearSelectedPreviewForRemovedRenders,
+  filterLocalRenders,
+  getGenerationSkeletonCount,
+  hasRemovedRenderRefs,
+  isGenerationGroupLoading,
+  pruneBatchHeroes,
+} from '../_lib/workspace-render-groups';
+import {
+  applyPolledJobStatusToRender,
+  applyPolledJobStatusToSelectedPreview,
+  buildRecentJobIdSet,
+  getRendersNeedingStatusRefresh,
+  mergeRecentJobsIntoLocalRenders,
+  shouldRemoveCompletedSyncedRender,
+} from '../_lib/workspace-render-status';
+import { STORAGE_KEYS } from '../_lib/workspace-storage';
+
+type UseWorkspaceRenderStateOptions = {
+  recentJobs: Job[];
+  engineIdByLabel: ReadonlyMap<string, string>;
+  provider: ResultProvider;
+  storageScope: string;
+  hydratedForScope: string | null;
+  formIterations: number | null | undefined;
+  compositeOverride: VideoGroup | null;
+  compositeOverrideSummary: GroupSummary | null;
+  writeScopedStorage: (base: string, value: string | null) => void;
+};
+
+type UseWorkspaceRenderStateResult = {
+  renders: LocalRender[];
+  setRenders: Dispatch<SetStateAction<LocalRender[]>>;
+  rendersRef: MutableRefObject<LocalRender[]>;
+  selectedPreview: SelectedVideoPreview | null;
+  setSelectedPreview: Dispatch<SetStateAction<SelectedVideoPreview | null>>;
+  activeBatchId: string | null;
+  setActiveBatchId: Dispatch<SetStateAction<string | null>>;
+  batchHeroes: Record<string, string>;
+  setBatchHeroes: Dispatch<SetStateAction<Record<string, string>>>;
+  activeGroupId: string | null;
+  setActiveGroupId: Dispatch<SetStateAction<string | null>>;
+  viewMode: 'single' | 'quad';
+  setViewMode: Dispatch<SetStateAction<'single' | 'quad'>>;
+  renderGroups: ReturnType<typeof buildRenderGroups>;
+  pendingGroups: GroupSummary[];
+  normalizedPendingGroups: GroupSummary[];
+  pendingSummaryMap: Map<string, GroupSummary>;
+  activeVideoGroups: VideoGroup[];
+  activeVideoGroup: VideoGroup | null;
+  isGenerationLoading: boolean;
+  generationSkeletonCount: number;
+  hydratePendingRendersFromStorage: (value: string | null) => void;
+  resetRenderState: () => void;
+};
+
+export function useWorkspaceRenderState({
+  recentJobs,
+  engineIdByLabel,
+  provider,
+  storageScope,
+  hydratedForScope,
+  formIterations,
+  compositeOverride,
+  compositeOverrideSummary,
+  writeScopedStorage,
+}: UseWorkspaceRenderStateOptions): UseWorkspaceRenderStateResult {
+  const [renders, setRenders] = useState<LocalRender[]>([]);
+  const [selectedPreview, setSelectedPreview] = useState<SelectedVideoPreview | null>(null);
+  const [activeBatchId, setActiveBatchId] = useState<string | null>(null);
+  const [batchHeroes, setBatchHeroes] = useState<Record<string, string>>({});
+  const [galleryRetentionTick, setGalleryRetentionTick] = useState(0);
+  const [activeGroupId, setActiveGroupId] = useState<string | null>(null);
+  const [viewMode, setViewMode] = useState<'single' | 'quad'>('single');
+  const rendersRef = useRef<LocalRender[]>([]);
+  const persistedRendersRef = useRef<string | null>(null);
+  const pendingPollRef = useRef<number | null>(null);
+  const statusErrorCountsRef = useRef<Map<string, { unauthorized: number }>>(new Map());
+
+  const resetRenderState = useCallback(() => {
+    setRenders([]);
+    setBatchHeroes({});
+    setActiveBatchId(null);
+    setActiveGroupId(null);
+  }, []);
+
+  const hydratePendingRendersFromStorage = useCallback((value: string | null) => {
+    const pendingHydration = buildPendingRenderHydrationState(value);
+    if (pendingHydration.pendingRenders.length) {
+      setRenders(pendingHydration.pendingRenders);
+      setBatchHeroes(pendingHydration.batchHeroes);
+      setActiveBatchId(pendingHydration.activeBatchId);
+      setActiveGroupId(pendingHydration.activeGroupId);
+    } else {
+      setRenders([]);
+      setBatchHeroes({});
+      setActiveBatchId(null);
+      setActiveGroupId(null);
+    }
+    persistedRendersRef.current = pendingHydration.serialized;
+  }, []);
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      setGalleryRetentionTick((current) => current + 1);
+    }, 5_000);
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  useEffect(() => {
+    rendersRef.current = renders;
+  }, [renders]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (hydratedForScope !== storageScope) return;
+    const serialized = serializePendingRenders(renders);
+    if (serialized === persistedRendersRef.current) return;
+    persistedRendersRef.current = serialized;
+    writeScopedStorage(STORAGE_KEYS.pendingRenders, serialized);
+  }, [hydratedForScope, renders, storageScope, writeScopedStorage]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const jobsNeedingRefresh = getRendersNeedingStatusRefresh(renders);
+    if (!jobsNeedingRefresh.length) {
+      if (pendingPollRef.current !== null) {
+        window.clearInterval(pendingPollRef.current);
+        pendingPollRef.current = null;
+      }
+      return;
+    }
+    let cancelled = false;
+
+    const poll = async () => {
+      await Promise.all(
+        jobsNeedingRefresh.map(async (render) => {
+          if (!render.jobId) return;
+          try {
+            const status = await getJobStatus(render.jobId);
+            statusErrorCountsRef.current.delete(render.jobId);
+            if (cancelled) return;
+            setRenders((prev) =>
+              prev.map((item) =>
+                item.jobId === render.jobId ? applyPolledJobStatusToRender(item, status) : item
+              )
+            );
+            setSelectedPreview((cur) => applyPolledJobStatusToSelectedPreview(cur, render, status));
+          } catch (error) {
+            const statusCode = typeof error === 'object' && error ? (error as { status?: unknown }).status : undefined;
+            if (statusCode === 404) {
+              statusErrorCountsRef.current.delete(render.jobId);
+              if (cancelled) return;
+              setRenders((prev) => prev.filter((item) => item.jobId !== render.jobId));
+              setSelectedPreview((cur) => (cur && cur.id === render.jobId ? null : cur));
+              return;
+            }
+
+            if (statusCode === 401) {
+              const meta = statusErrorCountsRef.current.get(render.jobId) ?? { unauthorized: 0 };
+              meta.unauthorized += 1;
+              statusErrorCountsRef.current.set(render.jobId, meta);
+              if (meta.unauthorized >= 3) {
+                statusErrorCountsRef.current.delete(render.jobId);
+                if (cancelled) return;
+                setRenders((prev) => prev.filter((item) => item.jobId !== render.jobId));
+                setSelectedPreview((cur) => (cur && cur.id === render.jobId ? null : cur));
+              }
+              return;
+            }
+
+            // ignore other transient errors and retry on next tick
+          }
+        })
+      );
+    };
+
+    void poll();
+    if (pendingPollRef.current !== null) {
+      window.clearInterval(pendingPollRef.current);
+    }
+    pendingPollRef.current = window.setInterval(() => {
+      void poll();
+    }, 4000);
+
+    return () => {
+      cancelled = true;
+      if (pendingPollRef.current !== null) {
+        window.clearInterval(pendingPollRef.current);
+        pendingPollRef.current = null;
+      }
+    };
+  }, [renders]);
+
+  useEffect(() => {
+    if (!recentJobs.length) return;
+    let heroCandidates: Array<{ batchId: string | null; localKey: string }> = [];
+
+    setRenders((previous) => {
+      if (!recentJobs.length) return previous;
+      const result = mergeRecentJobsIntoLocalRenders(previous, recentJobs, { engineIdByLabel });
+      heroCandidates = result.heroCandidates;
+      return result.renders;
+    });
+
+    if (heroCandidates.length) {
+      setBatchHeroes((previous) => {
+        const next = { ...previous };
+        let modified = false;
+        heroCandidates.forEach(({ batchId, localKey }) => {
+          if (!batchId || !localKey) return;
+          if (!next[batchId]) {
+            next[batchId] = localKey;
+            modified = true;
+          }
+        });
+        return modified ? next : previous;
+      });
+    }
+  }, [engineIdByLabel, recentJobs]);
+
+  useEffect(() => {
+    const shouldRemove = (render: LocalRender) =>
+      isAudioWorkspaceRender({ jobId: render.jobId, engineId: render.engineId });
+    const removedRefs = filterLocalRenders(renders, shouldRemove);
+    if (!hasRemovedRenderRefs(removedRefs)) {
+      return;
+    }
+
+    setRenders((prev) => {
+      if (prev === renders) return removedRefs.renders;
+      const nextRemoval = filterLocalRenders(prev, shouldRemove);
+      return nextRemoval.changed ? nextRemoval.renders : prev;
+    });
+
+    setBatchHeroes((prev) => pruneBatchHeroes(prev, removedRefs.removedGroupIds));
+    setActiveBatchId((current) => clearRemovedGroupId(current, removedRefs.removedGroupIds));
+    setActiveGroupId((current) => clearRemovedGroupId(current, removedRefs.removedGroupIds));
+    setSelectedPreview((current) =>
+      clearSelectedPreviewForRemovedRenders(current, removedRefs, { clearAudioPreview: true })
+    );
+  }, [renders]);
+
+  useEffect(() => {
+    if (!renders.length || !recentJobs.length) return;
+    const recentJobIds = buildRecentJobIdSet(recentJobs);
+    if (!recentJobIds.size) return;
+    const shouldRemove = (render: LocalRender) => shouldRemoveCompletedSyncedRender(render, recentJobIds);
+    const removedRefs = filterLocalRenders(renders, shouldRemove);
+    if (!hasRemovedRenderRefs(removedRefs)) {
+      return;
+    }
+    setRenders((prev) => {
+      if (prev === renders) return removedRefs.renders;
+      const nextRemoval = filterLocalRenders(prev, shouldRemove);
+      return nextRemoval.changed ? nextRemoval.renders : prev;
+    });
+    setBatchHeroes((prev) => pruneBatchHeroes(prev, removedRefs.removedGroupIds));
+    setActiveBatchId((current) => clearRemovedGroupId(current, removedRefs.removedGroupIds));
+    setActiveGroupId((current) => clearRemovedGroupId(current, removedRefs.removedGroupIds));
+    setSelectedPreview((current) => clearSelectedPreviewForRemovedRenders(current, removedRefs));
+  }, [recentJobs, renders]);
+
+  useEffect(() => {
+    if (!renders.length) return;
+    const now = Date.now();
+    const shouldRemove = (render: LocalRender) => isExpiredRefundedFailedGalleryItem(render, now);
+    const removedRefs = filterLocalRenders(renders, shouldRemove);
+    if (!hasRemovedRenderRefs(removedRefs)) {
+      return;
+    }
+    setRenders((prev) => {
+      if (prev === renders) return removedRefs.renders;
+      const nextRemoval = filterLocalRenders(prev, shouldRemove);
+      return nextRemoval.changed ? nextRemoval.renders : prev;
+    });
+    setBatchHeroes((prev) => pruneBatchHeroes(prev, removedRefs.removedGroupIds));
+    setActiveBatchId((current) => clearRemovedGroupId(current, removedRefs.removedGroupIds));
+    setActiveGroupId((current) => clearRemovedGroupId(current, removedRefs.removedGroupIds));
+    setSelectedPreview((current) => clearSelectedPreviewForRemovedRenders(current, removedRefs));
+  }, [renders, galleryRetentionTick]);
+
+  const renderGroups = useMemo(() => buildRenderGroups(renders), [renders]);
+  const effectiveBatchId = useMemo(
+    () => activeBatchId ?? selectedPreview?.batchId ?? null,
+    [activeBatchId, selectedPreview?.batchId]
+  );
+
+  useEffect(() => {
+    if (!effectiveBatchId) return;
+    if (batchHeroes[effectiveBatchId]) return;
+    const group = renderGroups.get(effectiveBatchId);
+    if (!group || !group.items.length) return;
+    setBatchHeroes((prev) => {
+      if (prev[effectiveBatchId]) return prev;
+      return { ...prev, [effectiveBatchId]: group.items[0].localKey };
+    });
+  }, [effectiveBatchId, renderGroups, batchHeroes]);
+
+  useEffect(() => {
+    const currentIterations = formIterations ?? 1;
+    if (currentIterations <= 1 && viewMode !== 'single') {
+      setViewMode('single');
+    }
+  }, [formIterations, viewMode]);
+
+  const pendingGroups = useMemo(() => buildPendingGroupSummaries(renderGroups, batchHeroes), [renderGroups, batchHeroes]);
+  const normalizedPendingGroups = useMemo(() => normalizeGroupSummaries(pendingGroups), [pendingGroups]);
+  const pendingSummaryMap = useMemo(() => buildPendingSummaryMap(pendingGroups), [pendingGroups]);
+  const activeVideoGroups = useMemo(() => adaptGroupSummaries(pendingGroups, provider), [pendingGroups, provider]);
+
+  useEffect(() => {
+    if (compositeOverrideSummary) {
+      return;
+    }
+    if (!pendingGroups.length) {
+      if (activeGroupId !== null) {
+        setActiveGroupId(null);
+      }
+      return;
+    }
+    if (!activeGroupId || !pendingGroups.some((group) => group.id === activeGroupId)) {
+      setActiveGroupId(pendingGroups[0].id);
+    }
+  }, [pendingGroups, activeGroupId, compositeOverrideSummary]);
+
+  const activeVideoGroup = useMemo<VideoGroup | null>(() => {
+    if (compositeOverride) return null;
+    if (!activeVideoGroups.length) return null;
+    if (!activeGroupId) return activeVideoGroups[0] ?? null;
+    return activeVideoGroups.find((group) => group.id === activeGroupId) ?? activeVideoGroups[0] ?? null;
+  }, [activeVideoGroups, activeGroupId, compositeOverride]);
+
+  const isGenerationLoading = useMemo(() => isGenerationGroupLoading(pendingGroups), [pendingGroups]);
+  const generationSkeletonCount = useMemo(
+    () => getGenerationSkeletonCount(renders, formIterations),
+    [renders, formIterations]
+  );
+
+  return {
+    renders,
+    setRenders,
+    rendersRef,
+    selectedPreview,
+    setSelectedPreview,
+    activeBatchId,
+    setActiveBatchId,
+    batchHeroes,
+    setBatchHeroes,
+    activeGroupId,
+    setActiveGroupId,
+    viewMode,
+    setViewMode,
+    renderGroups,
+    pendingGroups,
+    normalizedPendingGroups,
+    pendingSummaryMap,
+    activeVideoGroups,
+    activeVideoGroup,
+    isGenerationLoading,
+    generationSkeletonCount,
+    hydratePendingRendersFromStorage,
+    resetRenderState,
+  };
+}

--- a/tests/workspace-gallery-rail-contract.test.ts
+++ b/tests/workspace-gallery-rail-contract.test.ts
@@ -111,6 +111,10 @@ test('video polling waits for a real static thumbnail', () => {
     path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/_lib/workspace-generation-polling.ts'),
     'utf8'
   );
+  const renderStateHookSource = fs.readFileSync(
+    path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceRenderState.ts'),
+    'utf8'
+  );
 
   assert.match(renderPersistenceSource, /export function resolvePolledThumbUrl/);
   assert.match(renderPersistenceSource, /next && !isPlaceholderMediaUrl\(next\)/);
@@ -119,5 +123,5 @@ test('video polling waits for a real static thumbnail', () => {
   assert.match(generationPollingSource, /thumbUrl:\s*resolvePolledThumbUrl\(render\.thumbUrl,\s*projection\.status\.thumbUrl\)/);
   assert.match(generationPollingSource, /thumbUrl:\s*resolvePolledThumbUrl\(current\.thumbUrl,\s*projection\.status\.thumbUrl\)/);
   assert.match(appSource, /applyGenerationPollToRender\(r,\s*pollProjection\)/);
-  assert.match(appSource, /applyPolledJobStatusToRender\(item,\s*status\)/);
+  assert.match(renderStateHookSource, /applyPolledJobStatusToRender\(item,\s*status\)/);
 });

--- a/tests/workspace-render-state-hook-contract.test.ts
+++ b/tests/workspace-render-state-hook-contract.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+test('workspace render state and polling are owned by a route-local hook', () => {
+  const appSource = fs.readFileSync(
+    path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/AppClient.tsx'),
+    'utf8'
+  );
+  const hookPath = path.join(
+    process.cwd(),
+    'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceRenderState.ts'
+  );
+  assert.equal(fs.existsSync(hookPath), true);
+
+  const hookSource = fs.readFileSync(hookPath, 'utf8');
+
+  assert.match(appSource, /import \{ useWorkspaceRenderState \} from '\.\/_hooks\/useWorkspaceRenderState';/);
+  assert.match(appSource, /useWorkspaceRenderState\(\{/);
+  assert.doesNotMatch(appSource, /const \[renders, setRenders\] = useState<LocalRender\[]>/);
+  assert.doesNotMatch(appSource, /const pendingPollRef = useRef/);
+  assert.doesNotMatch(appSource, /const galleryRetentionTick/);
+  assert.doesNotMatch(appSource, /buildPendingGroupSummaries\(/);
+
+  assert.match(hookSource, /export function useWorkspaceRenderState/);
+  assert.match(hookSource, /const hydratePendingRendersFromStorage = useCallback/);
+  assert.match(hookSource, /getRendersNeedingStatusRefresh/);
+  assert.match(hookSource, /mergeRecentJobsIntoLocalRenders/);
+  assert.match(hookSource, /buildPendingGroupSummaries/);
+});


### PR DESCRIPTION
## Summary
- Extracts local workspace render state, pending-render persistence, status polling, recent-job reconciliation, cleanup, and active group derivation into useWorkspaceRenderState.
- Keeps AppClient focused on UI wiring while preserving startRender and gallery action behavior.
- Updates the route guide and contract tests so future refactors keep polling/render state out of AppClient.

## Test plan
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/workspace-render-state-hook-contract.test.ts tests/workspace-video-settings-hook-contract.test.ts tests/workspace-assets-hook-contract.test.ts tests/workspace-gallery-rail-contract.test.ts tests/video-preview-group.test.ts tests/workspace-generation-inputs.test.ts tests/workspace-generation-request-helpers.test.ts tests/workspace-generation-polling.test.ts tests/workspace-render-status.test.ts tests/workspace-hydration.test.ts tests/workspace-local-generation-render.test.ts
- pnpm run test:validate
- npm --prefix frontend run build
- npm --prefix frontend run lint
- cd frontend && ./node_modules/.bin/tsc --noEmit
- git diff --check

Note: an earlier tsc run was started concurrently with next build and failed while .next/types was being regenerated. It was rerun after build completed and passed.