### PR TITLE
Split workspace draft hydration and surfaces

### DIFF
--- a/frontend/app/(core)/(workspace)/app/AGENTS.md
+++ b/frontend/app/(core)/(workspace)/app/AGENTS.md
@@ -4,9 +4,9 @@ This route is the main signed-in video generation workspace.
 
 ## Responsibilities
 
-- `AppClient.tsx`: top-level state orchestration while the workspace is being split.
-- `_components`: route-local chrome, panels, skeletons, wallet/auth modals, and presentational UI.
-- `_hooks`: route-local stateful workflow hooks for bounded client concerns such as asset library, upload orchestration, composer mode/settings orchestration, gallery action orchestration, pricing/auth gate orchestration, generation runner orchestration, render state and polling, video settings application, and hydration.
+- `AppClient.tsx`: top-level orchestration only; it wires route-local hooks into route-local surfaces.
+- `_components`: route-local chrome, boot surfaces, gallery/preview surfaces, runtime modals, panels, skeletons, wallet/auth modals, and presentational UI.
+- `_hooks`: route-local stateful workflow hooks for bounded client concerns such as draft storage/hydration, asset library, upload orchestration, composer mode/settings orchestration, gallery action orchestration, pricing/auth gate orchestration, generation runner orchestration, render state and polling, and video settings application.
 - `_lib`: route-local pure helpers for previews, render grouping, render status reconciliation, generation input preparation, generation guards, local render preparation, generation payloads, accepted results, generation polling projections, video settings hydration, workspace boot hydration, storage, copy fallback, client constants, asset normalization, asset selection, payload builders, input normalization, and workflow mapping.
 - Tool-specific workspaces should stay in their own route folders unless code is clearly shared.
 
@@ -25,7 +25,8 @@ This route is the main signed-in video generation workspace.
 - Keep accepted `runGenerate` response projection and immediate render/preview patches in `_lib`; `AppClient.tsx` should dispatch events and start polling.
 - Keep generation polling projections and poll-delay decisions in `_lib`; `AppClient.tsx` should own `getJobStatus`, timers, and React setters.
 - Keep video settings snapshot parsing and job media patch mapping in `_lib`; route-local hooks should wire those results into React state and own settings hydration requests.
-- Keep workspace request parsing and boot hydration decisions in `_lib`; `AppClient.tsx` should apply the resolved state.
+- Keep workspace request parsing and boot hydration decisions in `_lib`; route-local draft hooks should apply the resolved state and keep browser storage reads/writes out of `AppClient.tsx`.
+- Keep route shell UI in `_components`; `AppClient.tsx` should render named surfaces instead of owning gallery cards, preview dock internals, boot skeleton composition, or runtime modal JSX inline.
 - Keep asset-library selection, reference slot insertion, and Kling library asset mapping in `_lib`; route-local hooks should own bounded asset library state, upload orchestration, and network calls.
 - Keep generation, polling, wallet, preflight, and upload behavior unchanged unless the task explicitly targets those flows.
 - Keep browser storage keys and pending-render serialization backward compatible.

--- a/frontend/app/(core)/(workspace)/app/AppClient.tsx
+++ b/frontend/app/(core)/(workspace)/app/AppClient.tsx
@@ -3,11 +3,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useEngines, useInfiniteJobs, getJobStatus } from '@/lib/api';
 import { authFetch } from '@/lib/authFetch';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import type { EngineCaps, EngineInputField, Mode } from '@/types/engines';
+import { useRouter } from 'next/navigation';
+import type { EngineCaps, EngineInputField } from '@/types/engines';
 import { SettingsControls } from '@/components/SettingsControls';
 import { CoreSettingsBar } from '@/components/CoreSettingsBar';
-import { EngineSettingsBar } from '@/components/EngineSettingsBar';
 import {
   Composer,
   type MultiPromptScene,
@@ -15,7 +14,6 @@ import {
 import type { KlingElementState, KlingElementsBuilderProps } from '@/components/KlingElementsBuilder';
 import type { GalleryRailProps } from '@/components/GalleryRail';
 import type { GroupSummary } from '@/types/groups';
-import type { CompositePreviewDockProps } from '@/components/groups/CompositePreviewDock';
 import dynamic from 'next/dynamic';
 import { DEFAULT_PROCESSING_COPY } from '@/components/groups/ProcessingOverlay';
 import { ENV as CLIENT_ENV } from '@/lib/env';
@@ -26,12 +24,9 @@ import {
   type SharedVideoPreview,
 } from '@/lib/video-preview-group';
 import { useResultProvider } from '@/hooks/useResultProvider';
-import { GroupedJobCard } from '@/components/GroupedJobCard';
 import { normalizeGroupSummary } from '@/lib/normalize-group-summary';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
-import { readLastKnownUserId } from '@/lib/last-known';
 import { Button } from '@/components/ui/Button';
-import type { AssetLibraryModalProps } from '@/components/library/AssetLibraryModal';
 import {
   isLumaRay2EngineId,
   isLumaRay2GenerateMode,
@@ -46,24 +41,20 @@ import {
   getLocalizedWorkflowCopy,
   normalizeUiLocale,
 } from '@/lib/ltx-localization';
+import { WorkspaceBootSurface } from './_components/WorkspaceBootSurface';
+import { WorkspaceCenterGallery } from './_components/WorkspaceCenterGallery';
 import { WorkspaceChrome } from './_components/WorkspaceChrome';
 import {
-  ComposerBootSkeleton,
-  CompositePreviewDockSkeleton,
-  EngineSettingsBootSkeleton,
   GalleryRailSkeleton,
-  WorkspaceBootPreview,
 } from './_components/WorkspaceBootSkeletons';
-import { WorkspaceAuthGateModal } from './_components/WorkspaceAuthGateModal';
-import { WorkspaceTopUpModal } from './_components/WorkspaceTopUpModal';
+import { WorkspacePreviewDock } from './_components/WorkspacePreviewDock';
+import type { WorkspaceViewerTarget } from './_components/WorkspacePreviewDock';
+import { WorkspaceRuntimeModals } from './_components/WorkspaceRuntimeModals';
 import { getCompositePreviewPosterSrc } from './_lib/composite-preview';
 import {
   normalizeExtraInputValue,
   type FormState,
 } from './_lib/workspace-form-state';
-import {
-  getEngineModeLabel,
-} from './_lib/workspace-engine-helpers';
 import {
   buildAssetFieldIdSet,
   buildComposerAttachments,
@@ -81,25 +72,10 @@ import {
 } from './_lib/workspace-client-helpers';
 import {
   createKlingElement,
-  createLocalId,
   createMultiPromptScene,
   MULTI_PROMPT_MAX_SEC,
   MULTI_PROMPT_MIN_SEC,
 } from './_lib/workspace-input-helpers';
-import {
-  readScopedWorkspaceStorage,
-  readWorkspaceStorage,
-  STORAGE_KEYS,
-  writeScopedWorkspaceStorage,
-  writeWorkspaceStorage,
-} from './_lib/workspace-storage';
-import {
-  buildInitialWorkspaceFormState,
-  consumeWorkspaceOnboardingSkipIntent,
-  parseStoredMultiPromptScenes,
-  readStoredWorkspaceForm,
-  resolveWorkspaceRequestParams,
-} from './_lib/workspace-hydration';
 import {
   buildComposerPromotedActions,
   summarizeWorkspaceInputSchema,
@@ -107,23 +83,13 @@ import {
 import { useWorkspaceAssets } from './_hooks/useWorkspaceAssets';
 import { useWorkspaceComposerState } from './_hooks/useWorkspaceComposerState';
 import { useWorkspaceDesktopLayout } from './_hooks/useWorkspaceDesktopLayout';
+import { useWorkspaceDraftHydration } from './_hooks/useWorkspaceDraftHydration';
+import { useWorkspaceDraftStorage } from './_hooks/useWorkspaceDraftStorage';
 import { useWorkspaceGalleryActions } from './_hooks/useWorkspaceGalleryActions';
 import { useWorkspaceGenerationRunner } from './_hooks/useWorkspaceGenerationRunner';
 import { useWorkspacePricingGate } from './_hooks/useWorkspacePricingGate';
 import { useWorkspaceRenderState } from './_hooks/useWorkspaceRenderState';
 import { useWorkspaceVideoSettings } from './_hooks/useWorkspaceVideoSettings';
-
-const AssetLibraryModal = dynamic<AssetLibraryModalProps>(
-  () => import('@/components/library/AssetLibraryModal').then((mod) => mod.AssetLibraryModal),
-  { ssr: false }
-);
-
-const CompositePreviewDock = dynamic<CompositePreviewDockProps>(
-  () => import('@/components/groups/CompositePreviewDock').then((mod) => mod.CompositePreviewDock),
-  {
-    loading: () => <CompositePreviewDockSkeleton />,
-  }
-);
 
 const GalleryRail = dynamic<GalleryRailProps>(
   () => import('@/components/GalleryRail').then((mod) => mod.GalleryRail),
@@ -137,34 +103,6 @@ const KlingElementsBuilder = dynamic<KlingElementsBuilderProps>(
   () => import('@/components/KlingElementsBuilder').then((mod) => mod.KlingElementsBuilder),
   { ssr: false }
 );
-
-function WorkspaceBootContent({
-  initialPreviewGroup,
-  initialPreviewPosterSrc,
-}: {
-  initialPreviewGroup?: VideoGroup | null;
-  initialPreviewPosterSrc?: string | null;
-}) {
-  const posterSrc = getCompositePreviewPosterSrc(initialPreviewGroup ?? null) ?? initialPreviewPosterSrc ?? null;
-
-  return (
-    <div className="stack-gap-lg">
-      {initialPreviewGroup ? (
-        <>
-          <CompositePreviewDock
-            group={initialPreviewGroup}
-            isLoading={false}
-            showTitle={false}
-            engineSettings={<EngineSettingsBootSkeleton />}
-          />
-        </>
-      ) : (
-        <WorkspaceBootPreview posterSrc={posterSrc} />
-      )}
-      <ComposerBootSkeleton />
-    </div>
-  );
-}
 
 export default function AppClientPage({ initialPreviewGroup = null }: { initialPreviewGroup?: VideoGroup | null }) {
   const { data, error: enginesError, isLoading } = useEngines();
@@ -209,11 +147,6 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
   );
 
   const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const [userId, setUserId] = useState<string | null>(null);
-  const [authChecked, setAuthChecked] = useState(false);
-  const [hydratedForScope, setHydratedForScope] = useState<string | null>(null);
 
   const [form, setForm] = useState<FormState | null>(null);
   const [prompt, setPrompt] = useState<string>(DEFAULT_PROMPT);
@@ -227,86 +160,36 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
   const [memberTier, setMemberTier] = useState<'Member' | 'Plus' | 'Pro'>('Member');
   const [notice, setNotice] = useState<string | null>(null);
 
-  const storageScope = useMemo(() => userId ?? 'anon', [userId]);
-  const readScopedStorage = useCallback(
-    (base: string): string | null => {
-      return readScopedWorkspaceStorage(base, storageScope);
-    },
-    [storageScope]
-  );
-  const readStorage = useCallback(
-    (base: string): string | null => {
-      return readWorkspaceStorage(base, storageScope);
-    },
-    [storageScope]
-  );
-  const writeScopedStorage = useCallback(
-    (base: string, value: string | null) => {
-      writeScopedWorkspaceStorage(base, storageScope, value);
-    },
-    [storageScope]
-  );
-  const writeStorage = useCallback(
-    (base: string, value: string | null) => {
-      writeWorkspaceStorage(base, storageScope, value);
-    },
-    [storageScope]
-  );
-  const workspaceRequest = useMemo(
-    () => resolveWorkspaceRequestParams(searchParams, pathname),
-    [pathname, searchParams]
-  );
   const {
     fromVideoId,
     requestedJobId,
-    resolvedRequestedEngineId,
-    requestedEngineToken,
-    requestedMode,
     searchString,
     loginRedirectTarget,
-  } = workspaceRequest;
-  const skipOnboardingRef = useRef<boolean>(false);
-  const preserveStoredDraftRef = useRef<boolean>(false);
-  const requestedEngineOverrideIdRef = useRef<string | null>(null);
-  const requestedEngineOverrideTokenRef = useRef<string | null>(null);
-  const requestedModeOverrideRef = useRef<Mode | null>(null);
-
-  useEffect(() => {
-    if (!resolvedRequestedEngineId) return;
-    requestedEngineOverrideIdRef.current = resolvedRequestedEngineId;
-    requestedEngineOverrideTokenRef.current = requestedEngineToken;
-    requestedModeOverrideRef.current = requestedMode;
-  }, [resolvedRequestedEngineId, requestedEngineToken, requestedMode]);
-
-  const effectiveRequestedEngineId = resolvedRequestedEngineId ?? requestedEngineOverrideIdRef.current;
-  const effectiveRequestedEngineToken = requestedEngineToken ?? requestedEngineOverrideTokenRef.current;
-  const effectiveRequestedMode = requestedMode ?? requestedModeOverrideRef.current;
-
-  useEffect(() => {
-    const skipIntent = consumeWorkspaceOnboardingSkipIntent(fromVideoId);
-    if (skipIntent.shouldSkip) {
-      skipOnboardingRef.current = true;
-    }
-    if (process.env.NODE_ENV !== 'production') {
-      if (skipIntent.skippedViaFlag) {
-        console.log('[app] skip onboarding via flag');
-      }
-      if (skipIntent.lastTarget) {
-        console.log('[app] read last target', {
-          lastTarget: skipIntent.lastTarget,
-          shouldSkip: skipIntent.lastTargetShouldSkip,
-        });
-      }
-      if (skipIntent.fromVideoId) {
-        console.log('[app] skip onboarding due to fromVideoId', { fromVideoId: skipIntent.fromVideoId });
-      }
-    }
-  }, [fromVideoId]);
+    effectiveRequestedEngineId,
+    effectiveRequestedEngineToken,
+    effectiveRequestedMode,
+    authChecked,
+    storageScope,
+    hydratedForScope,
+    setHydratedForScope,
+    readScopedStorage,
+    readStorage,
+    writeScopedStorage,
+    writeStorage,
+    skipOnboardingRef,
+    preserveStoredDraftRef,
+    hasStoredFormRef,
+    requestedEngineOverrideIdRef,
+    requestedEngineOverrideTokenRef,
+    requestedModeOverrideRef,
+  } = useWorkspaceDraftStorage({
+    authLoading,
+    authStatus,
+    authenticatedUserId: user?.id,
+  });
   const [sharedPrompt, setSharedPrompt] = useState<string | null>(null);
   const [sharedVideoSettings, setSharedVideoSettings] = useState<SharedVideoPreview | null>(null);
-  const [viewerTarget, setViewerTarget] = useState<
-    { kind: 'pending'; id: string } | { kind: 'summary'; summary: GroupSummary } | { kind: 'group'; group: VideoGroup } | null
-  >(null);
+  const [viewerTarget, setViewerTarget] = useState<WorkspaceViewerTarget>(null);
   const isDesktopLayout = useWorkspaceDesktopLayout();
   const [compositeOverride, setCompositeOverride] = useState<VideoGroup | null>(null);
   const [compositeOverrideSummary, setCompositeOverrideSummary] = useState<GroupSummary | null>(null);
@@ -341,115 +224,45 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
     writeScopedStorage,
   });
   const applyVideoSettingsSnapshotRef = useRef<(snapshot: unknown) => void>(() => undefined);
-  const hydratedScopeRef = useRef<string | null>(null);
-  const hasStoredFormRef = useRef<boolean>(false);
 
-  useEffect(() => {
-    if (authLoading) return;
-    if (user?.id) {
-      setUserId(user.id);
-      setAuthChecked(true);
-      return;
-    }
-    if (authStatus === 'refreshing' || authStatus === 'unknown') {
-      const lastKnownUserId = readLastKnownUserId();
-      if (lastKnownUserId) {
-        setUserId(lastKnownUserId);
-      } else {
-        setUserId(null);
-      }
-      setAuthChecked(true);
-      return;
-    }
-    setUserId(null);
-    setAuthChecked(true);
-  }, [authLoading, authStatus, user?.id]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    if (!engines.length) return;
-    if (requestedJobId) return;
-    if (hydratedScopeRef.current === storageScope) return;
-    hydratedScopeRef.current = storageScope;
-    setHydratedForScope(null);
-
-    resetRenderState();
-
-    try {
-      const promptValue = readStorage(STORAGE_KEYS.prompt);
-      setPrompt(promptValue ?? DEFAULT_PROMPT);
-
-      const negativeValue = readStorage(STORAGE_KEYS.negativePrompt);
-      setNegativePrompt(negativeValue ?? '');
-
-      const storedMultiPromptEnabled = readStorage(STORAGE_KEYS.multiPromptEnabled);
-      setMultiPromptEnabled(storedMultiPromptEnabled === 'true');
-      setMultiPromptScenes(
-        parseStoredMultiPromptScenes(readStorage(STORAGE_KEYS.multiPromptScenes), createLocalId, createMultiPromptScene)
-      );
-
-      const storedShotType = readStorage(STORAGE_KEYS.shotType);
-      if (storedShotType === 'customize' || storedShotType === 'intelligent') {
-        setShotType(storedShotType);
-      }
-      const storedVoiceIds = readStorage(STORAGE_KEYS.voiceIds);
-      if (typeof storedVoiceIds === 'string') {
-        setVoiceIdsInput(storedVoiceIds);
-      }
-
-      const formValue = readStorage(STORAGE_KEYS.form);
-      const initialForm = buildInitialWorkspaceFormState({
-        engines,
-        storedFormRaw: readStoredWorkspaceForm(storageScope, formValue),
-        effectiveRequestedEngineId,
-        effectiveRequestedEngineToken,
-        effectiveRequestedMode,
-      });
-      preserveStoredDraftRef.current = initialForm.preserveStoredDraft;
-      hasStoredFormRef.current = initialForm.hasStoredForm;
-      if (initialForm.form) {
-        setForm(initialForm.form);
-      }
-      if (initialForm.debugEngineOverride && process.env.NODE_ENV !== 'production') {
-        console.log('[generate] engine override from storage hydrate', initialForm.debugEngineOverride);
-      }
-      if (initialForm.formToPersist) {
-        const formToPersist = initialForm.formToPersist;
-        queueMicrotask(() => {
-          try {
-            writeStorage(STORAGE_KEYS.form, JSON.stringify(formToPersist));
-          } catch {
-            // noop
-          }
-        });
-      }
-
-      const storedTier = readStorage(STORAGE_KEYS.memberTier);
-      if (storedTier === 'Member' || storedTier === 'Plus' || storedTier === 'Pro') {
-        setMemberTier(storedTier);
-      }
-
-      const pendingValue = readScopedStorage(STORAGE_KEYS.pendingRenders);
-      hydratePendingRendersFromStorage(pendingValue);
-    } catch {
-      resetRenderState();
-    } finally {
-      setHydratedForScope(storageScope);
-    }
-  }, [
+  useWorkspaceDraftHydration({
     engines,
-    hydratePendingRendersFromStorage,
-    readScopedStorage,
-    readStorage,
-    resetRenderState,
-    writeStorage,
-    setMemberTier,
-    storageScope,
-    effectiveRequestedEngineId,
-    effectiveRequestedMode,
-    effectiveRequestedEngineToken,
     requestedJobId,
-  ]);
+    fromVideoId,
+    effectiveRequestedEngineId,
+    effectiveRequestedEngineToken,
+    effectiveRequestedMode,
+    storageScope,
+    hydratedForScope,
+    setHydratedForScope,
+    readStorage,
+    readScopedStorage,
+    writeStorage,
+    form,
+    prompt,
+    negativePrompt,
+    multiPromptEnabled,
+    multiPromptScenes,
+    shotType,
+    voiceIdsInput,
+    memberTier,
+    recentJobs,
+    selectedPreview,
+    rendersLength: renders.length,
+    preserveStoredDraftRef,
+    hasStoredFormRef,
+    setForm,
+    setPrompt,
+    setNegativePrompt,
+    setMultiPromptEnabled,
+    setMultiPromptScenes,
+    setShotType,
+    setVoiceIdsInput,
+    setMemberTier,
+    setSelectedPreview,
+    hydratePendingRendersFromStorage,
+    resetRenderState,
+  });
 
   const compositeGroup = compositeOverride ?? activeVideoGroup ?? null;
   const selectedPreviewGroup = useMemo(() => mapSelectedPreviewToGroup(selectedPreview, provider), [selectedPreview, provider]);
@@ -472,93 +285,6 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
     }
     return adaptGroupSummary(normalizeGroupSummary(viewerTarget.summary), provider);
   }, [viewerTarget, pendingSummaryMap, provider]);
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    if (hydratedForScope !== storageScope) return;
-    if (!form) return;
-    if (preserveStoredDraftRef.current) return;
-    try {
-      writeStorage(STORAGE_KEYS.form, JSON.stringify({ ...form, updatedAt: Date.now() }));
-    } catch {
-      // noop
-    }
-  }, [form, hydratedForScope, storageScope, writeStorage]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    if (hydratedForScope !== storageScope) return;
-    if (preserveStoredDraftRef.current) return;
-    try {
-      writeStorage(STORAGE_KEYS.prompt, prompt);
-    } catch {
-      // noop
-    }
-  }, [prompt, hydratedForScope, storageScope, writeStorage]);
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    if (hydratedForScope !== storageScope) return;
-    if (preserveStoredDraftRef.current) return;
-    try {
-      writeStorage(STORAGE_KEYS.negativePrompt, negativePrompt);
-    } catch {
-      // noop
-    }
-  }, [negativePrompt, hydratedForScope, storageScope, writeStorage]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    if (hydratedForScope !== storageScope) return;
-    if (preserveStoredDraftRef.current) return;
-    try {
-      writeStorage(STORAGE_KEYS.multiPromptEnabled, multiPromptEnabled ? 'true' : 'false');
-    } catch {
-      // noop
-    }
-  }, [multiPromptEnabled, hydratedForScope, storageScope, writeStorage]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    if (hydratedForScope !== storageScope) return;
-    if (preserveStoredDraftRef.current) return;
-    try {
-      writeStorage(STORAGE_KEYS.multiPromptScenes, JSON.stringify(multiPromptScenes));
-    } catch {
-      // noop
-    }
-  }, [multiPromptScenes, hydratedForScope, storageScope, writeStorage]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    if (hydratedForScope !== storageScope) return;
-    if (preserveStoredDraftRef.current) return;
-    try {
-      writeStorage(STORAGE_KEYS.shotType, shotType);
-    } catch {
-      // noop
-    }
-  }, [shotType, hydratedForScope, storageScope, writeStorage]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    if (hydratedForScope !== storageScope) return;
-    if (preserveStoredDraftRef.current) return;
-    try {
-      writeStorage(STORAGE_KEYS.voiceIds, voiceIdsInput);
-    } catch {
-      // noop
-    }
-  }, [voiceIdsInput, hydratedForScope, storageScope, writeStorage]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    if (hydratedForScope !== storageScope) return;
-    if (preserveStoredDraftRef.current) return;
-    try {
-      writeStorage(STORAGE_KEYS.memberTier, memberTier);
-    } catch {
-      // noop
-    }
-  }, [memberTier, hydratedForScope, storageScope, writeStorage]);
 
   const composerRef = useRef<HTMLTextAreaElement | null>(null);
   const noticeTimeoutRef = useRef<number | null>(null);
@@ -651,7 +377,7 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
     return () => {
       cancelled = true;
     };
-  }, [authChecked, router]);
+  }, [authChecked, router, skipOnboardingRef]);
 
   useEffect(() => {
     return () => {
@@ -660,34 +386,6 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
       }
     };
   }, []);
-
-  useEffect(() => {
-    if (selectedPreview || renders.length > 0) return;
-    if (effectiveRequestedEngineId || effectiveRequestedEngineToken) return;
-    if (hasStoredFormRef.current) return;
-    const storedPreviewJobId = (readScopedStorage(STORAGE_KEYS.previewJobId) ?? '').trim();
-    if (storedPreviewJobId.startsWith('job_')) return;
-    const latestJobWithMedia = recentJobs.find((job) => job.thumbUrl || job.videoUrl);
-    if (!latestJobWithMedia) return;
-    setSelectedPreview({
-      id: latestJobWithMedia.jobId,
-      videoUrl: latestJobWithMedia.videoUrl ?? undefined,
-      previewVideoUrl: latestJobWithMedia.previewVideoUrl ?? undefined,
-      aspectRatio: latestJobWithMedia.aspectRatio ?? undefined,
-      thumbUrl: latestJobWithMedia.thumbUrl ?? undefined,
-      priceCents: latestJobWithMedia.finalPriceCents ?? latestJobWithMedia.pricingSnapshot?.totalCents,
-      currency: latestJobWithMedia.currency ?? latestJobWithMedia.pricingSnapshot?.currency,
-      prompt: latestJobWithMedia.prompt ?? undefined,
-    });
-  }, [
-    effectiveRequestedEngineId,
-    effectiveRequestedEngineToken,
-    readScopedStorage,
-    recentJobs,
-    renders.length,
-    selectedPreview,
-    setSelectedPreview,
-  ]);
 
   const focusComposer = useCallback(() => {
     if (!composerRef.current) return;
@@ -1120,15 +818,11 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
 
   if (isLoading && engines.length === 0) {
     return (
-      <>
-        <WorkspaceChrome
-          isDesktopLayout={isDesktopLayout}
-          desktopRail={<GalleryRailSkeleton />}
-          mobileRail={<GalleryRailSkeleton />}
-        >
-          <WorkspaceBootContent initialPreviewGroup={initialPreviewFallbackGroup} initialPreviewPosterSrc={compositePreviewPosterSrc} />
-        </WorkspaceChrome>
-      </>
+      <WorkspaceBootSurface
+        isDesktopLayout={isDesktopLayout}
+        initialPreviewGroup={initialPreviewFallbackGroup}
+        initialPreviewPosterSrc={compositePreviewPosterSrc}
+      />
     );
   }
 
@@ -1143,15 +837,11 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
   if (!selectedEngine || !form) {
     if (engines.length > 0) {
       return (
-        <>
-          <WorkspaceChrome
-            isDesktopLayout={isDesktopLayout}
-            desktopRail={<GalleryRailSkeleton />}
-            mobileRail={<GalleryRailSkeleton />}
-          >
-            <WorkspaceBootContent initialPreviewGroup={initialPreviewFallbackGroup} initialPreviewPosterSrc={compositePreviewPosterSrc} />
-          </WorkspaceChrome>
-        </>
+        <WorkspaceBootSurface
+          isDesktopLayout={isDesktopLayout}
+          initialPreviewGroup={initialPreviewFallbackGroup}
+          initialPreviewPosterSrc={compositePreviewPosterSrc}
+        />
       );
     }
 
@@ -1195,76 +885,35 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
               </div>
             )}
             <div className="stack-gap-lg">
-              {showCenterGallery ? (
-                normalizedPendingGroups.length === 0 && !isGenerationLoading ? (
-                  <div className="rounded-card border border-border bg-surface-glass-80 p-5 text-center text-sm text-text-secondary">
-                    {workspaceCopy.gallery.empty}
-                  </div>
-                ) : (
-                  <div className="grid grid-gap-sm sm:grid-cols-2">
-                    {normalizedPendingGroups.map((group, index) => {
-                      const engineId = group.hero.engineId;
-                      const engine = engineId ? engineMap.get(engineId) ?? null : null;
-                      return (
-                        <GroupedJobCard
-                          key={group.id}
-                          group={group}
-                          engine={engine ?? undefined}
-                          onOpen={handleActiveGroupOpen}
-                          onAction={handleActiveGroupAction}
-                          allowRemove={false}
-                          eagerPreview={index === 0}
-                        />
-                      );
-                    })}
-                    {isGenerationLoading &&
-                      Array.from({ length: normalizedPendingGroups.length ? 0 : generationSkeletonCount }).map((_, index) => (
-                        <div key={`workspace-gallery-skeleton-${index}`} className="rounded-card border border-border bg-surface-glass-60 p-0" aria-hidden>
-                          <div className="relative overflow-hidden rounded-card">
-                            <div className="relative" style={{ aspectRatio: '16 / 9' }}>
-                              <div className="skeleton absolute inset-0" />
-                            </div>
-                          </div>
-                          <div className="border-t border-border bg-surface-glass-70 px-3 py-2">
-                            <div className="h-3 w-24 rounded-full bg-skeleton" />
-                          </div>
-                        </div>
-                      ))}
-                  </div>
-                )
-              ) : null}
-              <CompositePreviewDock
+              <WorkspaceCenterGallery
+                show={showCenterGallery}
+                groups={normalizedPendingGroups}
+                engineMap={engineMap}
+                isGenerationLoading={isGenerationLoading}
+                generationSkeletonCount={generationSkeletonCount}
+                emptyLabel={workspaceCopy.gallery.empty}
+                onOpenGroup={handleActiveGroupOpen}
+                onGroupAction={handleActiveGroupAction}
+              />
+              <WorkspacePreviewDock
                 group={displayCompositeGroup}
                 isLoading={isGenerationLoading && !displayCompositeGroup}
                 autoPlayRequestId={previewAutoPlayRequestId}
-                copyPrompt={sharedVideoSettings ? null : sharedPrompt}
-                onCopyPrompt={sharedVideoSettings ? undefined : sharedPrompt ? handleCopySharedPrompt : undefined}
-                showTitle={false}
+                sharedPrompt={sharedPrompt}
+                hasSharedVideoSettings={Boolean(sharedVideoSettings)}
+                onCopySharedPrompt={handleCopySharedPrompt}
                 guidedNavigation={guidedNavigation}
-                engineSettings={
-                  <EngineSettingsBar
-                    engines={engines}
-                    engineId={form.engineId}
-                    onEngineChange={handleEngineChange}
-                    mode={activeMode}
-                    onModeChange={handleModeChange}
-                    modeOptions={engineModeOptions}
-                    modeLabel={getEngineModeLabel(selectedEngine?.id, activeMode, uiLocale)}
-                    showModeBadge={false}
-                  />
-                }
-                onOpenModal={(group) => {
-                  if (!group) return;
-                  if (renderGroups.has(group.id)) {
-                    setViewerTarget({ kind: 'pending', id: group.id });
-                    return;
-                  }
-                  if (compositeOverrideSummary && compositeOverrideSummary.id === group.id) {
-                    setViewerTarget({ kind: 'summary', summary: compositeOverrideSummary });
-                    return;
-                  }
-                  setViewerTarget({ kind: 'group', group });
-                }}
+                engines={engines}
+                engineId={form.engineId}
+                selectedEngineId={selectedEngine.id}
+                activeMode={activeMode}
+                engineModeOptions={engineModeOptions}
+                modeLabelLocale={uiLocale}
+                onEngineChange={handleEngineChange}
+                onModeChange={handleModeChange}
+                renderGroups={renderGroups}
+                compositeOverrideSummary={compositeOverrideSummary}
+                setViewerTarget={setViewerTarget}
               />
               <Composer
                 engine={selectedEngine}
@@ -1441,66 +1090,39 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
               />
             </div>
       </WorkspaceChrome>
-      {viewerGroup ? (
-        <GroupViewerModal
-          group={viewerGroup}
-          onClose={() => setViewerTarget(null)}
-          onRefreshJob={handleRefreshJob}
-        />
-      ) : null}
-      {topUpModal ? (
-        <WorkspaceTopUpModal
-          modal={topUpModal}
-          copy={workspaceCopy.topUp}
-          currency={currency}
-          topUpAmount={topUpAmount}
-          isTopUpLoading={isTopUpLoading}
-          topUpError={topUpError}
-          onClose={closeTopUpModal}
-          onSubmit={handleTopUpSubmit}
-          onSelectPresetAmount={handleSelectPresetAmount}
-          onCustomAmountChange={handleCustomAmountChange}
-        />
-      ) : null}
-      {authModalOpen ? (
-        <WorkspaceAuthGateModal
-          copy={workspaceCopy.authGate}
-          loginRedirectTarget={loginRedirectTarget}
-          onClose={() => setAuthModalOpen(false)}
-        />
-      ) : null}
-      {assetPickerTarget && (
-        <AssetLibraryModal
-          fieldLabel={
-            assetPickerTarget.kind === 'field'
-              ? assetPickerTarget.field.label ?? workspaceCopy.assetLibrary.fieldFallback
-              : assetPickerTarget.slot === 'frontal'
-                ? 'Kling frontal image'
-                : `Kling reference ${typeof assetPickerTarget.slotIndex === 'number' ? assetPickerTarget.slotIndex + 1 : ''}`.trim()
-          }
-          assetType={assetLibraryKind}
-          assets={visibleAssetLibrary}
-          isLoading={isAssetLibraryLoading}
-          error={assetLibraryError}
-          source={assetLibrarySource}
-          onSourceChange={handleAssetLibrarySourceChange}
-          onClose={closeAssetLibrary}
-          onRefresh={(sourceOverride) => fetchAssetLibrary({ source: sourceOverride ?? assetLibrarySource, kind: assetLibraryKind })}
-          onSelect={(asset) => {
-            if (assetPickerTarget.kind === 'field') {
-              void handleSelectLibraryAsset(assetPickerTarget.field, asset, assetPickerTarget.slotIndex);
-              return;
-            }
-            handleSelectKlingLibraryAsset(assetPickerTarget, asset);
-          }}
-          onDelete={handleDeleteLibraryAsset}
-          deletingAssetId={assetDeletePendingId}
-        />
-      )}
+      <WorkspaceRuntimeModals
+        viewerGroup={viewerGroup}
+        onCloseViewer={() => setViewerTarget(null)}
+        onRefreshJob={handleRefreshJob}
+        topUpModal={topUpModal}
+        topUpCopy={workspaceCopy.topUp}
+        currency={currency}
+        topUpAmount={topUpAmount}
+        isTopUpLoading={isTopUpLoading}
+        topUpError={topUpError}
+        onCloseTopUp={closeTopUpModal}
+        onTopUpSubmit={handleTopUpSubmit}
+        onSelectPresetAmount={handleSelectPresetAmount}
+        onCustomAmountChange={handleCustomAmountChange}
+        authModalOpen={authModalOpen}
+        authGateCopy={workspaceCopy.authGate}
+        loginRedirectTarget={loginRedirectTarget}
+        onCloseAuthModal={() => setAuthModalOpen(false)}
+        assetPickerTarget={assetPickerTarget}
+        assetLibraryKind={assetLibraryKind}
+        assetLibrarySource={assetLibrarySource}
+        visibleAssetLibrary={visibleAssetLibrary}
+        isAssetLibraryLoading={isAssetLibraryLoading}
+        assetLibraryError={assetLibraryError}
+        assetDeletePendingId={assetDeletePendingId}
+        fieldFallbackLabel={workspaceCopy.assetLibrary.fieldFallback}
+        onAssetLibrarySourceChange={handleAssetLibrarySourceChange}
+        onCloseAssetLibrary={closeAssetLibrary}
+        onRefreshAssets={fetchAssetLibrary}
+        onSelectFieldAsset={handleSelectLibraryAsset}
+        onSelectKlingAsset={handleSelectKlingLibraryAsset}
+        onDeleteAsset={handleDeleteLibraryAsset}
+      />
     </>
   );
 }
-const GroupViewerModal = dynamic(
-  () => import('@/components/groups/GroupViewerModal').then((mod) => mod.GroupViewerModal),
-  { ssr: false }
-);

--- a/frontend/app/(core)/(workspace)/app/_components/WorkspaceBootSurface.tsx
+++ b/frontend/app/(core)/(workspace)/app/_components/WorkspaceBootSurface.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import type { CompositePreviewDockProps } from '@/components/groups/CompositePreviewDock';
+import type { VideoGroup } from '@/types/video-groups';
+import { getCompositePreviewPosterSrc } from '../_lib/composite-preview';
+import {
+  ComposerBootSkeleton,
+  CompositePreviewDockSkeleton,
+  EngineSettingsBootSkeleton,
+  GalleryRailSkeleton,
+  WorkspaceBootPreview,
+} from './WorkspaceBootSkeletons';
+import { WorkspaceChrome } from './WorkspaceChrome';
+
+const CompositePreviewDock = dynamic<CompositePreviewDockProps>(
+  () => import('@/components/groups/CompositePreviewDock').then((mod) => mod.CompositePreviewDock),
+  {
+    loading: () => <CompositePreviewDockSkeleton />,
+  }
+);
+
+function WorkspaceBootContent({
+  initialPreviewGroup,
+  initialPreviewPosterSrc,
+}: {
+  initialPreviewGroup?: VideoGroup | null;
+  initialPreviewPosterSrc?: string | null;
+}) {
+  const posterSrc = getCompositePreviewPosterSrc(initialPreviewGroup ?? null) ?? initialPreviewPosterSrc ?? null;
+
+  return (
+    <div className="stack-gap-lg">
+      {initialPreviewGroup ? (
+        <CompositePreviewDock
+          group={initialPreviewGroup}
+          isLoading={false}
+          showTitle={false}
+          engineSettings={<EngineSettingsBootSkeleton />}
+        />
+      ) : (
+        <WorkspaceBootPreview posterSrc={posterSrc} />
+      )}
+      <ComposerBootSkeleton />
+    </div>
+  );
+}
+
+export function WorkspaceBootSurface({
+  isDesktopLayout,
+  initialPreviewGroup,
+  initialPreviewPosterSrc,
+}: {
+  isDesktopLayout: boolean;
+  initialPreviewGroup?: VideoGroup | null;
+  initialPreviewPosterSrc?: string | null;
+}) {
+  return (
+    <WorkspaceChrome
+      isDesktopLayout={isDesktopLayout}
+      desktopRail={<GalleryRailSkeleton />}
+      mobileRail={<GalleryRailSkeleton />}
+    >
+      <WorkspaceBootContent
+        initialPreviewGroup={initialPreviewGroup}
+        initialPreviewPosterSrc={initialPreviewPosterSrc}
+      />
+    </WorkspaceChrome>
+  );
+}

--- a/frontend/app/(core)/(workspace)/app/_components/WorkspaceCenterGallery.tsx
+++ b/frontend/app/(core)/(workspace)/app/_components/WorkspaceCenterGallery.tsx
@@ -1,0 +1,71 @@
+import { GroupedJobCard } from '@/components/GroupedJobCard';
+import type { GroupedJobAction } from '@/components/GroupedJobCard';
+import type { EngineCaps } from '@/types/engines';
+import type { GroupSummary } from '@/types/groups';
+
+export function WorkspaceCenterGallery({
+  show,
+  groups,
+  engineMap,
+  isGenerationLoading,
+  generationSkeletonCount,
+  emptyLabel,
+  onOpenGroup,
+  onGroupAction,
+}: {
+  show: boolean;
+  groups: GroupSummary[];
+  engineMap: ReadonlyMap<string, EngineCaps>;
+  isGenerationLoading: boolean;
+  generationSkeletonCount: number;
+  emptyLabel: string;
+  onOpenGroup: (group: GroupSummary) => void;
+  onGroupAction: (group: GroupSummary, action: GroupedJobAction) => void;
+}) {
+  if (!show) return null;
+
+  if (groups.length === 0 && !isGenerationLoading) {
+    return (
+      <div className="rounded-card border border-border bg-surface-glass-80 p-5 text-center text-sm text-text-secondary">
+        {emptyLabel}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-gap-sm sm:grid-cols-2">
+      {groups.map((group, index) => {
+        const engineId = group.hero.engineId;
+        const engine = engineId ? engineMap.get(engineId) ?? null : null;
+        return (
+          <GroupedJobCard
+            key={group.id}
+            group={group}
+            engine={engine ?? undefined}
+            onOpen={onOpenGroup}
+            onAction={onGroupAction}
+            allowRemove={false}
+            eagerPreview={index === 0}
+          />
+        );
+      })}
+      {isGenerationLoading &&
+        Array.from({ length: groups.length ? 0 : generationSkeletonCount }).map((_, index) => (
+          <div
+            key={`workspace-gallery-skeleton-${index}`}
+            className="rounded-card border border-border bg-surface-glass-60 p-0"
+            aria-hidden
+          >
+            <div className="relative overflow-hidden rounded-card">
+              <div className="relative" style={{ aspectRatio: '16 / 9' }}>
+                <div className="skeleton absolute inset-0" />
+              </div>
+            </div>
+            <div className="border-t border-border bg-surface-glass-70 px-3 py-2">
+              <div className="h-3 w-24 rounded-full bg-skeleton" />
+            </div>
+          </div>
+        ))}
+    </div>
+  );
+}

--- a/frontend/app/(core)/(workspace)/app/_components/WorkspacePreviewDock.tsx
+++ b/frontend/app/(core)/(workspace)/app/_components/WorkspacePreviewDock.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import type { Dispatch, SetStateAction } from 'react';
+import dynamic from 'next/dynamic';
+import { EngineSettingsBar } from '@/components/EngineSettingsBar';
+import type { CompositePreviewDockProps } from '@/components/groups/CompositePreviewDock';
+import type { EngineCaps, Mode } from '@/types/engines';
+import type { GroupSummary } from '@/types/groups';
+import type { VideoGroup } from '@/types/video-groups';
+import { getEngineModeLabel } from '../_lib/workspace-engine-helpers';
+import { CompositePreviewDockSkeleton } from './WorkspaceBootSkeletons';
+
+const CompositePreviewDock = dynamic<CompositePreviewDockProps>(
+  () => import('@/components/groups/CompositePreviewDock').then((mod) => mod.CompositePreviewDock),
+  {
+    loading: () => <CompositePreviewDockSkeleton />,
+  }
+);
+
+export type WorkspaceViewerTarget =
+  | { kind: 'pending'; id: string }
+  | { kind: 'summary'; summary: GroupSummary }
+  | { kind: 'group'; group: VideoGroup }
+  | null;
+
+export function WorkspacePreviewDock({
+  group,
+  isLoading,
+  autoPlayRequestId,
+  sharedPrompt,
+  hasSharedVideoSettings,
+  onCopySharedPrompt,
+  guidedNavigation,
+  engines,
+  engineId,
+  selectedEngineId,
+  activeMode,
+  engineModeOptions,
+  modeLabelLocale,
+  onEngineChange,
+  onModeChange,
+  renderGroups,
+  compositeOverrideSummary,
+  setViewerTarget,
+}: {
+  group: VideoGroup | null;
+  isLoading: boolean;
+  autoPlayRequestId: CompositePreviewDockProps['autoPlayRequestId'];
+  sharedPrompt: string | null;
+  hasSharedVideoSettings: boolean;
+  onCopySharedPrompt: () => void;
+  guidedNavigation: CompositePreviewDockProps['guidedNavigation'];
+  engines: EngineCaps[];
+  engineId: string;
+  selectedEngineId?: string | null;
+  activeMode: Mode;
+  engineModeOptions: Mode[] | undefined;
+  modeLabelLocale: string;
+  onEngineChange: (engineId: string) => void;
+  onModeChange: (mode: Mode) => void;
+  renderGroups: ReadonlyMap<string, unknown>;
+  compositeOverrideSummary: GroupSummary | null;
+  setViewerTarget: Dispatch<SetStateAction<WorkspaceViewerTarget>>;
+}) {
+  return (
+    <CompositePreviewDock
+      group={group}
+      isLoading={isLoading}
+      autoPlayRequestId={autoPlayRequestId}
+      copyPrompt={hasSharedVideoSettings ? null : sharedPrompt}
+      onCopyPrompt={hasSharedVideoSettings ? undefined : sharedPrompt ? onCopySharedPrompt : undefined}
+      showTitle={false}
+      guidedNavigation={guidedNavigation}
+      engineSettings={
+        <EngineSettingsBar
+          engines={engines}
+          engineId={engineId}
+          onEngineChange={onEngineChange}
+          mode={activeMode}
+          onModeChange={onModeChange}
+          modeOptions={engineModeOptions}
+          modeLabel={getEngineModeLabel(selectedEngineId, activeMode, modeLabelLocale)}
+          showModeBadge={false}
+        />
+      }
+      onOpenModal={(nextGroup) => {
+        if (!nextGroup) return;
+        if (renderGroups.has(nextGroup.id)) {
+          setViewerTarget({ kind: 'pending', id: nextGroup.id });
+          return;
+        }
+        if (compositeOverrideSummary && compositeOverrideSummary.id === nextGroup.id) {
+          setViewerTarget({ kind: 'summary', summary: compositeOverrideSummary });
+          return;
+        }
+        setViewerTarget({ kind: 'group', group: nextGroup });
+      }}
+    />
+  );
+}

--- a/frontend/app/(core)/(workspace)/app/_components/WorkspaceRuntimeModals.tsx
+++ b/frontend/app/(core)/(workspace)/app/_components/WorkspaceRuntimeModals.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import type { ChangeEvent, ComponentProps, FormEvent } from 'react';
+import dynamic from 'next/dynamic';
+import type { AssetLibraryModalProps } from '@/components/library/AssetLibraryModal';
+import type { EngineInputField } from '@/types/engines';
+import type { VideoGroup } from '@/types/video-groups';
+import type { TopUpModalState } from '../_hooks/useWorkspacePricingGate';
+import type {
+  AssetLibraryKind,
+  AssetLibrarySource,
+  AssetPickerTarget,
+  UserAsset,
+} from '../_lib/workspace-assets';
+import { WorkspaceAuthGateModal } from './WorkspaceAuthGateModal';
+import { WorkspaceTopUpModal } from './WorkspaceTopUpModal';
+
+const AssetLibraryModal = dynamic<AssetLibraryModalProps>(
+  () => import('@/components/library/AssetLibraryModal').then((mod) => mod.AssetLibraryModal),
+  { ssr: false }
+);
+
+const GroupViewerModal = dynamic(
+  () => import('@/components/groups/GroupViewerModal').then((mod) => mod.GroupViewerModal),
+  { ssr: false }
+);
+
+export function WorkspaceRuntimeModals({
+  viewerGroup,
+  onCloseViewer,
+  onRefreshJob,
+  topUpModal,
+  topUpCopy,
+  currency,
+  topUpAmount,
+  isTopUpLoading,
+  topUpError,
+  onCloseTopUp,
+  onTopUpSubmit,
+  onSelectPresetAmount,
+  onCustomAmountChange,
+  authModalOpen,
+  authGateCopy,
+  loginRedirectTarget,
+  onCloseAuthModal,
+  assetPickerTarget,
+  assetLibraryKind,
+  assetLibrarySource,
+  visibleAssetLibrary,
+  isAssetLibraryLoading,
+  assetLibraryError,
+  assetDeletePendingId,
+  fieldFallbackLabel,
+  onAssetLibrarySourceChange,
+  onCloseAssetLibrary,
+  onRefreshAssets,
+  onSelectFieldAsset,
+  onSelectKlingAsset,
+  onDeleteAsset,
+}: {
+  viewerGroup: VideoGroup | null;
+  onCloseViewer: () => void;
+  onRefreshJob: (jobId: string) => Promise<void>;
+  topUpModal: TopUpModalState;
+  topUpCopy: ComponentProps<typeof WorkspaceTopUpModal>['copy'];
+  currency: string;
+  topUpAmount: number;
+  isTopUpLoading: boolean;
+  topUpError: string | null;
+  onCloseTopUp: () => void;
+  onTopUpSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onSelectPresetAmount: (value: number) => void;
+  onCustomAmountChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  authModalOpen: boolean;
+  authGateCopy: ComponentProps<typeof WorkspaceAuthGateModal>['copy'];
+  loginRedirectTarget: string;
+  onCloseAuthModal: () => void;
+  assetPickerTarget: AssetPickerTarget | null;
+  assetLibraryKind: AssetLibraryKind;
+  assetLibrarySource: AssetLibrarySource;
+  visibleAssetLibrary: UserAsset[];
+  isAssetLibraryLoading: boolean;
+  assetLibraryError: string | null;
+  assetDeletePendingId: string | null;
+  fieldFallbackLabel: string;
+  onAssetLibrarySourceChange: (source: AssetLibrarySource) => void;
+  onCloseAssetLibrary: () => void;
+  onRefreshAssets: (options: { source: AssetLibrarySource; kind: AssetLibraryKind }) => void | Promise<void>;
+  onSelectFieldAsset: (field: EngineInputField, asset: UserAsset, slotIndex?: number) => void | Promise<void>;
+  onSelectKlingAsset: (target: Extract<AssetPickerTarget, { kind: 'kling' }>, asset: UserAsset) => void;
+  onDeleteAsset: (asset: UserAsset) => void | Promise<void>;
+}) {
+  return (
+    <>
+      {viewerGroup ? (
+        <GroupViewerModal
+          group={viewerGroup}
+          onClose={onCloseViewer}
+          onRefreshJob={onRefreshJob}
+        />
+      ) : null}
+      {topUpModal ? (
+        <WorkspaceTopUpModal
+          modal={topUpModal}
+          copy={topUpCopy}
+          currency={currency}
+          topUpAmount={topUpAmount}
+          isTopUpLoading={isTopUpLoading}
+          topUpError={topUpError}
+          onClose={onCloseTopUp}
+          onSubmit={onTopUpSubmit}
+          onSelectPresetAmount={onSelectPresetAmount}
+          onCustomAmountChange={onCustomAmountChange}
+        />
+      ) : null}
+      {authModalOpen ? (
+        <WorkspaceAuthGateModal
+          copy={authGateCopy}
+          loginRedirectTarget={loginRedirectTarget}
+          onClose={onCloseAuthModal}
+        />
+      ) : null}
+      {assetPickerTarget ? (
+        <AssetLibraryModal
+          fieldLabel={
+            assetPickerTarget.kind === 'field'
+              ? assetPickerTarget.field.label ?? fieldFallbackLabel
+              : assetPickerTarget.slot === 'frontal'
+                ? 'Kling frontal image'
+                : `Kling reference ${typeof assetPickerTarget.slotIndex === 'number' ? assetPickerTarget.slotIndex + 1 : ''}`.trim()
+          }
+          assetType={assetLibraryKind}
+          assets={visibleAssetLibrary}
+          isLoading={isAssetLibraryLoading}
+          error={assetLibraryError}
+          source={assetLibrarySource}
+          onSourceChange={onAssetLibrarySourceChange}
+          onClose={onCloseAssetLibrary}
+          onRefresh={(sourceOverride) =>
+            onRefreshAssets({ source: sourceOverride ?? assetLibrarySource, kind: assetLibraryKind })
+          }
+          onSelect={(asset) => {
+            if (assetPickerTarget.kind === 'field') {
+              void onSelectFieldAsset(assetPickerTarget.field, asset, assetPickerTarget.slotIndex);
+              return;
+            }
+            onSelectKlingAsset(assetPickerTarget, asset);
+          }}
+          onDelete={onDeleteAsset}
+          deletingAssetId={assetDeletePendingId}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceDraftHydration.ts
+++ b/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceDraftHydration.ts
@@ -1,0 +1,315 @@
+import { useEffect } from 'react';
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
+import type { MultiPromptScene } from '@/components/Composer';
+import type { SelectedVideoPreview } from '@/lib/video-preview-group';
+import type { EngineCaps, Mode } from '@/types/engines';
+import type { Job } from '@/types/jobs';
+import { DEFAULT_PROMPT } from '../_lib/workspace-client-helpers';
+import type { FormState } from '../_lib/workspace-form-state';
+import {
+  buildInitialWorkspaceFormState,
+  parseStoredMultiPromptScenes,
+  readStoredWorkspaceForm,
+} from '../_lib/workspace-hydration';
+import {
+  createLocalId,
+  createMultiPromptScene,
+} from '../_lib/workspace-input-helpers';
+import { STORAGE_KEYS } from '../_lib/workspace-storage';
+
+type ShotType = 'customize' | 'intelligent';
+type MemberTier = 'Member' | 'Plus' | 'Pro';
+
+type UseWorkspaceDraftHydrationOptions = {
+  engines: EngineCaps[];
+  requestedJobId: string | null;
+  fromVideoId: string | null;
+  effectiveRequestedEngineId: string | null;
+  effectiveRequestedEngineToken: string;
+  effectiveRequestedMode: Mode | null;
+  storageScope: string;
+  hydratedForScope: string | null;
+  setHydratedForScope: Dispatch<SetStateAction<string | null>>;
+  readStorage: (base: string) => string | null;
+  readScopedStorage: (base: string) => string | null;
+  writeStorage: (base: string, value: string | null) => void;
+  form: FormState | null;
+  prompt: string;
+  negativePrompt: string;
+  multiPromptEnabled: boolean;
+  multiPromptScenes: MultiPromptScene[];
+  shotType: ShotType;
+  voiceIdsInput: string;
+  memberTier: MemberTier;
+  recentJobs: Job[];
+  selectedPreview: SelectedVideoPreview | null;
+  rendersLength: number;
+  preserveStoredDraftRef: MutableRefObject<boolean>;
+  hasStoredFormRef: MutableRefObject<boolean>;
+  setForm: Dispatch<SetStateAction<FormState | null>>;
+  setPrompt: Dispatch<SetStateAction<string>>;
+  setNegativePrompt: Dispatch<SetStateAction<string>>;
+  setMultiPromptEnabled: Dispatch<SetStateAction<boolean>>;
+  setMultiPromptScenes: Dispatch<SetStateAction<MultiPromptScene[]>>;
+  setShotType: Dispatch<SetStateAction<ShotType>>;
+  setVoiceIdsInput: Dispatch<SetStateAction<string>>;
+  setMemberTier: Dispatch<SetStateAction<MemberTier>>;
+  setSelectedPreview: Dispatch<SetStateAction<SelectedVideoPreview | null>>;
+  hydratePendingRendersFromStorage: (value: string | null) => void;
+  resetRenderState: () => void;
+};
+
+export function useWorkspaceDraftHydration({
+  engines,
+  requestedJobId,
+  fromVideoId,
+  effectiveRequestedEngineId,
+  effectiveRequestedEngineToken,
+  effectiveRequestedMode,
+  storageScope,
+  hydratedForScope,
+  setHydratedForScope,
+  readStorage,
+  readScopedStorage,
+  writeStorage,
+  form,
+  prompt,
+  negativePrompt,
+  multiPromptEnabled,
+  multiPromptScenes,
+  shotType,
+  voiceIdsInput,
+  memberTier,
+  recentJobs,
+  selectedPreview,
+  rendersLength,
+  preserveStoredDraftRef,
+  hasStoredFormRef,
+  setForm,
+  setPrompt,
+  setNegativePrompt,
+  setMultiPromptEnabled,
+  setMultiPromptScenes,
+  setShotType,
+  setVoiceIdsInput,
+  setMemberTier,
+  setSelectedPreview,
+  hydratePendingRendersFromStorage,
+  resetRenderState,
+}: UseWorkspaceDraftHydrationOptions): void {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!engines.length) return;
+    if (requestedJobId) return;
+    if (hydratedForScope === storageScope) return;
+    setHydratedForScope(null);
+
+    resetRenderState();
+
+    try {
+      const promptValue = readStorage(STORAGE_KEYS.prompt);
+      setPrompt(promptValue ?? DEFAULT_PROMPT);
+
+      const negativeValue = readStorage(STORAGE_KEYS.negativePrompt);
+      setNegativePrompt(negativeValue ?? '');
+
+      const storedMultiPromptEnabled = readStorage(STORAGE_KEYS.multiPromptEnabled);
+      setMultiPromptEnabled(storedMultiPromptEnabled === 'true');
+      setMultiPromptScenes(
+        parseStoredMultiPromptScenes(readStorage(STORAGE_KEYS.multiPromptScenes), createLocalId, createMultiPromptScene)
+      );
+
+      const storedShotType = readStorage(STORAGE_KEYS.shotType);
+      if (storedShotType === 'customize' || storedShotType === 'intelligent') {
+        setShotType(storedShotType);
+      }
+      const storedVoiceIds = readStorage(STORAGE_KEYS.voiceIds);
+      if (typeof storedVoiceIds === 'string') {
+        setVoiceIdsInput(storedVoiceIds);
+      }
+
+      const formValue = readStorage(STORAGE_KEYS.form);
+      const initialForm = buildInitialWorkspaceFormState({
+        engines,
+        storedFormRaw: readStoredWorkspaceForm(storageScope, formValue),
+        effectiveRequestedEngineId,
+        effectiveRequestedEngineToken,
+        effectiveRequestedMode,
+      });
+      preserveStoredDraftRef.current = initialForm.preserveStoredDraft;
+      hasStoredFormRef.current = initialForm.hasStoredForm;
+      if (initialForm.form) {
+        setForm(initialForm.form);
+      }
+      if (initialForm.debugEngineOverride && process.env.NODE_ENV !== 'production') {
+        console.log('[generate] engine override from storage hydrate', initialForm.debugEngineOverride);
+      }
+      if (initialForm.formToPersist) {
+        const formToPersist = initialForm.formToPersist;
+        queueMicrotask(() => {
+          try {
+            writeStorage(STORAGE_KEYS.form, JSON.stringify(formToPersist));
+          } catch {
+            // noop
+          }
+        });
+      }
+
+      const storedTier = readStorage(STORAGE_KEYS.memberTier);
+      if (storedTier === 'Member' || storedTier === 'Plus' || storedTier === 'Pro') {
+        setMemberTier(storedTier);
+      }
+
+      const pendingValue = readScopedStorage(STORAGE_KEYS.pendingRenders);
+      hydratePendingRendersFromStorage(pendingValue);
+    } catch {
+      resetRenderState();
+    } finally {
+      setHydratedForScope(storageScope);
+    }
+  }, [
+    engines,
+    hydratePendingRendersFromStorage,
+    readScopedStorage,
+    readStorage,
+    resetRenderState,
+    writeStorage,
+    setHydratedForScope,
+    setMemberTier,
+    storageScope,
+    hydratedForScope,
+    effectiveRequestedEngineId,
+    effectiveRequestedMode,
+    effectiveRequestedEngineToken,
+    requestedJobId,
+    preserveStoredDraftRef,
+    hasStoredFormRef,
+    setForm,
+    setPrompt,
+    setNegativePrompt,
+    setMultiPromptEnabled,
+    setMultiPromptScenes,
+    setShotType,
+    setVoiceIdsInput,
+  ]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (hydratedForScope !== storageScope) return;
+    if (!form) return;
+    if (preserveStoredDraftRef.current) return;
+    try {
+      writeStorage(STORAGE_KEYS.form, JSON.stringify({ ...form, updatedAt: Date.now() }));
+    } catch {
+      // noop
+    }
+  }, [form, hydratedForScope, storageScope, writeStorage, preserveStoredDraftRef]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (hydratedForScope !== storageScope) return;
+    if (preserveStoredDraftRef.current) return;
+    try {
+      writeStorage(STORAGE_KEYS.prompt, prompt);
+    } catch {
+      // noop
+    }
+  }, [prompt, hydratedForScope, storageScope, writeStorage, preserveStoredDraftRef]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (hydratedForScope !== storageScope) return;
+    if (preserveStoredDraftRef.current) return;
+    try {
+      writeStorage(STORAGE_KEYS.negativePrompt, negativePrompt);
+    } catch {
+      // noop
+    }
+  }, [negativePrompt, hydratedForScope, storageScope, writeStorage, preserveStoredDraftRef]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (hydratedForScope !== storageScope) return;
+    if (preserveStoredDraftRef.current) return;
+    try {
+      writeStorage(STORAGE_KEYS.multiPromptEnabled, multiPromptEnabled ? 'true' : 'false');
+    } catch {
+      // noop
+    }
+  }, [multiPromptEnabled, hydratedForScope, storageScope, writeStorage, preserveStoredDraftRef]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (hydratedForScope !== storageScope) return;
+    if (preserveStoredDraftRef.current) return;
+    try {
+      writeStorage(STORAGE_KEYS.multiPromptScenes, JSON.stringify(multiPromptScenes));
+    } catch {
+      // noop
+    }
+  }, [multiPromptScenes, hydratedForScope, storageScope, writeStorage, preserveStoredDraftRef]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (hydratedForScope !== storageScope) return;
+    if (preserveStoredDraftRef.current) return;
+    try {
+      writeStorage(STORAGE_KEYS.shotType, shotType);
+    } catch {
+      // noop
+    }
+  }, [shotType, hydratedForScope, storageScope, writeStorage, preserveStoredDraftRef]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (hydratedForScope !== storageScope) return;
+    if (preserveStoredDraftRef.current) return;
+    try {
+      writeStorage(STORAGE_KEYS.voiceIds, voiceIdsInput);
+    } catch {
+      // noop
+    }
+  }, [voiceIdsInput, hydratedForScope, storageScope, writeStorage, preserveStoredDraftRef]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (hydratedForScope !== storageScope) return;
+    if (preserveStoredDraftRef.current) return;
+    try {
+      writeStorage(STORAGE_KEYS.memberTier, memberTier);
+    } catch {
+      // noop
+    }
+  }, [memberTier, hydratedForScope, storageScope, writeStorage, preserveStoredDraftRef]);
+
+  useEffect(() => {
+    if (selectedPreview || rendersLength > 0) return;
+    if (effectiveRequestedEngineId || effectiveRequestedEngineToken) return;
+    if (hasStoredFormRef.current) return;
+    const storedPreviewJobId = (readScopedStorage(STORAGE_KEYS.previewJobId) ?? '').trim();
+    if (storedPreviewJobId.startsWith('job_')) return;
+    const latestJobWithMedia = recentJobs.find((job) => job.thumbUrl || job.videoUrl);
+    if (!latestJobWithMedia) return;
+    setSelectedPreview({
+      id: latestJobWithMedia.jobId,
+      videoUrl: latestJobWithMedia.videoUrl ?? undefined,
+      previewVideoUrl: latestJobWithMedia.previewVideoUrl ?? undefined,
+      aspectRatio: latestJobWithMedia.aspectRatio ?? undefined,
+      thumbUrl: latestJobWithMedia.thumbUrl ?? undefined,
+      priceCents: latestJobWithMedia.finalPriceCents ?? latestJobWithMedia.pricingSnapshot?.totalCents,
+      currency: latestJobWithMedia.currency ?? latestJobWithMedia.pricingSnapshot?.currency,
+      prompt: latestJobWithMedia.prompt ?? undefined,
+    });
+  }, [
+    effectiveRequestedEngineId,
+    effectiveRequestedEngineToken,
+    fromVideoId,
+    hasStoredFormRef,
+    readScopedStorage,
+    recentJobs,
+    rendersLength,
+    requestedJobId,
+    selectedPreview,
+    setSelectedPreview,
+  ]);
+}

--- a/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceDraftStorage.ts
+++ b/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceDraftStorage.ts
@@ -1,0 +1,179 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { readLastKnownUserId } from '@/lib/last-known';
+import type { Mode } from '@/types/engines';
+import {
+  consumeWorkspaceOnboardingSkipIntent,
+  resolveWorkspaceRequestParams,
+} from '../_lib/workspace-hydration';
+import {
+  readScopedWorkspaceStorage,
+  readWorkspaceStorage,
+  writeScopedWorkspaceStorage,
+  writeWorkspaceStorage,
+} from '../_lib/workspace-storage';
+
+type UseWorkspaceDraftStorageOptions = {
+  authLoading: boolean;
+  authStatus: string;
+  authenticatedUserId?: string | null;
+};
+
+type UseWorkspaceDraftStorageResult = {
+  authChecked: boolean;
+  storageScope: string;
+  hydratedForScope: string | null;
+  setHydratedForScope: Dispatch<SetStateAction<string | null>>;
+  readScopedStorage: (base: string) => string | null;
+  readStorage: (base: string) => string | null;
+  writeScopedStorage: (base: string, value: string | null) => void;
+  writeStorage: (base: string, value: string | null) => void;
+  fromVideoId: string | null;
+  requestedJobId: string | null;
+  resolvedRequestedEngineId: string | null;
+  requestedEngineToken: string;
+  requestedMode: Mode | null;
+  searchString: string;
+  loginRedirectTarget: string;
+  effectiveRequestedEngineId: string | null;
+  effectiveRequestedEngineToken: string;
+  effectiveRequestedMode: Mode | null;
+  skipOnboardingRef: MutableRefObject<boolean>;
+  preserveStoredDraftRef: MutableRefObject<boolean>;
+  hasStoredFormRef: MutableRefObject<boolean>;
+  requestedEngineOverrideIdRef: MutableRefObject<string | null>;
+  requestedEngineOverrideTokenRef: MutableRefObject<string | null>;
+  requestedModeOverrideRef: MutableRefObject<Mode | null>;
+};
+
+export function useWorkspaceDraftStorage({
+  authLoading,
+  authStatus,
+  authenticatedUserId,
+}: UseWorkspaceDraftStorageOptions): UseWorkspaceDraftStorageResult {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [userId, setUserId] = useState<string | null>(null);
+  const [authChecked, setAuthChecked] = useState(false);
+  const [hydratedForScope, setHydratedForScope] = useState<string | null>(null);
+
+  const storageScope = useMemo(() => userId ?? 'anon', [userId]);
+  const readScopedStorage = useCallback(
+    (base: string): string | null => readScopedWorkspaceStorage(base, storageScope),
+    [storageScope]
+  );
+  const readStorage = useCallback(
+    (base: string): string | null => readWorkspaceStorage(base, storageScope),
+    [storageScope]
+  );
+  const writeScopedStorage = useCallback(
+    (base: string, value: string | null) => {
+      writeScopedWorkspaceStorage(base, storageScope, value);
+    },
+    [storageScope]
+  );
+  const writeStorage = useCallback(
+    (base: string, value: string | null) => {
+      writeWorkspaceStorage(base, storageScope, value);
+    },
+    [storageScope]
+  );
+
+  const workspaceRequest = useMemo(
+    () => resolveWorkspaceRequestParams(searchParams, pathname),
+    [pathname, searchParams]
+  );
+  const {
+    fromVideoId,
+    requestedJobId,
+    resolvedRequestedEngineId,
+    requestedEngineToken,
+    requestedMode,
+    searchString,
+    loginRedirectTarget,
+  } = workspaceRequest;
+
+  const skipOnboardingRef = useRef<boolean>(false);
+  const preserveStoredDraftRef = useRef<boolean>(false);
+  const hasStoredFormRef = useRef<boolean>(false);
+  const requestedEngineOverrideIdRef = useRef<string | null>(null);
+  const requestedEngineOverrideTokenRef = useRef<string | null>(null);
+  const requestedModeOverrideRef = useRef<Mode | null>(null);
+
+  useEffect(() => {
+    if (!resolvedRequestedEngineId) return;
+    requestedEngineOverrideIdRef.current = resolvedRequestedEngineId;
+    requestedEngineOverrideTokenRef.current = requestedEngineToken;
+    requestedModeOverrideRef.current = requestedMode;
+  }, [resolvedRequestedEngineId, requestedEngineToken, requestedMode]);
+
+  const effectiveRequestedEngineId = resolvedRequestedEngineId ?? requestedEngineOverrideIdRef.current;
+  const effectiveRequestedEngineToken = requestedEngineToken ?? requestedEngineOverrideTokenRef.current;
+  const effectiveRequestedMode = requestedMode ?? requestedModeOverrideRef.current;
+
+  useEffect(() => {
+    const skipIntent = consumeWorkspaceOnboardingSkipIntent(fromVideoId);
+    if (skipIntent.shouldSkip) {
+      skipOnboardingRef.current = true;
+    }
+    if (process.env.NODE_ENV !== 'production') {
+      if (skipIntent.skippedViaFlag) {
+        console.log('[app] skip onboarding via flag');
+      }
+      if (skipIntent.lastTarget) {
+        console.log('[app] read last target', {
+          lastTarget: skipIntent.lastTarget,
+          shouldSkip: skipIntent.lastTargetShouldSkip,
+        });
+      }
+      if (skipIntent.fromVideoId) {
+        console.log('[app] skip onboarding due to fromVideoId', { fromVideoId: skipIntent.fromVideoId });
+      }
+    }
+  }, [fromVideoId]);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (authenticatedUserId) {
+      setUserId(authenticatedUserId);
+      setAuthChecked(true);
+      return;
+    }
+    if (authStatus === 'refreshing' || authStatus === 'unknown') {
+      const lastKnownUserId = readLastKnownUserId();
+      setUserId(lastKnownUserId ?? null);
+      setAuthChecked(true);
+      return;
+    }
+    setUserId(null);
+    setAuthChecked(true);
+  }, [authLoading, authStatus, authenticatedUserId]);
+
+  return {
+    authChecked,
+    storageScope,
+    hydratedForScope,
+    setHydratedForScope,
+    readScopedStorage,
+    readStorage,
+    writeScopedStorage,
+    writeStorage,
+    fromVideoId,
+    requestedJobId,
+    resolvedRequestedEngineId,
+    requestedEngineToken,
+    requestedMode,
+    searchString,
+    loginRedirectTarget,
+    effectiveRequestedEngineId,
+    effectiveRequestedEngineToken,
+    effectiveRequestedMode,
+    skipOnboardingRef,
+    preserveStoredDraftRef,
+    hasStoredFormRef,
+    requestedEngineOverrideIdRef,
+    requestedEngineOverrideTokenRef,
+    requestedModeOverrideRef,
+  };
+}

--- a/tests/workspace-draft-and-surfaces-contract.test.ts
+++ b/tests/workspace-draft-and-surfaces-contract.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const appClientPath = 'frontend/app/(core)/(workspace)/app/AppClient.tsx';
+const draftStorageHookPath = 'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceDraftStorage.ts';
+const draftHydrationHookPath = 'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceDraftHydration.ts';
+const bootSurfacePath = 'frontend/app/(core)/(workspace)/app/_components/WorkspaceBootSurface.tsx';
+const centerGalleryPath = 'frontend/app/(core)/(workspace)/app/_components/WorkspaceCenterGallery.tsx';
+const previewDockPath = 'frontend/app/(core)/(workspace)/app/_components/WorkspacePreviewDock.tsx';
+const runtimeModalsPath = 'frontend/app/(core)/(workspace)/app/_components/WorkspaceRuntimeModals.tsx';
+
+test('workspace draft storage and hydration are owned by route-local hooks', () => {
+  assert.equal(existsSync(draftStorageHookPath), true);
+  assert.equal(existsSync(draftHydrationHookPath), true);
+
+  const appSource = readFileSync(appClientPath, 'utf8');
+  const storageHookSource = readFileSync(draftStorageHookPath, 'utf8');
+  const hydrationHookSource = readFileSync(draftHydrationHookPath, 'utf8');
+
+  assert.match(appSource, /import \{ useWorkspaceDraftStorage \} from '\.\/_hooks\/useWorkspaceDraftStorage';/);
+  assert.match(appSource, /import \{ useWorkspaceDraftHydration \} from '\.\/_hooks\/useWorkspaceDraftHydration';/);
+  assert.match(appSource, /useWorkspaceDraftStorage\(\{/);
+  assert.match(appSource, /useWorkspaceDraftHydration\(\{/);
+
+  assert.doesNotMatch(appSource, /readWorkspaceStorage/);
+  assert.doesNotMatch(appSource, /writeWorkspaceStorage/);
+  assert.doesNotMatch(appSource, /readScopedWorkspaceStorage/);
+  assert.doesNotMatch(appSource, /writeScopedWorkspaceStorage/);
+  assert.doesNotMatch(appSource, /buildInitialWorkspaceFormState/);
+  assert.doesNotMatch(appSource, /parseStoredMultiPromptScenes/);
+  assert.doesNotMatch(appSource, /readStoredWorkspaceForm/);
+  assert.doesNotMatch(appSource, /consumeWorkspaceOnboardingSkipIntent/);
+  assert.doesNotMatch(appSource, /readLastKnownUserId/);
+  assert.doesNotMatch(appSource, /writeStorage\(STORAGE_KEYS\./);
+
+  assert.match(storageHookSource, /export function useWorkspaceDraftStorage/);
+  assert.match(storageHookSource, /resolveWorkspaceRequestParams/);
+  assert.match(storageHookSource, /consumeWorkspaceOnboardingSkipIntent/);
+  assert.match(storageHookSource, /readLastKnownUserId/);
+  assert.match(storageHookSource, /readWorkspaceStorage/);
+  assert.match(storageHookSource, /writeWorkspaceStorage/);
+
+  assert.match(hydrationHookSource, /export function useWorkspaceDraftHydration/);
+  assert.match(hydrationHookSource, /buildInitialWorkspaceFormState/);
+  assert.match(hydrationHookSource, /parseStoredMultiPromptScenes/);
+  assert.match(hydrationHookSource, /readStoredWorkspaceForm/);
+  assert.match(hydrationHookSource, /writeStorage\(STORAGE_KEYS\.form/);
+  assert.match(hydrationHookSource, /hydratePendingRendersFromStorage/);
+});
+
+test('workspace app shell surfaces are split into route-local components', () => {
+  assert.equal(existsSync(bootSurfacePath), true);
+  assert.equal(existsSync(centerGalleryPath), true);
+  assert.equal(existsSync(previewDockPath), true);
+  assert.equal(existsSync(runtimeModalsPath), true);
+
+  const appSource = readFileSync(appClientPath, 'utf8');
+  const previewDockSource = readFileSync(previewDockPath, 'utf8');
+  const modalsSource = readFileSync(runtimeModalsPath, 'utf8');
+
+  assert.match(appSource, /import \{ WorkspaceBootSurface \} from '\.\/_components\/WorkspaceBootSurface';/);
+  assert.match(appSource, /import \{ WorkspaceCenterGallery \} from '\.\/_components\/WorkspaceCenterGallery';/);
+  assert.match(appSource, /import \{ WorkspacePreviewDock \}/);
+  assert.match(appSource, /import \{ WorkspaceRuntimeModals \} from '\.\/_components\/WorkspaceRuntimeModals';/);
+  assert.match(appSource, /<WorkspaceBootSurface/);
+  assert.match(appSource, /<WorkspaceCenterGallery/);
+  assert.match(appSource, /<WorkspacePreviewDock/);
+  assert.match(appSource, /<WorkspaceRuntimeModals/);
+
+  assert.doesNotMatch(appSource, /<CompositePreviewDock/);
+  assert.doesNotMatch(appSource, /<EngineSettingsBar/);
+  assert.doesNotMatch(appSource, /<GroupedJobCard/);
+  assert.doesNotMatch(appSource, /<WorkspaceTopUpModal/);
+  assert.doesNotMatch(appSource, /<WorkspaceAuthGateModal/);
+  assert.doesNotMatch(appSource, /<AssetLibraryModal/);
+
+  assert.match(previewDockSource, /CompositePreviewDock/);
+  assert.match(previewDockSource, /EngineSettingsBar/);
+  assert.match(modalsSource, /WorkspaceTopUpModal/);
+  assert.match(modalsSource, /WorkspaceAuthGateModal/);
+  assert.match(modalsSource, /AssetLibraryModal/);
+});

--- a/tests/workspace-gallery-rail-contract.test.ts
+++ b/tests/workspace-gallery-rail-contract.test.ts
@@ -40,10 +40,14 @@ test('composite preview modal button opens direct preview groups', () => {
     path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/AppClient.tsx'),
     'utf8'
   );
+  const previewDockSource = fs.readFileSync(
+    path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/_components/WorkspacePreviewDock.tsx'),
+    'utf8'
+  );
 
-  assert.match(appSource, /\|\s*\{\s*kind:\s*'group';\s*group:\s*VideoGroup\s*\}/);
+  assert.match(previewDockSource, /\|\s*\{\s*kind:\s*'group';\s*group:\s*VideoGroup\s*\}/);
   assert.match(appSource, /if\s*\(viewerTarget\.kind === 'group'\)\s*\{\s*return viewerTarget\.group;\s*\}/);
-  assert.match(appSource, /setViewerTarget\(\{\s*kind:\s*'group',\s*group\s*\}\)/);
+  assert.match(previewDockSource, /setViewerTarget\(\{\s*kind:\s*'group',\s*group:\s*nextGroup\s*\}\)/);
 });
 
 test('composite preview preserves preview urls but plays canonical video urls', () => {

--- a/tests/workspace-pricing-gate-hook-contract.test.ts
+++ b/tests/workspace-pricing-gate-hook-contract.test.ts
@@ -20,18 +20,23 @@ test('workspace pricing and auth gate orchestration is owned by route-local modu
     process.cwd(),
     'frontend/app/(core)/(workspace)/app/_components/WorkspaceAuthGateModal.tsx'
   );
+  const runtimeModalsPath = path.join(
+    process.cwd(),
+    'frontend/app/(core)/(workspace)/app/_components/WorkspaceRuntimeModals.tsx'
+  );
 
   assert.equal(fs.existsSync(hookPath), true);
   assert.equal(fs.existsSync(topUpModalPath), true);
   assert.equal(fs.existsSync(authGateModalPath), true);
+  assert.equal(fs.existsSync(runtimeModalsPath), true);
 
   const hookSource = fs.readFileSync(hookPath, 'utf8');
   const topUpModalSource = fs.readFileSync(topUpModalPath, 'utf8');
   const authGateModalSource = fs.readFileSync(authGateModalPath, 'utf8');
+  const runtimeModalsSource = fs.readFileSync(runtimeModalsPath, 'utf8');
 
   assert.match(appSource, /import \{ useWorkspacePricingGate \} from '\.\/_hooks\/useWorkspacePricingGate';/);
-  assert.match(appSource, /import \{ WorkspaceTopUpModal \} from '\.\/_components\/WorkspaceTopUpModal';/);
-  assert.match(appSource, /import \{ WorkspaceAuthGateModal \} from '\.\/_components\/WorkspaceAuthGateModal';/);
+  assert.match(appSource, /import \{ WorkspaceRuntimeModals \} from '\.\/_components\/WorkspaceRuntimeModals';/);
   assert.match(appSource, /useWorkspacePricingGate\(\{/);
 
   assert.doesNotMatch(appSource, /const \[preflight, setPreflight\] = useState/);
@@ -54,4 +59,8 @@ test('workspace pricing and auth gate orchestration is owned by route-local modu
   assert.match(authGateModalSource, /export function WorkspaceAuthGateModal/);
   assert.match(authGateModalSource, /ButtonLink/);
   assert.match(authGateModalSource, /encodeURIComponent\(loginRedirectTarget\)/);
+
+  assert.match(runtimeModalsSource, /WorkspaceTopUpModal/);
+  assert.match(runtimeModalsSource, /WorkspaceAuthGateModal/);
+  assert.match(runtimeModalsSource, /AssetLibraryModal/);
 });


### PR DESCRIPTION
## Summary
- move workspace draft storage/hydration out of AppClient into route-local hooks
- split boot, center gallery, preview dock, and runtime modals into focused workspace components
- add architecture contracts and update AGENTS guidance for the workspace route

## Verification
- ./node_modules/.bin/tsc --noEmit
- npm --prefix frontend run lint
- pnpm run test:validate
- git diff --check
- npm --prefix frontend run build

## Notes
- branch was refreshed against latest origin/main before commit
- build passes; only existing non-blocking Supabase/Edge warning appeared on the earlier build run