### PR TITLE
Split workspace asset hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ For the authenticated workspace route, keep `frontend/app/(core)/(workspace)/app
 - Keep notice timers, onboarding route redirects, and preview/viewer composition in route-local hooks under `_hooks/`.
 - Keep composer engine/mode orchestration in `_hooks/useWorkspaceEngineModeState.ts`; `useWorkspaceComposerState.ts` should focus on composer input field state and field handlers.
 - Keep wallet balance preflight in `_hooks/useWorkspaceWalletPreflight.ts`; `useWorkspaceGenerationRunner.ts` should focus on generation submission, local render state, accepted results, and polling.
+- Keep workspace asset library, reference field assets, and Kling element assets split across `_hooks/useWorkspaceAssetLibrary.ts`, `_hooks/useWorkspaceReferenceAssets.ts`, and `_hooks/useWorkspaceKlingElementAssets.ts`; `useWorkspaceAssets.ts` should stay an orchestrator.
 - Keep composer JSX in `_components/WorkspaceComposerSurface.tsx` and shared modal wiring in `_components/WorkspaceRuntimeModals.tsx`.
 - Add or update contract tests in `tests/workspace-*-contract.test.ts` when moving workspace responsibilities, so the architecture stays explicit.
 

--- a/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceAssetLibrary.ts
+++ b/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceAssetLibrary.ts
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import { authFetch } from '@/lib/authFetch';
+import {
+  buildAssetLibraryCacheKey,
+  buildAssetLibraryUrl,
+  normalizeAssetLibraryPayload,
+  revokeAssetPreview,
+  type AssetLibraryKind,
+  type AssetLibrarySource,
+  type AssetPickerTarget,
+  type ReferenceAsset,
+  type UserAsset,
+} from '../_lib/workspace-assets';
+
+type FetchAssetLibraryOptions = {
+  source?: AssetLibrarySource;
+  kind?: AssetLibraryKind;
+};
+
+type UseWorkspaceAssetLibraryOptions = {
+  showNotice: (message: string) => void;
+  setInputAssets: Dispatch<SetStateAction<Record<string, (ReferenceAsset | null)[]>>>;
+};
+
+export function useWorkspaceAssetLibrary({
+  showNotice,
+  setInputAssets,
+}: UseWorkspaceAssetLibraryOptions) {
+  const [assetPickerTarget, setAssetPickerTarget] = useState<AssetPickerTarget | null>(null);
+  const [assetLibrary, setAssetLibrary] = useState<UserAsset[]>([]);
+  const [isAssetLibraryLoading, setIsAssetLibraryLoading] = useState(false);
+  const [assetLibraryError, setAssetLibraryError] = useState<string | null>(null);
+  const [assetLibrarySource, setAssetLibrarySource] = useState<AssetLibrarySource>('all');
+  const [assetLibraryLoadedKey, setAssetLibraryLoadedKey] = useState<string | null>(null);
+  const [assetDeletePendingId, setAssetDeletePendingId] = useState<string | null>(null);
+
+  const assetLibraryKind = useMemo<AssetLibraryKind>(() => {
+    if (!assetPickerTarget) return 'image';
+    if (assetPickerTarget.kind === 'field' && assetPickerTarget.field.type === 'video') {
+      return 'video';
+    }
+    return 'image';
+  }, [assetPickerTarget]);
+  const assetLibraryRequestKey = assetPickerTarget
+    ? buildAssetLibraryCacheKey(assetLibraryKind, assetLibrarySource)
+    : null;
+  const visibleAssetLibrary = useMemo(
+    () => assetLibrary.filter((asset) => asset.kind === assetLibraryKind),
+    [assetLibrary, assetLibraryKind]
+  );
+
+  const resetAssetLibraryForSource = useCallback((nextSource: AssetLibrarySource) => {
+    setAssetLibrarySource(nextSource);
+    setAssetLibrary([]);
+    setAssetLibraryError(null);
+    setAssetLibraryLoadedKey(null);
+  }, []);
+
+  const fetchAssetLibrary = useCallback(async (options?: FetchAssetLibraryOptions) => {
+    const source = options?.source ?? assetLibrarySource;
+    const kind = options?.kind ?? assetLibraryKind;
+    const requestKey = buildAssetLibraryCacheKey(kind, source);
+    setIsAssetLibraryLoading(true);
+    setAssetLibraryError(null);
+    try {
+      const assetResponse = await authFetch(buildAssetLibraryUrl(kind, source));
+      if (assetResponse.status === 401) {
+        setAssetLibrary([]);
+        setAssetLibraryError(
+          kind === 'video' ? 'Sign in to access your video library.' : 'Sign in to access your image library.'
+        );
+        setAssetLibraryLoadedKey(requestKey);
+        return;
+      }
+      const payload = await assetResponse.json().catch(() => null);
+      if (!assetResponse.ok || !payload?.ok) {
+        const message =
+          typeof payload?.error === 'string'
+            ? payload.error
+            : kind === 'video'
+              ? 'Failed to load videos'
+              : 'Failed to load images';
+        throw new Error(message);
+      }
+      setAssetLibrary(normalizeAssetLibraryPayload(payload, source, kind));
+      setAssetLibraryLoadedKey(requestKey);
+    } catch (error) {
+      console.error('[assets] failed to load library', error);
+      setAssetLibraryError(
+        error instanceof Error
+          ? error.message
+          : kind === 'video'
+            ? 'Failed to load videos'
+            : 'Failed to load images'
+      );
+      setAssetLibraryLoadedKey(requestKey);
+    } finally {
+      setIsAssetLibraryLoading(false);
+    }
+  }, [assetLibraryKind, assetLibrarySource]);
+
+  useEffect(() => {
+    if (!assetPickerTarget || !assetLibraryRequestKey || isAssetLibraryLoading) return;
+    if (assetLibraryLoadedKey === assetLibraryRequestKey) return;
+    setAssetLibrary([]);
+    setAssetLibraryError(null);
+    void fetchAssetLibrary({ kind: assetLibraryKind, source: assetLibrarySource });
+  }, [
+    assetLibraryKind,
+    assetLibraryLoadedKey,
+    assetLibraryRequestKey,
+    assetLibrarySource,
+    assetPickerTarget,
+    fetchAssetLibrary,
+    isAssetLibraryLoading,
+  ]);
+
+  const handleDeleteLibraryAsset = useCallback(
+    async (asset: UserAsset) => {
+      if (!asset?.id) return;
+      setAssetDeletePendingId(asset.id);
+      try {
+        const response = await authFetch('/api/user-assets', {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id: asset.id }),
+        });
+        const payload = await response.json().catch(() => null);
+        const success = response.ok && Boolean(payload?.ok);
+        const notFound = response.status === 404 || payload?.error === 'NOT_FOUND';
+        if (!success && !notFound) {
+          const message = typeof payload?.error === 'string' ? payload.error : 'Failed to delete image';
+          throw new Error(message);
+        }
+
+        setAssetLibrary((previous) => previous.filter((entry) => entry.id !== asset.id));
+        setInputAssets((previous) => {
+          let changed = false;
+          const next: typeof previous = {};
+          for (const [fieldId, entries] of Object.entries(previous)) {
+            let fieldChanged = false;
+            const updated = entries.map((entry) => {
+              if (entry && entry.assetId === asset.id) {
+                fieldChanged = true;
+                changed = true;
+                revokeAssetPreview(entry);
+                return null;
+              }
+              return entry;
+            });
+            next[fieldId] = fieldChanged ? updated : entries;
+          }
+          return changed ? next : previous;
+        });
+      } catch (error) {
+        console.error('[assets] failed to delete asset', error);
+        showNotice(error instanceof Error ? error.message : 'Failed to delete image');
+        throw error;
+      } finally {
+        setAssetDeletePendingId(null);
+      }
+    },
+    [setInputAssets, showNotice]
+  );
+
+  const handleAssetLibrarySourceChange = useCallback(
+    (nextSource: AssetLibrarySource) => {
+      if (nextSource === assetLibrarySource) return;
+      resetAssetLibraryForSource(nextSource);
+    },
+    [assetLibrarySource, resetAssetLibraryForSource]
+  );
+
+  const closeAssetLibrary = useCallback(() => {
+    setAssetPickerTarget(null);
+  }, []);
+
+  return {
+    assetPickerTarget,
+    setAssetPickerTarget,
+    assetLibraryKind,
+    assetLibrarySource,
+    setAssetLibrary,
+    visibleAssetLibrary,
+    isAssetLibraryLoading,
+    assetLibraryError,
+    assetDeletePendingId,
+    fetchAssetLibrary,
+    handleAssetLibrarySourceChange,
+    closeAssetLibrary,
+    handleDeleteLibraryAsset,
+    resetAssetLibraryForSource,
+  };
+}

--- a/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceAssets.ts
+++ b/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceAssets.ts
@@ -1,43 +1,10 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useState } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
-import type { KlingElementAsset, KlingElementState } from '@/components/KlingElementsBuilder';
-import { saveAssetToLibrary, saveImageToLibrary } from '@/lib/api';
-import { authFetch } from '@/lib/authFetch';
-import { prepareImageFileForUpload } from '@/lib/client-image-upload';
-import {
-  getSeedanceFieldBlockKey,
-  isUnifiedSeedanceEngineId,
-} from '@/lib/seedance-workflow';
-import type { EngineInputField } from '@/types/engines';
-import {
-  buildAssetLibraryCacheKey,
-  buildAssetLibraryUrl,
-  buildKlingLibraryAsset,
-  buildReferenceAssetFromLibraryAsset,
-  getAssetLibrarySourceForField,
-  getLibraryAssetFieldMismatchMessage,
-  insertKlingLibraryAsset,
-  insertReferenceAsset,
-  mergeMirroredLibraryAsset,
-  normalizeAssetLibraryPayload,
-  removeReferenceAsset,
-  revokeAssetPreview,
-  revokeKlingAssetPreview,
-  shouldMirrorCharacterImageAsset,
-  shouldMirrorVideoLibraryAsset,
-  type AssetLibraryKind,
-  type AssetLibrarySource,
-  type AssetPickerTarget,
-  type ReferenceAsset,
-  type UserAsset,
-} from '../_lib/workspace-assets';
-import { createKlingElement, createLocalId } from '../_lib/workspace-input-helpers';
-import {
-  createUploadFailure,
-  getUploadFailureMessage,
-  type UploadableAssetKind,
-  type UploadFailure,
-} from '../_lib/workspace-upload-errors';
+import type { KlingElementState } from '@/components/KlingElementsBuilder';
+import type { ReferenceAsset } from '../_lib/workspace-assets';
+import { useWorkspaceAssetLibrary } from './useWorkspaceAssetLibrary';
+import { useWorkspaceKlingElementAssets } from './useWorkspaceKlingElementAssets';
+import { useWorkspaceReferenceAssets } from './useWorkspaceReferenceAssets';
 
 type UseWorkspaceAssetsOptions = {
   engineId?: string | null;
@@ -50,18 +17,6 @@ type UseWorkspaceAssetsOptions = {
   setKlingElements: Dispatch<SetStateAction<KlingElementState[]>>;
 };
 
-type FetchAssetLibraryOptions = {
-  source?: AssetLibrarySource;
-  kind?: AssetLibraryKind;
-};
-
-function createReferenceAssetId(): string {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID();
-  }
-  return `asset_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
-}
-
 export function useWorkspaceAssets({
   engineId,
   workflowCopy,
@@ -70,608 +25,59 @@ export function useWorkspaceAssets({
   setKlingElements,
 }: UseWorkspaceAssetsOptions) {
   const [inputAssets, setInputAssets] = useState<Record<string, (ReferenceAsset | null)[]>>({});
-  const [assetPickerTarget, setAssetPickerTarget] = useState<AssetPickerTarget | null>(null);
-  const [assetLibrary, setAssetLibrary] = useState<UserAsset[]>([]);
-  const [isAssetLibraryLoading, setIsAssetLibraryLoading] = useState(false);
-  const [assetLibraryError, setAssetLibraryError] = useState<string | null>(null);
-  const [assetLibrarySource, setAssetLibrarySource] = useState<AssetLibrarySource>('all');
-  const [assetLibraryLoadedKey, setAssetLibraryLoadedKey] = useState<string | null>(null);
-  const [assetDeletePendingId, setAssetDeletePendingId] = useState<string | null>(null);
 
-  const assetLibraryKind = useMemo<AssetLibraryKind>(() => {
-    if (!assetPickerTarget) return 'image';
-    if (assetPickerTarget.kind === 'field' && assetPickerTarget.field.type === 'video') {
-      return 'video';
-    }
-    return 'image';
-  }, [assetPickerTarget]);
-  const assetLibraryRequestKey = assetPickerTarget
-    ? buildAssetLibraryCacheKey(assetLibraryKind, assetLibrarySource)
-    : null;
-  const visibleAssetLibrary = useMemo(
-    () => assetLibrary.filter((asset) => asset.kind === assetLibraryKind),
-    [assetLibrary, assetLibraryKind]
-  );
-
-  const assetsRef = useRef<Record<string, (ReferenceAsset | null)[]>>({});
-  const klingElementsRef = useRef<KlingElementState[]>([]);
-
-  useEffect(() => {
-    assetsRef.current = inputAssets;
-  }, [inputAssets]);
-
-  useEffect(() => {
-    return () => {
-      Object.values(assetsRef.current).forEach((entries) => {
-        entries.forEach((asset) => {
-          revokeAssetPreview(asset);
-        });
-      });
-    };
-  }, []);
-
-  useEffect(() => {
-    klingElementsRef.current = klingElements;
-  }, [klingElements]);
-
-  useEffect(() => {
-    return () => {
-      klingElementsRef.current.forEach((element) => {
-        revokeKlingAssetPreview(element.frontal);
-        element.references.forEach((asset) => revokeKlingAssetPreview(asset));
-        revokeKlingAssetPreview(element.video);
-      });
-    };
-  }, []);
-
-  const fetchAssetLibrary = useCallback(async (options?: FetchAssetLibraryOptions) => {
-    const source = options?.source ?? assetLibrarySource;
-    const kind = options?.kind ?? assetLibraryKind;
-    const requestKey = buildAssetLibraryCacheKey(kind, source);
-    setIsAssetLibraryLoading(true);
-    setAssetLibraryError(null);
-    try {
-      const assetResponse = await authFetch(buildAssetLibraryUrl(kind, source));
-      if (assetResponse.status === 401) {
-        setAssetLibrary([]);
-        setAssetLibraryError(
-          kind === 'video' ? 'Sign in to access your video library.' : 'Sign in to access your image library.'
-        );
-        setAssetLibraryLoadedKey(requestKey);
-        return;
-      }
-      const payload = await assetResponse.json().catch(() => null);
-      if (!assetResponse.ok || !payload?.ok) {
-        const message =
-          typeof payload?.error === 'string'
-            ? payload.error
-            : kind === 'video'
-              ? 'Failed to load videos'
-              : 'Failed to load images';
-        throw new Error(message);
-      }
-      setAssetLibrary(normalizeAssetLibraryPayload(payload, source, kind));
-      setAssetLibraryLoadedKey(requestKey);
-    } catch (error) {
-      console.error('[assets] failed to load library', error);
-      setAssetLibraryError(
-        error instanceof Error
-          ? error.message
-          : kind === 'video'
-            ? 'Failed to load videos'
-            : 'Failed to load images'
-      );
-      setAssetLibraryLoadedKey(requestKey);
-    } finally {
-      setIsAssetLibraryLoading(false);
-    }
-  }, [assetLibraryKind, assetLibrarySource]);
-
-  useEffect(() => {
-    if (!assetPickerTarget || !assetLibraryRequestKey || isAssetLibraryLoading) return;
-    if (assetLibraryLoadedKey === assetLibraryRequestKey) return;
-    setAssetLibrary([]);
-    setAssetLibraryError(null);
-    void fetchAssetLibrary({ kind: assetLibraryKind, source: assetLibrarySource });
-  }, [
-    assetLibraryKind,
-    assetLibraryLoadedKey,
-    assetLibraryRequestKey,
-    assetLibrarySource,
+  const {
     assetPickerTarget,
-    fetchAssetLibrary,
+    setAssetPickerTarget,
+    assetLibraryKind,
+    assetLibrarySource,
+    setAssetLibrary,
+    visibleAssetLibrary,
     isAssetLibraryLoading,
-  ]);
+    assetLibraryError,
+    assetDeletePendingId,
+    fetchAssetLibrary,
+    handleAssetLibrarySourceChange,
+    closeAssetLibrary,
+    handleDeleteLibraryAsset,
+    resetAssetLibraryForSource,
+  } = useWorkspaceAssetLibrary({
+    showNotice,
+    setInputAssets,
+  });
 
-  const handleDeleteLibraryAsset = useCallback(
-    async (asset: UserAsset) => {
-      if (!asset?.id) return;
-      setAssetDeletePendingId(asset.id);
-      try {
-        const response = await authFetch('/api/user-assets', {
-          method: 'DELETE',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ id: asset.id }),
-        });
-        const payload = await response.json().catch(() => null);
-        const success = response.ok && Boolean(payload?.ok);
-        const notFound = response.status === 404 || payload?.error === 'NOT_FOUND';
-        if (!success && !notFound) {
-          const message = typeof payload?.error === 'string' ? payload.error : 'Failed to delete image';
-          throw new Error(message);
-        }
+  const {
+    handleOpenAssetLibrary,
+    handleSelectLibraryAsset,
+    handleAssetAdd,
+    handleAssetRemove,
+  } = useWorkspaceReferenceAssets({
+    engineId,
+    workflowCopy,
+    showNotice,
+    inputAssets,
+    setInputAssets,
+    assetLibrarySource,
+    resetAssetLibraryForSource,
+    setAssetPickerTarget,
+    setAssetLibrary,
+  });
 
-        setAssetLibrary((previous) => previous.filter((entry) => entry.id !== asset.id));
-        setInputAssets((previous) => {
-          let changed = false;
-          const next: typeof previous = {};
-          for (const [fieldId, entries] of Object.entries(previous)) {
-            let fieldChanged = false;
-            const updated = entries.map((entry) => {
-              if (entry && entry.assetId === asset.id) {
-                fieldChanged = true;
-                changed = true;
-                if (entry.previewUrl.startsWith('blob:')) {
-                  URL.revokeObjectURL(entry.previewUrl);
-                }
-                return null;
-              }
-              return entry;
-            });
-            next[fieldId] = fieldChanged ? updated : entries;
-          }
-          return changed ? next : previous;
-        });
-      } catch (error) {
-        console.error('[assets] failed to delete asset', error);
-        showNotice(error instanceof Error ? error.message : 'Failed to delete image');
-        throw error;
-      } finally {
-        setAssetDeletePendingId(null);
-      }
-    },
-    [showNotice]
-  );
-
-  const getSeedanceFieldBlockedMessage = useCallback(
-    (field: EngineInputField) => {
-      if (!isUnifiedSeedanceEngineId(engineId)) return null;
-      const fieldHasOwnAssets = (inputAssets[field.id] ?? []).some((asset) => asset !== null);
-      const blockKey = getSeedanceFieldBlockKey(field.id, inputAssets, fieldHasOwnAssets);
-      if (blockKey === 'clearReferences') {
-        return workflowCopy.clearReferencesToUseStartEnd;
-      }
-      if (blockKey === 'clearStartEnd') {
-        return workflowCopy.clearStartEndToUseReferences;
-      }
-      return null;
-    },
-    [engineId, inputAssets, workflowCopy.clearReferencesToUseStartEnd, workflowCopy.clearStartEndToUseReferences]
-  );
-
-  const resetAssetLibraryForSource = useCallback((nextSource: AssetLibrarySource) => {
-    setAssetLibrarySource(nextSource);
-    setAssetLibrary([]);
-    setAssetLibraryError(null);
-    setAssetLibraryLoadedKey(null);
-  }, []);
-
-  const handleOpenAssetLibrary = useCallback(
-    (field: EngineInputField, slotIndex?: number) => {
-      const blockedMessage = getSeedanceFieldBlockedMessage(field);
-      if (blockedMessage) {
-        showNotice(blockedMessage);
-        return;
-      }
-      const nextSource = getAssetLibrarySourceForField(field);
-      if (nextSource !== assetLibrarySource) {
-        resetAssetLibraryForSource(nextSource);
-      }
-      setAssetPickerTarget({ kind: 'field', field, slotIndex });
-    },
-    [assetLibrarySource, getSeedanceFieldBlockedMessage, resetAssetLibraryForSource, showNotice]
-  );
-
-  const handleOpenKlingAssetLibrary = useCallback(
-    (elementId: string, slot: 'frontal' | 'reference', slotIndex?: number) => {
-      if (assetLibrarySource !== 'all') {
-        resetAssetLibraryForSource('all');
-      }
-      setAssetPickerTarget({ kind: 'kling', elementId, slot, slotIndex });
-    },
-    [assetLibrarySource, resetAssetLibraryForSource]
-  );
-
-  const handleSelectLibraryAsset = useCallback(
-    async (field: EngineInputField, asset: UserAsset, slotIndex?: number) => {
-      const blockedMessage = getSeedanceFieldBlockedMessage(field);
-      if (blockedMessage) {
-        showNotice(blockedMessage);
-        return;
-      }
-      const mismatchMessage = getLibraryAssetFieldMismatchMessage(field, asset);
-      if (mismatchMessage) {
-        showNotice(mismatchMessage);
-        return;
-      }
-
-      let resolvedAsset = asset;
-
-      if (field.type === 'video' && asset.kind === 'video') {
-        try {
-          if (shouldMirrorVideoLibraryAsset(asset)) {
-            const mirrored = await saveAssetToLibrary({
-              url: asset.url,
-              label:
-                field.label ??
-                asset.url.split('/').pop() ??
-                'Video',
-              source: asset.source === 'recent' ? 'saved_job_output' : asset.source,
-              kind: 'video',
-              jobId: asset.jobId ?? null,
-              sourceOutputId: asset.sourceOutputId ?? null,
-            });
-            resolvedAsset = mergeMirroredLibraryAsset(asset, mirrored);
-            setAssetLibrary((previous) =>
-              previous.map((entry) =>
-                entry.id === asset.id || entry.url === asset.url ? resolvedAsset : entry
-              )
-            );
-          }
-        } catch (error) {
-          console.error('[assets] failed to mirror generated video asset', error);
-          showNotice(error instanceof Error ? error.message : 'Unable to prepare this video. Try importing the source clip directly.');
-          return;
-        }
-      }
-
-      if (field.type === 'image' && asset.kind === 'image') {
-        try {
-          if (shouldMirrorCharacterImageAsset(asset)) {
-            const mirrored = await saveImageToLibrary({
-              url: asset.url,
-              label:
-                field.label ??
-                asset.url.split('/').pop() ??
-                'Image',
-              source: asset.source,
-            });
-            resolvedAsset = mergeMirroredLibraryAsset(asset, mirrored);
-            setAssetLibrary((previous) =>
-              previous.map((entry) =>
-                entry.id === asset.id || entry.url === asset.url ? resolvedAsset : entry
-              )
-            );
-          }
-        } catch (error) {
-          console.error('[assets] failed to mirror character library asset', error);
-          showNotice(error instanceof Error ? error.message : 'Unable to prepare this character asset. Try another image.');
-          return;
-        }
-      }
-
-      const newAsset = buildReferenceAssetFromLibraryAsset(field, resolvedAsset);
-
-      setInputAssets((previous) => {
-        return insertReferenceAsset(previous, field, newAsset, slotIndex, {
-          release: revokeAssetPreview,
-          onMaxReached: () => showNotice(`Maximum ${field.label ?? 'reference image'} count reached for this engine.`),
-        });
-      });
-
-      setAssetPickerTarget(null);
-    },
-    [getSeedanceFieldBlockedMessage, showNotice]
-  );
-
-  const handleSelectKlingLibraryAsset = useCallback(
-    (target: Extract<AssetPickerTarget, { kind: 'kling' }>, asset: UserAsset) => {
-      const newAsset = buildKlingLibraryAsset(asset);
-      setKlingElements((previous) =>
-        insertKlingLibraryAsset(previous, target, newAsset, revokeKlingAssetPreview)
-      );
-
-      setAssetPickerTarget(null);
-    },
-    [setKlingElements]
-  );
-
-  const handleAssetAdd = useCallback(
-    (field: EngineInputField, file: File, slotIndex?: number, meta?: { durationSec?: number }) => {
-      const blockedMessage = getSeedanceFieldBlockedMessage(field);
-      if (blockedMessage) {
-        showNotice(blockedMessage);
-        return;
-      }
-      const assetId = createReferenceAssetId();
-      const previewUrl = URL.createObjectURL(file);
-      const baseAsset: ReferenceAsset = {
-        id: assetId,
-        fieldId: field.id,
-        previewUrl,
-        kind: field.type === 'video' ? 'video' : field.type === 'audio' ? 'audio' : 'image',
-        name: file.name,
-        size: file.size,
-        type: file.type,
-        durationSec: typeof meta?.durationSec === 'number' ? meta.durationSec : null,
-        status: 'uploading' as const,
-      };
-
-      setInputAssets((previous) => {
-        return insertReferenceAsset(previous, field, baseAsset, slotIndex, {
-          release: revokeAssetPreview,
-          onMaxReached: () => revokeAssetPreview(baseAsset),
-        });
-      });
-
-      const upload = async () => {
-        try {
-          const preparedFile =
-            field.type === 'image'
-              ? await prepareImageFileForUpload(file, { maxBytes: 25 * 1024 * 1024 })
-              : file;
-          const formData = new FormData();
-          formData.append('file', preparedFile, preparedFile.name);
-          const uploadEndpoint =
-            field.type === 'video'
-              ? '/api/uploads/video'
-              : field.type === 'audio'
-                ? '/api/uploads/audio'
-                : '/api/uploads/image';
-          const uploadAssetType: UploadableAssetKind =
-            field.type === 'video' ? 'video' : field.type === 'audio' ? 'audio' : 'image';
-          const response = await authFetch(uploadEndpoint, {
-            method: 'POST',
-            body: formData,
-          });
-          const payload = await response.json().catch(() => null);
-          if (!response.ok || !payload?.ok) {
-            throw createUploadFailure(uploadAssetType, response.status, payload, 'Upload failed');
-          }
-          const assetResponse = payload.asset as {
-            id: string;
-            url: string;
-            width?: number | null;
-            height?: number | null;
-            size?: number;
-            mime?: string;
-            name?: string;
-          };
-          setInputAssets((previous) => {
-            const current = previous[field.id];
-            if (!current) return previous;
-            const next = current.map((entry) => {
-              if (!entry || entry.id !== assetId) return entry;
-              return {
-                ...entry,
-                status: 'ready' as const,
-                url: assetResponse.url,
-                width: assetResponse.width ?? entry.width,
-                height: assetResponse.height ?? entry.height,
-                size: assetResponse.size ?? entry.size,
-                type: assetResponse.mime ?? entry.type,
-                assetId: assetResponse.id,
-              };
-            });
-            return { ...previous, [field.id]: next };
-          });
-        } catch (error) {
-          const uploadAssetType: UploadableAssetKind =
-            field.type === 'video' ? 'video' : field.type === 'audio' ? 'audio' : 'image';
-          const message = getUploadFailureMessage(uploadAssetType, error, 'Upload failed');
-          const uploadError = error as UploadFailure;
-          console.error(
-            '[assets] upload failed',
-            {
-              fieldId: field.id,
-              assetType: uploadAssetType,
-              status: uploadError?.status ?? null,
-              code: uploadError?.code ?? null,
-              maxMB: uploadError?.maxMB ?? null,
-              message,
-            },
-            error
-          );
-          setInputAssets((previous) => {
-            const current = previous[field.id];
-            if (!current) return previous;
-            const next = current.map((entry) => {
-              if (!entry || entry.id !== assetId) return entry;
-              return {
-                ...entry,
-                status: 'error' as const,
-                error: message,
-              };
-            });
-            return { ...previous, [field.id]: next };
-          });
-          showNotice(message);
-        }
-      };
-
-      void upload();
-    },
-    [getSeedanceFieldBlockedMessage, showNotice]
-  );
-
-  const handleAssetRemove = useCallback((field: EngineInputField, index: number) => {
-    setInputAssets((previous) => {
-      return removeReferenceAsset(previous, field, index, revokeAssetPreview);
-    });
-  }, []);
-
-  const handleKlingElementAdd = useCallback(() => {
-    setKlingElements((previous) => [...previous, createKlingElement()]);
-  }, [setKlingElements]);
-
-  const handleKlingElementRemove = useCallback((id: string) => {
-    setKlingElements((previous) => {
-      const next = previous.filter((element) => element.id !== id);
-      return next.length ? next : [createKlingElement()];
-    });
-  }, [setKlingElements]);
-
-  const handleKlingElementAssetRemove = useCallback(
-    (elementId: string, slot: 'frontal' | 'reference' | 'video', index?: number) => {
-      setKlingElements((previous) =>
-        previous.map((element) => {
-          if (element.id !== elementId) return element;
-          if (slot === 'frontal') {
-            revokeKlingAssetPreview(element.frontal);
-            return { ...element, frontal: null };
-          }
-          if (slot === 'video') {
-            revokeKlingAssetPreview(element.video);
-            return { ...element, video: null };
-          }
-          const references = [...element.references];
-          if (typeof index === 'number' && index >= 0 && index < references.length) {
-            revokeKlingAssetPreview(references[index]);
-            references[index] = null;
-          }
-          return { ...element, references };
-        })
-      );
-    },
-    [setKlingElements]
-  );
-
-  const handleKlingElementAssetAdd = useCallback(
-    (elementId: string, slot: 'frontal' | 'reference' | 'video', file: File, index?: number) => {
-      const assetId = createLocalId('element_asset');
-      const previewUrl = URL.createObjectURL(file);
-      const baseAsset: KlingElementAsset = {
-        id: assetId,
-        previewUrl,
-        name: file.name,
-        kind: slot === 'video' ? 'video' : 'image',
-        status: 'uploading' as const,
-        url: undefined as string | undefined,
-      };
-
-      setKlingElements((previous) =>
-        previous.map((element) => {
-          if (element.id !== elementId) return element;
-          if (slot === 'frontal') {
-            revokeKlingAssetPreview(element.frontal);
-            return { ...element, frontal: baseAsset };
-          }
-          if (slot === 'video') {
-            revokeKlingAssetPreview(element.video);
-            return { ...element, video: baseAsset };
-          }
-          const references = [...element.references];
-          let targetIndex = typeof index === 'number' ? index : references.findIndex((entry) => entry === null);
-          if (targetIndex < 0) {
-            targetIndex = references.length;
-          }
-          if (targetIndex >= references.length) {
-            return element;
-          }
-          revokeKlingAssetPreview(references[targetIndex]);
-          references[targetIndex] = baseAsset;
-          return { ...element, references };
-        })
-      );
-
-      const upload = async () => {
-        try {
-          const preparedFile =
-            slot === 'video'
-              ? file
-              : await prepareImageFileForUpload(file, { maxBytes: 25 * 1024 * 1024 });
-          const formData = new FormData();
-          formData.append('file', preparedFile, preparedFile.name);
-          const uploadEndpoint = slot === 'video' ? '/api/uploads/video' : '/api/uploads/image';
-          const response = await authFetch(uploadEndpoint, {
-            method: 'POST',
-            body: formData,
-          });
-          const payload = await response.json().catch(() => null);
-          if (!response.ok || !payload?.ok) {
-            throw createUploadFailure(slot === 'video' ? 'video' : 'image', response.status, payload, 'Upload failed');
-          }
-          const assetResponse = payload.asset as {
-            id: string;
-            url: string;
-            name?: string;
-          };
-          setKlingElements((previous) =>
-            previous.map((element) => {
-              if (element.id !== elementId) return element;
-              const updateAsset = (asset: typeof baseAsset | null) => {
-                if (!asset || asset.id !== assetId) return asset;
-                if (asset.previewUrl.startsWith('blob:')) {
-                  URL.revokeObjectURL(asset.previewUrl);
-                }
-                return {
-                  ...asset,
-                  status: 'ready' as const,
-                  url: assetResponse.url,
-                  previewUrl: assetResponse.url || asset.previewUrl,
-                  name: assetResponse.name ?? asset.name,
-                };
-              };
-              if (slot === 'frontal') {
-                return { ...element, frontal: updateAsset(element.frontal) };
-              }
-              if (slot === 'video') {
-                return { ...element, video: updateAsset(element.video) };
-              }
-              const references = element.references.map((asset) => updateAsset(asset));
-              return { ...element, references };
-            })
-          );
-        } catch (error) {
-          const assetType = slot === 'video' ? 'video' : 'image';
-          const message = getUploadFailureMessage(assetType, error, 'Upload failed.');
-          const uploadError = error as UploadFailure;
-          console.error(
-            '[kling-assets] upload failed',
-            {
-              elementId,
-              slot,
-              assetType,
-              status: uploadError?.status ?? null,
-              code: uploadError?.code ?? null,
-              maxMB: uploadError?.maxMB ?? null,
-              message,
-            },
-            error
-          );
-          setKlingElements((previous) =>
-            previous.map((element) => {
-              if (element.id !== elementId) return element;
-              const markError = (asset: typeof baseAsset | null) => {
-                if (!asset || asset.id !== assetId) return asset;
-                return { ...asset, status: 'error' as const, error: message };
-              };
-              if (slot === 'frontal') return { ...element, frontal: markError(element.frontal) };
-              if (slot === 'video') return { ...element, video: markError(element.video) };
-              const references = element.references.map((asset) => markError(asset));
-              return { ...element, references };
-            })
-          );
-          showNotice(message);
-        }
-      };
-
-      void upload();
-    },
-    [setKlingElements, showNotice]
-  );
-
-  const handleAssetLibrarySourceChange = useCallback(
-    (nextSource: AssetLibrarySource) => {
-      if (nextSource === assetLibrarySource) return;
-      resetAssetLibraryForSource(nextSource);
-    },
-    [assetLibrarySource, resetAssetLibraryForSource]
-  );
-
-  const closeAssetLibrary = useCallback(() => {
-    setAssetPickerTarget(null);
-  }, []);
+  const {
+    handleOpenKlingAssetLibrary,
+    handleSelectKlingLibraryAsset,
+    handleKlingElementAdd,
+    handleKlingElementRemove,
+    handleKlingElementAssetRemove,
+    handleKlingElementAssetAdd,
+  } = useWorkspaceKlingElementAssets({
+    showNotice,
+    klingElements,
+    setKlingElements,
+    assetLibrarySource,
+    resetAssetLibraryForSource,
+    setAssetPickerTarget,
+  });
 
   return {
     inputAssets,

--- a/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceKlingElementAssets.ts
+++ b/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceKlingElementAssets.ts
@@ -1,0 +1,245 @@
+import { useCallback, useEffect, useRef } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import type { KlingElementAsset, KlingElementState } from '@/components/KlingElementsBuilder';
+import { authFetch } from '@/lib/authFetch';
+import { prepareImageFileForUpload } from '@/lib/client-image-upload';
+import {
+  buildKlingLibraryAsset,
+  insertKlingLibraryAsset,
+  revokeKlingAssetPreview,
+  type AssetLibrarySource,
+  type AssetPickerTarget,
+  type UserAsset,
+} from '../_lib/workspace-assets';
+import { createKlingElement, createLocalId } from '../_lib/workspace-input-helpers';
+import {
+  createUploadFailure,
+  getUploadFailureMessage,
+  type UploadFailure,
+} from '../_lib/workspace-upload-errors';
+
+type UseWorkspaceKlingElementAssetsOptions = {
+  showNotice: (message: string) => void;
+  klingElements: KlingElementState[];
+  setKlingElements: Dispatch<SetStateAction<KlingElementState[]>>;
+  assetLibrarySource: AssetLibrarySource;
+  resetAssetLibraryForSource: (nextSource: AssetLibrarySource) => void;
+  setAssetPickerTarget: Dispatch<SetStateAction<AssetPickerTarget | null>>;
+};
+
+export function useWorkspaceKlingElementAssets({
+  showNotice,
+  klingElements,
+  setKlingElements,
+  assetLibrarySource,
+  resetAssetLibraryForSource,
+  setAssetPickerTarget,
+}: UseWorkspaceKlingElementAssetsOptions) {
+  const klingElementsRef = useRef<KlingElementState[]>([]);
+
+  useEffect(() => {
+    klingElementsRef.current = klingElements;
+  }, [klingElements]);
+
+  useEffect(() => {
+    return () => {
+      klingElementsRef.current.forEach((element) => {
+        revokeKlingAssetPreview(element.frontal);
+        element.references.forEach((asset) => revokeKlingAssetPreview(asset));
+        revokeKlingAssetPreview(element.video);
+      });
+    };
+  }, []);
+
+  const handleOpenKlingAssetLibrary = useCallback(
+    (elementId: string, slot: 'frontal' | 'reference', slotIndex?: number) => {
+      if (assetLibrarySource !== 'all') {
+        resetAssetLibraryForSource('all');
+      }
+      setAssetPickerTarget({ kind: 'kling', elementId, slot, slotIndex });
+    },
+    [assetLibrarySource, resetAssetLibraryForSource, setAssetPickerTarget]
+  );
+
+  const handleSelectKlingLibraryAsset = useCallback(
+    (target: Extract<AssetPickerTarget, { kind: 'kling' }>, asset: UserAsset) => {
+      const newAsset = buildKlingLibraryAsset(asset);
+      setKlingElements((previous) =>
+        insertKlingLibraryAsset(previous, target, newAsset, revokeKlingAssetPreview)
+      );
+
+      setAssetPickerTarget(null);
+    },
+    [setAssetPickerTarget, setKlingElements]
+  );
+
+  const handleKlingElementAdd = useCallback(() => {
+    setKlingElements((previous) => [...previous, createKlingElement()]);
+  }, [setKlingElements]);
+
+  const handleKlingElementRemove = useCallback((id: string) => {
+    setKlingElements((previous) => {
+      const next = previous.filter((element) => element.id !== id);
+      return next.length ? next : [createKlingElement()];
+    });
+  }, [setKlingElements]);
+
+  const handleKlingElementAssetRemove = useCallback(
+    (elementId: string, slot: 'frontal' | 'reference' | 'video', index?: number) => {
+      setKlingElements((previous) =>
+        previous.map((element) => {
+          if (element.id !== elementId) return element;
+          if (slot === 'frontal') {
+            revokeKlingAssetPreview(element.frontal);
+            return { ...element, frontal: null };
+          }
+          if (slot === 'video') {
+            revokeKlingAssetPreview(element.video);
+            return { ...element, video: null };
+          }
+          const references = [...element.references];
+          if (typeof index === 'number' && index >= 0 && index < references.length) {
+            revokeKlingAssetPreview(references[index]);
+            references[index] = null;
+          }
+          return { ...element, references };
+        })
+      );
+    },
+    [setKlingElements]
+  );
+
+  const handleKlingElementAssetAdd = useCallback(
+    (elementId: string, slot: 'frontal' | 'reference' | 'video', file: File, index?: number) => {
+      const assetId = createLocalId('element_asset');
+      const previewUrl = URL.createObjectURL(file);
+      const baseAsset: KlingElementAsset = {
+        id: assetId,
+        previewUrl,
+        name: file.name,
+        kind: slot === 'video' ? 'video' : 'image',
+        status: 'uploading' as const,
+        url: undefined as string | undefined,
+      };
+
+      setKlingElements((previous) =>
+        previous.map((element) => {
+          if (element.id !== elementId) return element;
+          if (slot === 'frontal') {
+            revokeKlingAssetPreview(element.frontal);
+            return { ...element, frontal: baseAsset };
+          }
+          if (slot === 'video') {
+            revokeKlingAssetPreview(element.video);
+            return { ...element, video: baseAsset };
+          }
+          const references = [...element.references];
+          let targetIndex = typeof index === 'number' ? index : references.findIndex((entry) => entry === null);
+          if (targetIndex < 0) {
+            targetIndex = references.length;
+          }
+          if (targetIndex >= references.length) {
+            return element;
+          }
+          revokeKlingAssetPreview(references[targetIndex]);
+          references[targetIndex] = baseAsset;
+          return { ...element, references };
+        })
+      );
+
+      const upload = async () => {
+        try {
+          const preparedFile =
+            slot === 'video'
+              ? file
+              : await prepareImageFileForUpload(file, { maxBytes: 25 * 1024 * 1024 });
+          const formData = new FormData();
+          formData.append('file', preparedFile, preparedFile.name);
+          const uploadEndpoint = slot === 'video' ? '/api/uploads/video' : '/api/uploads/image';
+          const response = await authFetch(uploadEndpoint, {
+            method: 'POST',
+            body: formData,
+          });
+          const payload = await response.json().catch(() => null);
+          if (!response.ok || !payload?.ok) {
+            throw createUploadFailure(slot === 'video' ? 'video' : 'image', response.status, payload, 'Upload failed');
+          }
+          const assetResponse = payload.asset as {
+            id: string;
+            url: string;
+            name?: string;
+          };
+          setKlingElements((previous) =>
+            previous.map((element) => {
+              if (element.id !== elementId) return element;
+              const updateAsset = (asset: typeof baseAsset | null) => {
+                if (!asset || asset.id !== assetId) return asset;
+                if (asset.previewUrl.startsWith('blob:')) {
+                  URL.revokeObjectURL(asset.previewUrl);
+                }
+                return {
+                  ...asset,
+                  status: 'ready' as const,
+                  url: assetResponse.url,
+                  previewUrl: assetResponse.url || asset.previewUrl,
+                  name: assetResponse.name ?? asset.name,
+                };
+              };
+              if (slot === 'frontal') {
+                return { ...element, frontal: updateAsset(element.frontal) };
+              }
+              if (slot === 'video') {
+                return { ...element, video: updateAsset(element.video) };
+              }
+              const references = element.references.map((asset) => updateAsset(asset));
+              return { ...element, references };
+            })
+          );
+        } catch (error) {
+          const assetType = slot === 'video' ? 'video' : 'image';
+          const message = getUploadFailureMessage(assetType, error, 'Upload failed.');
+          const uploadError = error as UploadFailure;
+          console.error(
+            '[kling-assets] upload failed',
+            {
+              elementId,
+              slot,
+              assetType,
+              status: uploadError?.status ?? null,
+              code: uploadError?.code ?? null,
+              maxMB: uploadError?.maxMB ?? null,
+              message,
+            },
+            error
+          );
+          setKlingElements((previous) =>
+            previous.map((element) => {
+              if (element.id !== elementId) return element;
+              const markError = (asset: typeof baseAsset | null) => {
+                if (!asset || asset.id !== assetId) return asset;
+                return { ...asset, status: 'error' as const, error: message };
+              };
+              if (slot === 'frontal') return { ...element, frontal: markError(element.frontal) };
+              if (slot === 'video') return { ...element, video: markError(element.video) };
+              const references = element.references.map((asset) => markError(asset));
+              return { ...element, references };
+            })
+          );
+          showNotice(message);
+        }
+      };
+
+      void upload();
+    },
+    [setKlingElements, showNotice]
+  );
+
+  return {
+    handleOpenKlingAssetLibrary,
+    handleSelectKlingLibraryAsset,
+    handleKlingElementAdd,
+    handleKlingElementRemove,
+    handleKlingElementAssetRemove,
+    handleKlingElementAssetAdd,
+  };
+}

--- a/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceReferenceAssets.ts
+++ b/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceReferenceAssets.ts
@@ -1,0 +1,326 @@
+import { useCallback, useEffect, useRef } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import { saveAssetToLibrary, saveImageToLibrary } from '@/lib/api';
+import { authFetch } from '@/lib/authFetch';
+import { prepareImageFileForUpload } from '@/lib/client-image-upload';
+import {
+  getSeedanceFieldBlockKey,
+  isUnifiedSeedanceEngineId,
+} from '@/lib/seedance-workflow';
+import type { EngineInputField } from '@/types/engines';
+import {
+  buildReferenceAssetFromLibraryAsset,
+  getAssetLibrarySourceForField,
+  getLibraryAssetFieldMismatchMessage,
+  insertReferenceAsset,
+  mergeMirroredLibraryAsset,
+  removeReferenceAsset,
+  revokeAssetPreview,
+  shouldMirrorCharacterImageAsset,
+  shouldMirrorVideoLibraryAsset,
+  type AssetLibrarySource,
+  type AssetPickerTarget,
+  type ReferenceAsset,
+  type UserAsset,
+} from '../_lib/workspace-assets';
+import {
+  createUploadFailure,
+  getUploadFailureMessage,
+  type UploadableAssetKind,
+  type UploadFailure,
+} from '../_lib/workspace-upload-errors';
+
+type UseWorkspaceReferenceAssetsOptions = {
+  engineId?: string | null;
+  workflowCopy: {
+    clearReferencesToUseStartEnd: string;
+    clearStartEndToUseReferences: string;
+  };
+  showNotice: (message: string) => void;
+  inputAssets: Record<string, (ReferenceAsset | null)[]>;
+  setInputAssets: Dispatch<SetStateAction<Record<string, (ReferenceAsset | null)[]>>>;
+  assetLibrarySource: AssetLibrarySource;
+  resetAssetLibraryForSource: (nextSource: AssetLibrarySource) => void;
+  setAssetPickerTarget: Dispatch<SetStateAction<AssetPickerTarget | null>>;
+  setAssetLibrary: Dispatch<SetStateAction<UserAsset[]>>;
+};
+
+function createReferenceAssetId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `asset_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function useWorkspaceReferenceAssets({
+  engineId,
+  workflowCopy,
+  showNotice,
+  inputAssets,
+  setInputAssets,
+  assetLibrarySource,
+  resetAssetLibraryForSource,
+  setAssetPickerTarget,
+  setAssetLibrary,
+}: UseWorkspaceReferenceAssetsOptions) {
+  const assetsRef = useRef<Record<string, (ReferenceAsset | null)[]>>({});
+
+  useEffect(() => {
+    assetsRef.current = inputAssets;
+  }, [inputAssets]);
+
+  useEffect(() => {
+    return () => {
+      Object.values(assetsRef.current).forEach((entries) => {
+        entries.forEach((asset) => {
+          revokeAssetPreview(asset);
+        });
+      });
+    };
+  }, []);
+
+  const getSeedanceFieldBlockedMessage = useCallback(
+    (field: EngineInputField) => {
+      if (!isUnifiedSeedanceEngineId(engineId)) return null;
+      const fieldHasOwnAssets = (inputAssets[field.id] ?? []).some((asset) => asset !== null);
+      const blockKey = getSeedanceFieldBlockKey(field.id, inputAssets, fieldHasOwnAssets);
+      if (blockKey === 'clearReferences') {
+        return workflowCopy.clearReferencesToUseStartEnd;
+      }
+      if (blockKey === 'clearStartEnd') {
+        return workflowCopy.clearStartEndToUseReferences;
+      }
+      return null;
+    },
+    [engineId, inputAssets, workflowCopy.clearReferencesToUseStartEnd, workflowCopy.clearStartEndToUseReferences]
+  );
+
+  const handleOpenAssetLibrary = useCallback(
+    (field: EngineInputField, slotIndex?: number) => {
+      const blockedMessage = getSeedanceFieldBlockedMessage(field);
+      if (blockedMessage) {
+        showNotice(blockedMessage);
+        return;
+      }
+      const nextSource = getAssetLibrarySourceForField(field);
+      if (nextSource !== assetLibrarySource) {
+        resetAssetLibraryForSource(nextSource);
+      }
+      setAssetPickerTarget({ kind: 'field', field, slotIndex });
+    },
+    [assetLibrarySource, getSeedanceFieldBlockedMessage, resetAssetLibraryForSource, setAssetPickerTarget, showNotice]
+  );
+
+  const handleSelectLibraryAsset = useCallback(
+    async (field: EngineInputField, asset: UserAsset, slotIndex?: number) => {
+      const blockedMessage = getSeedanceFieldBlockedMessage(field);
+      if (blockedMessage) {
+        showNotice(blockedMessage);
+        return;
+      }
+      const mismatchMessage = getLibraryAssetFieldMismatchMessage(field, asset);
+      if (mismatchMessage) {
+        showNotice(mismatchMessage);
+        return;
+      }
+
+      let resolvedAsset = asset;
+
+      if (field.type === 'video' && asset.kind === 'video') {
+        try {
+          if (shouldMirrorVideoLibraryAsset(asset)) {
+            const mirrored = await saveAssetToLibrary({
+              url: asset.url,
+              label:
+                field.label ??
+                asset.url.split('/').pop() ??
+                'Video',
+              source: asset.source === 'recent' ? 'saved_job_output' : asset.source,
+              kind: 'video',
+              jobId: asset.jobId ?? null,
+              sourceOutputId: asset.sourceOutputId ?? null,
+            });
+            resolvedAsset = mergeMirroredLibraryAsset(asset, mirrored);
+            setAssetLibrary((previous) =>
+              previous.map((entry) =>
+                entry.id === asset.id || entry.url === asset.url ? resolvedAsset : entry
+              )
+            );
+          }
+        } catch (error) {
+          console.error('[assets] failed to mirror generated video asset', error);
+          showNotice(error instanceof Error ? error.message : 'Unable to prepare this video. Try importing the source clip directly.');
+          return;
+        }
+      }
+
+      if (field.type === 'image' && asset.kind === 'image') {
+        try {
+          if (shouldMirrorCharacterImageAsset(asset)) {
+            const mirrored = await saveImageToLibrary({
+              url: asset.url,
+              label:
+                field.label ??
+                asset.url.split('/').pop() ??
+                'Image',
+              source: asset.source,
+            });
+            resolvedAsset = mergeMirroredLibraryAsset(asset, mirrored);
+            setAssetLibrary((previous) =>
+              previous.map((entry) =>
+                entry.id === asset.id || entry.url === asset.url ? resolvedAsset : entry
+              )
+            );
+          }
+        } catch (error) {
+          console.error('[assets] failed to mirror character library asset', error);
+          showNotice(error instanceof Error ? error.message : 'Unable to prepare this character asset. Try another image.');
+          return;
+        }
+      }
+
+      const newAsset = buildReferenceAssetFromLibraryAsset(field, resolvedAsset);
+
+      setInputAssets((previous) => {
+        return insertReferenceAsset(previous, field, newAsset, slotIndex, {
+          release: revokeAssetPreview,
+          onMaxReached: () => showNotice(`Maximum ${field.label ?? 'reference image'} count reached for this engine.`),
+        });
+      });
+
+      setAssetPickerTarget(null);
+    },
+    [getSeedanceFieldBlockedMessage, setAssetLibrary, setAssetPickerTarget, setInputAssets, showNotice]
+  );
+
+  const handleAssetAdd = useCallback(
+    (field: EngineInputField, file: File, slotIndex?: number, meta?: { durationSec?: number }) => {
+      const blockedMessage = getSeedanceFieldBlockedMessage(field);
+      if (blockedMessage) {
+        showNotice(blockedMessage);
+        return;
+      }
+      const assetId = createReferenceAssetId();
+      const previewUrl = URL.createObjectURL(file);
+      const baseAsset: ReferenceAsset = {
+        id: assetId,
+        fieldId: field.id,
+        previewUrl,
+        kind: field.type === 'video' ? 'video' : field.type === 'audio' ? 'audio' : 'image',
+        name: file.name,
+        size: file.size,
+        type: file.type,
+        durationSec: typeof meta?.durationSec === 'number' ? meta.durationSec : null,
+        status: 'uploading' as const,
+      };
+
+      setInputAssets((previous) => {
+        return insertReferenceAsset(previous, field, baseAsset, slotIndex, {
+          release: revokeAssetPreview,
+          onMaxReached: () => revokeAssetPreview(baseAsset),
+        });
+      });
+
+      const upload = async () => {
+        try {
+          const preparedFile =
+            field.type === 'image'
+              ? await prepareImageFileForUpload(file, { maxBytes: 25 * 1024 * 1024 })
+              : file;
+          const formData = new FormData();
+          formData.append('file', preparedFile, preparedFile.name);
+          const uploadEndpoint =
+            field.type === 'video'
+              ? '/api/uploads/video'
+              : field.type === 'audio'
+                ? '/api/uploads/audio'
+                : '/api/uploads/image';
+          const uploadAssetType: UploadableAssetKind =
+            field.type === 'video' ? 'video' : field.type === 'audio' ? 'audio' : 'image';
+          const response = await authFetch(uploadEndpoint, {
+            method: 'POST',
+            body: formData,
+          });
+          const payload = await response.json().catch(() => null);
+          if (!response.ok || !payload?.ok) {
+            throw createUploadFailure(uploadAssetType, response.status, payload, 'Upload failed');
+          }
+          const assetResponse = payload.asset as {
+            id: string;
+            url: string;
+            width?: number | null;
+            height?: number | null;
+            size?: number;
+            mime?: string;
+            name?: string;
+          };
+          setInputAssets((previous) => {
+            const current = previous[field.id];
+            if (!current) return previous;
+            const next = current.map((entry) => {
+              if (!entry || entry.id !== assetId) return entry;
+              return {
+                ...entry,
+                status: 'ready' as const,
+                url: assetResponse.url,
+                width: assetResponse.width ?? entry.width,
+                height: assetResponse.height ?? entry.height,
+                size: assetResponse.size ?? entry.size,
+                type: assetResponse.mime ?? entry.type,
+                assetId: assetResponse.id,
+              };
+            });
+            return { ...previous, [field.id]: next };
+          });
+        } catch (error) {
+          const uploadAssetType: UploadableAssetKind =
+            field.type === 'video' ? 'video' : field.type === 'audio' ? 'audio' : 'image';
+          const message = getUploadFailureMessage(uploadAssetType, error, 'Upload failed');
+          const uploadError = error as UploadFailure;
+          console.error(
+            '[assets] upload failed',
+            {
+              fieldId: field.id,
+              assetType: uploadAssetType,
+              status: uploadError?.status ?? null,
+              code: uploadError?.code ?? null,
+              maxMB: uploadError?.maxMB ?? null,
+              message,
+            },
+            error
+          );
+          setInputAssets((previous) => {
+            const current = previous[field.id];
+            if (!current) return previous;
+            const next = current.map((entry) => {
+              if (!entry || entry.id !== assetId) return entry;
+              return {
+                ...entry,
+                status: 'error' as const,
+                error: message,
+              };
+            });
+            return { ...previous, [field.id]: next };
+          });
+          showNotice(message);
+        }
+      };
+
+      void upload();
+    },
+    [getSeedanceFieldBlockedMessage, setInputAssets, showNotice]
+  );
+
+  const handleAssetRemove = useCallback((field: EngineInputField, index: number) => {
+    setInputAssets((previous) => {
+      return removeReferenceAsset(previous, field, index, revokeAssetPreview);
+    });
+  }, [setInputAssets]);
+
+  return {
+    handleOpenAssetLibrary,
+    handleSelectLibraryAsset,
+    handleAssetAdd,
+    handleAssetRemove,
+  };
+}

--- a/tests/workspace-assets-hook-contract.test.ts
+++ b/tests/workspace-assets-hook-contract.test.ts
@@ -12,9 +12,27 @@ test('workspace asset workflow is owned by a route-local hook', () => {
     process.cwd(),
     'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceAssets.ts'
   );
+  const assetLibraryHookPath = path.join(
+    process.cwd(),
+    'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceAssetLibrary.ts'
+  );
+  const referenceAssetsHookPath = path.join(
+    process.cwd(),
+    'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceReferenceAssets.ts'
+  );
+  const klingAssetsHookPath = path.join(
+    process.cwd(),
+    'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceKlingElementAssets.ts'
+  );
   assert.equal(fs.existsSync(hookPath), true);
+  assert.equal(fs.existsSync(assetLibraryHookPath), true);
+  assert.equal(fs.existsSync(referenceAssetsHookPath), true);
+  assert.equal(fs.existsSync(klingAssetsHookPath), true);
 
   const hookSource = fs.readFileSync(hookPath, 'utf8');
+  const assetLibraryHookSource = fs.readFileSync(assetLibraryHookPath, 'utf8');
+  const referenceAssetsHookSource = fs.readFileSync(referenceAssetsHookPath, 'utf8');
+  const klingAssetsHookSource = fs.readFileSync(klingAssetsHookPath, 'utf8');
 
   assert.match(appSource, /import \{ useWorkspaceAssets \} from '\.\/_hooks\/useWorkspaceAssets';/);
   assert.match(appSource, /useWorkspaceAssets\(\{/);
@@ -23,8 +41,12 @@ test('workspace asset workflow is owned by a route-local hook', () => {
   assert.doesNotMatch(appSource, /const handleKlingElementAssetAdd = useCallback/);
 
   assert.match(hookSource, /export function useWorkspaceAssets/);
-  assert.match(hookSource, /const fetchAssetLibrary = useCallback/);
-  assert.match(hookSource, /const handleAssetAdd = useCallback/);
-  assert.match(hookSource, /const handleKlingElementAssetAdd = useCallback/);
+  assert.match(hookSource, /useWorkspaceAssetLibrary\(\{/);
+  assert.match(hookSource, /useWorkspaceReferenceAssets\(\{/);
+  assert.match(hookSource, /useWorkspaceKlingElementAssets\(\{/);
   assert.match(hookSource, /return \{/);
+
+  assert.match(assetLibraryHookSource, /const fetchAssetLibrary = useCallback/);
+  assert.match(referenceAssetsHookSource, /const handleAssetAdd = useCallback/);
+  assert.match(klingAssetsHookSource, /const handleKlingElementAssetAdd = useCallback/);
 });

--- a/tests/workspace-assets-split-contract.test.ts
+++ b/tests/workspace-assets-split-contract.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const assetsHookPath = 'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceAssets.ts';
+const assetLibraryHookPath = 'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceAssetLibrary.ts';
+const referenceAssetsHookPath = 'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceReferenceAssets.ts';
+const klingAssetsHookPath = 'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceKlingElementAssets.ts';
+
+test('workspace asset library, field assets, and Kling element assets are split from the assets orchestrator', () => {
+  assert.equal(existsSync(assetLibraryHookPath), true);
+  assert.equal(existsSync(referenceAssetsHookPath), true);
+  assert.equal(existsSync(klingAssetsHookPath), true);
+
+  const assetsHookSource = readFileSync(assetsHookPath, 'utf8');
+  const assetLibrarySource = readFileSync(assetLibraryHookPath, 'utf8');
+  const referenceAssetsSource = readFileSync(referenceAssetsHookPath, 'utf8');
+  const klingAssetsSource = readFileSync(klingAssetsHookPath, 'utf8');
+
+  assert.match(assetsHookSource, /useWorkspaceAssetLibrary\(\{/);
+  assert.match(assetsHookSource, /useWorkspaceReferenceAssets\(\{/);
+  assert.match(assetsHookSource, /useWorkspaceKlingElementAssets\(\{/);
+
+  assert.doesNotMatch(assetsHookSource, /const fetchAssetLibrary = useCallback/);
+  assert.doesNotMatch(assetsHookSource, /const handleSelectLibraryAsset = useCallback/);
+  assert.doesNotMatch(assetsHookSource, /const handleAssetAdd = useCallback/);
+  assert.doesNotMatch(assetsHookSource, /const handleKlingElementAssetAdd = useCallback/);
+  assert.doesNotMatch(assetsHookSource, /prepareImageFileForUpload/);
+  assert.doesNotMatch(assetsHookSource, /authFetch/);
+
+  assert.match(assetLibrarySource, /export function useWorkspaceAssetLibrary/);
+  assert.match(assetLibrarySource, /const fetchAssetLibrary = useCallback/);
+  assert.match(assetLibrarySource, /const handleDeleteLibraryAsset = useCallback/);
+  assert.match(assetLibrarySource, /buildAssetLibraryUrl/);
+
+  assert.match(referenceAssetsSource, /export function useWorkspaceReferenceAssets/);
+  assert.match(referenceAssetsSource, /const handleSelectLibraryAsset = useCallback/);
+  assert.match(referenceAssetsSource, /const handleAssetAdd = useCallback/);
+  assert.match(referenceAssetsSource, /prepareImageFileForUpload/);
+  assert.match(referenceAssetsSource, /insertReferenceAsset/);
+
+  assert.match(klingAssetsSource, /export function useWorkspaceKlingElementAssets/);
+  assert.match(klingAssetsSource, /const handleKlingElementAssetAdd = useCallback/);
+  assert.match(klingAssetsSource, /const handleKlingElementAssetRemove = useCallback/);
+  assert.match(klingAssetsSource, /insertKlingLibraryAsset/);
+});


### PR DESCRIPTION
## Summary
- Extract asset library source/loading/delete state into `useWorkspaceAssetLibrary`.
- Extract reference field upload and library selection handlers into `useWorkspaceReferenceAssets`.
- Extract Kling element asset handlers into `useWorkspaceKlingElementAssets`, leaving `useWorkspaceAssets` as a thin orchestrator.

## Test Plan
- `pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/workspace-assets-split-contract.test.ts tests/workspace-assets-hook-contract.test.ts tests/workspace-assets.test.ts`
- `pnpm --prefix frontend exec tsc --noEmit`
- `npm --prefix frontend run lint`
- `npm run lint:exposure`
- `pnpm test:validate`
- `pnpm --prefix frontend run build`
