### PR TITLE
Split workspace composer surface and input schema state

### DIFF
--- a/frontend/app/(core)/(workspace)/app/AGENTS.md
+++ b/frontend/app/(core)/(workspace)/app/AGENTS.md
@@ -14,11 +14,13 @@ This route is the main signed-in video generation workspace.
 
 - Extract stable UI and pure helpers before moving generation state.
 - Keep schema summarization, asset-library normalization, and copy merging in `_lib`; `AppClient.tsx` should consume those results instead of rebuilding them inline.
+- Keep workspace input-schema state in `_hooks/useWorkspaceInputSchemaState.ts`; `AppClient.tsx` should not derive promoted fields, asset field ids, upload lock reasons, or asset-pruning effects inline.
 - Keep render grouping and preview tile mapping in `_lib`; `AppClient.tsx` should decide state transitions, not rebuild group summary objects inline.
 - Keep job-to-render conversion, status polling projections, and recent-job reconciliation in `_lib`; route-local hooks should own render state, timers, and bounded network polling.
 - Keep generation attachment ordering, derived input URLs, Kling element payloads, and multi-prompt payloads in `_lib`; `AppClient.tsx` should consume prepared inputs instead of deriving attachment URLs inline.
 - Keep generation validation guards and `runGenerate` payload assembly in `_lib`; route-local hooks should own generation network orchestration while `AppClient.tsx` wires UI state.
 - Keep composer mode inference, engine switching, multi-prompt derived state, voice-control derived state, and settings handlers in route-local hooks; `AppClient.tsx` should wire returned values into composer, settings bars, and generation runner props.
+- Keep the composer and settings JSX in `_components/WorkspaceComposerSurface.tsx`; `AppClient.tsx` should not import `Composer`, `SettingsControls`, `CoreSettingsBar`, or Kling builder UI directly.
 - Keep gallery action orchestration, guided sample navigation, and preview open/continue/refine/copy behavior in route-local hooks; `AppClient.tsx` should pass returned handlers into rails, cards, and preview surfaces.
 - Keep preflight pricing, member-status refresh, wallet top-up modal state, and auth gate modal state in route-local hooks/components; `AppClient.tsx` should wire returned state into composer and generation runner props.
 - Keep local pending-render and selected-preview preparation in `_lib`; `AppClient.tsx` should apply returned state objects and own timers.

--- a/frontend/app/(core)/(workspace)/app/AppClient.tsx
+++ b/frontend/app/(core)/(workspace)/app/AppClient.tsx
@@ -4,14 +4,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useEngines, useInfiniteJobs, getJobStatus } from '@/lib/api';
 import { authFetch } from '@/lib/authFetch';
 import { useRouter } from 'next/navigation';
-import type { EngineCaps, EngineInputField } from '@/types/engines';
-import { SettingsControls } from '@/components/SettingsControls';
-import { CoreSettingsBar } from '@/components/CoreSettingsBar';
-import {
-  Composer,
-  type MultiPromptScene,
-} from '@/components/Composer';
-import type { KlingElementState, KlingElementsBuilderProps } from '@/components/KlingElementsBuilder';
+import type { EngineCaps } from '@/types/engines';
+import type { MultiPromptScene } from '@/components/Composer';
+import type { KlingElementState } from '@/components/KlingElementsBuilder';
 import type { GalleryRailProps } from '@/components/GalleryRail';
 import type { GroupSummary } from '@/types/groups';
 import dynamic from 'next/dynamic';
@@ -26,24 +21,15 @@ import {
 import { useResultProvider } from '@/hooks/useResultProvider';
 import { normalizeGroupSummary } from '@/lib/normalize-group-summary';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
-import { Button } from '@/components/ui/Button';
-import {
-  isLumaRay2EngineId,
-  isLumaRay2GenerateMode,
-} from '@/lib/luma-ray2';
 import { useI18n } from '@/lib/i18n/I18nProvider';
 import {
-  getSeedanceFieldBlockKey,
-  SEEDANCE_REFERENCE_AUDIO_FIELD_IDS,
-} from '@/lib/seedance-workflow';
-import {
-  getLocalizedModeLabel,
   getLocalizedWorkflowCopy,
   normalizeUiLocale,
 } from '@/lib/ltx-localization';
 import { WorkspaceBootSurface } from './_components/WorkspaceBootSurface';
 import { WorkspaceCenterGallery } from './_components/WorkspaceCenterGallery';
 import { WorkspaceChrome } from './_components/WorkspaceChrome';
+import { WorkspaceComposerSurface } from './_components/WorkspaceComposerSurface';
 import {
   GalleryRailSkeleton,
 } from './_components/WorkspaceBootSkeletons';
@@ -52,17 +38,8 @@ import type { WorkspaceViewerTarget } from './_components/WorkspacePreviewDock';
 import { WorkspaceRuntimeModals } from './_components/WorkspaceRuntimeModals';
 import { getCompositePreviewPosterSrc } from './_lib/composite-preview';
 import {
-  normalizeExtraInputValue,
   type FormState,
 } from './_lib/workspace-form-state';
-import {
-  buildAssetFieldIdSet,
-  buildComposerAttachments,
-  buildReferenceAudioFieldIds,
-  getPrimaryAssetFieldLabel,
-  revokeAssetPreview,
-  type ReferenceAsset,
-} from './_lib/workspace-assets';
 import {
   DEFAULT_WORKSPACE_COPY,
   mergeCopy,
@@ -73,13 +50,7 @@ import {
 import {
   createKlingElement,
   createMultiPromptScene,
-  MULTI_PROMPT_MAX_SEC,
-  MULTI_PROMPT_MIN_SEC,
 } from './_lib/workspace-input-helpers';
-import {
-  buildComposerPromotedActions,
-  summarizeWorkspaceInputSchema,
-} from './_lib/workspace-input-schema';
 import { useWorkspaceAssets } from './_hooks/useWorkspaceAssets';
 import { useWorkspaceComposerState } from './_hooks/useWorkspaceComposerState';
 import { useWorkspaceDesktopLayout } from './_hooks/useWorkspaceDesktopLayout';
@@ -87,6 +58,7 @@ import { useWorkspaceDraftHydration } from './_hooks/useWorkspaceDraftHydration'
 import { useWorkspaceDraftStorage } from './_hooks/useWorkspaceDraftStorage';
 import { useWorkspaceGalleryActions } from './_hooks/useWorkspaceGalleryActions';
 import { useWorkspaceGenerationRunner } from './_hooks/useWorkspaceGenerationRunner';
+import { useWorkspaceInputSchemaState } from './_hooks/useWorkspaceInputSchemaState';
 import { useWorkspacePricingGate } from './_hooks/useWorkspacePricingGate';
 import { useWorkspaceRenderState } from './_hooks/useWorkspaceRenderState';
 import { useWorkspaceVideoSettings } from './_hooks/useWorkspaceVideoSettings';
@@ -97,11 +69,6 @@ const GalleryRail = dynamic<GalleryRailProps>(
     ssr: false,
     loading: () => <GalleryRailSkeleton />,
   }
-);
-
-const KlingElementsBuilder = dynamic<KlingElementsBuilderProps>(
-  () => import('@/components/KlingElementsBuilder').then((mod) => mod.KlingElementsBuilder),
-  { ssr: false }
 );
 
 export default function AppClientPage({ initialPreviewGroup = null }: { initialPreviewGroup?: VideoGroup | null }) {
@@ -526,170 +493,30 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
     showNotice,
   });
 
-  const inputSchemaSummary = useMemo(
-    () =>
-      summarizeWorkspaceInputSchema({
-        selectedEngine,
-        activeMode,
-        allowsUnifiedVeoFirstLast,
-        isUnifiedHappyHorse,
-        isUnifiedSeedance,
-        uiLocale,
-      }),
-    [activeMode, allowsUnifiedVeoFirstLast, isUnifiedHappyHorse, isUnifiedSeedance, selectedEngine, uiLocale]
-  );
-
-  const extraInputFields = useMemo(
-    () => [...inputSchemaSummary.promotedFields, ...inputSchemaSummary.secondaryFields],
-    [inputSchemaSummary.promotedFields, inputSchemaSummary.secondaryFields]
-  );
-
-  useEffect(() => {
-    setForm((current) => {
-      if (!current) return current;
-      const allowedFieldIds = new Set(extraInputFields.map(({ field }) => field.id));
-      const nextExtraInputValues = Object.entries(current.extraInputValues).reduce<Record<string, unknown>>((acc, [key, value]) => {
-        if (allowedFieldIds.has(key)) {
-          acc[key] = value;
-        }
-        return acc;
-      }, {});
-      if (JSON.stringify(nextExtraInputValues) === JSON.stringify(current.extraInputValues)) {
-        return current;
-      }
-      return { ...current, extraInputValues: nextExtraInputValues };
-    });
-  }, [extraInputFields]);
-
-  useEffect(() => {
-    setInputAssets((previous) => {
-      if (!inputSchemaSummary.assetFields.length) {
-        if (Object.keys(previous).length === 0) return previous;
-        Object.values(previous).forEach((entries) => {
-          entries.forEach((asset) => revokeAssetPreview(asset));
-        });
-        return {};
-      }
-      const allowed = new Set(inputSchemaSummary.assetFields.map((entry) => entry.field.id));
-      let changed = false;
-      const next: Record<string, (ReferenceAsset | null)[]> = {};
-      Object.entries(previous).forEach(([fieldId, items]) => {
-        if (allowed.has(fieldId)) {
-          next[fieldId] = items;
-        } else {
-          changed = true;
-          items.forEach((asset) => revokeAssetPreview(asset));
-        }
-      });
-      return changed ? next : previous;
-    });
-  }, [inputSchemaSummary.assetFields, setInputAssets]);
-
-  const primaryAssetFieldIds = useMemo(
-    () => buildAssetFieldIdSet(inputSchemaSummary.assetFields, (entry) => entry.role === 'primary'),
-    [inputSchemaSummary.assetFields]
-  );
-
-  const referenceAssetFieldIds = useMemo(
-    () => buildAssetFieldIdSet(inputSchemaSummary.assetFields, (entry) => entry.role === 'reference'),
-    [inputSchemaSummary.assetFields]
-  );
-
-  const genericImageFieldIds = useMemo(
-    () => buildAssetFieldIdSet(
-      inputSchemaSummary.assetFields,
-      (entry) => entry.role === 'generic' && entry.field.type === 'image'
-    ),
-    [inputSchemaSummary.assetFields]
-  );
-
-  const frameAssetFieldIds = useMemo(
-    () => buildAssetFieldIdSet(inputSchemaSummary.assetFields, (entry) => entry.role === 'frame'),
-    [inputSchemaSummary.assetFields]
-  );
-  const referenceAudioFieldIds = useMemo(
-    () => buildReferenceAudioFieldIds(inputSchemaSummary.assetFields, SEEDANCE_REFERENCE_AUDIO_FIELD_IDS),
-    [inputSchemaSummary.assetFields]
-  );
-
-  const primaryAssetFieldLabel = useMemo(
-    () => getPrimaryAssetFieldLabel(inputSchemaSummary.assetFields),
-    [inputSchemaSummary.assetFields]
-  );
-  const guestUploadLockedReason = !authChecked || (!authLoading && !user?.id) ? workspaceCopy.authGate.uploadLocked : null;
-  const composerAssetFields = useMemo(() => {
-    return inputSchemaSummary.assetFields.map((entry) => {
-      const fieldHasOwnAssets = (inputAssets[entry.field.id] ?? []).some((asset) => asset !== null);
-      const blockKey = isUnifiedSeedance
-        ? getSeedanceFieldBlockKey(entry.field.id, inputAssets, fieldHasOwnAssets)
-        : null;
-      const workflowDisabledReason =
-        blockKey === 'clearReferences'
-          ? workflowCopy.clearReferencesToUseStartEnd
-          : blockKey === 'clearStartEnd'
-            ? workflowCopy.clearStartEndToUseReferences
-            : null;
-      const disabledReason = workflowDisabledReason ?? guestUploadLockedReason;
-      return {
-        ...entry,
-        disabled: Boolean(disabledReason),
-        disabledReason,
-      };
-    });
-  }, [
+  const {
+    inputSchemaSummary,
+    extraInputFields,
+    primaryAssetFieldIds,
+    referenceAssetFieldIds,
+    genericImageFieldIds,
+    frameAssetFieldIds,
+    referenceAudioFieldIds,
+    primaryAssetFieldLabel,
     guestUploadLockedReason,
-    inputAssets,
-    inputSchemaSummary.assetFields,
+  } = useWorkspaceInputSchemaState({
+    selectedEngine,
+    activeMode,
+    allowsUnifiedVeoFirstLast,
+    isUnifiedHappyHorse,
     isUnifiedSeedance,
-    workflowCopy.clearReferencesToUseStartEnd,
-    workflowCopy.clearStartEndToUseReferences,
-  ]);
-
-  useEffect(() => {
-    if (!selectedEngine) {
-      if (cfgScale !== null) {
-        setCfgScale(null);
-      }
-      return;
-    }
-    const cfgParam = selectedEngine.params?.cfg_scale;
-    if (cfgParam) {
-      if (cfgScale === null) {
-        setCfgScale(cfgParam.default ?? null);
-      }
-    } else {
-      if (cfgScale !== null) {
-        setCfgScale(null);
-      }
-    }
-  }, [cfgScale, selectedEngine, form?.mode]);
-
-  const composerAssets = useMemo(() => buildComposerAttachments(inputAssets), [inputAssets]);
-  const handleExtraInputValueChange = useCallback((field: EngineInputField, value: unknown) => {
-    setForm((current) => {
-      if (!current) return current;
-      const normalized = normalizeExtraInputValue(field, value);
-      const next = { ...current.extraInputValues };
-      if (normalized === undefined) {
-        delete next[field.id];
-      } else {
-        next[field.id] = normalized;
-      }
-      return { ...current, extraInputValues: next };
-    });
-  }, []);
-
-  const composerPromotedActions = useMemo(
-    () =>
-      buildComposerPromotedActions({
-        form,
-        promotedFields: inputSchemaSummary.promotedFields,
-        uiLocale,
-        onToggle: handleExtraInputValueChange,
-      }),
-    [form, handleExtraInputValueChange, inputSchemaSummary.promotedFields, uiLocale]
-  );
-
+    uiLocale,
+    authChecked,
+    authLoading,
+    authenticatedUserId: user?.id,
+    uploadLockedCopy: workspaceCopy.authGate.uploadLocked,
+    setInputAssets,
+    setForm,
+  });
   const {
     preflight,
     preflightError,
@@ -915,178 +742,81 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
                 compositeOverrideSummary={compositeOverrideSummary}
                 setViewerTarget={setViewerTarget}
               />
-              <Composer
-                engine={selectedEngine}
+              <WorkspaceComposerSurface
+                selectedEngine={selectedEngine}
+                form={form}
+                setForm={setForm}
                 prompt={prompt}
-                onPromptChange={setPrompt}
+                setPrompt={setPrompt}
                 negativePrompt={negativePrompt}
-                onNegativePromptChange={setNegativePrompt}
+                setNegativePrompt={setNegativePrompt}
                 price={price}
                 currency={currency}
-                isLoading={isPricing}
-                error={preflightError}
-                messages={preflight?.ok ? preflight.messages : undefined}
-                textareaRef={composerRef}
-                onGenerate={startRender}
+                isPricing={isPricing}
+                preflightError={preflightError}
                 preflight={preflight}
-                promptField={inputSchemaSummary.promptField}
-                promptRequired={inputSchemaSummary.promptRequired}
-                negativePromptField={inputSchemaSummary.negativePromptField}
-                negativePromptRequired={inputSchemaSummary.negativePromptRequired}
-                modeToggles={composerModeToggles}
+                composerRef={composerRef}
+                startRender={startRender}
+                inputSchemaSummary={inputSchemaSummary}
+                inputAssets={inputAssets}
+                isUnifiedSeedance={isUnifiedSeedance}
+                workflowCopy={workflowCopy}
+                guestUploadLockedReason={guestUploadLockedReason}
+                uiLocale={uiLocale}
+                composerModeToggles={composerModeToggles}
                 activeManualMode={activeManualMode}
-                onModeToggle={handleComposerModeToggle}
-                workflowNotice={composerWorkflowNotice}
-                promotedActions={composerPromotedActions}
-                assetFields={composerAssetFields}
-                assets={composerAssets}
-                onAssetAdd={handleAssetAdd}
-                onAssetRemove={handleAssetRemove}
-                onNotice={showNotice}
-                onOpenLibrary={handleOpenAssetLibrary}
-                multiPrompt={
-                  supportsKlingV3Controls
-                    ? {
-                        enabled: multiPromptEnabled,
-                        scenes: multiPromptScenes,
-                        totalDurationSec: multiPromptTotalSec,
-                        minDurationSec: MULTI_PROMPT_MIN_SEC,
-                        maxDurationSec: MULTI_PROMPT_MAX_SEC,
-                        onToggle: setMultiPromptEnabled,
-                        onAddScene: handleMultiPromptAddScene,
-                        onRemoveScene: handleMultiPromptRemoveScene,
-                        onUpdateScene: handleMultiPromptUpdateScene,
-                        error: multiPromptError,
-                      }
-                    : null
-                }
-                disableGenerate={multiPromptInvalid || audioWorkflowUnsupported}
-                extraFields={
-                  <>
-                    {showRetakeWorkflowAction ? (
-                      <div className="flex flex-wrap items-center justify-between gap-3">
-                        <div className="space-y-0.5">
-                          <p className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">Edit workflow</p>
-                          <p className="text-xs text-text-secondary">Use retake when you want to reinterpret an existing clip.</p>
-                        </div>
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant={form.mode === 'retake' ? 'primary' : 'outline'}
-                          onClick={() => handleComposerModeToggle(form.mode === 'retake' ? null : 'retake')}
-                          disabled={audioWorkflowLocked}
-                          title={audioWorkflowLocked ? workflowCopy.removeAudioToUnlock : undefined}
-                          className="min-h-0 h-auto rounded-full px-3 py-2 text-[11px] font-semibold tracking-micro"
-                        >
-                          {getLocalizedModeLabel('retake', uiLocale)}
-                        </Button>
-                      </div>
-                    ) : null}
-                    {supportsKlingV3Controls && activeMode === 'i2v' ? (
-                      <KlingElementsBuilder
-                        elements={klingElements}
-                        onAddElement={handleKlingElementAdd}
-                        onRemoveElement={handleKlingElementRemove}
-                        onAddAsset={handleKlingElementAssetAdd}
-                        onRemoveAsset={handleKlingElementAssetRemove}
-                        onOpenLibrary={handleOpenKlingAssetLibrary}
-                      />
-                    ) : null}
-                    <SettingsControls
-                      engine={selectedEngine}
-                      caps={capability}
-                      durationSec={multiPromptActive ? multiPromptTotalSec : form.durationSec}
-                      durationOption={form.durationOption ?? null}
-                      onDurationChange={handleDurationChange}
-                      numFrames={form.numFrames ?? undefined}
-                      onNumFramesChange={handleFramesChange}
-                      resolution={form.resolution}
-                      onResolutionChange={handleResolutionChange}
-                      aspectRatio={form.aspectRatio}
-                      onAspectRatioChange={handleAspectRatioChange}
-                      fps={form.fps}
-                      onFpsChange={handleFpsChange}
-                      mode={submissionMode}
-                      showAudioControl={supportsAudioToggle}
-                      audioEnabled={form.audio}
-                      audioControlDisabled={voiceControlEnabled}
-                      audioControlNote={voiceControlEnabled ? 'Audio locked by voice control' : undefined}
-                      onAudioChange={(audio) => setForm((current) => (current ? { ...current, audio } : current))}
-                      showLoopControl={isLumaRay2EngineId(selectedEngine.id) && isLumaRay2GenerateMode(submissionMode)}
-                      loopEnabled={
-                        isLumaRay2EngineId(selectedEngine.id) && isLumaRay2GenerateMode(submissionMode)
-                          ? Boolean(form.loop)
-                          : undefined
-                      }
-                      onLoopChange={(next) =>
-                        setForm((current) => (current ? { ...current, loop: next } : current))
-                      }
-                      showExtendControl={false}
-                      seedLocked={form.seedLocked}
-                      onSeedLockedChange={(seedLocked) =>
-                        setForm((current) => (current ? { ...current, seedLocked } : current))
-                      }
-                      cfgScale={cfgScale}
-                      onCfgScaleChange={(value) => setCfgScale(value)}
-                      durationManaged={multiPromptActive}
-                      durationManagedLabel={`Duration managed by multi-prompt · ${multiPromptTotalSec}s`}
-                      showKlingV3Controls={supportsKlingV3Controls}
-                      showKlingV3VoiceControls={supportsKlingV3VoiceControl}
-                      klingShotType={shotType}
-                      onKlingShotTypeChange={(value) => setShotType(value)}
-                      voiceIdsValue={voiceIdsInput}
-                      onVoiceIdsChange={(value) => setVoiceIdsInput(value)}
-                      voiceControlActive={voiceControlEnabled}
-                      showSeedanceControls={isSeedance}
-                      seedValue={seedValue}
-                      onSeedChange={handleSeedChange}
-                      cameraFixed={cameraFixedValue}
-                      onCameraFixedChange={handleCameraFixedChange}
-                      safetyChecker={safetyCheckerValue}
-                      onSafetyCheckerChange={handleSafetyCheckerChange}
-                      showSafetyCheckerControl={showSafetyCheckerControl}
-                      advancedFields={inputSchemaSummary.secondaryFields}
-                      advancedFieldValues={form.extraInputValues}
-                      onAdvancedFieldChange={handleExtraInputValueChange}
-                      variant="advanced"
-                    />
-                  </>
-                }
-                settingsBar={
-                  <CoreSettingsBar
-                    engine={selectedEngine}
-                    mode={submissionMode}
-                    caps={capability}
-                    iterations={form.iterations}
-                    onIterationsChange={(iterations) =>
-                      setForm((current) => {
-                        const next = current ? { ...current, iterations } : current;
-                        if (iterations <= 1) {
-                          setViewMode('single');
-                        }
-                        return next;
-                      })
-                    }
-                    durationSec={multiPromptActive ? multiPromptTotalSec : form.durationSec}
-                    durationOption={form.durationOption ?? null}
-                    onDurationChange={handleDurationChange}
-                    numFrames={form.numFrames ?? undefined}
-                    onNumFramesChange={handleFramesChange}
-                    resolution={form.resolution}
-                    onResolutionChange={handleResolutionChange}
-                    aspectRatio={form.aspectRatio}
-                    onAspectRatioChange={handleAspectRatioChange}
-                    fps={form.fps}
-                    onFpsChange={handleFpsChange}
-                    showAudioControl={supportsAudioToggle}
-                    audioEnabled={form.audio}
-                    audioControlDisabled={voiceControlEnabled}
-                    audioControlNote={voiceControlEnabled ? 'Audio locked by voice control' : undefined}
-                    onAudioChange={(audio) => setForm((current) => (current ? { ...current, audio } : current))}
-                    durationManaged={multiPromptActive}
-                    durationManagedLabel={`Duration managed by multi-prompt · ${multiPromptTotalSec}s`}
-                  />
-                }
+                handleComposerModeToggle={handleComposerModeToggle}
+                composerWorkflowNotice={composerWorkflowNotice}
+                handleAssetAdd={handleAssetAdd}
+                handleAssetRemove={handleAssetRemove}
+                handleOpenAssetLibrary={handleOpenAssetLibrary}
+                showNotice={showNotice}
+                supportsKlingV3Controls={supportsKlingV3Controls}
+                supportsKlingV3VoiceControl={supportsKlingV3VoiceControl}
+                multiPromptEnabled={multiPromptEnabled}
+                setMultiPromptEnabled={setMultiPromptEnabled}
+                multiPromptScenes={multiPromptScenes}
+                multiPromptTotalSec={multiPromptTotalSec}
+                multiPromptActive={multiPromptActive}
+                multiPromptInvalid={multiPromptInvalid}
+                multiPromptError={multiPromptError}
+                handleMultiPromptAddScene={handleMultiPromptAddScene}
+                handleMultiPromptRemoveScene={handleMultiPromptRemoveScene}
+                handleMultiPromptUpdateScene={handleMultiPromptUpdateScene}
+                audioWorkflowUnsupported={audioWorkflowUnsupported}
+                audioWorkflowLocked={audioWorkflowLocked}
+                showRetakeWorkflowAction={showRetakeWorkflowAction}
+                activeMode={activeMode}
+                submissionMode={submissionMode}
+                capability={capability}
+                handleDurationChange={handleDurationChange}
+                handleFramesChange={handleFramesChange}
+                handleResolutionChange={handleResolutionChange}
+                handleAspectRatioChange={handleAspectRatioChange}
+                handleFpsChange={handleFpsChange}
+                supportsAudioToggle={supportsAudioToggle}
+                voiceControlEnabled={voiceControlEnabled}
+                cfgScale={cfgScale}
+                setCfgScale={setCfgScale}
+                shotType={shotType}
+                setShotType={setShotType}
+                voiceIdsInput={voiceIdsInput}
+                setVoiceIdsInput={setVoiceIdsInput}
+                isSeedance={isSeedance}
+                seedValue={seedValue}
+                handleSeedChange={handleSeedChange}
+                cameraFixedValue={cameraFixedValue}
+                handleCameraFixedChange={handleCameraFixedChange}
+                safetyCheckerValue={safetyCheckerValue}
+                handleSafetyCheckerChange={handleSafetyCheckerChange}
+                showSafetyCheckerControl={showSafetyCheckerControl}
+                klingElements={klingElements}
+                handleKlingElementAdd={handleKlingElementAdd}
+                handleKlingElementRemove={handleKlingElementRemove}
+                handleKlingElementAssetAdd={handleKlingElementAssetAdd}
+                handleKlingElementAssetRemove={handleKlingElementAssetRemove}
+                handleOpenKlingAssetLibrary={handleOpenKlingAssetLibrary}
+                setViewMode={setViewMode}
               />
             </div>
       </WorkspaceChrome>

--- a/frontend/app/(core)/(workspace)/app/_components/WorkspaceComposerSurface.tsx
+++ b/frontend/app/(core)/(workspace)/app/_components/WorkspaceComposerSurface.tsx
@@ -1,0 +1,470 @@
+'use client';
+
+import { useCallback, useEffect, useMemo } from 'react';
+import type { ComponentProps, Dispatch, SetStateAction } from 'react';
+import dynamic from 'next/dynamic';
+import { Composer, type MultiPromptScene } from '@/components/Composer';
+import { CoreSettingsBar } from '@/components/CoreSettingsBar';
+import { SettingsControls } from '@/components/SettingsControls';
+import type { KlingElementState, KlingElementsBuilderProps } from '@/components/KlingElementsBuilder';
+import { Button } from '@/components/ui/Button';
+import {
+  isLumaRay2EngineId,
+  isLumaRay2GenerateMode,
+} from '@/lib/luma-ray2';
+import { getLocalizedModeLabel } from '@/lib/ltx-localization';
+import { getSeedanceFieldBlockKey } from '@/lib/seedance-workflow';
+import type { EngineCaps, EngineInputField, EngineModeUiCaps, Mode } from '@/types/engines';
+import {
+  buildComposerAttachments,
+  type ReferenceAsset,
+} from '../_lib/workspace-assets';
+import type { FormState } from '../_lib/workspace-form-state';
+import { normalizeExtraInputValue } from '../_lib/workspace-form-state';
+import {
+  buildComposerPromotedActions,
+  type WorkspaceInputSchemaSummary,
+} from '../_lib/workspace-input-schema';
+import {
+  MULTI_PROMPT_MAX_SEC,
+  MULTI_PROMPT_MIN_SEC,
+} from '../_lib/workspace-input-helpers';
+
+const KlingElementsBuilder = dynamic<KlingElementsBuilderProps>(
+  () => import('@/components/KlingElementsBuilder').then((mod) => mod.KlingElementsBuilder),
+  { ssr: false }
+);
+
+type ComposerProps = ComponentProps<typeof Composer>;
+type ShotType = 'customize' | 'intelligent';
+type WorkflowCopy = {
+  clearReferencesToUseStartEnd: string;
+  clearStartEndToUseReferences: string;
+  removeAudioToUnlock: string;
+};
+
+type WorkspaceComposerSurfaceProps = {
+  selectedEngine: EngineCaps;
+  form: FormState;
+  setForm: Dispatch<SetStateAction<FormState | null>>;
+  prompt: string;
+  setPrompt: Dispatch<SetStateAction<string>>;
+  negativePrompt: string;
+  setNegativePrompt: Dispatch<SetStateAction<string>>;
+  price: ComposerProps['price'];
+  currency: ComposerProps['currency'];
+  isPricing: boolean;
+  preflightError: ComposerProps['error'];
+  preflight: ComposerProps['preflight'];
+  composerRef: ComposerProps['textareaRef'];
+  startRender: ComposerProps['onGenerate'];
+  inputSchemaSummary: WorkspaceInputSchemaSummary;
+  inputAssets: Record<string, (ReferenceAsset | null)[]>;
+  isUnifiedSeedance: boolean;
+  workflowCopy: WorkflowCopy;
+  guestUploadLockedReason: string | null;
+  uiLocale: string;
+  composerModeToggles: ComposerProps['modeToggles'];
+  activeManualMode: Mode | null;
+  handleComposerModeToggle: (mode: Mode | null) => void;
+  composerWorkflowNotice: string | null;
+  handleAssetAdd: NonNullable<ComposerProps['onAssetAdd']>;
+  handleAssetRemove: NonNullable<ComposerProps['onAssetRemove']>;
+  handleOpenAssetLibrary: NonNullable<ComposerProps['onOpenLibrary']>;
+  showNotice: (message: string) => void;
+  supportsKlingV3Controls: boolean;
+  supportsKlingV3VoiceControl: boolean;
+  multiPromptEnabled: boolean;
+  setMultiPromptEnabled: Dispatch<SetStateAction<boolean>>;
+  multiPromptScenes: MultiPromptScene[];
+  multiPromptTotalSec: number;
+  multiPromptActive: boolean;
+  multiPromptInvalid: boolean;
+  multiPromptError: string | null;
+  handleMultiPromptAddScene: () => void;
+  handleMultiPromptRemoveScene: (id: string) => void;
+  handleMultiPromptUpdateScene: (
+    id: string,
+    patch: Partial<Pick<MultiPromptScene, 'prompt' | 'duration'>>
+  ) => void;
+  audioWorkflowUnsupported: boolean;
+  audioWorkflowLocked: boolean;
+  showRetakeWorkflowAction: boolean;
+  activeMode: Mode;
+  submissionMode: Mode;
+  capability: EngineModeUiCaps | undefined;
+  handleDurationChange: (raw: number | string) => void;
+  handleFramesChange: (value: number) => void;
+  handleResolutionChange: (resolution: string) => void;
+  handleAspectRatioChange: (ratio: string) => void;
+  handleFpsChange: (fps: number) => void;
+  supportsAudioToggle: boolean;
+  voiceControlEnabled: boolean;
+  cfgScale: number | null;
+  setCfgScale: Dispatch<SetStateAction<number | null>>;
+  shotType: ShotType;
+  setShotType: Dispatch<SetStateAction<ShotType>>;
+  voiceIdsInput: string;
+  setVoiceIdsInput: Dispatch<SetStateAction<string>>;
+  isSeedance: boolean;
+  seedValue: string;
+  handleSeedChange: (value: string) => void;
+  cameraFixedValue: boolean;
+  handleCameraFixedChange: (value: boolean) => void;
+  safetyCheckerValue: boolean;
+  handleSafetyCheckerChange: (value: boolean) => void;
+  showSafetyCheckerControl: boolean;
+  klingElements: KlingElementState[];
+  handleKlingElementAdd: () => void;
+  handleKlingElementRemove: (id: string) => void;
+  handleKlingElementAssetAdd: KlingElementsBuilderProps['onAddAsset'];
+  handleKlingElementAssetRemove: KlingElementsBuilderProps['onRemoveAsset'];
+  handleOpenKlingAssetLibrary: (elementId: string, slot: 'frontal' | 'reference', slotIndex?: number) => void;
+  setViewMode: Dispatch<SetStateAction<'single' | 'quad'>>;
+};
+
+export function WorkspaceComposerSurface({
+  selectedEngine,
+  form,
+  setForm,
+  prompt,
+  setPrompt,
+  negativePrompt,
+  setNegativePrompt,
+  price,
+  currency,
+  isPricing,
+  preflightError,
+  preflight,
+  composerRef,
+  startRender,
+  inputSchemaSummary,
+  inputAssets,
+  isUnifiedSeedance,
+  workflowCopy,
+  guestUploadLockedReason,
+  uiLocale,
+  composerModeToggles,
+  activeManualMode,
+  handleComposerModeToggle,
+  composerWorkflowNotice,
+  handleAssetAdd,
+  handleAssetRemove,
+  handleOpenAssetLibrary,
+  showNotice,
+  supportsKlingV3Controls,
+  supportsKlingV3VoiceControl,
+  multiPromptEnabled,
+  setMultiPromptEnabled,
+  multiPromptScenes,
+  multiPromptTotalSec,
+  multiPromptActive,
+  multiPromptInvalid,
+  multiPromptError,
+  handleMultiPromptAddScene,
+  handleMultiPromptRemoveScene,
+  handleMultiPromptUpdateScene,
+  audioWorkflowUnsupported,
+  audioWorkflowLocked,
+  showRetakeWorkflowAction,
+  activeMode,
+  submissionMode,
+  capability,
+  handleDurationChange,
+  handleFramesChange,
+  handleResolutionChange,
+  handleAspectRatioChange,
+  handleFpsChange,
+  supportsAudioToggle,
+  voiceControlEnabled,
+  cfgScale,
+  setCfgScale,
+  shotType,
+  setShotType,
+  voiceIdsInput,
+  setVoiceIdsInput,
+  isSeedance,
+  seedValue,
+  handleSeedChange,
+  cameraFixedValue,
+  handleCameraFixedChange,
+  safetyCheckerValue,
+  handleSafetyCheckerChange,
+  showSafetyCheckerControl,
+  klingElements,
+  handleKlingElementAdd,
+  handleKlingElementRemove,
+  handleKlingElementAssetAdd,
+  handleKlingElementAssetRemove,
+  handleOpenKlingAssetLibrary,
+  setViewMode,
+}: WorkspaceComposerSurfaceProps) {
+  const composerAssetFields = useMemo(() => {
+    return inputSchemaSummary.assetFields.map((entry) => {
+      const fieldHasOwnAssets = (inputAssets[entry.field.id] ?? []).some((asset) => asset !== null);
+      const blockKey = isUnifiedSeedance
+        ? getSeedanceFieldBlockKey(entry.field.id, inputAssets, fieldHasOwnAssets)
+        : null;
+      const workflowDisabledReason =
+        blockKey === 'clearReferences'
+          ? workflowCopy.clearReferencesToUseStartEnd
+          : blockKey === 'clearStartEnd'
+            ? workflowCopy.clearStartEndToUseReferences
+            : null;
+      const disabledReason = workflowDisabledReason ?? guestUploadLockedReason;
+      return {
+        ...entry,
+        disabled: Boolean(disabledReason),
+        disabledReason,
+      };
+    });
+  }, [
+    guestUploadLockedReason,
+    inputAssets,
+    inputSchemaSummary.assetFields,
+    isUnifiedSeedance,
+    workflowCopy.clearReferencesToUseStartEnd,
+    workflowCopy.clearStartEndToUseReferences,
+  ]);
+
+  const handleExtraInputValueChange = useCallback(
+    (field: EngineInputField, value: unknown) => {
+      setForm((current) => {
+        if (!current) return current;
+        const normalized = normalizeExtraInputValue(field, value);
+        const next = { ...current.extraInputValues };
+        if (normalized === undefined) {
+          delete next[field.id];
+        } else {
+          next[field.id] = normalized;
+        }
+        return { ...current, extraInputValues: next };
+      });
+    },
+    [setForm]
+  );
+
+  const composerAssets = useMemo(() => buildComposerAttachments(inputAssets), [inputAssets]);
+  const composerPromotedActions = useMemo(
+    () =>
+      buildComposerPromotedActions({
+        form,
+        promotedFields: inputSchemaSummary.promotedFields,
+        uiLocale,
+        onToggle: handleExtraInputValueChange,
+      }),
+    [form, handleExtraInputValueChange, inputSchemaSummary.promotedFields, uiLocale]
+  );
+
+  useEffect(() => {
+    const cfgParam = selectedEngine.params?.cfg_scale;
+    if (cfgParam) {
+      if (cfgScale === null) {
+        setCfgScale(cfgParam.default ?? null);
+      }
+      return;
+    }
+    if (cfgScale !== null) {
+      setCfgScale(null);
+    }
+  }, [cfgScale, selectedEngine, form.mode, setCfgScale]);
+
+  const durationSec = multiPromptActive ? multiPromptTotalSec : form.durationSec;
+  const durationManagedLabel = `Duration managed by multi-prompt · ${multiPromptTotalSec}s`;
+  const audioControlNote = voiceControlEnabled ? 'Audio locked by voice control' : undefined;
+
+  const handleAudioChange = useCallback(
+    (audio: boolean) => {
+      setForm((current) => (current ? { ...current, audio } : current));
+    },
+    [setForm]
+  );
+  const handleLoopChange = useCallback(
+    (loop: boolean) => {
+      setForm((current) => (current ? { ...current, loop } : current));
+    },
+    [setForm]
+  );
+  const handleSeedLockedChange = useCallback(
+    (seedLocked: boolean) => {
+      setForm((current) => (current ? { ...current, seedLocked } : current));
+    },
+    [setForm]
+  );
+  const handleIterationsChange = useCallback(
+    (iterations: number) => {
+      setForm((current) => {
+        const next = current ? { ...current, iterations } : current;
+        if (iterations <= 1) {
+          setViewMode('single');
+        }
+        return next;
+      });
+    },
+    [setForm, setViewMode]
+  );
+
+  return (
+    <Composer
+      engine={selectedEngine}
+      prompt={prompt}
+      onPromptChange={setPrompt}
+      negativePrompt={negativePrompt}
+      onNegativePromptChange={setNegativePrompt}
+      price={price}
+      currency={currency}
+      isLoading={isPricing}
+      error={preflightError}
+      messages={preflight?.ok ? preflight.messages : undefined}
+      textareaRef={composerRef}
+      onGenerate={startRender}
+      preflight={preflight}
+      promptField={inputSchemaSummary.promptField}
+      promptRequired={inputSchemaSummary.promptRequired}
+      negativePromptField={inputSchemaSummary.negativePromptField}
+      negativePromptRequired={inputSchemaSummary.negativePromptRequired}
+      modeToggles={composerModeToggles}
+      activeManualMode={activeManualMode}
+      onModeToggle={handleComposerModeToggle}
+      workflowNotice={composerWorkflowNotice}
+      promotedActions={composerPromotedActions}
+      assetFields={composerAssetFields}
+      assets={composerAssets}
+      onAssetAdd={handleAssetAdd}
+      onAssetRemove={handleAssetRemove}
+      onNotice={showNotice}
+      onOpenLibrary={handleOpenAssetLibrary}
+      multiPrompt={
+        supportsKlingV3Controls
+          ? {
+              enabled: multiPromptEnabled,
+              scenes: multiPromptScenes,
+              totalDurationSec: multiPromptTotalSec,
+              minDurationSec: MULTI_PROMPT_MIN_SEC,
+              maxDurationSec: MULTI_PROMPT_MAX_SEC,
+              onToggle: setMultiPromptEnabled,
+              onAddScene: handleMultiPromptAddScene,
+              onRemoveScene: handleMultiPromptRemoveScene,
+              onUpdateScene: handleMultiPromptUpdateScene,
+              error: multiPromptError,
+            }
+          : null
+      }
+      disableGenerate={multiPromptInvalid || audioWorkflowUnsupported}
+      extraFields={
+        <>
+          {showRetakeWorkflowAction ? (
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="space-y-0.5">
+                <p className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">Edit workflow</p>
+                <p className="text-xs text-text-secondary">Use retake when you want to reinterpret an existing clip.</p>
+              </div>
+              <Button
+                type="button"
+                size="sm"
+                variant={form.mode === 'retake' ? 'primary' : 'outline'}
+                onClick={() => handleComposerModeToggle(form.mode === 'retake' ? null : 'retake')}
+                disabled={audioWorkflowLocked}
+                title={audioWorkflowLocked ? workflowCopy.removeAudioToUnlock : undefined}
+                className="min-h-0 h-auto rounded-full px-3 py-2 text-[11px] font-semibold tracking-micro"
+              >
+                {getLocalizedModeLabel('retake', uiLocale)}
+              </Button>
+            </div>
+          ) : null}
+          {supportsKlingV3Controls && activeMode === 'i2v' ? (
+            <KlingElementsBuilder
+              elements={klingElements}
+              onAddElement={handleKlingElementAdd}
+              onRemoveElement={handleKlingElementRemove}
+              onAddAsset={handleKlingElementAssetAdd}
+              onRemoveAsset={handleKlingElementAssetRemove}
+              onOpenLibrary={handleOpenKlingAssetLibrary}
+            />
+          ) : null}
+          <SettingsControls
+            engine={selectedEngine}
+            caps={capability}
+            durationSec={durationSec}
+            durationOption={form.durationOption ?? null}
+            onDurationChange={handleDurationChange}
+            numFrames={form.numFrames ?? undefined}
+            onNumFramesChange={handleFramesChange}
+            resolution={form.resolution}
+            onResolutionChange={handleResolutionChange}
+            aspectRatio={form.aspectRatio}
+            onAspectRatioChange={handleAspectRatioChange}
+            fps={form.fps}
+            onFpsChange={handleFpsChange}
+            mode={submissionMode}
+            showAudioControl={supportsAudioToggle}
+            audioEnabled={form.audio}
+            audioControlDisabled={voiceControlEnabled}
+            audioControlNote={audioControlNote}
+            onAudioChange={handleAudioChange}
+            showLoopControl={isLumaRay2EngineId(selectedEngine.id) && isLumaRay2GenerateMode(submissionMode)}
+            loopEnabled={
+              isLumaRay2EngineId(selectedEngine.id) && isLumaRay2GenerateMode(submissionMode)
+                ? Boolean(form.loop)
+                : undefined
+            }
+            onLoopChange={handleLoopChange}
+            showExtendControl={false}
+            seedLocked={form.seedLocked}
+            onSeedLockedChange={handleSeedLockedChange}
+            cfgScale={cfgScale}
+            onCfgScaleChange={setCfgScale}
+            durationManaged={multiPromptActive}
+            durationManagedLabel={durationManagedLabel}
+            showKlingV3Controls={supportsKlingV3Controls}
+            showKlingV3VoiceControls={supportsKlingV3VoiceControl}
+            klingShotType={shotType}
+            onKlingShotTypeChange={setShotType}
+            voiceIdsValue={voiceIdsInput}
+            onVoiceIdsChange={setVoiceIdsInput}
+            voiceControlActive={voiceControlEnabled}
+            showSeedanceControls={isSeedance}
+            seedValue={seedValue}
+            onSeedChange={handleSeedChange}
+            cameraFixed={cameraFixedValue}
+            onCameraFixedChange={handleCameraFixedChange}
+            safetyChecker={safetyCheckerValue}
+            onSafetyCheckerChange={handleSafetyCheckerChange}
+            showSafetyCheckerControl={showSafetyCheckerControl}
+            advancedFields={inputSchemaSummary.secondaryFields}
+            advancedFieldValues={form.extraInputValues}
+            onAdvancedFieldChange={handleExtraInputValueChange}
+            variant="advanced"
+          />
+        </>
+      }
+      settingsBar={
+        <CoreSettingsBar
+          engine={selectedEngine}
+          mode={submissionMode}
+          caps={capability}
+          iterations={form.iterations}
+          onIterationsChange={handleIterationsChange}
+          durationSec={durationSec}
+          durationOption={form.durationOption ?? null}
+          onDurationChange={handleDurationChange}
+          numFrames={form.numFrames ?? undefined}
+          onNumFramesChange={handleFramesChange}
+          resolution={form.resolution}
+          onResolutionChange={handleResolutionChange}
+          aspectRatio={form.aspectRatio}
+          onAspectRatioChange={handleAspectRatioChange}
+          fps={form.fps}
+          onFpsChange={handleFpsChange}
+          showAudioControl={supportsAudioToggle}
+          audioEnabled={form.audio}
+          audioControlDisabled={voiceControlEnabled}
+          audioControlNote={audioControlNote}
+          onAudioChange={handleAudioChange}
+          durationManaged={multiPromptActive}
+          durationManagedLabel={durationManagedLabel}
+        />
+      }
+    />
+  );
+}

--- a/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceInputSchemaState.ts
+++ b/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceInputSchemaState.ts
@@ -1,0 +1,154 @@
+import { useEffect, useMemo } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import { SEEDANCE_REFERENCE_AUDIO_FIELD_IDS } from '@/lib/seedance-workflow';
+import type { EngineCaps, Mode } from '@/types/engines';
+import {
+  buildAssetFieldIdSet,
+  buildReferenceAudioFieldIds,
+  getPrimaryAssetFieldLabel,
+  revokeAssetPreview,
+  type ReferenceAsset,
+} from '../_lib/workspace-assets';
+import type { FormState } from '../_lib/workspace-form-state';
+import { summarizeWorkspaceInputSchema } from '../_lib/workspace-input-schema';
+
+type UseWorkspaceInputSchemaStateOptions = {
+  selectedEngine: EngineCaps | null;
+  activeMode: Mode;
+  allowsUnifiedVeoFirstLast: boolean;
+  isUnifiedHappyHorse: boolean;
+  isUnifiedSeedance: boolean;
+  uiLocale: string;
+  authChecked: boolean;
+  authLoading: boolean;
+  authenticatedUserId?: string | null;
+  uploadLockedCopy: string;
+  setInputAssets: Dispatch<SetStateAction<Record<string, (ReferenceAsset | null)[]>>>;
+  setForm: Dispatch<SetStateAction<FormState | null>>;
+};
+
+export function useWorkspaceInputSchemaState({
+  selectedEngine,
+  activeMode,
+  allowsUnifiedVeoFirstLast,
+  isUnifiedHappyHorse,
+  isUnifiedSeedance,
+  uiLocale,
+  authChecked,
+  authLoading,
+  authenticatedUserId,
+  uploadLockedCopy,
+  setInputAssets,
+  setForm,
+}: UseWorkspaceInputSchemaStateOptions) {
+  const inputSchemaSummary = useMemo(
+    () =>
+      summarizeWorkspaceInputSchema({
+        selectedEngine,
+        activeMode,
+        allowsUnifiedVeoFirstLast,
+        isUnifiedHappyHorse,
+        isUnifiedSeedance,
+        uiLocale,
+      }),
+    [activeMode, allowsUnifiedVeoFirstLast, isUnifiedHappyHorse, isUnifiedSeedance, selectedEngine, uiLocale]
+  );
+
+  const extraInputFields = useMemo(
+    () => [...inputSchemaSummary.promotedFields, ...inputSchemaSummary.secondaryFields],
+    [inputSchemaSummary.promotedFields, inputSchemaSummary.secondaryFields]
+  );
+
+  useEffect(() => {
+    setForm((current) => {
+      if (!current) return current;
+      const allowedFieldIds = new Set(extraInputFields.map(({ field }) => field.id));
+      const nextExtraInputValues = Object.entries(current.extraInputValues).reduce<Record<string, unknown>>(
+        (acc, [key, value]) => {
+          if (allowedFieldIds.has(key)) {
+            acc[key] = value;
+          }
+          return acc;
+        },
+        {}
+      );
+      if (JSON.stringify(nextExtraInputValues) === JSON.stringify(current.extraInputValues)) {
+        return current;
+      }
+      return { ...current, extraInputValues: nextExtraInputValues };
+    });
+  }, [extraInputFields, setForm]);
+
+  useEffect(() => {
+    setInputAssets((previous) => {
+      if (!inputSchemaSummary.assetFields.length) {
+        if (Object.keys(previous).length === 0) return previous;
+        Object.values(previous).forEach((entries) => {
+          entries.forEach((asset) => revokeAssetPreview(asset));
+        });
+        return {};
+      }
+      const allowed = new Set(inputSchemaSummary.assetFields.map((entry) => entry.field.id));
+      let changed = false;
+      const next: Record<string, (ReferenceAsset | null)[]> = {};
+      Object.entries(previous).forEach(([fieldId, items]) => {
+        if (allowed.has(fieldId)) {
+          next[fieldId] = items;
+        } else {
+          changed = true;
+          items.forEach((asset) => revokeAssetPreview(asset));
+        }
+      });
+      return changed ? next : previous;
+    });
+  }, [inputSchemaSummary.assetFields, setInputAssets]);
+
+  const primaryAssetFieldIds = useMemo(
+    () => buildAssetFieldIdSet(inputSchemaSummary.assetFields, (entry) => entry.role === 'primary'),
+    [inputSchemaSummary.assetFields]
+  );
+
+  const referenceAssetFieldIds = useMemo(
+    () => buildAssetFieldIdSet(inputSchemaSummary.assetFields, (entry) => entry.role === 'reference'),
+    [inputSchemaSummary.assetFields]
+  );
+
+  const genericImageFieldIds = useMemo(
+    () =>
+      buildAssetFieldIdSet(
+        inputSchemaSummary.assetFields,
+        (entry) => entry.role === 'generic' && entry.field.type === 'image'
+      ),
+    [inputSchemaSummary.assetFields]
+  );
+
+  const frameAssetFieldIds = useMemo(
+    () => buildAssetFieldIdSet(inputSchemaSummary.assetFields, (entry) => entry.role === 'frame'),
+    [inputSchemaSummary.assetFields]
+  );
+
+  const referenceAudioFieldIds = useMemo(
+    () => buildReferenceAudioFieldIds(inputSchemaSummary.assetFields, SEEDANCE_REFERENCE_AUDIO_FIELD_IDS),
+    [inputSchemaSummary.assetFields]
+  );
+
+  const primaryAssetFieldLabel = useMemo(
+    () => getPrimaryAssetFieldLabel(inputSchemaSummary.assetFields),
+    [inputSchemaSummary.assetFields]
+  );
+
+  const guestUploadLockedReason =
+    !authChecked || (!authLoading && !authenticatedUserId) ? uploadLockedCopy : null;
+
+  return {
+    inputSchemaSummary,
+    extraInputFields,
+    primaryAssetFieldIds,
+    referenceAssetFieldIds,
+    genericImageFieldIds,
+    frameAssetFieldIds,
+    referenceAudioFieldIds,
+    primaryAssetFieldLabel,
+    guestUploadLockedReason,
+  };
+}

--- a/tests/workspace-composer-surface-contract.test.ts
+++ b/tests/workspace-composer-surface-contract.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const appClientPath = 'frontend/app/(core)/(workspace)/app/AppClient.tsx';
+const composerSurfacePath = 'frontend/app/(core)/(workspace)/app/_components/WorkspaceComposerSurface.tsx';
+
+test('workspace composer and settings surface is owned by a route-local component', () => {
+  assert.equal(existsSync(composerSurfacePath), true);
+
+  const appSource = readFileSync(appClientPath, 'utf8');
+  const surfaceSource = readFileSync(composerSurfacePath, 'utf8');
+
+  assert.match(appSource, /import \{ WorkspaceComposerSurface \} from '\.\/_components\/WorkspaceComposerSurface';/);
+  assert.match(appSource, /<WorkspaceComposerSurface/);
+
+  assert.doesNotMatch(appSource, /<Composer\b/);
+  assert.doesNotMatch(appSource, /<SettingsControls\b/);
+  assert.doesNotMatch(appSource, /<CoreSettingsBar\b/);
+  assert.doesNotMatch(appSource, /<KlingElementsBuilder\b/);
+  assert.doesNotMatch(appSource, /buildComposerAttachments/);
+  assert.doesNotMatch(appSource, /buildComposerPromotedActions/);
+  assert.doesNotMatch(appSource, /normalizeExtraInputValue/);
+  assert.doesNotMatch(appSource, /getSeedanceFieldBlockKey/);
+  assert.doesNotMatch(appSource, /MULTI_PROMPT_MIN_SEC/);
+  assert.doesNotMatch(appSource, /getLocalizedModeLabel/);
+
+  assert.match(surfaceSource, /export function WorkspaceComposerSurface/);
+  assert.match(surfaceSource, /<Composer\b/);
+  assert.match(surfaceSource, /<SettingsControls\b/);
+  assert.match(surfaceSource, /<CoreSettingsBar\b/);
+  assert.match(surfaceSource, /KlingElementsBuilder/);
+  assert.match(surfaceSource, /buildComposerAttachments/);
+  assert.match(surfaceSource, /buildComposerPromotedActions/);
+  assert.match(surfaceSource, /normalizeExtraInputValue/);
+  assert.match(surfaceSource, /getSeedanceFieldBlockKey/);
+  assert.match(surfaceSource, /MULTI_PROMPT_MIN_SEC/);
+  assert.match(surfaceSource, /getLocalizedModeLabel/);
+});

--- a/tests/workspace-input-schema-hook-contract.test.ts
+++ b/tests/workspace-input-schema-hook-contract.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const appClientPath = 'frontend/app/(core)/(workspace)/app/AppClient.tsx';
+const inputSchemaHookPath = 'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceInputSchemaState.ts';
+
+test('workspace input schema derivation is owned by a route-local hook', () => {
+  assert.equal(existsSync(inputSchemaHookPath), true);
+
+  const appSource = readFileSync(appClientPath, 'utf8');
+  const hookSource = readFileSync(inputSchemaHookPath, 'utf8');
+
+  assert.match(appSource, /import \{ useWorkspaceInputSchemaState \} from '\.\/_hooks\/useWorkspaceInputSchemaState';/);
+  assert.match(appSource, /useWorkspaceInputSchemaState\(\{/);
+
+  assert.doesNotMatch(appSource, /summarizeWorkspaceInputSchema/);
+  assert.doesNotMatch(appSource, /buildAssetFieldIdSet/);
+  assert.doesNotMatch(appSource, /buildReferenceAudioFieldIds/);
+  assert.doesNotMatch(appSource, /getPrimaryAssetFieldLabel/);
+  assert.doesNotMatch(appSource, /revokeAssetPreview/);
+  assert.doesNotMatch(appSource, /SEEDANCE_REFERENCE_AUDIO_FIELD_IDS/);
+
+  assert.match(hookSource, /export function useWorkspaceInputSchemaState/);
+  assert.match(hookSource, /summarizeWorkspaceInputSchema/);
+  assert.match(hookSource, /buildAssetFieldIdSet/);
+  assert.match(hookSource, /buildReferenceAudioFieldIds/);
+  assert.match(hookSource, /getPrimaryAssetFieldLabel/);
+  assert.match(hookSource, /revokeAssetPreview/);
+  assert.match(hookSource, /SEEDANCE_REFERENCE_AUDIO_FIELD_IDS/);
+});


### PR DESCRIPTION
## Summary
- move the workspace Composer, advanced settings, core settings bar, and Kling element UI into `WorkspaceComposerSurface`
- move workspace input schema derivation, field id sets, upload lock reason, and stale asset pruning into `useWorkspaceInputSchemaState`
- add architecture contracts and AGENTS guidance so `AppClient.tsx` stays as orchestration only

## Verification
- ./node_modules/.bin/tsc --noEmit
- npm --prefix frontend run lint
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/workspace-composer-surface-contract.test.ts tests/workspace-input-schema-hook-contract.test.ts tests/workspace-composer-state-hook-contract.test.ts tests/workspace-video-settings-hook-contract.test.ts tests/workspace-draft-and-surfaces-contract.test.ts tests/workspace-generation-runner-hook-contract.test.ts tests/workspace-pricing-gate-hook-contract.test.ts tests/workspace-gallery-rail-contract.test.ts
- pnpm run test:validate
- git diff --check
- npm --prefix frontend run build

## Notes
- `AppClient.tsx` is now 858 lines, down from 1128 after the previous PR
- branch was checked against latest `origin/main` before push