### PR TITLE
Split workspace shell route state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,15 @@ For large files, split by responsibility rather than by technical layer:
 - client-only interactions
 - tables/charts/panels
 
+## Workspace App Boundaries
+
+For the authenticated workspace route, keep `frontend/app/(core)/(workspace)/app/AppClient.tsx` as the route-level orchestrator.
+
+- Keep route shell rendering in `_components/WorkspaceAppShell.tsx`; `AppClient.tsx` should not compose `WorkspaceChrome`, `GalleryRail`, the center gallery, or the preview dock inline.
+- Keep notice timers, onboarding route redirects, and preview/viewer composition in route-local hooks under `_hooks/`.
+- Keep composer JSX in `_components/WorkspaceComposerSurface.tsx` and shared modal wiring in `_components/WorkspaceRuntimeModals.tsx`.
+- Add or update contract tests in `tests/workspace-*-contract.test.ts` when moving workspace responsibilities, so the architecture stays explicit.
+
 ## Verification
 
 Use focused checks first:
@@ -127,4 +136,3 @@ For client app pages, verify:
 ## Documentation
 
 When adding a new feature area, add or update the relevant guide in `docs/engineering/` if future work would otherwise require rediscovering the architecture.
-

--- a/frontend/app/(core)/(workspace)/app/AppClient.tsx
+++ b/frontend/app/(core)/(workspace)/app/AppClient.tsx
@@ -2,41 +2,25 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useEngines, useInfiniteJobs, getJobStatus } from '@/lib/api';
-import { authFetch } from '@/lib/authFetch';
-import { useRouter } from 'next/navigation';
 import type { EngineCaps } from '@/types/engines';
 import type { MultiPromptScene } from '@/components/Composer';
 import type { KlingElementState } from '@/components/KlingElementsBuilder';
-import type { GalleryRailProps } from '@/components/GalleryRail';
 import type { GroupSummary } from '@/types/groups';
-import dynamic from 'next/dynamic';
 import { DEFAULT_PROCESSING_COPY } from '@/components/groups/ProcessingOverlay';
 import { ENV as CLIENT_ENV } from '@/lib/env';
-import { adaptGroupSummary } from '@/lib/video-group-adapter';
 import type { VideoGroup } from '@/types/video-groups';
-import {
-  mapSelectedPreviewToGroup,
-  type SharedVideoPreview,
-} from '@/lib/video-preview-group';
+import type { SharedVideoPreview } from '@/lib/video-preview-group';
 import { useResultProvider } from '@/hooks/useResultProvider';
-import { normalizeGroupSummary } from '@/lib/normalize-group-summary';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { useI18n } from '@/lib/i18n/I18nProvider';
 import {
   getLocalizedWorkflowCopy,
   normalizeUiLocale,
 } from '@/lib/ltx-localization';
+import { WorkspaceAppShell } from './_components/WorkspaceAppShell';
 import { WorkspaceBootSurface } from './_components/WorkspaceBootSurface';
-import { WorkspaceCenterGallery } from './_components/WorkspaceCenterGallery';
-import { WorkspaceChrome } from './_components/WorkspaceChrome';
 import { WorkspaceComposerSurface } from './_components/WorkspaceComposerSurface';
-import {
-  GalleryRailSkeleton,
-} from './_components/WorkspaceBootSkeletons';
-import { WorkspacePreviewDock } from './_components/WorkspacePreviewDock';
-import type { WorkspaceViewerTarget } from './_components/WorkspacePreviewDock';
 import { WorkspaceRuntimeModals } from './_components/WorkspaceRuntimeModals';
-import { getCompositePreviewPosterSrc } from './_lib/composite-preview';
 import {
   type FormState,
 } from './_lib/workspace-form-state';
@@ -59,17 +43,12 @@ import { useWorkspaceDraftStorage } from './_hooks/useWorkspaceDraftStorage';
 import { useWorkspaceGalleryActions } from './_hooks/useWorkspaceGalleryActions';
 import { useWorkspaceGenerationRunner } from './_hooks/useWorkspaceGenerationRunner';
 import { useWorkspaceInputSchemaState } from './_hooks/useWorkspaceInputSchemaState';
+import { useWorkspaceNotice } from './_hooks/useWorkspaceNotice';
+import { useWorkspacePreviewState } from './_hooks/useWorkspacePreviewState';
 import { useWorkspacePricingGate } from './_hooks/useWorkspacePricingGate';
 import { useWorkspaceRenderState } from './_hooks/useWorkspaceRenderState';
+import { useWorkspaceRouteNavigation } from './_hooks/useWorkspaceRouteNavigation';
 import { useWorkspaceVideoSettings } from './_hooks/useWorkspaceVideoSettings';
-
-const GalleryRail = dynamic<GalleryRailProps>(
-  () => import('@/components/GalleryRail').then((mod) => mod.GalleryRail),
-  {
-    ssr: false,
-    loading: () => <GalleryRailSkeleton />,
-  }
-);
 
 export default function AppClientPage({ initialPreviewGroup = null }: { initialPreviewGroup?: VideoGroup | null }) {
   const { data, error: enginesError, isLoading } = useEngines();
@@ -113,8 +92,6 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
     [processingCopy.takeLabel]
   );
 
-  const router = useRouter();
-
   const [form, setForm] = useState<FormState | null>(null);
   const [prompt, setPrompt] = useState<string>(DEFAULT_PROMPT);
   const [negativePrompt, setNegativePrompt] = useState<string>('');
@@ -125,7 +102,7 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
   const [klingElements, setKlingElements] = useState<KlingElementState[]>(() => [createKlingElement()]);
   const [cfgScale, setCfgScale] = useState<number | null>(null);
   const [memberTier, setMemberTier] = useState<'Member' | 'Plus' | 'Pro'>('Member');
-  const [notice, setNotice] = useState<string | null>(null);
+  const { notice, showNotice, setNotice } = useWorkspaceNotice();
 
   const {
     fromVideoId,
@@ -154,9 +131,12 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
     authStatus,
     authenticatedUserId: user?.id,
   });
+  const { replaceWorkspaceRoute } = useWorkspaceRouteNavigation({
+    authChecked,
+    skipOnboardingRef,
+  });
   const [sharedPrompt, setSharedPrompt] = useState<string | null>(null);
   const [sharedVideoSettings, setSharedVideoSettings] = useState<SharedVideoPreview | null>(null);
-  const [viewerTarget, setViewerTarget] = useState<WorkspaceViewerTarget>(null);
   const isDesktopLayout = useWorkspaceDesktopLayout();
   const [compositeOverride, setCompositeOverride] = useState<VideoGroup | null>(null);
   const [compositeOverrideSummary, setCompositeOverrideSummary] = useState<GroupSummary | null>(null);
@@ -231,40 +211,26 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
     resetRenderState,
   });
 
-  const compositeGroup = compositeOverride ?? activeVideoGroup ?? null;
-  const selectedPreviewGroup = useMemo(() => mapSelectedPreviewToGroup(selectedPreview, provider), [selectedPreview, provider]);
-  const initialPreviewFallbackGroup =
-    effectiveRequestedEngineId || effectiveRequestedEngineToken || requestedJobId || fromVideoId
-      ? null
-      : initialPreviewGroup;
-  const displayCompositeGroup = compositeGroup ?? selectedPreviewGroup ?? initialPreviewFallbackGroup;
-  const compositePreviewPosterSrc = useMemo(() => getCompositePreviewPosterSrc(displayCompositeGroup), [displayCompositeGroup]);
-
-  const viewerGroup = useMemo<VideoGroup | null>(() => {
-    if (!viewerTarget) return null;
-    if (viewerTarget.kind === 'pending') {
-      const summary = pendingSummaryMap.get(viewerTarget.id);
-      if (!summary) return null;
-      return adaptGroupSummary(normalizeGroupSummary(summary), provider);
-    }
-    if (viewerTarget.kind === 'group') {
-      return viewerTarget.group;
-    }
-    return adaptGroupSummary(normalizeGroupSummary(viewerTarget.summary), provider);
-  }, [viewerTarget, pendingSummaryMap, provider]);
+  const {
+    setViewerTarget,
+    viewerGroup,
+    initialPreviewFallbackGroup,
+    displayCompositeGroup,
+    compositePreviewPosterSrc,
+  } = useWorkspacePreviewState({
+    provider,
+    selectedPreview,
+    pendingSummaryMap,
+    compositeOverride,
+    activeVideoGroup,
+    initialPreviewGroup,
+    effectiveRequestedEngineId,
+    effectiveRequestedEngineToken,
+    requestedJobId,
+    fromVideoId,
+  });
 
   const composerRef = useRef<HTMLTextAreaElement | null>(null);
-  const noticeTimeoutRef = useRef<number | null>(null);
-  const showNotice = useCallback((message: string) => {
-    setNotice(message);
-    if (noticeTimeoutRef.current !== null) {
-      window.clearTimeout(noticeTimeoutRef.current);
-    }
-    noticeTimeoutRef.current = window.setTimeout(() => {
-      setNotice(null);
-      noticeTimeoutRef.current = null;
-    }, 6000);
-  }, []);
 
   const {
     inputAssets,
@@ -312,55 +278,10 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
     }
   }, []);
 
-  useEffect(() => {
-    if (!authChecked || skipOnboardingRef.current) return undefined;
-    if (process.env.NODE_ENV !== 'production') {
-      console.log('[app] onboarding check running', { skip: skipOnboardingRef.current });
-    }
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await authFetch('/api/user/exports/summary');
-        if (!res.ok) return;
-        const json = await res.json();
-        if (!json?.ok) return;
-        if (cancelled) return;
-        if ((json.total ?? 0) === 0 && json.onboardingDone !== true) {
-          const params: Record<string, string> = { tab: 'starter', first: '1' };
-          const search = new URLSearchParams(params).toString();
-          router.replace(`/gallery?${search}`);
-          await authFetch('/api/user/preferences', {
-            method: 'PATCH',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({ onboardingDone: true }),
-          }).catch(() => undefined);
-        }
-      } catch (error) {
-        console.warn('[app] onboarding redirect failed', error);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [authChecked, router, skipOnboardingRef]);
-
-  useEffect(() => {
-    return () => {
-      if (noticeTimeoutRef.current !== null) {
-        window.clearTimeout(noticeTimeoutRef.current);
-      }
-    };
-  }, []);
-
   const focusComposer = useCallback(() => {
     if (!composerRef.current) return;
     composerRef.current.focus({ preventScroll: true });
   }, []);
-  const replaceWorkspaceRoute = useCallback((href: string) => {
-    router.replace(href);
-  }, [router]);
 
   const engineMap = useMemo(() => {
     const map = new Map<string, EngineCaps>();
@@ -681,67 +602,39 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
 
   return (
     <>
-      <WorkspaceChrome
+      <WorkspaceAppShell
         isDesktopLayout={isDesktopLayout}
-        desktopRail={
-          <GalleryRail
-            engine={selectedEngine}
-            engineRegistry={engines}
-            activeGroups={normalizedPendingGroups}
-            onOpenGroup={openGroupViaGallery}
-            onGroupAction={handleGalleryGroupAction}
-            onFeedStateChange={handleGalleryFeedStateChange}
-            variant="desktop"
-          />
-        }
-        mobileRail={
-          <GalleryRail
-            engine={selectedEngine}
-            engineRegistry={engines}
-            activeGroups={normalizedPendingGroups}
-            onOpenGroup={openGroupViaGallery}
-            onGroupAction={handleGalleryGroupAction}
-            onFeedStateChange={handleGalleryFeedStateChange}
-            variant="mobile"
-          />
-        }
-      >
-            {notice && (
-              <div className="rounded-card border border-warning-border bg-warning-bg px-4 py-2 text-sm text-warning shadow-card">
-                {notice}
-              </div>
-            )}
-            <div className="stack-gap-lg">
-              <WorkspaceCenterGallery
-                show={showCenterGallery}
-                groups={normalizedPendingGroups}
-                engineMap={engineMap}
-                isGenerationLoading={isGenerationLoading}
-                generationSkeletonCount={generationSkeletonCount}
-                emptyLabel={workspaceCopy.gallery.empty}
-                onOpenGroup={handleActiveGroupOpen}
-                onGroupAction={handleActiveGroupAction}
-              />
-              <WorkspacePreviewDock
-                group={displayCompositeGroup}
-                isLoading={isGenerationLoading && !displayCompositeGroup}
-                autoPlayRequestId={previewAutoPlayRequestId}
-                sharedPrompt={sharedPrompt}
-                hasSharedVideoSettings={Boolean(sharedVideoSettings)}
-                onCopySharedPrompt={handleCopySharedPrompt}
-                guidedNavigation={guidedNavigation}
-                engines={engines}
-                engineId={form.engineId}
-                selectedEngineId={selectedEngine.id}
-                activeMode={activeMode}
-                engineModeOptions={engineModeOptions}
-                modeLabelLocale={uiLocale}
-                onEngineChange={handleEngineChange}
-                onModeChange={handleModeChange}
-                renderGroups={renderGroups}
-                compositeOverrideSummary={compositeOverrideSummary}
-                setViewerTarget={setViewerTarget}
-              />
+        selectedEngine={selectedEngine}
+        engines={engines}
+        normalizedPendingGroups={normalizedPendingGroups}
+        openGroupViaGallery={openGroupViaGallery}
+        handleGalleryGroupAction={handleGalleryGroupAction}
+        handleGalleryFeedStateChange={handleGalleryFeedStateChange}
+        notice={notice}
+        showCenterGallery={showCenterGallery}
+        engineMap={engineMap}
+        isGenerationLoading={isGenerationLoading}
+        generationSkeletonCount={generationSkeletonCount}
+        galleryEmptyLabel={workspaceCopy.gallery.empty}
+        handleActiveGroupOpen={handleActiveGroupOpen}
+        handleActiveGroupAction={handleActiveGroupAction}
+        displayCompositeGroup={displayCompositeGroup}
+        previewAutoPlayRequestId={previewAutoPlayRequestId}
+        sharedPrompt={sharedPrompt}
+        hasSharedVideoSettings={Boolean(sharedVideoSettings)}
+        handleCopySharedPrompt={handleCopySharedPrompt}
+        guidedNavigation={guidedNavigation}
+        engineId={form.engineId}
+        selectedEngineId={selectedEngine.id}
+        activeMode={activeMode}
+        engineModeOptions={engineModeOptions}
+        modeLabelLocale={uiLocale}
+        handleEngineChange={handleEngineChange}
+        handleModeChange={handleModeChange}
+        renderGroups={renderGroups}
+        compositeOverrideSummary={compositeOverrideSummary}
+        setViewerTarget={setViewerTarget}
+        composerSurface={
               <WorkspaceComposerSurface
                 selectedEngine={selectedEngine}
                 form={form}
@@ -818,8 +711,8 @@ export default function AppClientPage({ initialPreviewGroup = null }: { initialP
                 handleOpenKlingAssetLibrary={handleOpenKlingAssetLibrary}
                 setViewMode={setViewMode}
               />
-            </div>
-      </WorkspaceChrome>
+        }
+      />
       <WorkspaceRuntimeModals
         viewerGroup={viewerGroup}
         onCloseViewer={() => setViewerTarget(null)}

--- a/frontend/app/(core)/(workspace)/app/_components/WorkspaceAppShell.tsx
+++ b/frontend/app/(core)/(workspace)/app/_components/WorkspaceAppShell.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import type { ComponentProps, ReactNode } from 'react';
+import dynamic from 'next/dynamic';
+import type { GalleryRailProps } from '@/components/GalleryRail';
+import type { EngineCaps, Mode } from '@/types/engines';
+import type { GroupSummary } from '@/types/groups';
+import type { VideoGroup } from '@/types/video-groups';
+import { GalleryRailSkeleton } from './WorkspaceBootSkeletons';
+import { WorkspaceCenterGallery } from './WorkspaceCenterGallery';
+import { WorkspaceChrome } from './WorkspaceChrome';
+import { WorkspacePreviewDock } from './WorkspacePreviewDock';
+
+const GalleryRail = dynamic<GalleryRailProps>(
+  () => import('@/components/GalleryRail').then((mod) => mod.GalleryRail),
+  {
+    ssr: false,
+    loading: () => <GalleryRailSkeleton />,
+  }
+);
+
+type CenterGalleryProps = ComponentProps<typeof WorkspaceCenterGallery>;
+type PreviewDockProps = ComponentProps<typeof WorkspacePreviewDock>;
+
+type WorkspaceAppShellProps = {
+  isDesktopLayout: boolean;
+  selectedEngine: EngineCaps;
+  engines: EngineCaps[];
+  normalizedPendingGroups: GroupSummary[];
+  openGroupViaGallery: GalleryRailProps['onOpenGroup'];
+  handleGalleryGroupAction: GalleryRailProps['onGroupAction'];
+  handleGalleryFeedStateChange: GalleryRailProps['onFeedStateChange'];
+  notice: string | null;
+  showCenterGallery: boolean;
+  engineMap: ReadonlyMap<string, EngineCaps>;
+  isGenerationLoading: boolean;
+  generationSkeletonCount: number;
+  galleryEmptyLabel: string;
+  handleActiveGroupOpen: CenterGalleryProps['onOpenGroup'];
+  handleActiveGroupAction: CenterGalleryProps['onGroupAction'];
+  displayCompositeGroup: VideoGroup | null;
+  previewAutoPlayRequestId: PreviewDockProps['autoPlayRequestId'];
+  sharedPrompt: string | null;
+  hasSharedVideoSettings: boolean;
+  handleCopySharedPrompt: () => void;
+  guidedNavigation: PreviewDockProps['guidedNavigation'];
+  engineId: string;
+  selectedEngineId: string;
+  activeMode: Mode;
+  engineModeOptions: Mode[] | undefined;
+  modeLabelLocale: string;
+  handleEngineChange: (engineId: string) => void;
+  handleModeChange: (mode: Mode) => void;
+  renderGroups: PreviewDockProps['renderGroups'];
+  compositeOverrideSummary: PreviewDockProps['compositeOverrideSummary'];
+  setViewerTarget: PreviewDockProps['setViewerTarget'];
+  composerSurface: ReactNode;
+};
+
+export function WorkspaceAppShell({
+  isDesktopLayout,
+  selectedEngine,
+  engines,
+  normalizedPendingGroups,
+  openGroupViaGallery,
+  handleGalleryGroupAction,
+  handleGalleryFeedStateChange,
+  notice,
+  showCenterGallery,
+  engineMap,
+  isGenerationLoading,
+  generationSkeletonCount,
+  galleryEmptyLabel,
+  handleActiveGroupOpen,
+  handleActiveGroupAction,
+  displayCompositeGroup,
+  previewAutoPlayRequestId,
+  sharedPrompt,
+  hasSharedVideoSettings,
+  handleCopySharedPrompt,
+  guidedNavigation,
+  engineId,
+  selectedEngineId,
+  activeMode,
+  engineModeOptions,
+  modeLabelLocale,
+  handleEngineChange,
+  handleModeChange,
+  renderGroups,
+  compositeOverrideSummary,
+  setViewerTarget,
+  composerSurface,
+}: WorkspaceAppShellProps) {
+  return (
+    <WorkspaceChrome
+      isDesktopLayout={isDesktopLayout}
+      desktopRail={
+        <GalleryRail
+          engine={selectedEngine}
+          engineRegistry={engines}
+          activeGroups={normalizedPendingGroups}
+          onOpenGroup={openGroupViaGallery}
+          onGroupAction={handleGalleryGroupAction}
+          onFeedStateChange={handleGalleryFeedStateChange}
+          variant="desktop"
+        />
+      }
+      mobileRail={
+        <GalleryRail
+          engine={selectedEngine}
+          engineRegistry={engines}
+          activeGroups={normalizedPendingGroups}
+          onOpenGroup={openGroupViaGallery}
+          onGroupAction={handleGalleryGroupAction}
+          onFeedStateChange={handleGalleryFeedStateChange}
+          variant="mobile"
+        />
+      }
+    >
+      {notice && (
+        <div className="rounded-card border border-warning-border bg-warning-bg px-4 py-2 text-sm text-warning shadow-card">
+          {notice}
+        </div>
+      )}
+      <div className="stack-gap-lg">
+        <WorkspaceCenterGallery
+          show={showCenterGallery}
+          groups={normalizedPendingGroups}
+          engineMap={engineMap}
+          isGenerationLoading={isGenerationLoading}
+          generationSkeletonCount={generationSkeletonCount}
+          emptyLabel={galleryEmptyLabel}
+          onOpenGroup={handleActiveGroupOpen}
+          onGroupAction={handleActiveGroupAction}
+        />
+        <WorkspacePreviewDock
+          group={displayCompositeGroup}
+          isLoading={isGenerationLoading && !displayCompositeGroup}
+          autoPlayRequestId={previewAutoPlayRequestId}
+          sharedPrompt={sharedPrompt}
+          hasSharedVideoSettings={hasSharedVideoSettings}
+          onCopySharedPrompt={handleCopySharedPrompt}
+          guidedNavigation={guidedNavigation}
+          engines={engines}
+          engineId={engineId}
+          selectedEngineId={selectedEngineId}
+          activeMode={activeMode}
+          engineModeOptions={engineModeOptions}
+          modeLabelLocale={modeLabelLocale}
+          onEngineChange={handleEngineChange}
+          onModeChange={handleModeChange}
+          renderGroups={renderGroups}
+          compositeOverrideSummary={compositeOverrideSummary}
+          setViewerTarget={setViewerTarget}
+        />
+        {composerSurface}
+      </div>
+    </WorkspaceChrome>
+  );
+}

--- a/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceNotice.ts
+++ b/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceNotice.ts
@@ -1,0 +1,31 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export function useWorkspaceNotice() {
+  const [notice, setNotice] = useState<string | null>(null);
+  const noticeTimeoutRef = useRef<number | null>(null);
+
+  const showNotice = useCallback((message: string) => {
+    setNotice(message);
+    if (noticeTimeoutRef.current !== null) {
+      window.clearTimeout(noticeTimeoutRef.current);
+    }
+    noticeTimeoutRef.current = window.setTimeout(() => {
+      setNotice(null);
+      noticeTimeoutRef.current = null;
+    }, 6000);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (noticeTimeoutRef.current !== null) {
+        window.clearTimeout(noticeTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  return {
+    notice,
+    showNotice,
+    setNotice,
+  };
+}

--- a/frontend/app/(core)/(workspace)/app/_hooks/useWorkspacePreviewState.ts
+++ b/frontend/app/(core)/(workspace)/app/_hooks/useWorkspacePreviewState.ts
@@ -1,0 +1,76 @@
+import { useMemo, useState } from 'react';
+import { adaptGroupSummary } from '@/lib/video-group-adapter';
+import {
+  mapSelectedPreviewToGroup,
+  type SelectedVideoPreview,
+} from '@/lib/video-preview-group';
+import { normalizeGroupSummary } from '@/lib/normalize-group-summary';
+import type { GroupSummary } from '@/types/groups';
+import type { ResultProvider, VideoGroup } from '@/types/video-groups';
+import { getCompositePreviewPosterSrc } from '../_lib/composite-preview';
+import type { WorkspaceViewerTarget } from '../_components/WorkspacePreviewDock';
+
+type UseWorkspacePreviewStateOptions = {
+  provider: ResultProvider;
+  selectedPreview: SelectedVideoPreview | null;
+  pendingSummaryMap: Map<string, GroupSummary>;
+  compositeOverride: VideoGroup | null;
+  activeVideoGroup: VideoGroup | null;
+  initialPreviewGroup: VideoGroup | null;
+  effectiveRequestedEngineId: string | null;
+  effectiveRequestedEngineToken: string | null;
+  requestedJobId: string | null;
+  fromVideoId: string | null;
+};
+
+export function useWorkspacePreviewState({
+  provider,
+  selectedPreview,
+  pendingSummaryMap,
+  compositeOverride,
+  activeVideoGroup,
+  initialPreviewGroup,
+  effectiveRequestedEngineId,
+  effectiveRequestedEngineToken,
+  requestedJobId,
+  fromVideoId,
+}: UseWorkspacePreviewStateOptions) {
+  const [viewerTarget, setViewerTarget] = useState<WorkspaceViewerTarget>(null);
+
+  const compositeGroup = compositeOverride ?? activeVideoGroup ?? null;
+  const selectedPreviewGroup = useMemo(
+    () => mapSelectedPreviewToGroup(selectedPreview, provider),
+    [selectedPreview, provider]
+  );
+  const initialPreviewFallbackGroup =
+    effectiveRequestedEngineId || effectiveRequestedEngineToken || requestedJobId || fromVideoId
+      ? null
+      : initialPreviewGroup;
+  const displayCompositeGroup = compositeGroup ?? selectedPreviewGroup ?? initialPreviewFallbackGroup;
+  const compositePreviewPosterSrc = useMemo(
+    () => getCompositePreviewPosterSrc(displayCompositeGroup),
+    [displayCompositeGroup]
+  );
+
+  const viewerGroup = useMemo<VideoGroup | null>(() => {
+    if (!viewerTarget) return null;
+    if (viewerTarget.kind === 'pending') {
+      const summary = pendingSummaryMap.get(viewerTarget.id);
+      if (!summary) return null;
+      return adaptGroupSummary(normalizeGroupSummary(summary), provider);
+    }
+    if (viewerTarget.kind === 'group') {
+      return viewerTarget.group;
+    }
+    return adaptGroupSummary(normalizeGroupSummary(viewerTarget.summary), provider);
+  }, [viewerTarget, pendingSummaryMap, provider]);
+
+  return {
+    viewerTarget,
+    setViewerTarget,
+    viewerGroup,
+    initialPreviewFallbackGroup,
+    displayCompositeGroup,
+    compositePreviewPosterSrc,
+  };
+}

--- a/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceRouteNavigation.ts
+++ b/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceRouteNavigation.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect } from 'react';
+import type { MutableRefObject } from 'react';
+import { useRouter } from 'next/navigation';
+import { authFetch } from '@/lib/authFetch';
+
+type UseWorkspaceRouteNavigationOptions = {
+  authChecked: boolean;
+  skipOnboardingRef: MutableRefObject<boolean>;
+};
+
+export function useWorkspaceRouteNavigation({
+  authChecked,
+  skipOnboardingRef,
+}: UseWorkspaceRouteNavigationOptions) {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!authChecked || skipOnboardingRef.current) return undefined;
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('[app] onboarding check running', { skip: skipOnboardingRef.current });
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await authFetch('/api/user/exports/summary');
+        if (!res.ok) return;
+        const json = await res.json();
+        if (!json?.ok) return;
+        if (cancelled) return;
+        if ((json.total ?? 0) === 0 && json.onboardingDone !== true) {
+          const params: Record<string, string> = { tab: 'starter', first: '1' };
+          const search = new URLSearchParams(params).toString();
+          router.replace(`/gallery?${search}`);
+          await authFetch('/api/user/preferences', {
+            method: 'PATCH',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ onboardingDone: true }),
+          }).catch(() => undefined);
+        }
+      } catch (error) {
+        console.warn('[app] onboarding redirect failed', error);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [authChecked, router, skipOnboardingRef]);
+
+  const replaceWorkspaceRoute = useCallback(
+    (href: string) => {
+      router.replace(href);
+    },
+    [router]
+  );
+
+  return {
+    replaceWorkspaceRoute,
+  };
+}

--- a/tests/workspace-draft-and-surfaces-contract.test.ts
+++ b/tests/workspace-draft-and-surfaces-contract.test.ts
@@ -5,6 +5,7 @@ import test from 'node:test';
 const appClientPath = 'frontend/app/(core)/(workspace)/app/AppClient.tsx';
 const draftStorageHookPath = 'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceDraftStorage.ts';
 const draftHydrationHookPath = 'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceDraftHydration.ts';
+const appShellPath = 'frontend/app/(core)/(workspace)/app/_components/WorkspaceAppShell.tsx';
 const bootSurfacePath = 'frontend/app/(core)/(workspace)/app/_components/WorkspaceBootSurface.tsx';
 const centerGalleryPath = 'frontend/app/(core)/(workspace)/app/_components/WorkspaceCenterGallery.tsx';
 const previewDockPath = 'frontend/app/(core)/(workspace)/app/_components/WorkspacePreviewDock.tsx';
@@ -50,23 +51,27 @@ test('workspace draft storage and hydration are owned by route-local hooks', () 
 });
 
 test('workspace app shell surfaces are split into route-local components', () => {
+  assert.equal(existsSync(appShellPath), true);
   assert.equal(existsSync(bootSurfacePath), true);
   assert.equal(existsSync(centerGalleryPath), true);
   assert.equal(existsSync(previewDockPath), true);
   assert.equal(existsSync(runtimeModalsPath), true);
 
   const appSource = readFileSync(appClientPath, 'utf8');
+  const appShellSource = readFileSync(appShellPath, 'utf8');
   const previewDockSource = readFileSync(previewDockPath, 'utf8');
   const modalsSource = readFileSync(runtimeModalsPath, 'utf8');
 
+  assert.match(appSource, /import \{ WorkspaceAppShell \} from '\.\/_components\/WorkspaceAppShell';/);
   assert.match(appSource, /import \{ WorkspaceBootSurface \} from '\.\/_components\/WorkspaceBootSurface';/);
-  assert.match(appSource, /import \{ WorkspaceCenterGallery \} from '\.\/_components\/WorkspaceCenterGallery';/);
-  assert.match(appSource, /import \{ WorkspacePreviewDock \}/);
   assert.match(appSource, /import \{ WorkspaceRuntimeModals \} from '\.\/_components\/WorkspaceRuntimeModals';/);
+  assert.match(appSource, /<WorkspaceAppShell/);
   assert.match(appSource, /<WorkspaceBootSurface/);
-  assert.match(appSource, /<WorkspaceCenterGallery/);
-  assert.match(appSource, /<WorkspacePreviewDock/);
   assert.match(appSource, /<WorkspaceRuntimeModals/);
+  assert.doesNotMatch(appSource, /<WorkspaceCenterGallery/);
+  assert.doesNotMatch(appSource, /<WorkspacePreviewDock/);
+  assert.doesNotMatch(appSource, /<WorkspaceChrome/);
+  assert.doesNotMatch(appSource, /<GalleryRail/);
 
   assert.doesNotMatch(appSource, /<CompositePreviewDock/);
   assert.doesNotMatch(appSource, /<EngineSettingsBar/);
@@ -75,6 +80,10 @@ test('workspace app shell surfaces are split into route-local components', () =>
   assert.doesNotMatch(appSource, /<WorkspaceAuthGateModal/);
   assert.doesNotMatch(appSource, /<AssetLibraryModal/);
 
+  assert.match(appShellSource, /WorkspaceChrome/);
+  assert.match(appShellSource, /GalleryRail/);
+  assert.match(appShellSource, /WorkspaceCenterGallery/);
+  assert.match(appShellSource, /WorkspacePreviewDock/);
   assert.match(previewDockSource, /CompositePreviewDock/);
   assert.match(previewDockSource, /EngineSettingsBar/);
   assert.match(modalsSource, /WorkspaceTopUpModal/);

--- a/tests/workspace-gallery-rail-contract.test.ts
+++ b/tests/workspace-gallery-rail-contract.test.ts
@@ -36,8 +36,8 @@ test('Seedance completion persists canonical video outputs before preview enrich
 });
 
 test('composite preview modal button opens direct preview groups', () => {
-  const appSource = fs.readFileSync(
-    path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/AppClient.tsx'),
+  const previewStateHookSource = fs.readFileSync(
+    path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/_hooks/useWorkspacePreviewState.ts'),
     'utf8'
   );
   const previewDockSource = fs.readFileSync(
@@ -46,7 +46,7 @@ test('composite preview modal button opens direct preview groups', () => {
   );
 
   assert.match(previewDockSource, /\|\s*\{\s*kind:\s*'group';\s*group:\s*VideoGroup\s*\}/);
-  assert.match(appSource, /if\s*\(viewerTarget\.kind === 'group'\)\s*\{\s*return viewerTarget\.group;\s*\}/);
+  assert.match(previewStateHookSource, /if\s*\(viewerTarget\.kind === 'group'\)\s*\{\s*return viewerTarget\.group;\s*\}/);
   assert.match(previewDockSource, /setViewerTarget\(\{\s*kind:\s*'group',\s*group:\s*nextGroup\s*\}\)/);
 });
 

--- a/tests/workspace-shell-route-state-contract.test.ts
+++ b/tests/workspace-shell-route-state-contract.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const appClientPath = 'frontend/app/(core)/(workspace)/app/AppClient.tsx';
+const appShellPath = 'frontend/app/(core)/(workspace)/app/_components/WorkspaceAppShell.tsx';
+const noticeHookPath = 'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceNotice.ts';
+const previewStateHookPath = 'frontend/app/(core)/(workspace)/app/_hooks/useWorkspacePreviewState.ts';
+const routeNavigationHookPath = 'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceRouteNavigation.ts';
+
+test('workspace shell, notice, preview composition, and route navigation are owned by route-local modules', () => {
+  assert.equal(existsSync(appShellPath), true);
+  assert.equal(existsSync(noticeHookPath), true);
+  assert.equal(existsSync(previewStateHookPath), true);
+  assert.equal(existsSync(routeNavigationHookPath), true);
+
+  const appSource = readFileSync(appClientPath, 'utf8');
+  const shellSource = readFileSync(appShellPath, 'utf8');
+  const noticeHookSource = readFileSync(noticeHookPath, 'utf8');
+  const previewHookSource = readFileSync(previewStateHookPath, 'utf8');
+  const routeHookSource = readFileSync(routeNavigationHookPath, 'utf8');
+
+  assert.match(appSource, /import \{ WorkspaceAppShell \} from '\.\/_components\/WorkspaceAppShell';/);
+  assert.match(appSource, /import \{ useWorkspaceNotice \} from '\.\/_hooks\/useWorkspaceNotice';/);
+  assert.match(appSource, /import \{ useWorkspacePreviewState \} from '\.\/_hooks\/useWorkspacePreviewState';/);
+  assert.match(appSource, /import \{ useWorkspaceRouteNavigation \} from '\.\/_hooks\/useWorkspaceRouteNavigation';/);
+  assert.match(appSource, /<WorkspaceAppShell/);
+  assert.match(appSource, /useWorkspaceNotice\(\)/);
+  assert.match(appSource, /useWorkspacePreviewState\(\{/);
+  assert.match(appSource, /useWorkspaceRouteNavigation\(\{/);
+
+  assert.doesNotMatch(appSource, /authFetch/);
+  assert.doesNotMatch(appSource, /useRouter/);
+  assert.doesNotMatch(appSource, /noticeTimeoutRef/);
+  assert.doesNotMatch(appSource, /window\.setTimeout/);
+  assert.doesNotMatch(appSource, /window\.clearTimeout/);
+  assert.doesNotMatch(appSource, /mapSelectedPreviewToGroup/);
+  assert.doesNotMatch(appSource, /adaptGroupSummary/);
+  assert.doesNotMatch(appSource, /normalizeGroupSummary/);
+  assert.doesNotMatch(appSource, /getCompositePreviewPosterSrc/);
+  assert.doesNotMatch(appSource, /<WorkspaceChrome/);
+  assert.doesNotMatch(appSource, /<GalleryRail/);
+  assert.doesNotMatch(appSource, /<WorkspaceCenterGallery/);
+  assert.doesNotMatch(appSource, /<WorkspacePreviewDock/);
+
+  assert.match(shellSource, /WorkspaceChrome/);
+  assert.match(shellSource, /GalleryRail/);
+  assert.match(shellSource, /WorkspaceCenterGallery/);
+  assert.match(shellSource, /WorkspacePreviewDock/);
+
+  assert.match(noticeHookSource, /window\.setTimeout/);
+  assert.match(noticeHookSource, /window\.clearTimeout/);
+
+  assert.match(previewHookSource, /mapSelectedPreviewToGroup/);
+  assert.match(previewHookSource, /adaptGroupSummary/);
+  assert.match(previewHookSource, /normalizeGroupSummary/);
+  assert.match(previewHookSource, /getCompositePreviewPosterSrc/);
+
+  assert.match(routeHookSource, /authFetch/);
+  assert.match(routeHookSource, /useRouter/);
+  assert.match(routeHookSource, /onboarding/);
+});


### PR DESCRIPTION
## Summary
- Extract the authenticated workspace chrome, gallery rail, center gallery, and preview dock into `WorkspaceAppShell`.
- Move notice timers, onboarding route redirects, and preview/viewer composition into route-local hooks.
- Update workspace architecture guidance and contract tests so `AppClient.tsx` stays an orchestrator.

## Test Plan
- [x] `pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/workspace-shell-route-state-contract.test.ts tests/workspace-draft-and-surfaces-contract.test.ts tests/workspace-gallery-rail-contract.test.ts`
- [x] `pnpm --prefix frontend exec tsc --noEmit`
- [x] `npm --prefix frontend run lint`
- [x] `npm run lint:exposure`
- [x] `pnpm test:validate`
- [x] `pnpm --prefix frontend run build`