### PR TITLE
[codex] Extract workspace pricing gate

### DIFF
--- a/frontend/app/(core)/(workspace)/app/AGENTS.md
+++ b/frontend/app/(core)/(workspace)/app/AGENTS.md
@@ -5,8 +5,8 @@ This route is the main signed-in video generation workspace.
 ## Responsibilities
 
 - `AppClient.tsx`: top-level state orchestration while the workspace is being split.
-- `_components`: route-local chrome, panels, skeletons, modals, and presentational UI.
-- `_hooks`: route-local stateful workflow hooks for bounded client concerns such as asset library, upload orchestration, gallery action orchestration, generation runner orchestration, render state and polling, video settings application, and hydration.
+- `_components`: route-local chrome, panels, skeletons, wallet/auth modals, and presentational UI.
+- `_hooks`: route-local stateful workflow hooks for bounded client concerns such as asset library, upload orchestration, gallery action orchestration, pricing/auth gate orchestration, generation runner orchestration, render state and polling, video settings application, and hydration.
 - `_lib`: route-local pure helpers for previews, render grouping, render status reconciliation, generation input preparation, generation guards, local render preparation, generation payloads, accepted results, generation polling projections, video settings hydration, workspace boot hydration, storage, copy fallback, client constants, asset normalization, asset selection, payload builders, input normalization, and workflow mapping.
 - Tool-specific workspaces should stay in their own route folders unless code is clearly shared.
 
@@ -19,6 +19,7 @@ This route is the main signed-in video generation workspace.
 - Keep generation attachment ordering, derived input URLs, Kling element payloads, and multi-prompt payloads in `_lib`; `AppClient.tsx` should consume prepared inputs instead of deriving attachment URLs inline.
 - Keep generation validation guards and `runGenerate` payload assembly in `_lib`; route-local hooks should own generation network orchestration while `AppClient.tsx` wires UI state.
 - Keep gallery action orchestration, guided sample navigation, and preview open/continue/refine/copy behavior in route-local hooks; `AppClient.tsx` should pass returned handlers into rails, cards, and preview surfaces.
+- Keep preflight pricing, member-status refresh, wallet top-up modal state, and auth gate modal state in route-local hooks/components; `AppClient.tsx` should wire returned state into composer and generation runner props.
 - Keep local pending-render and selected-preview preparation in `_lib`; `AppClient.tsx` should apply returned state objects and own timers.
 - Keep accepted `runGenerate` response projection and immediate render/preview patches in `_lib`; `AppClient.tsx` should dispatch events and start polling.
 - Keep generation polling projections and poll-delay decisions in `_lib`; `AppClient.tsx` should own `getJobStatus`, timers, and React setters.

--- a/frontend/app/(core)/(workspace)/app/AppClient.tsx
+++ b/frontend/app/(core)/(workspace)/app/AppClient.tsx
@@ -1,12 +1,10 @@
 'use client';
 
-import clsx from 'clsx';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { FormEvent } from 'react';
-import { useEngines, useInfiniteJobs, runPreflight, getJobStatus } from '@/lib/api';
+import { useEngines, useInfiniteJobs, getJobStatus } from '@/lib/api';
 import { authFetch } from '@/lib/authFetch';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import type { EngineCaps, EngineInputField, Mode, PreflightRequest, PreflightResponse } from '@/types/engines';
+import type { EngineCaps, EngineInputField, Mode } from '@/types/engines';
 import { SettingsControls } from '@/components/SettingsControls';
 import { CoreSettingsBar } from '@/components/CoreSettingsBar';
 import { EngineSettingsBar } from '@/components/EngineSettingsBar';
@@ -20,7 +18,6 @@ import type { GroupSummary } from '@/types/groups';
 import type { CompositePreviewDockProps } from '@/components/groups/CompositePreviewDock';
 import dynamic from 'next/dynamic';
 import { DEFAULT_PROCESSING_COPY } from '@/components/groups/ProcessingOverlay';
-import { CURRENCY_LOCALE } from '@/lib/intl';
 import { ENV as CLIENT_ENV } from '@/lib/env';
 import { adaptGroupSummary } from '@/lib/video-group-adapter';
 import type { VideoGroup } from '@/types/video-groups';
@@ -34,8 +31,7 @@ import { normalizeGroupSummary } from '@/lib/normalize-group-summary';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { supportsAudioPricingToggle } from '@/lib/pricing-addons';
 import { readLastKnownUserId } from '@/lib/last-known';
-import { Button, ButtonLink } from '@/components/ui/Button';
-import { Input } from '@/components/ui/Input';
+import { Button } from '@/components/ui/Button';
 import type { AssetLibraryModalProps } from '@/components/library/AssetLibraryModal';
 import {
   isLumaRay2EngineId,
@@ -66,6 +62,8 @@ import {
   GalleryRailSkeleton,
   WorkspaceBootPreview,
 } from './_components/WorkspaceBootSkeletons';
+import { WorkspaceAuthGateModal } from './_components/WorkspaceAuthGateModal';
+import { WorkspaceTopUpModal } from './_components/WorkspaceTopUpModal';
 import { getCompositePreviewPosterSrc } from './_lib/composite-preview';
 import {
   normalizeExtraInputValue,
@@ -100,7 +98,6 @@ import {
   mergeCopy,
 } from './_lib/workspace-copy';
 import {
-  DEBOUNCE_MS,
   DEFAULT_PROMPT,
   DESKTOP_RAIL_MIN_WIDTH,
   UNIFIED_VEO_FIRST_LAST_ENGINE_IDS,
@@ -134,6 +131,7 @@ import {
 import { useWorkspaceAssets } from './_hooks/useWorkspaceAssets';
 import { useWorkspaceGalleryActions } from './_hooks/useWorkspaceGalleryActions';
 import { useWorkspaceGenerationRunner } from './_hooks/useWorkspaceGenerationRunner';
+import { useWorkspacePricingGate } from './_hooks/useWorkspacePricingGate';
 import { useWorkspaceRenderState } from './_hooks/useWorkspaceRenderState';
 import { useWorkspaceVideoSettings } from './_hooks/useWorkspaceVideoSettings';
 
@@ -248,20 +246,8 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
   const [voiceIdsInput, setVoiceIdsInput] = useState<string>('');
   const [klingElements, setKlingElements] = useState<KlingElementState[]>(() => [createKlingElement()]);
   const [cfgScale, setCfgScale] = useState<number | null>(null);
-  const [preflight, setPreflight] = useState<PreflightResponse | null>(null);
-  const [preflightError, setPreflightError] = useState<string | undefined>();
-  const [isPricing, setPricing] = useState(false);
   const [memberTier, setMemberTier] = useState<'Member' | 'Plus' | 'Pro'>('Member');
   const [notice, setNotice] = useState<string | null>(null);
-  const [topUpModal, setTopUpModal] = useState<{
-    message: string;
-    amountLabel?: string;
-    shortfallCents?: number;
-  } | null>(null);
-  const [authModalOpen, setAuthModalOpen] = useState(false);
-  const [topUpAmount, setTopUpAmount] = useState<number>(1000);
-  const [isTopUpLoading, setIsTopUpLoading] = useState(false);
-  const [topUpError, setTopUpError] = useState<string | null>(null);
 
   const storageScope = useMemo(() => userId ?? 'anon', [userId]);
   const readScopedStorage = useCallback(
@@ -658,10 +644,6 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
     setKlingElements,
   });
 
-  const showComposerError = useCallback((message: string) => {
-    setPreflightError(message);
-  }, []);
-
   const handleRefreshJob = useCallback(async (jobId: string) => {
     try {
       const status = await getJobStatus(jobId);
@@ -674,12 +656,6 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
     } catch (error) {
       throw error instanceof Error ? error : new Error('Unable to refresh render status.');
     }
-  }, []);
-
-  const closeTopUpModal = useCallback(() => {
-    setTopUpModal(null);
-    setTopUpAmount(1000);
-    setTopUpError(null);
   }, []);
 
   const handleMultiPromptAddScene = useCallback(() => {
@@ -723,76 +699,6 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
     setForm((current) => (current ? { ...current, safetyChecker: value } : current));
   }, []);
 
-  const handleSelectPresetAmount = useCallback((value: number) => {
-    setTopUpAmount(value);
-  }, []);
-
-  const handleCustomAmountChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = Number(event.target.value);
-    if (Number.isNaN(value)) {
-      setTopUpAmount(1000);
-      return;
-    }
-    setTopUpAmount(Math.max(1000, Math.round(value * 100)));
-  }, []);
-
-  const handleConfirmTopUp = useCallback(async () => {
-    if (!topUpModal) return;
-    const amountCents = Math.max(1000, topUpAmount);
-    setIsTopUpLoading(true);
-    setTopUpError(null);
-    try {
-      const res = await authFetch('/api/wallet', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ amountCents }),
-      });
-      const json = await res.json();
-      if (!res.ok) {
-        throw new Error(json?.error ?? 'Wallet top-up failed');
-      }
-      if (json?.url) {
-        window.location.href = json.url as string;
-        return;
-      }
-      closeTopUpModal();
-      showNotice('Top-up initiated. Complete the payment to update your balance.');
-    } catch (error) {
-      setTopUpError(error instanceof Error ? error.message : 'Failed to start top-up');
-    } finally {
-      setIsTopUpLoading(false);
-    }
-  }, [topUpAmount, topUpModal, closeTopUpModal, showNotice]);
-
-  const handleTopUpSubmit = useCallback(
-    (event: FormEvent<HTMLFormElement>) => {
-      event.preventDefault();
-      void handleConfirmTopUp();
-    },
-    [handleConfirmTopUp]
-  );
-
-  useEffect(() => {
-    if (!authChecked) return undefined;
-    let mounted = true;
-    (async () => {
-      try {
-        const res = await authFetch('/api/member-status');
-        if (!res.ok) return;
-        const json = await res.json();
-        if (mounted) {
-          const tier = (json?.tier ?? 'Member') as 'Member' | 'Plus' | 'Pro';
-          setMemberTier(tier);
-        }
-      } catch {
-        // noop
-      }
-    })();
-    return () => {
-      mounted = false;
-    };
-  }, [authChecked]);
-
   useEffect(() => {
     if (!authChecked || skipOnboardingRef.current) return undefined;
     if (process.env.NODE_ENV !== 'production') {
@@ -826,17 +732,6 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
       cancelled = true;
     };
   }, [authChecked, router]);
-
-  useEffect(() => {
-    if (!topUpModal) return undefined;
-    const handleKey = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        closeTopUpModal();
-      }
-    };
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
-  }, [topUpModal, closeTopUpModal]);
 
   useEffect(() => {
     return () => {
@@ -1514,6 +1409,38 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
     [form, handleExtraInputValueChange, inputSchemaSummary.promotedFields, uiLocale]
   );
 
+  const {
+    preflight,
+    preflightError,
+    isPricing,
+    price,
+    currency,
+    topUpModal,
+    topUpAmount,
+    isTopUpLoading,
+    topUpError,
+    authModalOpen,
+    showComposerError,
+    closeTopUpModal,
+    handleSelectPresetAmount,
+    handleCustomAmountChange,
+    handleTopUpSubmit,
+    setAuthModalOpen,
+    setPreflightError,
+    setTopUpModal,
+  } = useWorkspacePricingGate({
+    form,
+    selectedEngine,
+    authChecked,
+    memberTier,
+    setMemberTier,
+    supportsAudioToggle,
+    effectiveDurationSec,
+    voiceControlEnabled,
+    submissionMode,
+    showNotice,
+  });
+
   const { startRender } = useWorkspaceGenerationRunner({
     audioWorkflowUnsupported,
     form,
@@ -1604,62 +1531,6 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
     });
   }, [selectedEngine, authChecked]);
 
-  useEffect(() => {
-    if (!form || !selectedEngine || !authChecked) return;
-    let canceled = false;
-
-    const payload: PreflightRequest = {
-      engine: form.engineId,
-      mode: submissionMode,
-      durationSec: effectiveDurationSec,
-      resolution: form.resolution as PreflightRequest['resolution'],
-      aspectRatio: form.aspectRatio as PreflightRequest['aspectRatio'],
-      fps: form.fps,
-      seedLocked: Boolean(form.seedLocked),
-      loop: form.loop,
-      ...(supportsAudioToggle ? { audio: form.audio } : {}),
-      ...(voiceControlEnabled ? { voiceControl: true } : {}),
-      user: { memberTier },
-    };
-    setPricing(true);
-    setPreflightError(undefined);
-
-    const timeout = setTimeout(() => {
-      Promise.resolve()
-        .then(() => runPreflight(payload))
-        .then((response) => {
-          if (canceled) return;
-          setPreflight(response);
-          if (!response.ok) {
-            const message =
-              (typeof response.error?.message === 'string' && response.error.message.trim().length
-                ? response.error.message.trim()
-                : undefined) ??
-              response.messages?.find((entry) => typeof entry === 'string' && entry.trim().length)?.trim() ??
-              'Unable to compute pricing';
-            setPreflightError(message);
-            return;
-          }
-          setPreflightError(undefined);
-        })
-        .catch((err) => {
-          if (canceled) return;
-          console.error('[preflight] failed', err);
-          setPreflightError(err instanceof Error ? err.message : 'Preflight failed');
-        })
-        .finally(() => {
-          if (!canceled) {
-            setPricing(false);
-          }
-        });
-    }, DEBOUNCE_MS);
-
-    return () => {
-      canceled = true;
-      clearTimeout(timeout);
-    };
-  }, [form, selectedEngine, memberTier, authChecked, supportsAudioToggle, effectiveDurationSec, voiceControlEnabled, submissionMode]);
-
   const fallbackEngineId = selectedEngine?.id ?? 'unknown-engine';
   const {
     previewAutoPlayRequestId,
@@ -1694,15 +1565,6 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
     setCompositeOverrideSummary,
     setSharedPrompt,
   });
-
-  const singlePriceCents = typeof preflight?.total === 'number' ? preflight.total : null;
-  const singlePrice =
-    typeof singlePriceCents === 'number' ? singlePriceCents / 100 : null;
-  const price =
-    typeof singlePrice === 'number' && form?.iterations
-      ? singlePrice * form.iterations
-      : singlePrice;
-  const currency = preflight?.currency ?? 'USD';
 
   if (isLoading && engines.length === 0) {
     return (
@@ -2034,143 +1896,27 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
           onRefreshJob={handleRefreshJob}
         />
       ) : null}
-      {topUpModal && (
-        <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-surface-on-media-dark-40 px-4">
-          <div className="absolute inset-0" role="presentation" onClick={closeTopUpModal} />
-          <form
-            className="relative z-10 w-full max-w-md rounded-modal border border-border bg-surface p-6 shadow-float"
-            onSubmit={handleTopUpSubmit}
-          >
-            <div className="flex items-start justify-between gap-4">
-              <div className="flex-1">
-                <h2 className="text-base font-semibold text-text-primary">Wallet balance too low</h2>
-                <p className="mt-2 text-sm text-text-secondary">{topUpModal.message}</p>
-                {topUpModal.amountLabel && (
-                  <p className="mt-2 text-sm font-medium text-text-primary">
-                    Suggested top-up: {topUpModal.amountLabel}
-                  </p>
-                )}
-                <div className="mt-4">
-                  <p className="text-xs font-semibold uppercase tracking-micro text-text-muted">{workspaceCopy.topUp.title}</p>
-                  <div className="mt-2 flex flex-wrap gap-2">
-                    {[1000, 2500, 5000].map((value) => {
-                      const formatted = (() => {
-                        try {
-                          return new Intl.NumberFormat(CURRENCY_LOCALE, { style: 'currency', currency }).format(value / 100);
-                        } catch {
-                          return `${currency} ${(value / 100).toFixed(2)}`;
-                        }
-                      })();
-                      const isActive = topUpAmount === value;
-                      return (
-                        <Button
-                          key={value}
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          onClick={() => handleSelectPresetAmount(value)}
-                          className={clsx(
-                            'min-h-0 h-8 px-3 py-1.5 text-sm font-medium',
-                            isActive
-                              ? 'border-brand bg-surface-2 text-brand hover:border-brand'
-                              : 'border-hairline bg-surface text-text-secondary hover:border-text-muted hover:bg-surface-2'
-                          )}
-                        >
-                          {formatted}
-                        </Button>
-                      );
-                    })}
-                  </div>
-                  <div className="mt-3">
-                    <label htmlFor="custom-topup" className="text-xs font-semibold uppercase tracking-micro text-text-muted">
-                      {workspaceCopy.topUp.otherAmountLabel}
-                    </label>
-                    <div className="mt-1 flex items-center gap-2">
-                      <div className="relative flex-1">
-                        <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-sm text-text-secondary">
-                          $
-                        </span>
-                        <Input
-                          id="custom-topup"
-                          type="number"
-                          min={10}
-                          step={1}
-                          value={Math.max(10, Math.round(topUpAmount / 100))}
-                          onChange={handleCustomAmountChange}
-                          className="h-10 pl-6 pr-3"
-                        />
-                      </div>
-                      <span className="text-xs text-text-muted">
-                        {workspaceCopy.topUp.minLabel.replace('{amount}', '$10')}
-                      </span>
-                    </div>
-                  </div>
-                  {topUpError && <p className="mt-2 text-sm text-state-warning">{topUpError}</p>}
-                </div>
-              </div>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={closeTopUpModal}
-                className="rounded-full border-hairline bg-surface-glass-80 px-3 py-1.5 text-sm text-text-muted hover:bg-surface-2"
-                aria-label={workspaceCopy.topUp.close}
-              >
-                {workspaceCopy.topUp.close}
-              </Button>
-            </div>
-            <div className="mt-6 flex flex-col gap-4 sm:flex-row sm:justify-end">
-              <Button type="button" variant="outline" size="sm" onClick={closeTopUpModal} className="px-4">
-                {workspaceCopy.topUp.maybeLater}
-              </Button>
-              <Button
-                type="submit"
-                size="sm"
-                disabled={isTopUpLoading}
-                className={clsx('px-4', !isTopUpLoading && 'hover:brightness-105')}
-              >
-                {isTopUpLoading ? workspaceCopy.topUp.submitting : workspaceCopy.topUp.submit}
-              </Button>
-            </div>
-          </form>
-        </div>
-      )}
-      {authModalOpen && (
-        <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-surface-on-media-dark-40 px-4">
-          <div className="absolute inset-0" role="presentation" onClick={() => setAuthModalOpen(false)} />
-          <div className="relative z-10 w-full max-w-md rounded-modal border border-border bg-surface p-6 shadow-float">
-            <div className="flex items-start justify-between gap-4">
-              <div className="flex-1">
-                <h2 className="text-base font-semibold text-text-primary">{workspaceCopy.authGate.title}</h2>
-                <p className="mt-2 text-sm text-text-secondary">{workspaceCopy.authGate.body}</p>
-              </div>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => setAuthModalOpen(false)}
-                className="rounded-full border-hairline bg-surface-glass-80 px-3 py-1.5 text-sm text-text-muted hover:bg-surface-2"
-                aria-label={workspaceCopy.authGate.close}
-              >
-                {workspaceCopy.authGate.close}
-              </Button>
-            </div>
-            <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
-              <ButtonLink href={`/login?next=${encodeURIComponent(loginRedirectTarget)}`} size="sm" className="px-4">
-                {workspaceCopy.authGate.primary}
-              </ButtonLink>
-              <ButtonLink
-                href={`/login?mode=signin&next=${encodeURIComponent(loginRedirectTarget)}`}
-                variant="outline"
-                size="sm"
-                className="px-4"
-              >
-                {workspaceCopy.authGate.secondary}
-              </ButtonLink>
-            </div>
-          </div>
-        </div>
-      )}
+      {topUpModal ? (
+        <WorkspaceTopUpModal
+          modal={topUpModal}
+          copy={workspaceCopy.topUp}
+          currency={currency}
+          topUpAmount={topUpAmount}
+          isTopUpLoading={isTopUpLoading}
+          topUpError={topUpError}
+          onClose={closeTopUpModal}
+          onSubmit={handleTopUpSubmit}
+          onSelectPresetAmount={handleSelectPresetAmount}
+          onCustomAmountChange={handleCustomAmountChange}
+        />
+      ) : null}
+      {authModalOpen ? (
+        <WorkspaceAuthGateModal
+          copy={workspaceCopy.authGate}
+          loginRedirectTarget={loginRedirectTarget}
+          onClose={() => setAuthModalOpen(false)}
+        />
+      ) : null}
       {assetPickerTarget && (
         <AssetLibraryModal
           fieldLabel={

--- a/frontend/app/(core)/(workspace)/app/_components/WorkspaceAuthGateModal.tsx
+++ b/frontend/app/(core)/(workspace)/app/_components/WorkspaceAuthGateModal.tsx
@@ -1,0 +1,58 @@
+import { Button, ButtonLink } from '@/components/ui/Button';
+
+type WorkspaceAuthGateCopy = {
+  title: string;
+  body: string;
+  primary: string;
+  secondary: string;
+  close: string;
+};
+
+type WorkspaceAuthGateModalProps = {
+  copy: WorkspaceAuthGateCopy;
+  loginRedirectTarget: string;
+  onClose: () => void;
+};
+
+export function WorkspaceAuthGateModal({
+  copy,
+  loginRedirectTarget,
+  onClose,
+}: WorkspaceAuthGateModalProps) {
+  return (
+    <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-surface-on-media-dark-40 px-4">
+      <div className="absolute inset-0" role="presentation" onClick={onClose} />
+      <div className="relative z-10 w-full max-w-md rounded-modal border border-border bg-surface p-6 shadow-float">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1">
+            <h2 className="text-base font-semibold text-text-primary">{copy.title}</h2>
+            <p className="mt-2 text-sm text-text-secondary">{copy.body}</p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onClose}
+            className="rounded-full border-hairline bg-surface-glass-80 px-3 py-1.5 text-sm text-text-muted hover:bg-surface-2"
+            aria-label={copy.close}
+          >
+            {copy.close}
+          </Button>
+        </div>
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
+          <ButtonLink href={`/login?next=${encodeURIComponent(loginRedirectTarget)}`} size="sm" className="px-4">
+            {copy.primary}
+          </ButtonLink>
+          <ButtonLink
+            href={`/login?mode=signin&next=${encodeURIComponent(loginRedirectTarget)}`}
+            variant="outline"
+            size="sm"
+            className="px-4"
+          >
+            {copy.secondary}
+          </ButtonLink>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/(core)/(workspace)/app/_components/WorkspaceTopUpModal.tsx
+++ b/frontend/app/(core)/(workspace)/app/_components/WorkspaceTopUpModal.tsx
@@ -1,0 +1,144 @@
+import clsx from 'clsx';
+import type { ChangeEvent, FormEvent } from 'react';
+import { Input } from '@/components/ui/Input';
+import { Button } from '@/components/ui/Button';
+import { CURRENCY_LOCALE } from '@/lib/intl';
+import type { TopUpModalState } from '../_hooks/useWorkspacePricingGate';
+
+type WorkspaceTopUpCopy = {
+  title: string;
+  otherAmountLabel: string;
+  minLabel: string;
+  close: string;
+  maybeLater: string;
+  submit: string;
+  submitting: string;
+};
+
+type WorkspaceTopUpModalProps = {
+  modal: NonNullable<TopUpModalState>;
+  copy: WorkspaceTopUpCopy;
+  currency: string;
+  topUpAmount: number;
+  isTopUpLoading: boolean;
+  topUpError: string | null;
+  onClose: () => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onSelectPresetAmount: (value: number) => void;
+  onCustomAmountChange: (event: ChangeEvent<HTMLInputElement>) => void;
+};
+
+export function WorkspaceTopUpModal({
+  modal,
+  copy,
+  currency,
+  topUpAmount,
+  isTopUpLoading,
+  topUpError,
+  onClose,
+  onSubmit,
+  onSelectPresetAmount,
+  onCustomAmountChange,
+}: WorkspaceTopUpModalProps) {
+  return (
+    <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-surface-on-media-dark-40 px-4">
+      <div className="absolute inset-0" role="presentation" onClick={onClose} />
+      <form
+        className="relative z-10 w-full max-w-md rounded-modal border border-border bg-surface p-6 shadow-float"
+        onSubmit={onSubmit}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1">
+            <h2 className="text-base font-semibold text-text-primary">Wallet balance too low</h2>
+            <p className="mt-2 text-sm text-text-secondary">{modal.message}</p>
+            {modal.amountLabel && (
+              <p className="mt-2 text-sm font-medium text-text-primary">
+                Suggested top-up: {modal.amountLabel}
+              </p>
+            )}
+            <div className="mt-4">
+              <p className="text-xs font-semibold uppercase tracking-micro text-text-muted">{copy.title}</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {[1000, 2500, 5000].map((value) => {
+                  const formatted = (() => {
+                    try {
+                      return new Intl.NumberFormat(CURRENCY_LOCALE, { style: 'currency', currency }).format(value / 100);
+                    } catch {
+                      return `${currency} ${(value / 100).toFixed(2)}`;
+                    }
+                  })();
+                  const isActive = topUpAmount === value;
+                  return (
+                    <Button
+                      key={value}
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => onSelectPresetAmount(value)}
+                      className={clsx(
+                        'min-h-0 h-8 px-3 py-1.5 text-sm font-medium',
+                        isActive
+                          ? 'border-brand bg-surface-2 text-brand hover:border-brand'
+                          : 'border-hairline bg-surface text-text-secondary hover:border-text-muted hover:bg-surface-2'
+                      )}
+                    >
+                      {formatted}
+                    </Button>
+                  );
+                })}
+              </div>
+              <div className="mt-3">
+                <label htmlFor="custom-topup" className="text-xs font-semibold uppercase tracking-micro text-text-muted">
+                  {copy.otherAmountLabel}
+                </label>
+                <div className="mt-1 flex items-center gap-2">
+                  <div className="relative flex-1">
+                    <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-sm text-text-secondary">
+                      $
+                    </span>
+                    <Input
+                      id="custom-topup"
+                      type="number"
+                      min={10}
+                      step={1}
+                      value={Math.max(10, Math.round(topUpAmount / 100))}
+                      onChange={onCustomAmountChange}
+                      className="h-10 pl-6 pr-3"
+                    />
+                  </div>
+                  <span className="text-xs text-text-muted">
+                    {copy.minLabel.replace('{amount}', '$10')}
+                  </span>
+                </div>
+              </div>
+              {topUpError && <p className="mt-2 text-sm text-state-warning">{topUpError}</p>}
+            </div>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onClose}
+            className="rounded-full border-hairline bg-surface-glass-80 px-3 py-1.5 text-sm text-text-muted hover:bg-surface-2"
+            aria-label={copy.close}
+          >
+            {copy.close}
+          </Button>
+        </div>
+        <div className="mt-6 flex flex-col gap-4 sm:flex-row sm:justify-end">
+          <Button type="button" variant="outline" size="sm" onClick={onClose} className="px-4">
+            {copy.maybeLater}
+          </Button>
+          <Button
+            type="submit"
+            size="sm"
+            disabled={isTopUpLoading}
+            className={clsx('px-4', !isTopUpLoading && 'hover:brightness-105')}
+          >
+            {isTopUpLoading ? copy.submitting : copy.submit}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/app/(core)/(workspace)/app/_hooks/useWorkspacePricingGate.ts
+++ b/frontend/app/(core)/(workspace)/app/_hooks/useWorkspacePricingGate.ts
@@ -1,0 +1,279 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { ChangeEvent, Dispatch, FormEvent, SetStateAction } from 'react';
+import { runPreflight } from '@/lib/api';
+import { authFetch } from '@/lib/authFetch';
+import type { EngineCaps, Mode, PreflightRequest, PreflightResponse } from '@/types/engines';
+import type { FormState } from '../_lib/workspace-form-state';
+import { DEBOUNCE_MS } from '../_lib/workspace-client-helpers';
+
+export type MemberTier = 'Member' | 'Plus' | 'Pro';
+
+export type TopUpModalState = {
+  message: string;
+  amountLabel?: string;
+  shortfallCents?: number;
+} | null;
+
+type UseWorkspacePricingGateOptions = {
+  form: FormState | null;
+  selectedEngine: EngineCaps | null;
+  authChecked: boolean;
+  memberTier: MemberTier;
+  setMemberTier: Dispatch<SetStateAction<MemberTier>>;
+  supportsAudioToggle: boolean;
+  effectiveDurationSec: number;
+  voiceControlEnabled: boolean;
+  submissionMode: Mode;
+  showNotice: (message: string) => void;
+};
+
+type UseWorkspacePricingGateResult = {
+  preflight: PreflightResponse | null;
+  preflightError: string | undefined;
+  isPricing: boolean;
+  price: number | null;
+  currency: string;
+  topUpModal: TopUpModalState;
+  topUpAmount: number;
+  isTopUpLoading: boolean;
+  topUpError: string | null;
+  authModalOpen: boolean;
+  showComposerError: (message: string) => void;
+  closeTopUpModal: () => void;
+  handleSelectPresetAmount: (value: number) => void;
+  handleCustomAmountChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  handleTopUpSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  setAuthModalOpen: Dispatch<SetStateAction<boolean>>;
+  setPreflightError: Dispatch<SetStateAction<string | undefined>>;
+  setTopUpModal: Dispatch<SetStateAction<TopUpModalState>>;
+};
+
+function getPreflightErrorMessage(response: PreflightResponse): string {
+  return (
+    (typeof response.error?.message === 'string' && response.error.message.trim().length
+      ? response.error.message.trim()
+      : undefined) ??
+    response.messages?.find((entry) => typeof entry === 'string' && entry.trim().length)?.trim() ??
+    'Unable to compute pricing'
+  );
+}
+
+export function useWorkspacePricingGate({
+  form,
+  selectedEngine,
+  authChecked,
+  memberTier,
+  setMemberTier,
+  supportsAudioToggle,
+  effectiveDurationSec,
+  voiceControlEnabled,
+  submissionMode,
+  showNotice,
+}: UseWorkspacePricingGateOptions): UseWorkspacePricingGateResult {
+  const [preflight, setPreflight] = useState<PreflightResponse | null>(null);
+  const [preflightError, setPreflightError] = useState<string | undefined>();
+  const [isPricing, setPricing] = useState(false);
+  const [topUpModal, setTopUpModal] = useState<TopUpModalState>(null);
+  const [authModalOpen, setAuthModalOpen] = useState(false);
+  const [topUpAmount, setTopUpAmount] = useState<number>(1000);
+  const [isTopUpLoading, setIsTopUpLoading] = useState(false);
+  const [topUpError, setTopUpError] = useState<string | null>(null);
+
+  const showComposerError = useCallback((message: string) => {
+    setPreflightError(message);
+  }, []);
+
+  const closeTopUpModal = useCallback(() => {
+    setTopUpModal(null);
+    setTopUpAmount(1000);
+    setTopUpError(null);
+  }, []);
+
+  const handleSelectPresetAmount = useCallback((value: number) => {
+    setTopUpAmount(value);
+  }, []);
+
+  const handleCustomAmountChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    const value = Number(event.target.value);
+    if (Number.isNaN(value)) {
+      setTopUpAmount(1000);
+      return;
+    }
+    setTopUpAmount(Math.max(1000, Math.round(value * 100)));
+  }, []);
+
+  const handleConfirmTopUp = useCallback(async () => {
+    if (!topUpModal) return;
+    const amountCents = Math.max(1000, topUpAmount);
+    setIsTopUpLoading(true);
+    setTopUpError(null);
+    try {
+      const res = await authFetch('/api/wallet', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ amountCents }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        throw new Error(json?.error ?? 'Wallet top-up failed');
+      }
+      if (json?.url) {
+        window.location.href = json.url as string;
+        return;
+      }
+      closeTopUpModal();
+      showNotice('Top-up initiated. Complete the payment to update your balance.');
+    } catch (error) {
+      setTopUpError(error instanceof Error ? error.message : 'Failed to start top-up');
+    } finally {
+      setIsTopUpLoading(false);
+    }
+  }, [closeTopUpModal, showNotice, topUpAmount, topUpModal]);
+
+  const handleTopUpSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      void handleConfirmTopUp();
+    },
+    [handleConfirmTopUp]
+  );
+
+  useEffect(() => {
+    if (!authChecked) return undefined;
+    let mounted = true;
+    (async () => {
+      try {
+        const res = await authFetch('/api/member-status');
+        if (!res.ok) return;
+        const json = await res.json();
+        if (mounted) {
+          const tier = (json?.tier ?? 'Member') as MemberTier;
+          setMemberTier(tier);
+        }
+      } catch {
+        // noop
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [authChecked, setMemberTier]);
+
+  useEffect(() => {
+    if (!topUpModal) return undefined;
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closeTopUpModal();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [topUpModal, closeTopUpModal]);
+
+  useEffect(() => {
+    if (!form || !selectedEngine || !authChecked) return;
+    let canceled = false;
+
+    const payload: PreflightRequest = {
+      engine: form.engineId,
+      mode: submissionMode,
+      durationSec: effectiveDurationSec,
+      resolution: form.resolution as PreflightRequest['resolution'],
+      aspectRatio: form.aspectRatio as PreflightRequest['aspectRatio'],
+      fps: form.fps,
+      seedLocked: Boolean(form.seedLocked),
+      loop: form.loop,
+      ...(supportsAudioToggle ? { audio: form.audio } : {}),
+      ...(voiceControlEnabled ? { voiceControl: true } : {}),
+      user: { memberTier },
+    };
+    setPricing(true);
+    setPreflightError(undefined);
+
+    const timeout = setTimeout(() => {
+      Promise.resolve()
+        .then(() => runPreflight(payload))
+        .then((response) => {
+          if (canceled) return;
+          setPreflight(response);
+          if (!response.ok) {
+            setPreflightError(getPreflightErrorMessage(response));
+            return;
+          }
+          setPreflightError(undefined);
+        })
+        .catch((err) => {
+          if (canceled) return;
+          console.error('[preflight] failed', err);
+          setPreflightError(err instanceof Error ? err.message : 'Preflight failed');
+        })
+        .finally(() => {
+          if (!canceled) {
+            setPricing(false);
+          }
+        });
+    }, DEBOUNCE_MS);
+
+    return () => {
+      canceled = true;
+      clearTimeout(timeout);
+    };
+  }, [
+    form,
+    selectedEngine,
+    memberTier,
+    authChecked,
+    supportsAudioToggle,
+    effectiveDurationSec,
+    voiceControlEnabled,
+    submissionMode,
+  ]);
+
+  const singlePriceCents = typeof preflight?.total === 'number' ? preflight.total : null;
+  const singlePrice = typeof singlePriceCents === 'number' ? singlePriceCents / 100 : null;
+  const price =
+    typeof singlePrice === 'number' && form?.iterations
+      ? singlePrice * form.iterations
+      : singlePrice;
+  const currency = preflight?.currency ?? 'USD';
+
+  return useMemo(
+    () => ({
+      preflight,
+      preflightError,
+      isPricing,
+      price,
+      currency,
+      topUpModal,
+      topUpAmount,
+      isTopUpLoading,
+      topUpError,
+      authModalOpen,
+      showComposerError,
+      closeTopUpModal,
+      handleSelectPresetAmount,
+      handleCustomAmountChange,
+      handleTopUpSubmit,
+      setAuthModalOpen,
+      setPreflightError,
+      setTopUpModal,
+    }),
+    [
+      authModalOpen,
+      closeTopUpModal,
+      currency,
+      handleCustomAmountChange,
+      handleSelectPresetAmount,
+      handleTopUpSubmit,
+      isPricing,
+      isTopUpLoading,
+      preflight,
+      preflightError,
+      price,
+      showComposerError,
+      topUpAmount,
+      topUpError,
+      topUpModal,
+    ]
+  );
+}

--- a/tests/workspace-pricing-gate-hook-contract.test.ts
+++ b/tests/workspace-pricing-gate-hook-contract.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+test('workspace pricing and auth gate orchestration is owned by route-local modules', () => {
+  const appSource = fs.readFileSync(
+    path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/AppClient.tsx'),
+    'utf8'
+  );
+  const hookPath = path.join(
+    process.cwd(),
+    'frontend/app/(core)/(workspace)/app/_hooks/useWorkspacePricingGate.ts'
+  );
+  const topUpModalPath = path.join(
+    process.cwd(),
+    'frontend/app/(core)/(workspace)/app/_components/WorkspaceTopUpModal.tsx'
+  );
+  const authGateModalPath = path.join(
+    process.cwd(),
+    'frontend/app/(core)/(workspace)/app/_components/WorkspaceAuthGateModal.tsx'
+  );
+
+  assert.equal(fs.existsSync(hookPath), true);
+  assert.equal(fs.existsSync(topUpModalPath), true);
+  assert.equal(fs.existsSync(authGateModalPath), true);
+
+  const hookSource = fs.readFileSync(hookPath, 'utf8');
+  const topUpModalSource = fs.readFileSync(topUpModalPath, 'utf8');
+  const authGateModalSource = fs.readFileSync(authGateModalPath, 'utf8');
+
+  assert.match(appSource, /import \{ useWorkspacePricingGate \} from '\.\/_hooks\/useWorkspacePricingGate';/);
+  assert.match(appSource, /import \{ WorkspaceTopUpModal \} from '\.\/_components\/WorkspaceTopUpModal';/);
+  assert.match(appSource, /import \{ WorkspaceAuthGateModal \} from '\.\/_components\/WorkspaceAuthGateModal';/);
+  assert.match(appSource, /useWorkspacePricingGate\(\{/);
+
+  assert.doesNotMatch(appSource, /const \[preflight, setPreflight\] = useState/);
+  assert.doesNotMatch(appSource, /const handleConfirmTopUp = useCallback/);
+  assert.doesNotMatch(appSource, /const payload: PreflightRequest =/);
+  assert.doesNotMatch(appSource, /const singlePriceCents =/);
+  assert.doesNotMatch(appSource, /Wallet balance too low/);
+
+  assert.match(hookSource, /export function useWorkspacePricingGate/);
+  assert.match(hookSource, /runPreflight/);
+  assert.match(hookSource, /authFetch\('\/api\/member-status'\)/);
+  assert.match(hookSource, /authFetch\('\/api\/wallet'/);
+  assert.match(hookSource, /const handleConfirmTopUp = useCallback/);
+  assert.match(hookSource, /const showComposerError = useCallback/);
+
+  assert.match(topUpModalSource, /export function WorkspaceTopUpModal/);
+  assert.match(topUpModalSource, /Wallet balance too low/);
+  assert.match(topUpModalSource, /custom-topup/);
+
+  assert.match(authGateModalSource, /export function WorkspaceAuthGateModal/);
+  assert.match(authGateModalSource, /ButtonLink/);
+  assert.match(authGateModalSource, /encodeURIComponent\(loginRedirectTarget\)/);
+});


### PR DESCRIPTION
## Summary
- move workspace preflight pricing, member-status refresh, top-up modal state, and auth gate modal state into useWorkspacePricingGate
- extract wallet top-up and auth gate overlays into route-local components
- add a contract test and update the workspace route guide

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/workspace-pricing-gate-hook-contract.test.ts tests/workspace-generation-runner-hook-contract.test.ts tests/workspace-gallery-actions-hook-contract.test.ts tests/workspace-assets-hook-contract.test.ts tests/workspace-render-state-hook-contract.test.ts tests/workspace-video-settings-hook-contract.test.ts
- ./node_modules/.bin/tsc --noEmit (frontend)
- npm --prefix frontend run lint
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/workspace-pricing-gate-hook-contract.test.ts tests/workspace-generation-runner-hook-contract.test.ts tests/workspace-local-generation-render.test.ts tests/workspace-generation-request-helpers.test.ts
- pnpm run test:validate
- npm --prefix frontend run build
- git diff --check