### PR TITLE
[codex] Extract workspace gallery actions hook

### DIFF
--- a/frontend/app/(core)/(workspace)/app/AGENTS.md
+++ b/frontend/app/(core)/(workspace)/app/AGENTS.md
@@ -6,7 +6,7 @@ This route is the main signed-in video generation workspace.
 
 - `AppClient.tsx`: top-level state orchestration while the workspace is being split.
 - `_components`: route-local chrome, panels, skeletons, modals, and presentational UI.
-- `_hooks`: route-local stateful workflow hooks for bounded client concerns such as asset library, upload orchestration, generation runner orchestration, render state and polling, video settings application, and hydration.
+- `_hooks`: route-local stateful workflow hooks for bounded client concerns such as asset library, upload orchestration, gallery action orchestration, generation runner orchestration, render state and polling, video settings application, and hydration.
 - `_lib`: route-local pure helpers for previews, render grouping, render status reconciliation, generation input preparation, generation guards, local render preparation, generation payloads, accepted results, generation polling projections, video settings hydration, workspace boot hydration, storage, copy fallback, client constants, asset normalization, asset selection, payload builders, input normalization, and workflow mapping.
 - Tool-specific workspaces should stay in their own route folders unless code is clearly shared.
 
@@ -18,6 +18,7 @@ This route is the main signed-in video generation workspace.
 - Keep job-to-render conversion, status polling projections, and recent-job reconciliation in `_lib`; route-local hooks should own render state, timers, and bounded network polling.
 - Keep generation attachment ordering, derived input URLs, Kling element payloads, and multi-prompt payloads in `_lib`; `AppClient.tsx` should consume prepared inputs instead of deriving attachment URLs inline.
 - Keep generation validation guards and `runGenerate` payload assembly in `_lib`; route-local hooks should own generation network orchestration while `AppClient.tsx` wires UI state.
+- Keep gallery action orchestration, guided sample navigation, and preview open/continue/refine/copy behavior in route-local hooks; `AppClient.tsx` should pass returned handlers into rails, cards, and preview surfaces.
 - Keep local pending-render and selected-preview preparation in `_lib`; `AppClient.tsx` should apply returned state objects and own timers.
 - Keep accepted `runGenerate` response projection and immediate render/preview patches in `_lib`; `AppClient.tsx` should dispatch events and start polling.
 - Keep generation polling projections and poll-delay decisions in `_lib`; `AppClient.tsx` should own `getJobStatus`, timers, and React setters.

--- a/frontend/app/(core)/(workspace)/app/AppClient.tsx
+++ b/frontend/app/(core)/(workspace)/app/AppClient.tsx
@@ -15,8 +15,7 @@ import {
   type MultiPromptScene,
 } from '@/components/Composer';
 import type { KlingElementState, KlingElementsBuilderProps } from '@/components/KlingElementsBuilder';
-import type { QuadPreviewTile, QuadTileAction } from '@/components/QuadPreviewPanel';
-import type { GalleryFeedState, GalleryRailProps } from '@/components/GalleryRail';
+import type { GalleryRailProps } from '@/components/GalleryRail';
 import type { GroupSummary } from '@/types/groups';
 import type { CompositePreviewDockProps } from '@/components/groups/CompositePreviewDock';
 import dynamic from 'next/dynamic';
@@ -30,7 +29,7 @@ import {
   type SharedVideoPreview,
 } from '@/lib/video-preview-group';
 import { useResultProvider } from '@/hooks/useResultProvider';
-import { GroupedJobCard, type GroupedJobAction } from '@/components/GroupedJobCard';
+import { GroupedJobCard } from '@/components/GroupedJobCard';
 import { normalizeGroupSummary } from '@/lib/normalize-group-summary';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { supportsAudioPricingToggle } from '@/lib/pricing-addons';
@@ -104,7 +103,6 @@ import {
   DEBOUNCE_MS,
   DEFAULT_PROMPT,
   DESKTOP_RAIL_MIN_WIDTH,
-  emitClientMetric,
   UNIFIED_VEO_FIRST_LAST_ENGINE_IDS,
 } from './_lib/workspace-client-helpers';
 import {
@@ -133,12 +131,8 @@ import {
   buildComposerPromotedActions,
   summarizeWorkspaceInputSchema,
 } from './_lib/workspace-input-schema';
-import {
-  buildQuadTileFromGroupMember,
-  buildQuadTileFromRender,
-  haveSameGroupOrder,
-} from './_lib/workspace-render-groups';
 import { useWorkspaceAssets } from './_hooks/useWorkspaceAssets';
+import { useWorkspaceGalleryActions } from './_hooks/useWorkspaceGalleryActions';
 import { useWorkspaceGenerationRunner } from './_hooks/useWorkspaceGenerationRunner';
 import { useWorkspaceRenderState } from './_hooks/useWorkspaceRenderState';
 import { useWorkspaceVideoSettings } from './_hooks/useWorkspaceVideoSettings';
@@ -346,8 +340,6 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
   }, [fromVideoId]);
   const [sharedPrompt, setSharedPrompt] = useState<string | null>(null);
   const [sharedVideoSettings, setSharedVideoSettings] = useState<SharedVideoPreview | null>(null);
-  const [guidedSampleFeed, setGuidedSampleFeed] = useState<GalleryFeedState>({ visibleGroups: [], sampleOnly: false });
-  const [previewAutoPlayRequestId, setPreviewAutoPlayRequestId] = useState(0);
   const [viewerTarget, setViewerTarget] = useState<
     { kind: 'pending'; id: string } | { kind: 'summary'; summary: GroupSummary } | { kind: 'group'; group: VideoGroup } | null
   >(null);
@@ -401,8 +393,6 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
     compositeOverrideSummary,
     writeScopedStorage,
   });
-  const isGuidedSamplesActive = guidedSampleFeed.sampleOnly;
-  const guidedSampleGroups = guidedSampleFeed.visibleGroups;
   const applyVideoSettingsSnapshotRef = useRef<(snapshot: unknown) => void>(() => undefined);
   const hydratedScopeRef = useRef<string | null>(null);
   const hasStoredFormRef = useRef<boolean>(false);
@@ -1670,315 +1660,40 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
     };
   }, [form, selectedEngine, memberTier, authChecked, supportsAudioToggle, effectiveDurationSec, voiceControlEnabled, submissionMode]);
 
-  const handleQuadTileAction = useCallback(
-    (action: QuadTileAction, tile: QuadPreviewTile) => {
-      emitClientMetric('tile_action', { action, batchId: tile.batchId, version: tile.iterationIndex + 1 });
-      const jobId = tile.jobId ?? tile.id;
-      switch (action) {
-        case 'continue': {
-          applyVideoSettingsFromTile(tile);
-          void hydrateVideoSettingsFromJob(jobId);
-          setPrompt(tile.prompt);
-          focusComposer();
-          break;
-        }
-        case 'refine': {
-          applyVideoSettingsFromTile(tile);
-          void hydrateVideoSettingsFromJob(jobId);
-          setPrompt(`${tile.prompt}\n\n// refine here`);
-          focusComposer();
-          break;
-        }
-        case 'branch': {
-          showNotice('Branching flow is coming soon in this build.');
-          break;
-        }
-        case 'copy': {
-          if (typeof navigator !== 'undefined' && navigator.clipboard) {
-            void navigator.clipboard.writeText(tile.prompt).then(
-              () => showNotice('Prompt copied to clipboard'),
-              () => showNotice('Unable to copy prompt, please copy manually.')
-            );
-          } else {
-            showNotice('Clipboard not available in this context.');
-          }
-          break;
-        }
-        case 'open': {
-          applyVideoSettingsFromTile(tile);
-          void hydrateVideoSettingsFromJob(jobId);
-          setActiveBatchId(tile.batchId);
-          setViewMode('quad');
-          setSelectedPreview({
-            id: tile.id,
-            localKey: tile.localKey,
-            batchId: tile.batchId,
-            iterationIndex: tile.iterationIndex,
-            iterationCount: tile.iterationCount,
-            videoUrl: tile.videoUrl,
-            previewVideoUrl: tile.previewVideoUrl,
-            aspectRatio: tile.aspectRatio,
-            thumbUrl: tile.thumbUrl,
-            progress: tile.progress,
-            message: tile.message,
-            priceCents: tile.priceCents,
-            currency: tile.currency,
-            etaLabel: tile.etaLabel,
-            prompt: tile.prompt,
-          });
-          break;
-        }
-        default:
-          break;
-      }
-    },
-    [
-      applyVideoSettingsFromTile,
-      focusComposer,
-      hydrateVideoSettingsFromJob,
-      setActiveBatchId,
-      setPrompt,
-      setSelectedPreview,
-      setViewMode,
-      showNotice,
-    ]
-  );
-
-  const handleCopySharedPrompt = useCallback(() => {
-    const promptValue = sharedPrompt ?? selectedPreview?.prompt ?? null;
-    if (!promptValue) {
-      showNotice('No prompt available to copy.');
-      return;
-    }
-    if (typeof navigator !== 'undefined' && navigator.clipboard) {
-      void navigator.clipboard.writeText(promptValue).then(
-        () => showNotice('Prompt copied to clipboard'),
-        () => showNotice('Unable to copy prompt, please copy manually.')
-      );
-    } else {
-      showNotice('Clipboard not available in this context.');
-    }
-  }, [sharedPrompt, selectedPreview, showNotice]);
-
   const fallbackEngineId = selectedEngine?.id ?? 'unknown-engine';
-
-  const handleGalleryGroupAction = useCallback(
-    (group: GroupSummary, action: GroupedJobAction, options?: { autoPlayPreview?: boolean }) => {
-      if (action === 'remove') {
-        return;
-      }
-      if (group.source === 'active') {
-        setActiveGroupId(group.id);
-        const renderGroup = renderGroups.get(group.id);
-        if (!renderGroup || renderGroup.items.length === 0) return;
-        const preferredHeroKey =
-          batchHeroes[group.id] ?? renderGroup.items.find((item) => item.videoUrl)?.localKey ?? renderGroup.items[0]?.localKey;
-        const heroRender = preferredHeroKey
-          ? renderGroup.items.find((item) => item.localKey === preferredHeroKey) ?? renderGroup.items[0]
-          : renderGroup.items[0];
-        if (!heroRender) return;
-        const heroJobId = heroRender.jobId ?? heroRender.id;
-        if (action === 'compare') {
-          emitClientMetric('compare_used', { batchId: group.id });
-          showNotice('Compare view is coming soon.');
-          return;
-        }
-        const tile = buildQuadTileFromRender(heroRender, renderGroup, preflight?.currency ?? 'USD');
-        if (action === 'open') {
-          if (options?.autoPlayPreview) {
-            setPreviewAutoPlayRequestId((current) => current + 1);
-          }
-          handleQuadTileAction('open', tile);
-          setCompositeOverride(null);
-          setCompositeOverrideSummary(null);
-          setSharedPrompt(null);
-          return;
-        }
-        if (action === 'continue') {
-          applyVideoSettingsFromTile(tile);
-          void hydrateVideoSettingsFromJob(heroJobId);
-          handleQuadTileAction('continue', tile);
-          return;
-        }
-        if (action === 'refine') {
-          applyVideoSettingsFromTile(tile);
-          void hydrateVideoSettingsFromJob(heroJobId);
-          handleQuadTileAction('refine', tile);
-          return;
-        }
-        if (action === 'branch') {
-          handleQuadTileAction('branch', tile);
-        }
-        return;
-      }
-
-      const hero = group.hero;
-
-      if (action === 'compare') {
-        emitClientMetric('compare_used', { batchId: group.id });
-        showNotice('Compare view is coming soon.');
-        return;
-      }
-
-      if (action === 'branch') {
-        showNotice('Branching flow is coming soon in this build.');
-        return;
-      }
-
-      const tile = buildQuadTileFromGroupMember(group, hero, fallbackEngineId);
-      const heroJobId = hero.jobId ?? tile.id;
-
-      if (action === 'open') {
-        if (options?.autoPlayPreview) {
-          setPreviewAutoPlayRequestId((current) => current + 1);
-        }
-        const targetBatchId = tile.batchId ?? group.batchId ?? null;
-        if (tile.iterationCount > 1) {
-          setViewMode('quad');
-        } else {
-          setViewMode('single');
-        }
-        if (targetBatchId) {
-          setActiveBatchId(targetBatchId);
-          if (tile.localKey) {
-            setBatchHeroes((prev) => ({ ...prev, [targetBatchId]: tile.localKey! }));
-          }
-        }
-        setSelectedPreview({
-          id: tile.id,
-          localKey: tile.localKey,
-          batchId: tile.batchId,
-          iterationIndex: tile.iterationIndex,
-          iterationCount: tile.iterationCount,
-          videoUrl: tile.videoUrl,
-          previewVideoUrl: tile.previewVideoUrl,
-          aspectRatio: tile.aspectRatio,
-          thumbUrl: tile.thumbUrl,
-          progress: tile.progress,
-          message: tile.message,
-          priceCents: tile.priceCents,
-          currency: tile.currency,
-          etaLabel: tile.etaLabel,
-          prompt: tile.prompt,
-        });
-        const normalizedSummary = normalizeGroupSummary(group);
-        setCompositeOverride(adaptGroupSummary(normalizedSummary, provider));
-        setCompositeOverrideSummary(normalizedSummary);
-        try {
-          if (heroJobId.startsWith('job_')) {
-            writeScopedStorage(STORAGE_KEYS.previewJobId, heroJobId);
-          }
-        } catch {
-          // ignore storage failures
-        }
-        applyVideoSettingsFromTile(tile);
-        void hydrateVideoSettingsFromJob(heroJobId);
-        return;
-      }
-
-      if (action === 'continue' || action === 'refine') {
-        applyVideoSettingsFromTile(tile);
-        void hydrateVideoSettingsFromJob(heroJobId);
-        handleQuadTileAction(action, tile);
-        return;
-      }
-    },
-    [
-      renderGroups,
-      batchHeroes,
-      preflight?.currency,
-      handleQuadTileAction,
-      showNotice,
-      fallbackEngineId,
-      setActiveGroupId,
-      setViewMode,
-      setActiveBatchId,
-      setBatchHeroes,
-      setSelectedPreview,
-      setPreviewAutoPlayRequestId,
-      provider,
-      setCompositeOverride,
-      setCompositeOverrideSummary,
-      applyVideoSettingsFromTile,
-      hydrateVideoSettingsFromJob,
-      writeScopedStorage,
-    ]
-  );
-
-  const handleGalleryFeedStateChange = useCallback((state: GalleryFeedState) => {
-    setGuidedSampleFeed((prev) => {
-      if (prev.sampleOnly === state.sampleOnly && haveSameGroupOrder(prev.visibleGroups, state.visibleGroups)) {
-        return prev;
-      }
-      return state;
-    });
-  }, []);
-
-  useEffect(() => {
-    if (isGuidedSamplesActive) return;
-    if (compositeOverrideSummary?.hero.job?.curated) {
-      setCompositeOverride(null);
-      setCompositeOverrideSummary(null);
-    }
-  }, [compositeOverrideSummary, isGuidedSamplesActive]);
-
-  useEffect(() => {
-    if (!isGuidedSamplesActive || guidedSampleGroups.length === 0) return;
-    const currentGroupId = compositeOverrideSummary?.id ?? null;
-    if (currentGroupId && guidedSampleGroups.some((group) => group.id === currentGroupId)) {
-      return;
-    }
-    handleGalleryGroupAction(guidedSampleGroups[0], 'open');
-  }, [compositeOverrideSummary?.id, guidedSampleGroups, handleGalleryGroupAction, isGuidedSamplesActive]);
-
-  const currentGuidedSampleIndex = useMemo(() => {
-    if (!isGuidedSamplesActive || guidedSampleGroups.length === 0) return -1;
-    const currentGroupId = compositeOverrideSummary?.id ?? null;
-    if (!currentGroupId) return -1;
-    return guidedSampleGroups.findIndex((group) => group.id === currentGroupId);
-  }, [compositeOverrideSummary?.id, guidedSampleGroups, isGuidedSamplesActive]);
-
-  const openGuidedSampleAt = useCallback(
-    (index: number) => {
-      const target = guidedSampleGroups[index];
-      if (!target) return;
-      handleGalleryGroupAction(target, 'open', { autoPlayPreview: true });
-    },
-    [guidedSampleGroups, handleGalleryGroupAction]
-  );
-
-  const guidedNavigation = useMemo(() => {
-    if (!isGuidedSamplesActive || guidedSampleGroups.length === 0) return null;
-    const activeIndex = currentGuidedSampleIndex >= 0 ? currentGuidedSampleIndex : 0;
-    return {
-      currentIndex: activeIndex,
-      total: guidedSampleGroups.length,
-      canPrev: activeIndex > 0,
-      canNext: activeIndex < guidedSampleGroups.length - 1,
-      onPrev: () => openGuidedSampleAt(activeIndex - 1),
-      onNext: () => openGuidedSampleAt(activeIndex + 1),
-    };
-  }, [currentGuidedSampleIndex, guidedSampleGroups, isGuidedSamplesActive, openGuidedSampleAt]);
-
-  const openGroupViaGallery = useCallback(
-    (group: GroupSummary) => {
-      handleGalleryGroupAction(group, 'open', { autoPlayPreview: true });
-    },
-    [handleGalleryGroupAction]
-  );
-  const handleActiveGroupOpen = useCallback(
-    (group: GroupSummary) => {
-      handleGalleryGroupAction(group, 'open', { autoPlayPreview: true });
-    },
-    [handleGalleryGroupAction]
-  );
-  const handleActiveGroupAction = useCallback(
-    (group: GroupSummary, action: GroupedJobAction) => {
-      if (action === 'remove') return;
-      handleGalleryGroupAction(group, action, { autoPlayPreview: action === 'open' });
-    },
-    [handleGalleryGroupAction]
-  );
+  const {
+    previewAutoPlayRequestId,
+    guidedNavigation,
+    handleCopySharedPrompt,
+    handleGalleryGroupAction,
+    handleGalleryFeedStateChange,
+    openGroupViaGallery,
+    handleActiveGroupOpen,
+    handleActiveGroupAction,
+  } = useWorkspaceGalleryActions({
+    provider,
+    renderGroups,
+    batchHeroes,
+    preflightCurrency: preflight?.currency,
+    fallbackEngineId,
+    sharedPrompt,
+    selectedPreview,
+    compositeOverrideSummary,
+    applyVideoSettingsFromTile,
+    hydrateVideoSettingsFromJob,
+    focusComposer,
+    showNotice,
+    writeScopedStorage,
+    setPrompt,
+    setActiveGroupId,
+    setViewMode,
+    setActiveBatchId,
+    setBatchHeroes,
+    setSelectedPreview,
+    setCompositeOverride,
+    setCompositeOverrideSummary,
+    setSharedPrompt,
+  });
 
   const singlePriceCents = typeof preflight?.total === 'number' ? preflight.total : null;
   const singlePrice =

--- a/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceGalleryActions.ts
+++ b/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceGalleryActions.ts
@@ -1,0 +1,424 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import type { GalleryFeedState } from '@/components/GalleryRail';
+import type { GroupedJobAction } from '@/components/GroupedJobCard';
+import type { QuadPreviewTile, QuadTileAction } from '@/components/QuadPreviewPanel';
+import { normalizeGroupSummary } from '@/lib/normalize-group-summary';
+import { adaptGroupSummary } from '@/lib/video-group-adapter';
+import type { SelectedVideoPreview } from '@/lib/video-preview-group';
+import type { GroupSummary } from '@/types/groups';
+import type { ResultProvider, VideoGroup } from '@/types/video-groups';
+import type { LocalRenderGroup } from '../_lib/render-persistence';
+import {
+  buildQuadTileFromGroupMember,
+  buildQuadTileFromRender,
+  haveSameGroupOrder,
+} from '../_lib/workspace-render-groups';
+import { emitClientMetric } from '../_lib/workspace-client-helpers';
+import { STORAGE_KEYS } from '../_lib/workspace-storage';
+
+type ViewMode = 'single' | 'quad';
+
+type GuidedNavigation = {
+  currentIndex: number;
+  total: number;
+  canPrev: boolean;
+  canNext: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+} | null;
+
+type UseWorkspaceGalleryActionsOptions = {
+  provider: ResultProvider;
+  renderGroups: Map<string, LocalRenderGroup>;
+  batchHeroes: Record<string, string>;
+  preflightCurrency?: string | null;
+  fallbackEngineId: string;
+  sharedPrompt: string | null;
+  selectedPreview: SelectedVideoPreview | null;
+  compositeOverrideSummary: GroupSummary | null;
+  applyVideoSettingsFromTile: (tile: QuadPreviewTile) => void;
+  hydrateVideoSettingsFromJob: (jobId: string | null | undefined) => Promise<void>;
+  focusComposer: () => void;
+  showNotice: (message: string) => void;
+  writeScopedStorage: (base: string, value: string | null) => void;
+  setPrompt: Dispatch<SetStateAction<string>>;
+  setActiveGroupId: Dispatch<SetStateAction<string | null>>;
+  setViewMode: Dispatch<SetStateAction<ViewMode>>;
+  setActiveBatchId: Dispatch<SetStateAction<string | null>>;
+  setBatchHeroes: Dispatch<SetStateAction<Record<string, string>>>;
+  setSelectedPreview: Dispatch<SetStateAction<SelectedVideoPreview | null>>;
+  setCompositeOverride: Dispatch<SetStateAction<VideoGroup | null>>;
+  setCompositeOverrideSummary: Dispatch<SetStateAction<GroupSummary | null>>;
+  setSharedPrompt: Dispatch<SetStateAction<string | null>>;
+};
+
+type UseWorkspaceGalleryActionsResult = {
+  previewAutoPlayRequestId: number;
+  guidedNavigation: GuidedNavigation;
+  handleCopySharedPrompt: () => void;
+  handleGalleryGroupAction: (
+    group: GroupSummary,
+    action: GroupedJobAction,
+    options?: { autoPlayPreview?: boolean }
+  ) => void;
+  handleGalleryFeedStateChange: (state: GalleryFeedState) => void;
+  openGroupViaGallery: (group: GroupSummary) => void;
+  handleActiveGroupOpen: (group: GroupSummary) => void;
+  handleActiveGroupAction: (group: GroupSummary, action: GroupedJobAction) => void;
+};
+
+export function useWorkspaceGalleryActions({
+  provider,
+  renderGroups,
+  batchHeroes,
+  preflightCurrency,
+  fallbackEngineId,
+  sharedPrompt,
+  selectedPreview,
+  compositeOverrideSummary,
+  applyVideoSettingsFromTile,
+  hydrateVideoSettingsFromJob,
+  focusComposer,
+  showNotice,
+  writeScopedStorage,
+  setPrompt,
+  setActiveGroupId,
+  setViewMode,
+  setActiveBatchId,
+  setBatchHeroes,
+  setSelectedPreview,
+  setCompositeOverride,
+  setCompositeOverrideSummary,
+  setSharedPrompt,
+}: UseWorkspaceGalleryActionsOptions): UseWorkspaceGalleryActionsResult {
+  const [guidedSampleFeed, setGuidedSampleFeed] = useState<GalleryFeedState>({
+    visibleGroups: [],
+    sampleOnly: false,
+  });
+  const [previewAutoPlayRequestId, setPreviewAutoPlayRequestId] = useState(0);
+
+  const isGuidedSamplesActive = guidedSampleFeed.sampleOnly;
+  const guidedSampleGroups = guidedSampleFeed.visibleGroups;
+
+  const handleQuadTileAction = useCallback(
+    (action: QuadTileAction, tile: QuadPreviewTile) => {
+      emitClientMetric('tile_action', { action, batchId: tile.batchId, version: tile.iterationIndex + 1 });
+      const jobId = tile.jobId ?? tile.id;
+      switch (action) {
+        case 'continue': {
+          applyVideoSettingsFromTile(tile);
+          void hydrateVideoSettingsFromJob(jobId);
+          setPrompt(tile.prompt);
+          focusComposer();
+          break;
+        }
+        case 'refine': {
+          applyVideoSettingsFromTile(tile);
+          void hydrateVideoSettingsFromJob(jobId);
+          setPrompt(`${tile.prompt}\n\n// refine here`);
+          focusComposer();
+          break;
+        }
+        case 'branch': {
+          showNotice('Branching flow is coming soon in this build.');
+          break;
+        }
+        case 'copy': {
+          if (typeof navigator !== 'undefined' && navigator.clipboard) {
+            void navigator.clipboard.writeText(tile.prompt).then(
+              () => showNotice('Prompt copied to clipboard'),
+              () => showNotice('Unable to copy prompt, please copy manually.')
+            );
+          } else {
+            showNotice('Clipboard not available in this context.');
+          }
+          break;
+        }
+        case 'open': {
+          applyVideoSettingsFromTile(tile);
+          void hydrateVideoSettingsFromJob(jobId);
+          setActiveBatchId(tile.batchId);
+          setViewMode('quad');
+          setSelectedPreview({
+            id: tile.id,
+            localKey: tile.localKey,
+            batchId: tile.batchId,
+            iterationIndex: tile.iterationIndex,
+            iterationCount: tile.iterationCount,
+            videoUrl: tile.videoUrl,
+            previewVideoUrl: tile.previewVideoUrl,
+            aspectRatio: tile.aspectRatio,
+            thumbUrl: tile.thumbUrl,
+            progress: tile.progress,
+            message: tile.message,
+            priceCents: tile.priceCents,
+            currency: tile.currency,
+            etaLabel: tile.etaLabel,
+            prompt: tile.prompt,
+          });
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    [
+      applyVideoSettingsFromTile,
+      focusComposer,
+      hydrateVideoSettingsFromJob,
+      setActiveBatchId,
+      setPrompt,
+      setSelectedPreview,
+      setViewMode,
+      showNotice,
+    ]
+  );
+
+  const handleCopySharedPrompt = useCallback(() => {
+    const promptValue = sharedPrompt ?? selectedPreview?.prompt ?? null;
+    if (!promptValue) {
+      showNotice('No prompt available to copy.');
+      return;
+    }
+    if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      void navigator.clipboard.writeText(promptValue).then(
+        () => showNotice('Prompt copied to clipboard'),
+        () => showNotice('Unable to copy prompt, please copy manually.')
+      );
+    } else {
+      showNotice('Clipboard not available in this context.');
+    }
+  }, [sharedPrompt, selectedPreview, showNotice]);
+
+  const handleGalleryGroupAction = useCallback(
+    (group: GroupSummary, action: GroupedJobAction, options?: { autoPlayPreview?: boolean }) => {
+      if (action === 'remove') {
+        return;
+      }
+      if (group.source === 'active') {
+        setActiveGroupId(group.id);
+        const renderGroup = renderGroups.get(group.id);
+        if (!renderGroup || renderGroup.items.length === 0) return;
+        const preferredHeroKey =
+          batchHeroes[group.id] ?? renderGroup.items.find((item) => item.videoUrl)?.localKey ?? renderGroup.items[0]?.localKey;
+        const heroRender = preferredHeroKey
+          ? renderGroup.items.find((item) => item.localKey === preferredHeroKey) ?? renderGroup.items[0]
+          : renderGroup.items[0];
+        if (!heroRender) return;
+        const heroJobId = heroRender.jobId ?? heroRender.id;
+        if (action === 'compare') {
+          emitClientMetric('compare_used', { batchId: group.id });
+          showNotice('Compare view is coming soon.');
+          return;
+        }
+        const tile = buildQuadTileFromRender(heroRender, renderGroup, preflightCurrency ?? 'USD');
+        if (action === 'open') {
+          if (options?.autoPlayPreview) {
+            setPreviewAutoPlayRequestId((current) => current + 1);
+          }
+          handleQuadTileAction('open', tile);
+          setCompositeOverride(null);
+          setCompositeOverrideSummary(null);
+          setSharedPrompt(null);
+          return;
+        }
+        if (action === 'continue') {
+          applyVideoSettingsFromTile(tile);
+          void hydrateVideoSettingsFromJob(heroJobId);
+          handleQuadTileAction('continue', tile);
+          return;
+        }
+        if (action === 'refine') {
+          applyVideoSettingsFromTile(tile);
+          void hydrateVideoSettingsFromJob(heroJobId);
+          handleQuadTileAction('refine', tile);
+          return;
+        }
+        if (action === 'branch') {
+          handleQuadTileAction('branch', tile);
+        }
+        return;
+      }
+
+      const hero = group.hero;
+
+      if (action === 'compare') {
+        emitClientMetric('compare_used', { batchId: group.id });
+        showNotice('Compare view is coming soon.');
+        return;
+      }
+
+      if (action === 'branch') {
+        showNotice('Branching flow is coming soon in this build.');
+        return;
+      }
+
+      const tile = buildQuadTileFromGroupMember(group, hero, fallbackEngineId);
+      const heroJobId = hero.jobId ?? tile.id;
+
+      if (action === 'open') {
+        if (options?.autoPlayPreview) {
+          setPreviewAutoPlayRequestId((current) => current + 1);
+        }
+        const targetBatchId = tile.batchId ?? group.batchId ?? null;
+        if (tile.iterationCount > 1) {
+          setViewMode('quad');
+        } else {
+          setViewMode('single');
+        }
+        if (targetBatchId) {
+          setActiveBatchId(targetBatchId);
+          if (tile.localKey) {
+            setBatchHeroes((prev) => ({ ...prev, [targetBatchId]: tile.localKey! }));
+          }
+        }
+        setSelectedPreview({
+          id: tile.id,
+          localKey: tile.localKey,
+          batchId: tile.batchId,
+          iterationIndex: tile.iterationIndex,
+          iterationCount: tile.iterationCount,
+          videoUrl: tile.videoUrl,
+          previewVideoUrl: tile.previewVideoUrl,
+          aspectRatio: tile.aspectRatio,
+          thumbUrl: tile.thumbUrl,
+          progress: tile.progress,
+          message: tile.message,
+          priceCents: tile.priceCents,
+          currency: tile.currency,
+          etaLabel: tile.etaLabel,
+          prompt: tile.prompt,
+        });
+        const normalizedSummary = normalizeGroupSummary(group);
+        setCompositeOverride(adaptGroupSummary(normalizedSummary, provider));
+        setCompositeOverrideSummary(normalizedSummary);
+        try {
+          if (heroJobId.startsWith('job_')) {
+            writeScopedStorage(STORAGE_KEYS.previewJobId, heroJobId);
+          }
+        } catch {
+          // ignore storage failures
+        }
+        applyVideoSettingsFromTile(tile);
+        void hydrateVideoSettingsFromJob(heroJobId);
+        return;
+      }
+
+      if (action === 'continue' || action === 'refine') {
+        applyVideoSettingsFromTile(tile);
+        void hydrateVideoSettingsFromJob(heroJobId);
+        handleQuadTileAction(action, tile);
+        return;
+      }
+    },
+    [
+      renderGroups,
+      batchHeroes,
+      preflightCurrency,
+      handleQuadTileAction,
+      showNotice,
+      fallbackEngineId,
+      setActiveGroupId,
+      setViewMode,
+      setActiveBatchId,
+      setBatchHeroes,
+      setSelectedPreview,
+      provider,
+      setCompositeOverride,
+      setCompositeOverrideSummary,
+      applyVideoSettingsFromTile,
+      hydrateVideoSettingsFromJob,
+      writeScopedStorage,
+      setSharedPrompt,
+    ]
+  );
+
+  const handleGalleryFeedStateChange = useCallback((state: GalleryFeedState) => {
+    setGuidedSampleFeed((prev) => {
+      if (prev.sampleOnly === state.sampleOnly && haveSameGroupOrder(prev.visibleGroups, state.visibleGroups)) {
+        return prev;
+      }
+      return state;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (isGuidedSamplesActive) return;
+    if (compositeOverrideSummary?.hero.job?.curated) {
+      setCompositeOverride(null);
+      setCompositeOverrideSummary(null);
+    }
+  }, [compositeOverrideSummary, isGuidedSamplesActive, setCompositeOverride, setCompositeOverrideSummary]);
+
+  useEffect(() => {
+    if (!isGuidedSamplesActive || guidedSampleGroups.length === 0) return;
+    const currentGroupId = compositeOverrideSummary?.id ?? null;
+    if (currentGroupId && guidedSampleGroups.some((group) => group.id === currentGroupId)) {
+      return;
+    }
+    handleGalleryGroupAction(guidedSampleGroups[0], 'open');
+  }, [compositeOverrideSummary?.id, guidedSampleGroups, handleGalleryGroupAction, isGuidedSamplesActive]);
+
+  const currentGuidedSampleIndex = useMemo(() => {
+    if (!isGuidedSamplesActive || guidedSampleGroups.length === 0) return -1;
+    const currentGroupId = compositeOverrideSummary?.id ?? null;
+    if (!currentGroupId) return -1;
+    return guidedSampleGroups.findIndex((group) => group.id === currentGroupId);
+  }, [compositeOverrideSummary?.id, guidedSampleGroups, isGuidedSamplesActive]);
+
+  const openGuidedSampleAt = useCallback(
+    (index: number) => {
+      const target = guidedSampleGroups[index];
+      if (!target) return;
+      handleGalleryGroupAction(target, 'open', { autoPlayPreview: true });
+    },
+    [guidedSampleGroups, handleGalleryGroupAction]
+  );
+
+  const guidedNavigation = useMemo(() => {
+    if (!isGuidedSamplesActive || guidedSampleGroups.length === 0) return null;
+    const activeIndex = currentGuidedSampleIndex >= 0 ? currentGuidedSampleIndex : 0;
+    return {
+      currentIndex: activeIndex,
+      total: guidedSampleGroups.length,
+      canPrev: activeIndex > 0,
+      canNext: activeIndex < guidedSampleGroups.length - 1,
+      onPrev: () => openGuidedSampleAt(activeIndex - 1),
+      onNext: () => openGuidedSampleAt(activeIndex + 1),
+    };
+  }, [currentGuidedSampleIndex, guidedSampleGroups, isGuidedSamplesActive, openGuidedSampleAt]);
+
+  const openGroupViaGallery = useCallback(
+    (group: GroupSummary) => {
+      handleGalleryGroupAction(group, 'open', { autoPlayPreview: true });
+    },
+    [handleGalleryGroupAction]
+  );
+
+  const handleActiveGroupOpen = useCallback(
+    (group: GroupSummary) => {
+      handleGalleryGroupAction(group, 'open', { autoPlayPreview: true });
+    },
+    [handleGalleryGroupAction]
+  );
+
+  const handleActiveGroupAction = useCallback(
+    (group: GroupSummary, action: GroupedJobAction) => {
+      if (action === 'remove') return;
+      handleGalleryGroupAction(group, action, { autoPlayPreview: action === 'open' });
+    },
+    [handleGalleryGroupAction]
+  );
+
+  return {
+    previewAutoPlayRequestId,
+    guidedNavigation,
+    handleCopySharedPrompt,
+    handleGalleryGroupAction,
+    handleGalleryFeedStateChange,
+    openGroupViaGallery,
+    handleActiveGroupOpen,
+    handleActiveGroupAction,
+  };
+}

--- a/tests/workspace-gallery-actions-hook-contract.test.ts
+++ b/tests/workspace-gallery-actions-hook-contract.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+test('workspace gallery actions are owned by a route-local hook', () => {
+  const appSource = fs.readFileSync(
+    path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/AppClient.tsx'),
+    'utf8'
+  );
+  const hookPath = path.join(
+    process.cwd(),
+    'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceGalleryActions.ts'
+  );
+  assert.equal(fs.existsSync(hookPath), true);
+
+  const hookSource = fs.readFileSync(hookPath, 'utf8');
+
+  assert.match(appSource, /import \{ useWorkspaceGalleryActions \} from '\.\/_hooks\/useWorkspaceGalleryActions';/);
+  assert.match(appSource, /useWorkspaceGalleryActions\(\{/);
+  assert.doesNotMatch(appSource, /const handleQuadTileAction = useCallback/);
+  assert.doesNotMatch(appSource, /const handleGalleryGroupAction = useCallback/);
+  assert.doesNotMatch(appSource, /const handleGalleryFeedStateChange = useCallback/);
+  assert.doesNotMatch(appSource, /const openGuidedSampleAt = useCallback/);
+
+  assert.match(hookSource, /export function useWorkspaceGalleryActions/);
+  assert.match(hookSource, /const handleQuadTileAction = useCallback/);
+  assert.match(hookSource, /const handleGalleryGroupAction = useCallback/);
+  assert.match(hookSource, /const handleGalleryFeedStateChange = useCallback/);
+  assert.match(hookSource, /const openGuidedSampleAt = useCallback/);
+  assert.match(hookSource, /buildQuadTileFromRender/);
+  assert.match(hookSource, /buildQuadTileFromGroupMember/);
+  assert.match(hookSource, /haveSameGroupOrder/);
+});

--- a/tests/workspace-gallery-rail-contract.test.ts
+++ b/tests/workspace-gallery-rail-contract.test.ts
@@ -47,10 +47,6 @@ test('composite preview modal button opens direct preview groups', () => {
 });
 
 test('composite preview preserves preview urls but plays canonical video urls', () => {
-  const appSource = fs.readFileSync(
-    path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/AppClient.tsx'),
-    'utf8'
-  );
   const renderGroupSource = fs.readFileSync(
     path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/_lib/workspace-render-groups.ts'),
     'utf8'
@@ -59,12 +55,16 @@ test('composite preview preserves preview urls but plays canonical video urls', 
     path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/_lib/workspace-video-settings.ts'),
     'utf8'
   );
+  const galleryActionsHookSource = fs.readFileSync(
+    path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceGalleryActions.ts'),
+    'utf8'
+  );
   const dockSource = fs.readFileSync(
     path.join(process.cwd(), 'frontend/components/groups/CompositePreviewDock.tsx'),
     'utf8'
   );
 
-  assert.match(appSource, /previewVideoUrl:\s*tile\.previewVideoUrl/);
+  assert.match(galleryActionsHookSource, /previewVideoUrl:\s*tile\.previewVideoUrl/);
   assert.match(videoSettingsSource, /previewVideoUrl:\s*patch\.previewVideoUrl\s*\?\?\s*current\.previewVideoUrl/);
   assert.match(videoSettingsSource, /previewUrl:\s*patch\.previewVideoUrl\s*\?\?\s*item\.previewUrl/);
   assert.match(renderGroupSource, /previewVideoUrl:\s*gatingActive\s*\?\s*null\s*:\s*item\.previewVideoUrl\s*\?\?\s*null/);
@@ -77,15 +77,19 @@ test('rail history previews do not mutate the active render group', () => {
     path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/AppClient.tsx'),
     'utf8'
   );
+  const galleryActionsHookSource = fs.readFileSync(
+    path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceGalleryActions.ts'),
+    'utf8'
+  );
 
-  assert.match(appSource, /if\s*\(group\.source === 'active'\)\s*\{\s*setActiveGroupId\(group\.id\)/);
-  assert.match(appSource, /const openGroupViaGallery = useCallback\(\s*\(\s*group: GroupSummary\s*\)\s*=>\s*\{\s*handleGalleryGroupAction\(group,\s*'open',\s*\{\s*autoPlayPreview:\s*true\s*\}\);/);
-  assert.doesNotMatch(appSource, /const openGroupViaGallery[\s\S]*?setActiveGroupId\(group\.id\)[\s\S]*?\[handleGalleryGroupAction\]/);
-  const activeOpenStart = appSource.indexOf("if (group.source === 'active')");
-  const activeOpenEnd = appSource.indexOf("if (action === 'continue')", activeOpenStart);
+  assert.match(galleryActionsHookSource, /if\s*\(group\.source === 'active'\)\s*\{\s*setActiveGroupId\(group\.id\)/);
+  assert.match(galleryActionsHookSource, /const openGroupViaGallery = useCallback\(\s*\(\s*group: GroupSummary\s*\)\s*=>\s*\{\s*handleGalleryGroupAction\(group,\s*'open',\s*\{\s*autoPlayPreview:\s*true\s*\}\);/);
+  assert.doesNotMatch(galleryActionsHookSource, /const openGroupViaGallery[\s\S]*?setActiveGroupId\(group\.id\)[\s\S]*?\[handleGalleryGroupAction\]/);
+  const activeOpenStart = galleryActionsHookSource.indexOf("if (group.source === 'active')");
+  const activeOpenEnd = galleryActionsHookSource.indexOf("if (action === 'continue')", activeOpenStart);
   assert.notEqual(activeOpenStart, -1);
   assert.notEqual(activeOpenEnd, -1);
-  const activeOpenBlock = appSource.slice(activeOpenStart, activeOpenEnd);
+  const activeOpenBlock = galleryActionsHookSource.slice(activeOpenStart, activeOpenEnd);
   assert.doesNotMatch(activeOpenBlock, /applyVideoSettingsFromTile\(tile\);/);
   assert.doesNotMatch(activeOpenBlock, /hydrateVideoSettingsFromJob\(heroJobId\);/);
   assert.doesNotMatch(


### PR DESCRIPTION
## Summary
- Extracts workspace gallery, preview, and guided sample actions from AppClient into useWorkspaceGalleryActions.
- Keeps AppClient focused on wiring rails, preview dock, composer, and modals while the hook owns open/continue/refine/copy behavior.
- Updates workspace route guidance and contracts so future preview/gallery behavior stays out of AppClient.

## Test Plan
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/workspace-gallery-actions-hook-contract.test.ts tests/workspace-gallery-rail-contract.test.ts tests/workspace-generation-runner-hook-contract.test.ts tests/supabase-auth-refresh-scope.test.ts tests/supabase-browser-session-cleanup.test.ts tests/auth-callback-redirect.test.ts tests/supabase-session-refresh-contract.test.ts
- npm --prefix frontend run lint
- ./node_modules/.bin/tsc --noEmit (from frontend)
- pnpm run test:validate
- npm --prefix frontend run build