### PR TITLE
Split workspace composer engine and wallet preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,8 @@ For the authenticated workspace route, keep `frontend/app/(core)/(workspace)/app
 
 - Keep route shell rendering in `_components/WorkspaceAppShell.tsx`; `AppClient.tsx` should not compose `WorkspaceChrome`, `GalleryRail`, the center gallery, or the preview dock inline.
 - Keep notice timers, onboarding route redirects, and preview/viewer composition in route-local hooks under `_hooks/`.
+- Keep composer engine/mode orchestration in `_hooks/useWorkspaceEngineModeState.ts`; `useWorkspaceComposerState.ts` should focus on composer input field state and field handlers.
+- Keep wallet balance preflight in `_hooks/useWorkspaceWalletPreflight.ts`; `useWorkspaceGenerationRunner.ts` should focus on generation submission, local render state, accepted results, and polling.
 - Keep composer JSX in `_components/WorkspaceComposerSurface.tsx` and shared modal wiring in `_components/WorkspaceRuntimeModals.tsx`.
 - Add or update contract tests in `tests/workspace-*-contract.test.ts` when moving workspace responsibilities, so the architecture stays explicit.
 

--- a/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceComposerState.ts
+++ b/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceComposerState.ts
@@ -1,35 +1,11 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 import type { MultiPromptScene } from '@/components/Composer';
-import { supportsAudioPricingToggle } from '@/lib/pricing-addons';
-import {
-  getSeedanceAssetState,
-  getUnifiedSeedanceMode,
-  isUnifiedSeedanceEngineId,
-} from '@/lib/seedance-workflow';
-import {
-  getUnifiedHappyHorseMode,
-  isHappyHorseEngineId,
-} from '@/lib/happy-horse-workflow';
 import type { EngineCaps, EngineModeUiCaps, Mode } from '@/types/engines';
-import {
-  getReferenceInputStatus,
-  hasInputAssetInSlots,
-  PRIMARY_IMAGE_SLOT_IDS,
-  PRIMARY_VIDEO_SLOT_IDS,
-  type ReferenceAsset,
-} from '../_lib/workspace-assets';
+import type { ReferenceAsset } from '../_lib/workspace-assets';
 import type { FormState } from '../_lib/workspace-form-state';
 import {
-  buildComposerModeToggles,
-  coerceFormState,
-  findGenerateAudioField,
   framesToSeconds,
-  getComposerWorkflowNotice,
-  getEngineModeOptions,
-  getModeCaps,
-  getPreferredEngineMode,
-  matchesEngineToken,
 } from '../_lib/workspace-engine-helpers';
 import {
   buildMultiPromptSummary,
@@ -38,17 +14,13 @@ import {
   MULTI_PROMPT_MIN_SEC,
 } from '../_lib/workspace-input-helpers';
 import {
-  STORAGE_KEYS,
-} from '../_lib/workspace-storage';
-import {
-  UNIFIED_VEO_FIRST_LAST_ENGINE_IDS,
-} from '../_lib/workspace-client-helpers';
+  useWorkspaceEngineModeState,
+  type WorkspaceComposerModeToggles,
+  type WorkspaceComposerWorkflowCopy,
+  type WorkspaceReferenceInputStatus,
+} from './useWorkspaceEngineModeState';
 
 type ShotType = 'customize' | 'intelligent';
-type ReferenceInputStatus = ReturnType<typeof getReferenceInputStatus>;
-type WorkspaceComposerWorkflowCopy = Parameters<typeof buildComposerModeToggles>[0]['workflowCopy'] & {
-  removeAudioToUseEdit: string;
-};
 
 type UseWorkspaceComposerStateOptions = {
   engines: EngineCaps[];
@@ -97,7 +69,7 @@ type UseWorkspaceComposerStateResult = {
   cameraFixedValue: boolean;
   safetyCheckerValue: boolean;
   effectivePrompt: string;
-  referenceInputStatus: ReferenceInputStatus;
+  referenceInputStatus: WorkspaceReferenceInputStatus;
   hasLastFrameInput: boolean;
   audioWorkflowLocked: boolean;
   audioWorkflowUnsupported: boolean;
@@ -110,7 +82,7 @@ type UseWorkspaceComposerStateResult = {
   capability: EngineModeUiCaps | undefined;
   supportsAudioToggle: boolean;
   engineModeOptions: Mode[] | undefined;
-  composerModeToggles: ReturnType<typeof buildComposerModeToggles>;
+  composerModeToggles: WorkspaceComposerModeToggles;
   showRetakeWorkflowAction: boolean;
   composerWorkflowNotice: string | null;
   handleMultiPromptAddScene: () => void;
@@ -131,26 +103,6 @@ type UseWorkspaceComposerStateResult = {
   handleAspectRatioChange: (ratio: string) => void;
   handleFpsChange: (fps: number) => void;
 };
-
-function hasFormStateChanged(previous: FormState, next: FormState): boolean {
-  return (
-    previous.engineId !== next.engineId ||
-    previous.mode !== next.mode ||
-    previous.durationSec !== next.durationSec ||
-    previous.durationOption !== next.durationOption ||
-    previous.numFrames !== next.numFrames ||
-    previous.resolution !== next.resolution ||
-    previous.aspectRatio !== next.aspectRatio ||
-    previous.fps !== next.fps ||
-    previous.iterations !== next.iterations ||
-    previous.seedLocked !== next.seedLocked ||
-    previous.loop !== next.loop ||
-    previous.audio !== next.audio ||
-    previous.seed !== next.seed ||
-    previous.cameraFixed !== next.cameraFixed ||
-    previous.safetyChecker !== next.safetyChecker
-  );
-}
 
 export function useWorkspaceComposerState({
   engines,
@@ -179,33 +131,54 @@ export function useWorkspaceComposerState({
   workflowCopy,
   showNotice,
 }: UseWorkspaceComposerStateOptions): UseWorkspaceComposerStateResult {
-  const engineOverride = useMemo<EngineCaps | null>(() => {
-    if (!effectiveRequestedEngineToken) return null;
-    if (!engines.length) return null;
-    if (hasStoredFormRef.current) return null;
-    return (
-      engines.find((engine) => matchesEngineToken(engine, effectiveRequestedEngineToken)) ?? null
-    );
-  }, [engines, effectiveRequestedEngineToken, hasStoredFormRef]);
-
-  const selectedEngine = useMemo<EngineCaps | null>(() => {
-    if (!engines.length) return null;
-    if (engineOverride) return engineOverride;
-    if (form && engines.some((engine) => engine.id === form.engineId)) {
-      return engines.find((engine) => engine.id === form.engineId) ?? engines[0];
-    }
-    return engines[0];
-  }, [engines, form, engineOverride]);
-
-  const supportsKlingV3Controls =
-    selectedEngine?.id === 'kling-3-pro' ||
-    selectedEngine?.id === 'kling-3-standard' ||
-    selectedEngine?.id === 'kling-3-4k';
-  const supportsKlingV3VoiceControl =
-    selectedEngine?.id === 'kling-3-pro' || selectedEngine?.id === 'kling-3-standard';
-  const isSeedance = selectedEngine?.id === 'seedance-1-5-pro';
-  const isUnifiedSeedance = isUnifiedSeedanceEngineId(selectedEngine?.id);
-  const isUnifiedHappyHorse = isHappyHorseEngineId(selectedEngine?.id);
+  const {
+    selectedEngine,
+    supportsKlingV3Controls,
+    supportsKlingV3VoiceControl,
+    isSeedance,
+    isUnifiedSeedance,
+    isUnifiedHappyHorse,
+    referenceInputStatus,
+    primaryAudioDurationSec,
+    primaryVideoDurationSec,
+    hasLastFrameInput,
+    audioWorkflowLocked,
+    audioWorkflowUnsupported,
+    activeManualMode,
+    activeMode,
+    allowsUnifiedVeoFirstLast,
+    submissionMode,
+    showSafetyCheckerControl,
+    capability,
+    supportsAudioToggle,
+    engineModeOptions,
+    composerModeToggles,
+    showRetakeWorkflowAction,
+    composerWorkflowNotice,
+    handleEngineChange,
+    handleModeChange,
+    handleComposerModeToggle,
+  } = useWorkspaceEngineModeState({
+    engines,
+    form,
+    setForm,
+    inputAssets,
+    shotType,
+    setShotType,
+    effectiveRequestedEngineToken,
+    authChecked,
+    hydratedForScope,
+    storageScope,
+    hasStoredFormRef,
+    preserveStoredDraftRef,
+    requestedEngineOverrideIdRef,
+    requestedEngineOverrideTokenRef,
+    requestedModeOverrideRef,
+    writeStorage,
+    uiLocale,
+    workflowCopy,
+    showNotice,
+  });
 
   const multiPromptTotalSec = useMemo(
     () => multiPromptScenes.reduce((sum, scene) => sum + (scene.duration || 0), 0),
@@ -239,123 +212,12 @@ export function useWorkspaceComposerState({
   const safetyCheckerValue = typeof form?.safetyChecker === 'boolean' ? form.safetyChecker : true;
   const effectivePrompt = multiPromptActive ? buildMultiPromptSummary(multiPromptScenes) : prompt;
 
-  const primaryAudioDurationSec = useMemo(() => {
-    for (const entries of Object.values(inputAssets)) {
-      for (const asset of entries) {
-        if (asset?.kind === 'audio' && typeof asset.durationSec === 'number' && Number.isFinite(asset.durationSec)) {
-          return Math.max(1, Math.round(asset.durationSec));
-        }
-      }
-    }
-    return null;
-  }, [inputAssets]);
-  const primaryVideoDurationSec = useMemo(() => {
-    for (const fieldId of PRIMARY_VIDEO_SLOT_IDS) {
-      const entries = inputAssets[fieldId] ?? [];
-      for (const asset of entries) {
-        if (asset?.kind === 'video' && typeof asset.durationSec === 'number' && Number.isFinite(asset.durationSec)) {
-          return Math.max(1, Math.round(asset.durationSec));
-        }
-      }
-    }
-    return null;
-  }, [inputAssets]);
-
   useEffect(() => {
     if (!supportsKlingV3Controls && multiPromptEnabled) {
       setMultiPromptEnabled(false);
     }
   }, [supportsKlingV3Controls, multiPromptEnabled, setMultiPromptEnabled]);
 
-  useEffect(() => {
-    if (form?.engineId === 'pika-image-to-video') {
-      setForm((current) => {
-        if (!current || current.engineId !== 'pika-image-to-video') return current;
-        return { ...current, engineId: 'pika-text-to-video' };
-      });
-    }
-  }, [form?.engineId, setForm]);
-
-  const engineModeOptions = useMemo(() => getEngineModeOptions(selectedEngine), [selectedEngine]);
-
-  const referenceInputStatus = useMemo(() => getReferenceInputStatus(inputAssets), [inputAssets]);
-  const seedanceAssetState = useMemo(() => getSeedanceAssetState(inputAssets), [inputAssets]);
-  const hasPrimaryImageInput = useMemo(
-    () => hasInputAssetInSlots(inputAssets, PRIMARY_IMAGE_SLOT_IDS, 'image'),
-    [inputAssets]
-  );
-  const hasLastFrameInput = useMemo(
-    () => hasInputAssetInSlots(inputAssets, ['last_frame_url'], 'image'),
-    [inputAssets]
-  );
-
-  const implicitMode = useMemo<Mode>(() => {
-    if (!selectedEngine) return form?.mode ?? 't2v';
-    if (isUnifiedSeedance) {
-      return getUnifiedSeedanceMode(inputAssets);
-    }
-    if (isUnifiedHappyHorse && (form?.mode === 't2v' || !form?.mode)) {
-      return getUnifiedHappyHorseMode(inputAssets);
-    }
-    const modes = selectedEngine.modes;
-    if (referenceInputStatus.hasAudio && modes.includes('a2v')) return 'a2v';
-    if (referenceInputStatus.hasVideo && modes.includes('v2v')) return 'v2v';
-    if (referenceInputStatus.hasVideo && modes.includes('r2v')) return 'r2v';
-    if (referenceInputStatus.hasVideo && modes.includes('reframe')) return 'reframe';
-    if (referenceInputStatus.hasImage && modes.includes('i2v')) return 'i2v';
-    if (modes.includes('t2v')) return 't2v';
-    return modes[0] ?? 't2v';
-  }, [form?.mode, inputAssets, isUnifiedHappyHorse, isUnifiedSeedance, referenceInputStatus.hasAudio, referenceInputStatus.hasImage, referenceInputStatus.hasVideo, selectedEngine]);
-
-  const audioToVideoSupported = Boolean(selectedEngine?.modes.includes('a2v'));
-  const audioWorkflowLocked = referenceInputStatus.hasAudio && audioToVideoSupported;
-  const audioWorkflowUnsupported =
-    referenceInputStatus.hasAudio &&
-    Boolean(selectedEngine) &&
-    !audioToVideoSupported &&
-    !(isUnifiedSeedance && seedanceAssetState.hasReferenceAudio);
-
-  const activeManualMode = useMemo<Mode | null>(() => {
-    if (!selectedEngine) return null;
-    if (isUnifiedSeedance) return null;
-    if (referenceInputStatus.hasAudio && !isUnifiedSeedance) return null;
-    const currentMode = form?.mode ?? null;
-    if (
-      (currentMode === 'v2v' ||
-        currentMode === 'reframe' ||
-        currentMode === 'ref2v' ||
-        currentMode === 'extend' ||
-        currentMode === 'retake') &&
-        selectedEngine.modes.includes(currentMode)
-    ) {
-      return currentMode;
-    }
-    return null;
-  }, [form?.mode, isUnifiedSeedance, referenceInputStatus.hasAudio, selectedEngine]);
-
-  const activeMode: Mode = activeManualMode ?? implicitMode;
-  const allowsUnifiedVeoFirstLast = useMemo(() => {
-    return Boolean(
-      selectedEngine &&
-        UNIFIED_VEO_FIRST_LAST_ENGINE_IDS.has(selectedEngine.id) &&
-        activeManualMode === null &&
-        (activeMode === 't2v' || activeMode === 'i2v')
-    );
-  }, [activeManualMode, activeMode, selectedEngine]);
-  const submissionMode = useMemo<Mode>(() => {
-    if (allowsUnifiedVeoFirstLast && hasPrimaryImageInput && hasLastFrameInput) {
-      return 'fl2v';
-    }
-    return activeMode;
-  }, [activeMode, allowsUnifiedVeoFirstLast, hasLastFrameInput, hasPrimaryImageInput]);
-  const showSafetyCheckerControl = useMemo(() => {
-    const schema = selectedEngine?.inputSchema;
-    if (!schema) return false;
-    return [...(schema.required ?? []), ...(schema.optional ?? [])].some((field) => {
-      if (field.id !== 'enable_safety_checker') return false;
-      return !field.modes || field.modes.includes(submissionMode);
-    });
-  }, [selectedEngine, submissionMode]);
   const effectiveDurationSec = useMemo(() => {
     if (multiPromptActive) return multiPromptTotalSec;
     if (submissionMode === 'a2v' && typeof primaryAudioDurationSec === 'number') return primaryAudioDurationSec;
@@ -366,156 +228,12 @@ export function useWorkspaceComposerState({
   }, [multiPromptActive, multiPromptTotalSec, submissionMode, primaryAudioDurationSec, primaryVideoDurationSec, form?.durationSec]);
 
   useEffect(() => {
-    if (!selectedEngine || !form) return;
-    if (activeManualMode) return;
-    if (form.mode === implicitMode) return;
-    setForm((current) => {
-      if (!current || current.mode === implicitMode) return current;
-      return coerceFormState(selectedEngine, implicitMode, { ...current, mode: implicitMode });
-    });
-  }, [activeManualMode, form, implicitMode, selectedEngine, setForm]);
-
-  useEffect(() => {
-    if (!supportsKlingV3Controls) return;
-    if (activeMode !== 'i2v') return;
-    if (shotType !== 'customize') {
-      setShotType('customize');
-    }
-  }, [activeMode, setShotType, shotType, supportsKlingV3Controls]);
-
-  const capability = useMemo(() => {
-    if (!selectedEngine) return undefined;
-    return getModeCaps(selectedEngine, submissionMode);
-  }, [selectedEngine, submissionMode]);
-
-  const generateAudioField = useMemo(() => {
-    if (!selectedEngine) return null;
-    return findGenerateAudioField(selectedEngine, submissionMode);
-  }, [selectedEngine, submissionMode]);
-
-  const supportsAudioToggle =
-    Boolean(selectedEngine && capability?.audioToggle && generateAudioField && supportsAudioPricingToggle(selectedEngine));
-
-  useEffect(() => {
     if (!voiceControlEnabled) return;
     setForm((current) => {
       if (!current || current.audio) return current;
       return { ...current, audio: true };
     });
   }, [setForm, voiceControlEnabled]);
-
-  const handleEngineChange = useCallback(
-    (engineId: string) => {
-      const nextEngine = engines.find((entry) => entry.id === engineId);
-      if (!nextEngine) return;
-      requestedEngineOverrideIdRef.current = null;
-      requestedEngineOverrideTokenRef.current = null;
-      requestedModeOverrideRef.current = null;
-      preserveStoredDraftRef.current = false;
-      setForm((current) => {
-        const candidate = current ?? null;
-        const nextMode = getPreferredEngineMode(nextEngine, candidate?.mode ?? null);
-        const normalizedPrevious = candidate ? { ...candidate, engineId: nextEngine.id, mode: nextMode } : null;
-        return coerceFormState(nextEngine, nextMode, normalizedPrevious);
-      });
-    },
-    [engines, preserveStoredDraftRef, requestedEngineOverrideIdRef, requestedEngineOverrideTokenRef, requestedModeOverrideRef, setForm]
-  );
-
-  useEffect(() => {
-    if (!engineOverride) return;
-    if (hasStoredFormRef.current) return;
-    setForm((current) => {
-      const candidate = current ?? null;
-      if (candidate?.engineId === engineOverride.id) return candidate;
-      const preferredMode = getPreferredEngineMode(engineOverride, candidate?.mode ?? null);
-      const normalizedPrevious = candidate ? { ...candidate, engineId: engineOverride.id, mode: preferredMode } : null;
-      const nextState = coerceFormState(engineOverride, preferredMode, normalizedPrevious);
-      if (process.env.NODE_ENV !== 'production') {
-        console.log('[generate] engine override applied', {
-          previous: candidate?.engineId,
-          next: nextState.engineId,
-        });
-      }
-      queueMicrotask(() => {
-        try {
-          writeStorage(STORAGE_KEYS.form, JSON.stringify(nextState));
-        } catch {
-          // noop
-        }
-      });
-      return nextState;
-    });
-  }, [engineOverride, hasStoredFormRef, setForm, writeStorage]);
-
-  useEffect(() => {
-    const pinnedToken = requestedEngineOverrideTokenRef.current;
-    if (!pinnedToken) return;
-    if (!authChecked) return;
-    if (hydratedForScope !== storageScope) return;
-    if (!selectedEngine) return;
-    if (matchesEngineToken(selectedEngine, pinnedToken)) return;
-    const pinnedEngine = engines.find((engine) => matchesEngineToken(engine, pinnedToken));
-    if (!pinnedEngine) return;
-    setForm((current) => {
-      const candidate = current ?? null;
-      const nextMode = getPreferredEngineMode(pinnedEngine, candidate?.mode ?? null);
-      const normalizedPrevious = candidate ? { ...candidate, engineId: pinnedEngine.id, mode: nextMode } : null;
-      return coerceFormState(pinnedEngine, nextMode, normalizedPrevious);
-    });
-  }, [authChecked, engines, hydratedForScope, requestedEngineOverrideTokenRef, selectedEngine, setForm, storageScope]);
-
-  const handleModeChange = useCallback(
-    (mode: Mode) => {
-      if (!selectedEngine) return;
-      const nextMode = getPreferredEngineMode(selectedEngine, mode);
-      setForm((current) => coerceFormState(selectedEngine, nextMode, current ? { ...current, mode: nextMode } : null));
-    },
-    [selectedEngine, setForm]
-  );
-
-  const composerModeToggles = useMemo(
-    () =>
-      buildComposerModeToggles({
-        selectedEngine,
-        audioWorkflowLocked,
-        uiLocale,
-        workflowCopy,
-      }),
-    [audioWorkflowLocked, selectedEngine, uiLocale, workflowCopy]
-  );
-
-  const showRetakeWorkflowAction = Boolean(selectedEngine?.id === 'ltx-2-3' && selectedEngine.modes.includes('retake'));
-
-  const composerWorkflowNotice = useMemo(
-    () =>
-      getComposerWorkflowNotice({
-        selectedEngine,
-        hasAudioInput: referenceInputStatus.hasAudio,
-        audioWorkflowUnsupported,
-        workflowCopy,
-      }),
-    [audioWorkflowUnsupported, referenceInputStatus.hasAudio, selectedEngine, workflowCopy]
-  );
-
-  const handleComposerModeToggle = useCallback(
-    (mode: Mode | null) => {
-      if (!selectedEngine) return;
-      if (
-        referenceInputStatus.hasAudio &&
-        !isUnifiedSeedance &&
-        (mode === 'v2v' || mode === 'reframe' || mode === 'extend' || mode === 'retake')
-      ) {
-        showNotice(workflowCopy.removeAudioToUseEdit);
-        return;
-      }
-      const nextMode = mode ?? implicitMode;
-      setForm((current) =>
-        coerceFormState(selectedEngine, nextMode, current ? { ...current, mode: nextMode } : null)
-      );
-    },
-    [implicitMode, isUnifiedSeedance, referenceInputStatus.hasAudio, selectedEngine, setForm, showNotice, workflowCopy]
-  );
 
   const handleDurationChange = useCallback(
     (raw: number | string) => {
@@ -653,18 +371,6 @@ export function useWorkspaceComposerState({
     },
     [setForm]
   );
-
-  useEffect(() => {
-    if (!selectedEngine || !authChecked) return;
-    setForm((current) => {
-      const candidate = current ?? null;
-      if (!candidate) return candidate;
-      const nextMode = getPreferredEngineMode(selectedEngine, candidate?.mode ?? null);
-      const normalizedPrevious = candidate ? { ...candidate, mode: nextMode } : null;
-      const nextState = coerceFormState(selectedEngine, nextMode, normalizedPrevious);
-      return hasFormStateChanged(candidate, nextState) ? nextState : candidate;
-    });
-  }, [selectedEngine, authChecked, setForm]);
 
   return {
     selectedEngine,

--- a/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceEngineModeState.ts
+++ b/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceEngineModeState.ts
@@ -1,0 +1,474 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
+import { supportsAudioPricingToggle } from '@/lib/pricing-addons';
+import {
+  getSeedanceAssetState,
+  getUnifiedSeedanceMode,
+  isUnifiedSeedanceEngineId,
+} from '@/lib/seedance-workflow';
+import {
+  getUnifiedHappyHorseMode,
+  isHappyHorseEngineId,
+} from '@/lib/happy-horse-workflow';
+import type { EngineCaps, EngineModeUiCaps, Mode } from '@/types/engines';
+import {
+  getReferenceInputStatus,
+  hasInputAssetInSlots,
+  PRIMARY_IMAGE_SLOT_IDS,
+  PRIMARY_VIDEO_SLOT_IDS,
+  type ReferenceAsset,
+} from '../_lib/workspace-assets';
+import type { FormState } from '../_lib/workspace-form-state';
+import {
+  buildComposerModeToggles,
+  coerceFormState,
+  findGenerateAudioField,
+  getComposerWorkflowNotice,
+  getEngineModeOptions,
+  getModeCaps,
+  getPreferredEngineMode,
+  matchesEngineToken,
+} from '../_lib/workspace-engine-helpers';
+import { STORAGE_KEYS } from '../_lib/workspace-storage';
+import { UNIFIED_VEO_FIRST_LAST_ENGINE_IDS } from '../_lib/workspace-client-helpers';
+
+type ShotType = 'customize' | 'intelligent';
+
+export type WorkspaceComposerWorkflowCopy = Parameters<typeof buildComposerModeToggles>[0]['workflowCopy'] & {
+  removeAudioToUseEdit: string;
+};
+export type WorkspaceReferenceInputStatus = ReturnType<typeof getReferenceInputStatus>;
+export type WorkspaceComposerModeToggles = ReturnType<typeof buildComposerModeToggles>;
+
+type UseWorkspaceEngineModeStateOptions = {
+  engines: EngineCaps[];
+  form: FormState | null;
+  setForm: Dispatch<SetStateAction<FormState | null>>;
+  inputAssets: Record<string, (ReferenceAsset | null)[]>;
+  shotType: ShotType;
+  setShotType: Dispatch<SetStateAction<ShotType>>;
+  effectiveRequestedEngineToken: string | null;
+  authChecked: boolean;
+  hydratedForScope: string | null;
+  storageScope: string;
+  hasStoredFormRef: MutableRefObject<boolean>;
+  preserveStoredDraftRef: MutableRefObject<boolean>;
+  requestedEngineOverrideIdRef: MutableRefObject<string | null>;
+  requestedEngineOverrideTokenRef: MutableRefObject<string | null>;
+  requestedModeOverrideRef: MutableRefObject<Mode | null>;
+  writeStorage: (base: string, value: string | null) => void;
+  uiLocale: string;
+  workflowCopy: WorkspaceComposerWorkflowCopy;
+  showNotice: (message: string) => void;
+};
+
+type UseWorkspaceEngineModeStateResult = {
+  selectedEngine: EngineCaps | null;
+  supportsKlingV3Controls: boolean;
+  supportsKlingV3VoiceControl: boolean;
+  isSeedance: boolean;
+  isUnifiedSeedance: boolean;
+  isUnifiedHappyHorse: boolean;
+  referenceInputStatus: WorkspaceReferenceInputStatus;
+  primaryAudioDurationSec: number | null;
+  primaryVideoDurationSec: number | null;
+  hasLastFrameInput: boolean;
+  audioWorkflowLocked: boolean;
+  audioWorkflowUnsupported: boolean;
+  activeManualMode: Mode | null;
+  activeMode: Mode;
+  allowsUnifiedVeoFirstLast: boolean;
+  submissionMode: Mode;
+  showSafetyCheckerControl: boolean;
+  capability: EngineModeUiCaps | undefined;
+  supportsAudioToggle: boolean;
+  engineModeOptions: Mode[] | undefined;
+  composerModeToggles: WorkspaceComposerModeToggles;
+  showRetakeWorkflowAction: boolean;
+  composerWorkflowNotice: string | null;
+  handleEngineChange: (engineId: string) => void;
+  handleModeChange: (mode: Mode) => void;
+  handleComposerModeToggle: (mode: Mode | null) => void;
+};
+
+function hasFormStateChanged(previous: FormState, next: FormState): boolean {
+  return (
+    previous.engineId !== next.engineId ||
+    previous.mode !== next.mode ||
+    previous.durationSec !== next.durationSec ||
+    previous.durationOption !== next.durationOption ||
+    previous.numFrames !== next.numFrames ||
+    previous.resolution !== next.resolution ||
+    previous.aspectRatio !== next.aspectRatio ||
+    previous.fps !== next.fps ||
+    previous.iterations !== next.iterations ||
+    previous.seedLocked !== next.seedLocked ||
+    previous.loop !== next.loop ||
+    previous.audio !== next.audio ||
+    previous.seed !== next.seed ||
+    previous.cameraFixed !== next.cameraFixed ||
+    previous.safetyChecker !== next.safetyChecker
+  );
+}
+
+export function useWorkspaceEngineModeState({
+  engines,
+  form,
+  setForm,
+  inputAssets,
+  shotType,
+  setShotType,
+  effectiveRequestedEngineToken,
+  authChecked,
+  hydratedForScope,
+  storageScope,
+  hasStoredFormRef,
+  preserveStoredDraftRef,
+  requestedEngineOverrideIdRef,
+  requestedEngineOverrideTokenRef,
+  requestedModeOverrideRef,
+  writeStorage,
+  uiLocale,
+  workflowCopy,
+  showNotice,
+}: UseWorkspaceEngineModeStateOptions): UseWorkspaceEngineModeStateResult {
+  const engineOverride = useMemo<EngineCaps | null>(() => {
+    if (!effectiveRequestedEngineToken) return null;
+    if (!engines.length) return null;
+    if (hasStoredFormRef.current) return null;
+    return engines.find((engine) => matchesEngineToken(engine, effectiveRequestedEngineToken)) ?? null;
+  }, [engines, effectiveRequestedEngineToken, hasStoredFormRef]);
+
+  const selectedEngine = useMemo<EngineCaps | null>(() => {
+    if (!engines.length) return null;
+    if (engineOverride) return engineOverride;
+    if (form && engines.some((engine) => engine.id === form.engineId)) {
+      return engines.find((engine) => engine.id === form.engineId) ?? engines[0];
+    }
+    return engines[0];
+  }, [engines, form, engineOverride]);
+
+  const supportsKlingV3Controls =
+    selectedEngine?.id === 'kling-3-pro' ||
+    selectedEngine?.id === 'kling-3-standard' ||
+    selectedEngine?.id === 'kling-3-4k';
+  const supportsKlingV3VoiceControl =
+    selectedEngine?.id === 'kling-3-pro' || selectedEngine?.id === 'kling-3-standard';
+  const isSeedance = selectedEngine?.id === 'seedance-1-5-pro';
+  const isUnifiedSeedance = isUnifiedSeedanceEngineId(selectedEngine?.id);
+  const isUnifiedHappyHorse = isHappyHorseEngineId(selectedEngine?.id);
+
+  const primaryAudioDurationSec = useMemo(() => {
+    for (const entries of Object.values(inputAssets)) {
+      for (const asset of entries) {
+        if (asset?.kind === 'audio' && typeof asset.durationSec === 'number' && Number.isFinite(asset.durationSec)) {
+          return Math.max(1, Math.round(asset.durationSec));
+        }
+      }
+    }
+    return null;
+  }, [inputAssets]);
+
+  const primaryVideoDurationSec = useMemo(() => {
+    for (const fieldId of PRIMARY_VIDEO_SLOT_IDS) {
+      const entries = inputAssets[fieldId] ?? [];
+      for (const asset of entries) {
+        if (asset?.kind === 'video' && typeof asset.durationSec === 'number' && Number.isFinite(asset.durationSec)) {
+          return Math.max(1, Math.round(asset.durationSec));
+        }
+      }
+    }
+    return null;
+  }, [inputAssets]);
+
+  useEffect(() => {
+    if (form?.engineId === 'pika-image-to-video') {
+      setForm((current) => {
+        if (!current || current.engineId !== 'pika-image-to-video') return current;
+        return { ...current, engineId: 'pika-text-to-video' };
+      });
+    }
+  }, [form?.engineId, setForm]);
+
+  const engineModeOptions = useMemo(() => getEngineModeOptions(selectedEngine), [selectedEngine]);
+
+  const referenceInputStatus = useMemo(() => getReferenceInputStatus(inputAssets), [inputAssets]);
+  const seedanceAssetState = useMemo(() => getSeedanceAssetState(inputAssets), [inputAssets]);
+  const hasPrimaryImageInput = useMemo(
+    () => hasInputAssetInSlots(inputAssets, PRIMARY_IMAGE_SLOT_IDS, 'image'),
+    [inputAssets]
+  );
+  const hasLastFrameInput = useMemo(
+    () => hasInputAssetInSlots(inputAssets, ['last_frame_url'], 'image'),
+    [inputAssets]
+  );
+
+  const implicitMode = useMemo<Mode>(() => {
+    if (!selectedEngine) return form?.mode ?? 't2v';
+    if (isUnifiedSeedance) {
+      return getUnifiedSeedanceMode(inputAssets);
+    }
+    if (isUnifiedHappyHorse && (form?.mode === 't2v' || !form?.mode)) {
+      return getUnifiedHappyHorseMode(inputAssets);
+    }
+    const modes = selectedEngine.modes;
+    if (referenceInputStatus.hasAudio && modes.includes('a2v')) return 'a2v';
+    if (referenceInputStatus.hasVideo && modes.includes('v2v')) return 'v2v';
+    if (referenceInputStatus.hasVideo && modes.includes('r2v')) return 'r2v';
+    if (referenceInputStatus.hasVideo && modes.includes('reframe')) return 'reframe';
+    if (referenceInputStatus.hasImage && modes.includes('i2v')) return 'i2v';
+    if (modes.includes('t2v')) return 't2v';
+    return modes[0] ?? 't2v';
+  }, [
+    form?.mode,
+    inputAssets,
+    isUnifiedHappyHorse,
+    isUnifiedSeedance,
+    referenceInputStatus.hasAudio,
+    referenceInputStatus.hasImage,
+    referenceInputStatus.hasVideo,
+    selectedEngine,
+  ]);
+
+  const audioToVideoSupported = Boolean(selectedEngine?.modes.includes('a2v'));
+  const audioWorkflowLocked = referenceInputStatus.hasAudio && audioToVideoSupported;
+  const audioWorkflowUnsupported =
+    referenceInputStatus.hasAudio &&
+    Boolean(selectedEngine) &&
+    !audioToVideoSupported &&
+    !(isUnifiedSeedance && seedanceAssetState.hasReferenceAudio);
+
+  const activeManualMode = useMemo<Mode | null>(() => {
+    if (!selectedEngine) return null;
+    if (isUnifiedSeedance) return null;
+    if (referenceInputStatus.hasAudio && !isUnifiedSeedance) return null;
+    const currentMode = form?.mode ?? null;
+    if (
+      (currentMode === 'v2v' ||
+        currentMode === 'reframe' ||
+        currentMode === 'ref2v' ||
+        currentMode === 'extend' ||
+        currentMode === 'retake') &&
+      selectedEngine.modes.includes(currentMode)
+    ) {
+      return currentMode;
+    }
+    return null;
+  }, [form?.mode, isUnifiedSeedance, referenceInputStatus.hasAudio, selectedEngine]);
+
+  const activeMode: Mode = activeManualMode ?? implicitMode;
+  const allowsUnifiedVeoFirstLast = useMemo(() => {
+    return Boolean(
+      selectedEngine &&
+        UNIFIED_VEO_FIRST_LAST_ENGINE_IDS.has(selectedEngine.id) &&
+        activeManualMode === null &&
+        (activeMode === 't2v' || activeMode === 'i2v')
+    );
+  }, [activeManualMode, activeMode, selectedEngine]);
+  const submissionMode = useMemo<Mode>(() => {
+    if (allowsUnifiedVeoFirstLast && hasPrimaryImageInput && hasLastFrameInput) {
+      return 'fl2v';
+    }
+    return activeMode;
+  }, [activeMode, allowsUnifiedVeoFirstLast, hasLastFrameInput, hasPrimaryImageInput]);
+  const showSafetyCheckerControl = useMemo(() => {
+    const schema = selectedEngine?.inputSchema;
+    if (!schema) return false;
+    return [...(schema.required ?? []), ...(schema.optional ?? [])].some((field) => {
+      if (field.id !== 'enable_safety_checker') return false;
+      return !field.modes || field.modes.includes(submissionMode);
+    });
+  }, [selectedEngine, submissionMode]);
+
+  useEffect(() => {
+    if (!selectedEngine || !form) return;
+    if (activeManualMode) return;
+    if (form.mode === implicitMode) return;
+    setForm((current) => {
+      if (!current || current.mode === implicitMode) return current;
+      return coerceFormState(selectedEngine, implicitMode, { ...current, mode: implicitMode });
+    });
+  }, [activeManualMode, form, implicitMode, selectedEngine, setForm]);
+
+  useEffect(() => {
+    if (!supportsKlingV3Controls) return;
+    if (activeMode !== 'i2v') return;
+    if (shotType !== 'customize') {
+      setShotType('customize');
+    }
+  }, [activeMode, setShotType, shotType, supportsKlingV3Controls]);
+
+  const capability = useMemo(() => {
+    if (!selectedEngine) return undefined;
+    return getModeCaps(selectedEngine, submissionMode);
+  }, [selectedEngine, submissionMode]);
+
+  const generateAudioField = useMemo(() => {
+    if (!selectedEngine) return null;
+    return findGenerateAudioField(selectedEngine, submissionMode);
+  }, [selectedEngine, submissionMode]);
+
+  const supportsAudioToggle =
+    Boolean(selectedEngine && capability?.audioToggle && generateAudioField && supportsAudioPricingToggle(selectedEngine));
+
+  const handleEngineChange = useCallback(
+    (engineId: string) => {
+      const nextEngine = engines.find((entry) => entry.id === engineId);
+      if (!nextEngine) return;
+      requestedEngineOverrideIdRef.current = null;
+      requestedEngineOverrideTokenRef.current = null;
+      requestedModeOverrideRef.current = null;
+      preserveStoredDraftRef.current = false;
+      setForm((current) => {
+        const candidate = current ?? null;
+        const nextMode = getPreferredEngineMode(nextEngine, candidate?.mode ?? null);
+        const normalizedPrevious = candidate ? { ...candidate, engineId: nextEngine.id, mode: nextMode } : null;
+        return coerceFormState(nextEngine, nextMode, normalizedPrevious);
+      });
+    },
+    [
+      engines,
+      preserveStoredDraftRef,
+      requestedEngineOverrideIdRef,
+      requestedEngineOverrideTokenRef,
+      requestedModeOverrideRef,
+      setForm,
+    ]
+  );
+
+  useEffect(() => {
+    if (!engineOverride) return;
+    if (hasStoredFormRef.current) return;
+    setForm((current) => {
+      const candidate = current ?? null;
+      if (candidate?.engineId === engineOverride.id) return candidate;
+      const preferredMode = getPreferredEngineMode(engineOverride, candidate?.mode ?? null);
+      const normalizedPrevious = candidate ? { ...candidate, engineId: engineOverride.id, mode: preferredMode } : null;
+      const nextState = coerceFormState(engineOverride, preferredMode, normalizedPrevious);
+      if (process.env.NODE_ENV !== 'production') {
+        console.log('[generate] engine override applied', {
+          previous: candidate?.engineId,
+          next: nextState.engineId,
+        });
+      }
+      queueMicrotask(() => {
+        try {
+          writeStorage(STORAGE_KEYS.form, JSON.stringify(nextState));
+        } catch {
+          // noop
+        }
+      });
+      return nextState;
+    });
+  }, [engineOverride, hasStoredFormRef, setForm, writeStorage]);
+
+  useEffect(() => {
+    const pinnedToken = requestedEngineOverrideTokenRef.current;
+    if (!pinnedToken) return;
+    if (!authChecked) return;
+    if (hydratedForScope !== storageScope) return;
+    if (!selectedEngine) return;
+    if (matchesEngineToken(selectedEngine, pinnedToken)) return;
+    const pinnedEngine = engines.find((engine) => matchesEngineToken(engine, pinnedToken));
+    if (!pinnedEngine) return;
+    setForm((current) => {
+      const candidate = current ?? null;
+      const nextMode = getPreferredEngineMode(pinnedEngine, candidate?.mode ?? null);
+      const normalizedPrevious = candidate ? { ...candidate, engineId: pinnedEngine.id, mode: nextMode } : null;
+      return coerceFormState(pinnedEngine, nextMode, normalizedPrevious);
+    });
+  }, [authChecked, engines, hydratedForScope, requestedEngineOverrideTokenRef, selectedEngine, setForm, storageScope]);
+
+  const handleModeChange = useCallback(
+    (mode: Mode) => {
+      if (!selectedEngine) return;
+      const nextMode = getPreferredEngineMode(selectedEngine, mode);
+      setForm((current) => coerceFormState(selectedEngine, nextMode, current ? { ...current, mode: nextMode } : null));
+    },
+    [selectedEngine, setForm]
+  );
+
+  const composerModeToggles = useMemo(
+    () =>
+      buildComposerModeToggles({
+        selectedEngine,
+        audioWorkflowLocked,
+        uiLocale,
+        workflowCopy,
+      }),
+    [audioWorkflowLocked, selectedEngine, uiLocale, workflowCopy]
+  );
+
+  const showRetakeWorkflowAction = Boolean(selectedEngine?.id === 'ltx-2-3' && selectedEngine.modes.includes('retake'));
+
+  const composerWorkflowNotice = useMemo(
+    () =>
+      getComposerWorkflowNotice({
+        selectedEngine,
+        hasAudioInput: referenceInputStatus.hasAudio,
+        audioWorkflowUnsupported,
+        workflowCopy,
+      }),
+    [audioWorkflowUnsupported, referenceInputStatus.hasAudio, selectedEngine, workflowCopy]
+  );
+
+  const handleComposerModeToggle = useCallback(
+    (mode: Mode | null) => {
+      if (!selectedEngine) return;
+      if (
+        referenceInputStatus.hasAudio &&
+        !isUnifiedSeedance &&
+        (mode === 'v2v' || mode === 'reframe' || mode === 'extend' || mode === 'retake')
+      ) {
+        showNotice(workflowCopy.removeAudioToUseEdit);
+        return;
+      }
+      const nextMode = mode ?? implicitMode;
+      setForm((current) =>
+        coerceFormState(selectedEngine, nextMode, current ? { ...current, mode: nextMode } : null)
+      );
+    },
+    [implicitMode, isUnifiedSeedance, referenceInputStatus.hasAudio, selectedEngine, setForm, showNotice, workflowCopy]
+  );
+
+  useEffect(() => {
+    if (!selectedEngine || !authChecked) return;
+    setForm((current) => {
+      const candidate = current ?? null;
+      if (!candidate) return candidate;
+      const nextMode = getPreferredEngineMode(selectedEngine, candidate?.mode ?? null);
+      const normalizedPrevious = candidate ? { ...candidate, mode: nextMode } : null;
+      const nextState = coerceFormState(selectedEngine, nextMode, normalizedPrevious);
+      return hasFormStateChanged(candidate, nextState) ? nextState : candidate;
+    });
+  }, [selectedEngine, authChecked, setForm]);
+
+  return {
+    selectedEngine,
+    supportsKlingV3Controls,
+    supportsKlingV3VoiceControl,
+    isSeedance,
+    isUnifiedSeedance,
+    isUnifiedHappyHorse,
+    referenceInputStatus,
+    primaryAudioDurationSec,
+    primaryVideoDurationSec,
+    hasLastFrameInput,
+    audioWorkflowLocked,
+    audioWorkflowUnsupported,
+    activeManualMode,
+    activeMode,
+    allowsUnifiedVeoFirstLast,
+    submissionMode,
+    showSafetyCheckerControl,
+    capability,
+    supportsAudioToggle,
+    engineModeOptions,
+    composerModeToggles,
+    showRetakeWorkflowAction,
+    composerWorkflowNotice,
+    handleEngineChange,
+    handleModeChange,
+    handleComposerModeToggle,
+  };
+}

--- a/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceGenerationRunner.ts
+++ b/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceGenerationRunner.ts
@@ -3,8 +3,6 @@ import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 import type { MultiPromptScene } from '@/components/Composer';
 import type { KlingElementState } from '@/components/KlingElementsBuilder';
 import { getJobStatus, runGenerate } from '@/lib/api';
-import { authFetch } from '@/lib/authFetch';
-import { CURRENCY_LOCALE } from '@/lib/intl';
 import { getLocalizedModeLabel } from '@/lib/ltx-localization';
 import { readBrowserSession } from '@/lib/supabase-auth-cleanup';
 import type {
@@ -51,6 +49,7 @@ import type {
 } from '../_lib/workspace-input-schema';
 import type { ReferenceAsset } from '../_lib/workspace-assets';
 import { STORAGE_KEYS } from '../_lib/workspace-storage';
+import { useWorkspaceWalletPreflight } from './useWorkspaceWalletPreflight';
 
 type MemberTier = 'Member' | 'Plus' | 'Pro';
 type ShotType = 'customize' | 'intelligent';
@@ -193,6 +192,12 @@ export function useWorkspaceGenerationRunner({
   shotType,
   klingElements,
 }: UseWorkspaceGenerationRunnerOptions) {
+  const { presentInsufficientFunds, verifyWalletBalance } = useWorkspaceWalletPreflight({
+    workspaceCopy,
+    setTopUpModal,
+    showComposerError,
+  });
+
   const startRender = useCallback(async () => {
     if (!form || !selectedEngine) return;
     const session = await readBrowserSession();
@@ -250,65 +255,9 @@ export function useWorkspaceGenerationRunner({
     const paymentMode: 'wallet' | 'platform' = token ? 'wallet' : 'platform';
     const currencyCode = preflight?.pricing?.currency ?? preflight?.currency ?? 'USD';
 
-    const presentInsufficientFunds = (shortfallCents?: number) => {
-      const normalizedShortfall = typeof shortfallCents === 'number' ? Math.max(0, shortfallCents) : undefined;
-
-      let friendlyNotice: string = workspaceCopy.wallet.insufficient;
-      let formattedShortfall: string | undefined;
-      if (typeof normalizedShortfall === 'number' && normalizedShortfall > 0) {
-        try {
-          formattedShortfall = new Intl.NumberFormat(CURRENCY_LOCALE, {
-            style: 'currency',
-            currency: currencyCode,
-          }).format(normalizedShortfall / 100);
-          friendlyNotice = workspaceCopy.wallet.insufficientWithAmount.replace('{amount}', formattedShortfall);
-        } catch {
-          formattedShortfall = `${currencyCode} ${(normalizedShortfall / 100).toFixed(2)}`;
-          friendlyNotice = workspaceCopy.wallet.insufficientWithAmount.replace('{amount}', formattedShortfall);
-        }
-      }
-
-      setTopUpModal({
-        message: friendlyNotice,
-        amountLabel: formattedShortfall,
-        shortfallCents: typeof normalizedShortfall === 'number' ? normalizedShortfall : undefined,
-      });
-      showComposerError(friendlyNotice);
-    };
-
     if (paymentMode === 'wallet') {
-      const unitCostCents =
-        typeof preflight?.pricing?.totalCents === 'number'
-          ? preflight.pricing.totalCents
-          : typeof preflight?.total === 'number'
-            ? preflight.total
-            : null;
-      if (typeof unitCostCents === 'number' && unitCostCents > 0) {
-        const requiredCents = unitCostCents * iterationCount;
-        try {
-          const res = await authFetch('/api/wallet');
-          if (res.ok) {
-            const walletJson = await res.json();
-            const balanceCents =
-              typeof walletJson.balanceCents === 'number'
-                ? walletJson.balanceCents
-                : typeof walletJson.balance === 'number'
-                  ? Math.round(walletJson.balance * 100)
-                  : typeof walletJson.balance === 'string'
-                    ? Math.round(Number(walletJson.balance) * 100)
-                    : undefined;
-            if (typeof balanceCents === 'number') {
-              const shortfall = requiredCents - balanceCents;
-              if (shortfall > 0) {
-                presentInsufficientFunds(shortfall);
-                return;
-              }
-            }
-          }
-        } catch (walletError) {
-          console.warn('[startRender] wallet balance check failed', walletError);
-        }
-      }
+      const hasWalletBalance = await verifyWalletBalance({ preflight, iterationCount, currencyCode });
+      if (!hasWalletBalance) return;
     }
 
     const generationInputs = prepareGenerationInputs({
@@ -645,7 +594,7 @@ export function useWorkspaceGenerationRunner({
         setSelectedPreview((cur) => (cur && cur.localKey === localKey ? null : cur));
         if (isInsufficientFundsError(error)) {
           const shortfallCents = error.details?.requiredCents;
-          presentInsufficientFunds(shortfallCents);
+          presentInsufficientFunds({ currencyCode, shortfallCents });
           return;
         }
         if (error && typeof error === 'object' && (error as { error?: string }).error === 'FAL_UNPROCESSABLE_ENTITY') {
@@ -703,7 +652,6 @@ export function useWorkspaceGenerationRunner({
     inputAssets,
     setAuthModalOpen,
     setPreflightError,
-    setTopUpModal,
     setActiveGroupId,
     setActiveBatchId,
     setBatchHeroes,
@@ -713,7 +661,6 @@ export function useWorkspaceGenerationRunner({
     rendersRef,
     uiLocale,
     workflowCopy,
-    workspaceCopy,
     capability,
     cfgScale,
     formatTakeLabel,
@@ -737,8 +684,10 @@ export function useWorkspaceGenerationRunner({
     promptLength,
     promptCharLimitExceeded,
     promptMaxChars,
+    presentInsufficientFunds,
     voiceIds,
     voiceControlEnabled,
+    verifyWalletBalance,
     shotType,
     klingElements,
   ]);

--- a/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceWalletPreflight.ts
+++ b/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceWalletPreflight.ts
@@ -1,0 +1,112 @@
+import { useCallback } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import { authFetch } from '@/lib/authFetch';
+import { CURRENCY_LOCALE } from '@/lib/intl';
+import type { PreflightResponse } from '@/types/engines';
+
+type TopUpModalState = {
+  message: string;
+  amountLabel?: string;
+  shortfallCents?: number;
+} | null;
+
+type WorkspaceWalletCopy = {
+  wallet: {
+    insufficient: string;
+    insufficientWithAmount: string;
+  };
+};
+
+type UseWorkspaceWalletPreflightOptions = {
+  workspaceCopy: WorkspaceWalletCopy;
+  setTopUpModal: Dispatch<SetStateAction<TopUpModalState>>;
+  showComposerError: (message: string) => void;
+};
+
+type VerifyWalletBalanceOptions = {
+  preflight: PreflightResponse | null;
+  iterationCount: number;
+  currencyCode: string;
+};
+
+type PresentInsufficientFundsOptions = {
+  currencyCode: string;
+  shortfallCents?: number;
+};
+
+function resolveWalletBalanceCents(walletJson: { balanceCents?: unknown; balance?: unknown }): number | undefined {
+  if (typeof walletJson.balanceCents === 'number') return walletJson.balanceCents;
+  if (typeof walletJson.balance === 'number') return Math.round(walletJson.balance * 100);
+  if (typeof walletJson.balance === 'string') return Math.round(Number(walletJson.balance) * 100);
+  return undefined;
+}
+
+function resolvePreflightUnitCostCents(preflight: PreflightResponse | null): number | null {
+  if (typeof preflight?.pricing?.totalCents === 'number') return preflight.pricing.totalCents;
+  if (typeof preflight?.total === 'number') return preflight.total;
+  return null;
+}
+
+export function useWorkspaceWalletPreflight({
+  workspaceCopy,
+  setTopUpModal,
+  showComposerError,
+}: UseWorkspaceWalletPreflightOptions) {
+  const presentInsufficientFunds = useCallback(
+    ({ currencyCode, shortfallCents }: PresentInsufficientFundsOptions) => {
+      const normalizedShortfall = typeof shortfallCents === 'number' ? Math.max(0, shortfallCents) : undefined;
+
+      let friendlyNotice: string = workspaceCopy.wallet.insufficient;
+      let formattedShortfall: string | undefined;
+      if (typeof normalizedShortfall === 'number' && normalizedShortfall > 0) {
+        try {
+          formattedShortfall = new Intl.NumberFormat(CURRENCY_LOCALE, {
+            style: 'currency',
+            currency: currencyCode,
+          }).format(normalizedShortfall / 100);
+          friendlyNotice = workspaceCopy.wallet.insufficientWithAmount.replace('{amount}', formattedShortfall);
+        } catch {
+          formattedShortfall = `${currencyCode} ${(normalizedShortfall / 100).toFixed(2)}`;
+          friendlyNotice = workspaceCopy.wallet.insufficientWithAmount.replace('{amount}', formattedShortfall);
+        }
+      }
+
+      setTopUpModal({
+        message: friendlyNotice,
+        amountLabel: formattedShortfall,
+        shortfallCents: typeof normalizedShortfall === 'number' ? normalizedShortfall : undefined,
+      });
+      showComposerError(friendlyNotice);
+    },
+    [setTopUpModal, showComposerError, workspaceCopy.wallet.insufficient, workspaceCopy.wallet.insufficientWithAmount]
+  );
+
+  const verifyWalletBalance = useCallback(
+    async ({ preflight, iterationCount, currencyCode }: VerifyWalletBalanceOptions) => {
+      const unitCostCents = resolvePreflightUnitCostCents(preflight);
+      if (typeof unitCostCents !== 'number' || unitCostCents <= 0) return true;
+
+      const requiredCents = unitCostCents * iterationCount;
+      try {
+        const res = await authFetch('/api/wallet');
+        if (!res.ok) return true;
+        const walletJson = await res.json();
+        const balanceCents = resolveWalletBalanceCents(walletJson);
+        if (typeof balanceCents !== 'number') return true;
+        const shortfall = requiredCents - balanceCents;
+        if (shortfall <= 0) return true;
+        presentInsufficientFunds({ currencyCode, shortfallCents: shortfall });
+        return false;
+      } catch (walletError) {
+        console.warn('[startRender] wallet balance check failed', walletError);
+        return true;
+      }
+    },
+    [presentInsufficientFunds]
+  );
+
+  return {
+    presentInsufficientFunds,
+    verifyWalletBalance,
+  };
+}

--- a/tests/workspace-composer-generation-split-contract.test.ts
+++ b/tests/workspace-composer-generation-split-contract.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const composerHookPath = 'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceComposerState.ts';
+const engineModeHookPath = 'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceEngineModeState.ts';
+const generationRunnerHookPath = 'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceGenerationRunner.ts';
+const walletPreflightHookPath = 'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceWalletPreflight.ts';
+
+test('workspace composer engine and mode orchestration is split from composer field handlers', () => {
+  assert.equal(existsSync(engineModeHookPath), true);
+
+  const composerSource = readFileSync(composerHookPath, 'utf8');
+  const engineModeSource = readFileSync(engineModeHookPath, 'utf8');
+
+  assert.match(composerSource, /useWorkspaceEngineModeState/);
+  assert.match(composerSource, /useWorkspaceEngineModeState\(\{/);
+
+  assert.doesNotMatch(composerSource, /getUnifiedSeedanceMode/);
+  assert.doesNotMatch(composerSource, /getUnifiedHappyHorseMode/);
+  assert.doesNotMatch(composerSource, /getReferenceInputStatus/);
+  assert.doesNotMatch(composerSource, /getModeCaps/);
+  assert.doesNotMatch(composerSource, /findGenerateAudioField/);
+  assert.doesNotMatch(composerSource, /supportsAudioPricingToggle/);
+  assert.doesNotMatch(composerSource, /UNIFIED_VEO_FIRST_LAST_ENGINE_IDS/);
+
+  assert.match(engineModeSource, /export function useWorkspaceEngineModeState/);
+  assert.match(engineModeSource, /getUnifiedSeedanceMode/);
+  assert.match(engineModeSource, /getUnifiedHappyHorseMode/);
+  assert.match(engineModeSource, /getReferenceInputStatus/);
+  assert.match(engineModeSource, /getModeCaps/);
+  assert.match(engineModeSource, /findGenerateAudioField/);
+  assert.match(engineModeSource, /supportsAudioPricingToggle/);
+  assert.match(engineModeSource, /UNIFIED_VEO_FIRST_LAST_ENGINE_IDS/);
+});
+
+test('workspace generation wallet preflight is split from generation submission orchestration', () => {
+  assert.equal(existsSync(walletPreflightHookPath), true);
+
+  const generationRunnerSource = readFileSync(generationRunnerHookPath, 'utf8');
+  const walletPreflightSource = readFileSync(walletPreflightHookPath, 'utf8');
+
+  assert.match(generationRunnerSource, /import \{ useWorkspaceWalletPreflight \} from '\.\/useWorkspaceWalletPreflight';/);
+  assert.match(generationRunnerSource, /useWorkspaceWalletPreflight\(\{/);
+
+  assert.doesNotMatch(generationRunnerSource, /CURRENCY_LOCALE/);
+  assert.doesNotMatch(generationRunnerSource, /authFetch\('\/api\/wallet'\)/);
+  assert.doesNotMatch(generationRunnerSource, /const presentInsufficientFunds =/);
+  assert.doesNotMatch(generationRunnerSource, /const unitCostCents =/);
+
+  assert.match(walletPreflightSource, /export function useWorkspaceWalletPreflight/);
+  assert.match(walletPreflightSource, /CURRENCY_LOCALE/);
+  assert.match(walletPreflightSource, /authFetch\('\/api\/wallet'\)/);
+  assert.match(walletPreflightSource, /presentInsufficientFunds/);
+  assert.match(walletPreflightSource, /verifyWalletBalance/);
+});

--- a/tests/workspace-composer-state-hook-contract.test.ts
+++ b/tests/workspace-composer-state-hook-contract.test.ts
@@ -12,9 +12,15 @@ test('workspace composer mode and settings state is owned by a route-local hook'
     process.cwd(),
     'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceComposerState.ts'
   );
+  const engineModeHookPath = path.join(
+    process.cwd(),
+    'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceEngineModeState.ts'
+  );
   assert.equal(fs.existsSync(hookPath), true);
+  assert.equal(fs.existsSync(engineModeHookPath), true);
 
   const hookSource = fs.readFileSync(hookPath, 'utf8');
+  const engineModeHookSource = fs.readFileSync(engineModeHookPath, 'utf8');
 
   assert.match(appSource, /import \{ useWorkspaceComposerState \} from '\.\/_hooks\/useWorkspaceComposerState';/);
   assert.match(appSource, /useWorkspaceComposerState\(\{/);
@@ -27,15 +33,23 @@ test('workspace composer mode and settings state is owned by a route-local hook'
   assert.doesNotMatch(appSource, /const handleResolutionChange = useCallback/);
 
   assert.match(hookSource, /export function useWorkspaceComposerState/);
+  assert.match(hookSource, /useWorkspaceEngineModeState/);
   assert.match(hookSource, /const multiPromptTotalSec = useMemo/);
-  assert.match(hookSource, /const implicitMode = useMemo<Mode>/);
-  assert.match(hookSource, /const audioWorkflowUnsupported =/);
-  assert.match(hookSource, /const handleEngineChange = useCallback/);
-  assert.match(hookSource, /const handleComposerModeToggle = useCallback/);
   assert.match(hookSource, /const handleDurationChange = useCallback/);
   assert.match(hookSource, /const handleResolutionChange = useCallback/);
-  assert.match(hookSource, /buildComposerModeToggles/);
-  assert.match(hookSource, /getComposerWorkflowNotice/);
-  assert.match(hookSource, /getUnifiedSeedanceMode/);
-  assert.match(hookSource, /getUnifiedHappyHorseMode/);
+
+  assert.doesNotMatch(hookSource, /const implicitMode = useMemo<Mode>/);
+  assert.doesNotMatch(hookSource, /const audioWorkflowUnsupported =/);
+  assert.doesNotMatch(hookSource, /getUnifiedSeedanceMode/);
+  assert.doesNotMatch(hookSource, /getUnifiedHappyHorseMode/);
+
+  assert.match(engineModeHookSource, /export function useWorkspaceEngineModeState/);
+  assert.match(engineModeHookSource, /const implicitMode = useMemo<Mode>/);
+  assert.match(engineModeHookSource, /const audioWorkflowUnsupported =/);
+  assert.match(engineModeHookSource, /const handleEngineChange = useCallback/);
+  assert.match(engineModeHookSource, /const handleComposerModeToggle = useCallback/);
+  assert.match(engineModeHookSource, /buildComposerModeToggles/);
+  assert.match(engineModeHookSource, /getComposerWorkflowNotice/);
+  assert.match(engineModeHookSource, /getUnifiedSeedanceMode/);
+  assert.match(engineModeHookSource, /getUnifiedHappyHorseMode/);
 });


### PR DESCRIPTION
## Summary
- Extract workspace engine/mode orchestration from `useWorkspaceComposerState` into `useWorkspaceEngineModeState`.
- Extract wallet balance preflight and insufficient-funds presentation from `useWorkspaceGenerationRunner` into `useWorkspaceWalletPreflight`.
- Update workspace architecture guidance and contract tests to keep these boundaries explicit.

## Test Plan
- [x] `pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/workspace-composer-generation-split-contract.test.ts tests/workspace-composer-state-hook-contract.test.ts tests/workspace-generation-runner-hook-contract.test.ts tests/supabase-browser-session-cleanup.test.ts`
- [x] `pnpm --prefix frontend exec tsc --noEmit`
- [x] `npm --prefix frontend run lint`
- [x] `npm run lint:exposure`
- [x] `pnpm test:validate`
- [x] `pnpm --prefix frontend run build`