### PR TITLE
Split image reference slot state

### DIFF
--- a/frontend/app/(core)/(workspace)/app/image/AGENTS.md
+++ b/frontend/app/(core)/(workspace)/app/image/AGENTS.md
@@ -15,6 +15,7 @@ This route owns the dedicated still-image generation workspace.
 - Keep reusable image workspace types and storage constants in `_lib/image-workspace-types.ts`.
 - Keep character reference parsing, labels, and slot merging in `_lib/image-workspace-character-references.ts`.
 - Keep job-to-history and local active group builders in `_lib/image-workspace-history.ts`.
+- Keep reference slot state, upload orchestration, library selection, and character toggling in `_hooks/useImageReferenceSlots.ts`.
 - Keep browser-only library UI in `_components/ImageLibraryModal.tsx`.
 - Keep `ImageWorkspace.tsx` focused on orchestration; do not add new inline helper blocks or route-local modal implementations there.
 - Keep image composer storage keys and stored payload shape backward compatible.

--- a/frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx
+++ b/frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx
@@ -28,15 +28,11 @@ import type { MediaLightboxEntry } from '@/components/MediaLightbox';
 import { ImageCompositePreviewDock, type ImageCompositePreviewEntry } from '@/components/groups/ImageCompositePreviewDock';
 import { buildVideoGroupFromImageRun } from '@/lib/image-groups';
 import { useI18n } from '@/lib/i18n/I18nProvider';
-import { prepareImageFileForUpload } from '@/lib/client-image-upload';
 import { formatAspectRatioLabel } from '@/lib/image/aspectRatios';
 import { FEATURES } from '@/content/feature-flags';
 import {
   formatSupportedImageFormatsLabel,
   getSupportedImageFormats,
-  inferImageFormatFromUrl,
-  isSupportedImageFormat,
-  isSupportedImageMime,
 } from '@/lib/image/formats';
 import {
   clampRequestedImageCount,
@@ -49,7 +45,6 @@ import {
   getImageFieldDefaultString,
   getImageFieldValues,
   getImageInputField,
-  getReferenceConstraints,
 } from '@/lib/image/inputSchema';
 import {
   GPT_IMAGE_2_SIZE_CONSTRAINTS,
@@ -66,6 +61,7 @@ import { groupJobsIntoSummaries } from '@/lib/job-groups';
 import { countResolvedVisualSlots } from '@/lib/group-progress';
 import { ImageLibraryModal } from './_components/ImageLibraryModal';
 import { useImageWorkspaceDesktopLayout } from './_hooks/useImageWorkspaceDesktopLayout';
+import { useImageReferenceSlots } from './_hooks/useImageReferenceSlots';
 import {
   createCharacterReferenceSlot,
   mergeCharacterReferencesIntoSlots,
@@ -90,8 +86,6 @@ import {
   formatQualityLabel,
 } from './_lib/image-workspace-utils';
 import {
-  DEFAULT_UPLOAD_LIMIT_MB,
-  DEFAULT_VISIBLE_REFERENCE_SLOTS,
   IMAGE_COMPOSER_STORAGE_DEBOUNCE_MS,
   IMAGE_COMPOSER_STORAGE_KEY,
   IMAGE_COMPOSER_STORAGE_VERSION,
@@ -100,13 +94,10 @@ import {
   type AssetsResponse,
   type HistoryEntry,
   type ImageEngineOption,
-  type ImageLibraryModalState,
   type LibraryAsset,
   type PersistedImageComposerState,
-  type PersistedReferenceSlot,
   type ReferenceSlotValue,
   type PricingEstimateResponse,
-  type UploadFailure,
 } from './_lib/image-workspace-types';
 
 export type { ImageEngineOption } from './_lib/image-workspace-types';
@@ -154,9 +145,6 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
   const [enableWebSearch, setEnableWebSearch] = useState(false);
   const [thinkingLevel, setThinkingLevel] = useState<string | null>(null);
   const [limitGenerations, setLimitGenerations] = useState(false);
-  const [referenceSlots, setReferenceSlots] = useState<(ReferenceSlotValue | null)[]>(
-    Array(MAX_REFERENCE_SLOTS).fill(null)
-  );
   const [localHistory, setLocalHistory] = useState<HistoryEntry[]>([]);
   const [selectedPreviewEntryId, setSelectedPreviewEntryId] = useState<string | null>(null);
   const [selectedPreviewImageIndex, setSelectedPreviewImageIndex] = useState(0);
@@ -164,17 +152,10 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
   const isDesktopLayout = useImageWorkspaceDesktopLayout();
   const [error, setError] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
-  const [areReferenceSlotsExpanded, setAreReferenceSlotsExpanded] = useState(false);
   const [isSavingToLibrary, setIsSavingToLibrary] = useState(false);
   const [isRemovingFromLibrary, setIsRemovingFromLibrary] = useState(false);
   const [copiedUrl, setCopiedUrl] = useState<string | null>(null);
   const [viewerGroup, setViewerGroup] = useState<VideoGroup | null>(null);
-  const [libraryModal, setLibraryModal] = useState<ImageLibraryModalState>({
-    open: false,
-    slotIndex: null,
-    selectionMode: 'reference',
-    initialSource: 'all',
-  });
   const [authModalOpen, setAuthModalOpen] = useState(false);
   const [
     priceEstimateKey,
@@ -231,13 +212,6 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
     [selectedEngineCaps, mode]
   );
   const isResolutionLocked = Boolean(resolutionField && resolutionOptions.length === 1);
-  const referenceConstraints = useMemo(
-    () =>
-      selectedEngineCaps
-        ? getReferenceConstraints(selectedEngineCaps, mode)
-        : { min: mode === 'i2i' ? 1 : 0, max: 4, requires: mode === 'i2i' },
-    [selectedEngineCaps, mode]
-  );
   const supportedReferenceFormats = useMemo(
     () => getSupportedImageFormats(selectedEngineCaps ?? null),
     [selectedEngineCaps]
@@ -246,6 +220,44 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
     () => formatSupportedImageFormatsLabel(supportedReferenceFormats),
     [supportedReferenceFormats]
   );
+  const {
+    canCollapseReferenceSlots,
+    characterSelectionLimit,
+    closeLibraryModal,
+    combinedReferenceUrls,
+    displayedReferenceSlotCount,
+    displayedReferenceSlots,
+    handleLibrarySelect,
+    handleReferenceFile,
+    handleReferenceUrl,
+    handleRemoveReferenceSlot,
+    hasAnyReferenceSelection,
+    libraryModal,
+    openCharacterLibrary,
+    openLibraryForSlot,
+    persistableReferenceSlots,
+    readyReferenceSizes,
+    readyReferenceUrls,
+    referenceHelperText,
+    referenceMinRequired,
+    referenceSizeSignature,
+    referenceSlotLimit,
+    referenceToggleLabel,
+    selectedCharacterReferences,
+    setAreReferenceSlotsExpanded,
+    setReferenceSlots,
+    supportsCharacterReferences,
+    toggleCharacterReference,
+  } = useImageReferenceSlots({
+    autoModeFromReferences,
+    mode,
+    resolvedCopy,
+    selectedEngineCaps,
+    setError,
+    supportedReferenceFormats,
+    supportedReferenceFormatsLabel,
+    toolsEnabled,
+  });
   const outputFormatField = useMemo(
     () => getImageInputField(selectedEngineCaps ?? null, 'output_format', mode),
     [selectedEngineCaps, mode]
@@ -285,83 +297,6 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
   const limitGenerationsField = useMemo(
     () => getImageInputField(selectedEngineCaps ?? null, 'limit_generations', mode),
     [selectedEngineCaps, mode]
-  );
-  const referenceMinRequired = referenceConstraints.min;
-  const referencePickerConstraints = useMemo(
-    () =>
-      autoModeFromReferences && selectedEngineCaps
-        ? getReferenceConstraints(selectedEngineCaps, 'i2i')
-        : referenceConstraints,
-    [autoModeFromReferences, referenceConstraints, selectedEngineCaps]
-  );
-  const baseReferenceSlotLimit = Math.min(MAX_REFERENCE_SLOTS, referencePickerConstraints.max);
-  const supportsCharacterReferences = toolsEnabled && baseReferenceSlotLimit > 0;
-  const visibleReferenceSlots = useMemo(
-    () => referenceSlots.slice(0, baseReferenceSlotLimit),
-    [baseReferenceSlotLimit, referenceSlots]
-  );
-  const referenceSizeSignature = useMemo(
-    () =>
-      visibleReferenceSlots
-        .filter((slot): slot is ReferenceSlotValue => Boolean(slot && slot.status === 'ready'))
-        .map((slot) => `${slot.width ?? ''}x${slot.height ?? ''}`)
-        .join('|'),
-    [visibleReferenceSlots]
-  );
-  const selectedCharacterReferences = useMemo(
-    () =>
-      visibleReferenceSlots.reduce<CharacterReferenceSelection[]>((acc, slot) => {
-        if (slot?.characterReference) {
-          acc.push(slot.characterReference);
-        }
-        return acc;
-      }, []),
-    [visibleReferenceSlots]
-  );
-  const totalRegularReferenceSelections = useMemo(
-    () => visibleReferenceSlots.filter((slot) => Boolean(slot && !slot.characterReference)).length,
-    [visibleReferenceSlots]
-  );
-  const characterSelectionLimit = useMemo(
-    () =>
-      supportsCharacterReferences
-        ? Math.max(0, baseReferenceSlotLimit - totalRegularReferenceSelections)
-        : 0,
-    [baseReferenceSlotLimit, supportsCharacterReferences, totalRegularReferenceSelections]
-  );
-  const referenceSlotLimit = baseReferenceSlotLimit;
-  const canCollapseReferenceSlots = referenceSlotLimit > DEFAULT_VISIBLE_REFERENCE_SLOTS;
-  const displayedReferenceSlotCount =
-    canCollapseReferenceSlots && !areReferenceSlotsExpanded
-      ? DEFAULT_VISIBLE_REFERENCE_SLOTS
-      : referenceSlotLimit;
-  const displayedReferenceSlots = useMemo(
-    () => visibleReferenceSlots.slice(0, displayedReferenceSlotCount),
-    [displayedReferenceSlotCount, visibleReferenceSlots]
-  );
-  const collapsedReferenceSlotCount = Math.max(referenceSlotLimit - displayedReferenceSlotCount, 0);
-  const hasCollapsedReferenceContent = useMemo(
-    () =>
-      referenceSlots
-        .slice(DEFAULT_VISIBLE_REFERENCE_SLOTS, referenceSlotLimit)
-        .some((slot) => Boolean(slot)),
-    [referenceSlotLimit, referenceSlots]
-  );
-  const referenceHelperText = useMemo(
-    () => formatTemplate(resolvedCopy.composer.referenceHelper, { count: referenceSlotLimit }),
-    [referenceSlotLimit, resolvedCopy.composer.referenceHelper]
-  );
-  const referenceToggleLabel = useMemo(
-    () =>
-      areReferenceSlotsExpanded
-        ? resolvedCopy.composer.referenceCollapse
-        : formatTemplate(resolvedCopy.composer.referenceExpand, { count: collapsedReferenceSlotCount }),
-    [
-      areReferenceSlotsExpanded,
-      collapsedReferenceSlotCount,
-      resolvedCopy.composer.referenceCollapse,
-      resolvedCopy.composer.referenceExpand,
-    ]
   );
   useEffect(() => {
     setNumImages((previous) => clampRequestedImageCount(selectedEngineCaps ?? null, mode, previous));
@@ -683,25 +618,6 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
     };
   }, [mutateJobs, pendingGroups]);
 
-  const readyReferenceUrls = useMemo(
-    () =>
-      visibleReferenceSlots
-        .filter((slot): slot is ReferenceSlotValue => Boolean(slot && slot.status === 'ready'))
-        .map((slot) => slot.url),
-    [visibleReferenceSlots]
-  );
-  const readyReferenceSizes = useMemo(
-    () =>
-      visibleReferenceSlots
-        .filter((slot): slot is ReferenceSlotValue => Boolean(slot && slot.status === 'ready'))
-        .map((slot) => ({ width: slot.width ?? null, height: slot.height ?? null })),
-    [visibleReferenceSlots]
-  );
-  const combinedReferenceUrls = readyReferenceUrls;
-  const hasAnyReferenceSelection = useMemo(
-    () => visibleReferenceSlots.some((slot) => Boolean(slot)),
-    [visibleReferenceSlots]
-  );
   const referenceNoteText = resolvedCopy.composer.referenceNote;
 
   useEffect(() => {
@@ -749,14 +665,6 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
       jobId: entry.jobId ?? entry.id,
       label: entry.label ?? undefined,
     });
-  }, []);
-
-  const cleanupSlotPreview = useCallback((slot: ReferenceSlotValue | null) => {
-    if (slot?.previewUrl && slot.previewUrl.startsWith('blob:')) {
-      try {
-        URL.revokeObjectURL(slot.previewUrl);
-      } catch {}
-    }
   }, []);
 
   useEffect(() => {
@@ -875,7 +783,7 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
     }
 
     setStorageHydrated(true);
-  }, [engines]);
+  }, [engines, setReferenceSlots]);
 
   const requestedJobId = useMemo(() => {
     const raw = searchParams?.get('job');
@@ -1079,7 +987,7 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
         setSelectedPreviewImageIndex(0);
       }
     },
-    [engines]
+    [engines, setReferenceSlots]
   );
 
   useEffect(() => {
@@ -1106,35 +1014,6 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
         setError(error instanceof Error ? error.message : resolvedCopy.errors.generic);
       });
   }, [applyImageSettingsSnapshot, requestedJobId, resolvedCopy.errors.generic]);
-
-  const persistableReferenceSlots = useMemo<PersistedReferenceSlot[]>(
-    () =>
-      referenceSlots.slice(0, MAX_REFERENCE_SLOTS).map((slot) => {
-        if (!slot || slot.status !== 'ready') return null;
-        const url = slot.url?.trim?.() ?? '';
-        if (!url || url.startsWith('blob:')) return null;
-        return {
-          url,
-          source: slot.source,
-          width: slot.width ?? null,
-          height: slot.height ?? null,
-          characterReference: slot.characterReference
-            ? {
-                id: slot.characterReference.id,
-                jobId: slot.characterReference.jobId,
-                imageUrl: slot.characterReference.imageUrl,
-                thumbUrl: slot.characterReference.thumbUrl ?? null,
-                prompt: slot.characterReference.prompt ?? null,
-                createdAt: slot.characterReference.createdAt ?? null,
-                engineLabel: slot.characterReference.engineLabel ?? null,
-                outputMode: slot.characterReference.outputMode ?? null,
-                action: slot.characterReference.action ?? null,
-              }
-            : null,
-        };
-      }),
-    [referenceSlots]
-  );
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -1203,33 +1082,6 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
     thinkingLevel,
   ]);
 
-  useEffect(() => {
-    setReferenceSlots((previous) => {
-      let mutated = false;
-      const next = previous.slice();
-      for (let index = baseReferenceSlotLimit; index < next.length; index += 1) {
-        if (next[index]) {
-          cleanupSlotPreview(next[index]);
-          next[index] = null;
-          mutated = true;
-        }
-      }
-      return mutated ? next : previous;
-    });
-  }, [baseReferenceSlotLimit, cleanupSlotPreview]);
-
-  useEffect(() => {
-    if (!canCollapseReferenceSlots && areReferenceSlotsExpanded) {
-      setAreReferenceSlotsExpanded(false);
-    }
-  }, [areReferenceSlotsExpanded, canCollapseReferenceSlots]);
-
-  useEffect(() => {
-    if (!areReferenceSlotsExpanded && hasCollapsedReferenceContent) {
-      setAreReferenceSlotsExpanded(true);
-    }
-  }, [areReferenceSlotsExpanded, hasCollapsedReferenceContent]);
-
   const setNumImagesPreset = useCallback((value: number) => {
     setNumImages(clampRequestedImageCount(selectedEngineCaps ?? null, mode, value));
   }, [selectedEngineCaps, mode]);
@@ -1242,284 +1094,6 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
       setCustomImageHeight(String(parsedSize.height));
     }
   }, []);
-
-  const showUnsupportedFormatError = useCallback(() => {
-    setError(
-      formatTemplate(resolvedCopy.errors.unsupportedFormat, {
-        formats: supportedReferenceFormatsLabel || 'JPG, JPEG, PNG, WEBP',
-      })
-    );
-  }, [resolvedCopy.errors.unsupportedFormat, supportedReferenceFormatsLabel]);
-
-  const isSupportedReferenceAsset = useCallback(
-    (mime?: string | null, locator?: string | null) => {
-      if (!supportedReferenceFormats.length) return true;
-      const supportedByMime = isSupportedImageMime(supportedReferenceFormats, mime);
-      if (supportedByMime != null) {
-        return supportedByMime;
-      }
-      const inferredFormat = inferImageFormatFromUrl(locator);
-      if (!inferredFormat) {
-        return true;
-      }
-      return isSupportedImageFormat(supportedReferenceFormats, inferredFormat);
-    },
-    [supportedReferenceFormats]
-  );
-
-  const handleRemoveReferenceSlot = useCallback(
-    (index: number) => {
-      setReferenceSlots((previous) => {
-        const next = previous.slice();
-        cleanupSlotPreview(next[index]);
-        next[index] = null;
-        return next;
-      });
-    },
-    [cleanupSlotPreview]
-  );
-
-  const handleReferenceFile = useCallback(
-    async (index: number, file: File | null) => {
-      if (!file) {
-        return;
-      }
-      if (!file.type.startsWith('image/')) {
-        setError(resolvedCopy.errors.onlyImages);
-        return;
-      }
-      const tempUrl = URL.createObjectURL(file);
-      const slotId = crypto.randomUUID();
-      setReferenceSlots((previous) => {
-        const next = previous.slice();
-        cleanupSlotPreview(next[index]);
-        next[index] = {
-          id: slotId,
-          url: tempUrl,
-          previewUrl: tempUrl,
-          name: file.name,
-          status: 'uploading',
-          source: 'upload',
-        };
-        return next;
-      });
-      try {
-        const preparedFile = await prepareImageFileForUpload(file, {
-          maxBytes: DEFAULT_UPLOAD_LIMIT_MB * 1024 * 1024,
-        });
-        const formData = new FormData();
-        formData.append('file', preparedFile, preparedFile.name);
-        const response = await authFetch('/api/uploads/image', {
-          method: 'POST',
-          body: formData,
-        });
-        const payload = await response.json().catch(() => null);
-        if (!response.ok || !payload?.ok) {
-          const uploadError = new Error(
-            typeof payload?.error === 'string' ? payload.error : 'UPLOAD_FAILED'
-          ) as UploadFailure;
-          uploadError.code = typeof payload?.error === 'string' ? payload.error : 'UPLOAD_FAILED';
-          if (typeof payload?.maxMB === 'number') {
-            uploadError.maxMB = payload.maxMB;
-          }
-          throw uploadError;
-        }
-        const asset = payload.asset as {
-          id: string;
-          url: string;
-          width?: number | null;
-          height?: number | null;
-        };
-        setReferenceSlots((previous) => {
-          const next = previous.slice();
-          const current = next[index];
-          if (!current || current.id !== slotId) {
-            return previous;
-          }
-          next[index] = {
-            id: slotId,
-            url: asset.url,
-            previewUrl: asset.url,
-            name: file.name,
-            status: 'ready',
-            source: 'upload',
-            width: asset.width ?? null,
-            height: asset.height ?? null,
-          };
-          if (current.previewUrl && current.previewUrl !== asset.url) {
-            try {
-              URL.revokeObjectURL(current.previewUrl);
-            } catch {}
-          }
-          return next;
-        });
-      } catch (uploadError) {
-        console.error('[image-workspace] reference upload failed', uploadError);
-        setReferenceSlots((previous) => {
-          const next = previous.slice();
-          const current = next[index];
-          if (current?.previewUrl) {
-            try {
-              URL.revokeObjectURL(current.previewUrl);
-            } catch {}
-          }
-          next[index] = null;
-          return next;
-        });
-        const failure = uploadError as UploadFailure;
-        const code = failure?.code;
-        if (code === 'FILE_TOO_LARGE') {
-          const limit =
-            typeof failure?.maxMB === 'number' && Number.isFinite(failure.maxMB)
-              ? failure.maxMB
-              : DEFAULT_UPLOAD_LIMIT_MB;
-          setError(formatTemplate(resolvedCopy.errors.fileTooLarge, { maxMB: limit }));
-        } else if (code === 'UNAUTHORIZED') {
-          setError(resolvedCopy.errors.unauthorized);
-        } else {
-          setError(resolvedCopy.errors.uploadFailed);
-        }
-      }
-    },
-    [
-      cleanupSlotPreview,
-      resolvedCopy.errors.onlyImages,
-      resolvedCopy.errors.uploadFailed,
-      resolvedCopy.errors.fileTooLarge,
-      resolvedCopy.errors.unauthorized,
-    ]
-  );
-
-  const handleReferenceUrl = useCallback(
-    (index: number, url: string, source: ReferenceSlotValue['source']) => {
-      if (!url) return;
-      if (!isSupportedReferenceAsset(null, url)) {
-        showUnsupportedFormatError();
-        return;
-      }
-      setReferenceSlots((previous) => {
-        const next = previous.slice();
-        cleanupSlotPreview(next[index]);
-        next[index] = {
-          id: crypto.randomUUID(),
-          url,
-          previewUrl: url,
-          status: 'ready',
-          source: source ?? 'paste',
-        };
-        return next;
-      });
-    },
-    [cleanupSlotPreview, isSupportedReferenceAsset, showUnsupportedFormatError]
-  );
-
-  const resolveTargetReferenceSlotIndex = useCallback(
-    (preferredIndex: number | null = null) => {
-      if (preferredIndex != null && preferredIndex >= 0 && preferredIndex < referenceSlotLimit) {
-        return preferredIndex;
-      }
-      const emptyIndex = referenceSlots.slice(0, referenceSlotLimit).findIndex((slot) => slot === null);
-      if (emptyIndex >= 0) {
-        return emptyIndex;
-      }
-      return Math.max(0, referenceSlotLimit - 1);
-    },
-    [referenceSlotLimit, referenceSlots]
-  );
-
-  const handleLibrarySelect = useCallback(
-    (asset: LibraryAsset) => {
-      if (!isSupportedReferenceAsset(asset.mime, asset.url)) {
-        showUnsupportedFormatError();
-        return;
-      }
-      const slotIndex = resolveTargetReferenceSlotIndex(libraryModal.slotIndex);
-      if (slotIndex >= referenceSlotLimit) {
-        setLibraryModal({ open: false, slotIndex: null, selectionMode: 'reference', initialSource: 'all' });
-        return;
-      }
-      const index = slotIndex;
-      if (index >= DEFAULT_VISIBLE_REFERENCE_SLOTS && canCollapseReferenceSlots) {
-        setAreReferenceSlotsExpanded(true);
-      }
-      setReferenceSlots((previous) => {
-        const next = previous.slice();
-        cleanupSlotPreview(next[index]);
-        next[index] = {
-          id: asset.id,
-          url: asset.url,
-          previewUrl: asset.url,
-          status: 'ready',
-          source: 'library',
-          width: asset.width ?? null,
-          height: asset.height ?? null,
-        };
-        return next;
-      });
-      setLibraryModal({ open: false, slotIndex: null, selectionMode: 'reference', initialSource: 'all' });
-    },
-    [
-      canCollapseReferenceSlots,
-      cleanupSlotPreview,
-      isSupportedReferenceAsset,
-      libraryModal.slotIndex,
-      referenceSlotLimit,
-      resolveTargetReferenceSlotIndex,
-      showUnsupportedFormatError,
-    ]
-  );
-
-  const openLibraryForSlot = useCallback(
-    (index: number) => {
-      setLibraryModal({ open: true, slotIndex: index, selectionMode: 'reference', initialSource: 'all' });
-    },
-    []
-  );
-
-  const toggleCharacterReference = useCallback(
-    (reference: CharacterReferenceSelection) => {
-      if (!supportsCharacterReferences) {
-        return;
-      }
-      const existingIndex = referenceSlots.findIndex((slot) => slot?.characterReference?.id === reference.id);
-      if (existingIndex >= 0) {
-        setReferenceSlots((previous) => {
-          const next = previous.slice();
-          cleanupSlotPreview(next[existingIndex]);
-          next[existingIndex] = null;
-          return next;
-        });
-        return;
-      }
-      if (selectedCharacterReferences.length >= characterSelectionLimit) {
-        return;
-      }
-      const nextIndex = resolveTargetReferenceSlotIndex(libraryModal.slotIndex);
-      if (nextIndex >= referenceSlotLimit) {
-        return;
-      }
-      if (nextIndex >= DEFAULT_VISIBLE_REFERENCE_SLOTS && canCollapseReferenceSlots) {
-        setAreReferenceSlotsExpanded(true);
-      }
-      setReferenceSlots((previous) => {
-        const next = previous.slice();
-        cleanupSlotPreview(next[nextIndex]);
-        next[nextIndex] = createCharacterReferenceSlot(reference);
-        return next;
-      });
-    },
-    [
-      canCollapseReferenceSlots,
-      characterSelectionLimit,
-      cleanupSlotPreview,
-      libraryModal.slotIndex,
-      referenceSlotLimit,
-      referenceSlots,
-      resolveTargetReferenceSlotIndex,
-      selectedCharacterReferences.length,
-      supportsCharacterReferences,
-    ]
-  );
 
   const handleRun = useCallback(
     async (event?: FormEvent<HTMLFormElement> | null) => {
@@ -1973,12 +1547,7 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
         size="sm"
         onClick={(event) => {
           event.stopPropagation();
-          setLibraryModal({
-            open: true,
-            slotIndex: null,
-            selectionMode: 'character',
-            initialSource: 'character',
-          });
+          openCharacterLibrary();
         }}
         className="min-h-0 h-7 gap-1.5 rounded-full px-2.5 py-0 text-[11px] font-medium text-text-secondary hover:bg-surface-2 hover:text-text-primary"
       >
@@ -1986,7 +1555,7 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
         <span>{resolvedCopy.composer.characterButton}</span>
       </Button>
     );
-  }, [resolvedCopy.composer.characterButton, supportsCharacterReferences]);
+  }, [openCharacterLibrary, resolvedCopy.composer.characterButton, supportsCharacterReferences]);
   const referenceAssetFields = useMemo<AssetFieldConfig[]>(() => {
     if (referenceSlotLimit <= 0) return [];
     return [
@@ -2411,7 +1980,7 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
       {libraryModal.open ? (
       <ImageLibraryModal
         open={libraryModal.open}
-        onClose={() => setLibraryModal({ open: false, slotIndex: null, selectionMode: 'reference', initialSource: 'all' })}
+        onClose={closeLibraryModal}
         onSelect={handleLibrarySelect}
         onToggleCharacter={toggleCharacterReference}
         selectedCharacterReferences={selectedCharacterReferences}

--- a/frontend/app/(core)/(workspace)/app/image/_hooks/useImageReferenceSlots.ts
+++ b/frontend/app/(core)/(workspace)/app/image/_hooks/useImageReferenceSlots.ts
@@ -1,0 +1,537 @@
+import { useCallback, useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
+import type { CharacterReferenceSelection, ImageGenerationMode } from '@/types/image-generation';
+import type { EngineCaps } from '@/types/engines';
+import { prepareImageFileForUpload } from '@/lib/client-image-upload';
+import { authFetch } from '@/lib/authFetch';
+import {
+  inferImageFormatFromUrl,
+  isSupportedImageFormat,
+  isSupportedImageMime,
+} from '@/lib/image/formats';
+import { getReferenceConstraints } from '@/lib/image/inputSchema';
+import { createCharacterReferenceSlot } from '../_lib/image-workspace-character-references';
+import { formatTemplate, type ImageWorkspaceCopy } from '../_lib/image-workspace-copy';
+import {
+  DEFAULT_UPLOAD_LIMIT_MB,
+  DEFAULT_VISIBLE_REFERENCE_SLOTS,
+  MAX_REFERENCE_SLOTS,
+  type ImageLibraryModalState,
+  type LibraryAsset,
+  type PersistedReferenceSlot,
+  type ReferenceSlotValue,
+  type UploadFailure,
+} from '../_lib/image-workspace-types';
+
+type UseImageReferenceSlotsParams = {
+  autoModeFromReferences: boolean;
+  mode: ImageGenerationMode;
+  resolvedCopy: ImageWorkspaceCopy;
+  selectedEngineCaps?: EngineCaps;
+  setError: Dispatch<SetStateAction<string | null>>;
+  supportedReferenceFormats: string[];
+  supportedReferenceFormatsLabel: string;
+  toolsEnabled: boolean;
+};
+
+function cleanupSlotPreview(slot: ReferenceSlotValue | null) {
+  if (slot?.previewUrl && slot.previewUrl.startsWith('blob:')) {
+    try {
+      URL.revokeObjectURL(slot.previewUrl);
+    } catch {}
+  }
+}
+
+export function useImageReferenceSlots({
+  autoModeFromReferences,
+  mode,
+  resolvedCopy,
+  selectedEngineCaps,
+  setError,
+  supportedReferenceFormats,
+  supportedReferenceFormatsLabel,
+  toolsEnabled,
+}: UseImageReferenceSlotsParams) {
+  const [referenceSlots, setReferenceSlots] = useState<(ReferenceSlotValue | null)[]>(
+    Array(MAX_REFERENCE_SLOTS).fill(null)
+  );
+  const [areReferenceSlotsExpanded, setAreReferenceSlotsExpanded] = useState(false);
+  const [libraryModal, setLibraryModal] = useState<ImageLibraryModalState>({
+    open: false,
+    slotIndex: null,
+    selectionMode: 'reference',
+    initialSource: 'all',
+  });
+
+  const referenceConstraints = useMemo(
+    () =>
+      selectedEngineCaps
+        ? getReferenceConstraints(selectedEngineCaps, mode)
+        : { min: mode === 'i2i' ? 1 : 0, max: 4, requires: mode === 'i2i' },
+    [selectedEngineCaps, mode]
+  );
+  const referenceMinRequired = referenceConstraints.min;
+  const referencePickerConstraints = useMemo(
+    () =>
+      autoModeFromReferences && selectedEngineCaps
+        ? getReferenceConstraints(selectedEngineCaps, 'i2i')
+        : referenceConstraints,
+    [autoModeFromReferences, referenceConstraints, selectedEngineCaps]
+  );
+  const baseReferenceSlotLimit = Math.min(MAX_REFERENCE_SLOTS, referencePickerConstraints.max);
+  const supportsCharacterReferences = toolsEnabled && baseReferenceSlotLimit > 0;
+  const visibleReferenceSlots = useMemo(
+    () => referenceSlots.slice(0, baseReferenceSlotLimit),
+    [baseReferenceSlotLimit, referenceSlots]
+  );
+  const referenceSizeSignature = useMemo(
+    () =>
+      visibleReferenceSlots
+        .filter((slot): slot is ReferenceSlotValue => Boolean(slot && slot.status === 'ready'))
+        .map((slot) => `${slot.width ?? ''}x${slot.height ?? ''}`)
+        .join('|'),
+    [visibleReferenceSlots]
+  );
+  const selectedCharacterReferences = useMemo(
+    () =>
+      visibleReferenceSlots.reduce<CharacterReferenceSelection[]>((acc, slot) => {
+        if (slot?.characterReference) {
+          acc.push(slot.characterReference);
+        }
+        return acc;
+      }, []),
+    [visibleReferenceSlots]
+  );
+  const totalRegularReferenceSelections = useMemo(
+    () => visibleReferenceSlots.filter((slot) => Boolean(slot && !slot.characterReference)).length,
+    [visibleReferenceSlots]
+  );
+  const characterSelectionLimit = useMemo(
+    () =>
+      supportsCharacterReferences
+        ? Math.max(0, baseReferenceSlotLimit - totalRegularReferenceSelections)
+        : 0,
+    [baseReferenceSlotLimit, supportsCharacterReferences, totalRegularReferenceSelections]
+  );
+  const referenceSlotLimit = baseReferenceSlotLimit;
+  const canCollapseReferenceSlots = referenceSlotLimit > DEFAULT_VISIBLE_REFERENCE_SLOTS;
+  const displayedReferenceSlotCount =
+    canCollapseReferenceSlots && !areReferenceSlotsExpanded
+      ? DEFAULT_VISIBLE_REFERENCE_SLOTS
+      : referenceSlotLimit;
+  const displayedReferenceSlots = useMemo(
+    () => visibleReferenceSlots.slice(0, displayedReferenceSlotCount),
+    [displayedReferenceSlotCount, visibleReferenceSlots]
+  );
+  const collapsedReferenceSlotCount = Math.max(referenceSlotLimit - displayedReferenceSlotCount, 0);
+  const hasCollapsedReferenceContent = useMemo(
+    () =>
+      referenceSlots
+        .slice(DEFAULT_VISIBLE_REFERENCE_SLOTS, referenceSlotLimit)
+        .some((slot) => Boolean(slot)),
+    [referenceSlotLimit, referenceSlots]
+  );
+  const referenceHelperText = useMemo(
+    () => formatTemplate(resolvedCopy.composer.referenceHelper, { count: referenceSlotLimit }),
+    [referenceSlotLimit, resolvedCopy.composer.referenceHelper]
+  );
+  const referenceToggleLabel = useMemo(
+    () =>
+      areReferenceSlotsExpanded
+        ? resolvedCopy.composer.referenceCollapse
+        : formatTemplate(resolvedCopy.composer.referenceExpand, { count: collapsedReferenceSlotCount }),
+    [
+      areReferenceSlotsExpanded,
+      collapsedReferenceSlotCount,
+      resolvedCopy.composer.referenceCollapse,
+      resolvedCopy.composer.referenceExpand,
+    ]
+  );
+  const readyReferenceUrls = useMemo(
+    () =>
+      visibleReferenceSlots
+        .filter((slot): slot is ReferenceSlotValue => Boolean(slot && slot.status === 'ready'))
+        .map((slot) => slot.url),
+    [visibleReferenceSlots]
+  );
+  const readyReferenceSizes = useMemo(
+    () =>
+      visibleReferenceSlots
+        .filter((slot): slot is ReferenceSlotValue => Boolean(slot && slot.status === 'ready'))
+        .map((slot) => ({ width: slot.width ?? null, height: slot.height ?? null })),
+    [visibleReferenceSlots]
+  );
+  const combinedReferenceUrls = readyReferenceUrls;
+  const hasAnyReferenceSelection = useMemo(
+    () => visibleReferenceSlots.some((slot) => Boolean(slot)),
+    [visibleReferenceSlots]
+  );
+  const persistableReferenceSlots = useMemo<PersistedReferenceSlot[]>(
+    () =>
+      referenceSlots.slice(0, MAX_REFERENCE_SLOTS).map((slot) => {
+        if (!slot || slot.status !== 'ready') return null;
+        const url = slot.url?.trim?.() ?? '';
+        if (!url || url.startsWith('blob:')) return null;
+        return {
+          url,
+          source: slot.source,
+          width: slot.width ?? null,
+          height: slot.height ?? null,
+          characterReference: slot.characterReference
+            ? {
+                id: slot.characterReference.id,
+                jobId: slot.characterReference.jobId,
+                imageUrl: slot.characterReference.imageUrl,
+                thumbUrl: slot.characterReference.thumbUrl ?? null,
+                prompt: slot.characterReference.prompt ?? null,
+                createdAt: slot.characterReference.createdAt ?? null,
+                engineLabel: slot.characterReference.engineLabel ?? null,
+                outputMode: slot.characterReference.outputMode ?? null,
+                action: slot.characterReference.action ?? null,
+              }
+            : null,
+        };
+      }),
+    [referenceSlots]
+  );
+
+  useEffect(() => {
+    setReferenceSlots((previous) => {
+      let mutated = false;
+      const next = previous.slice();
+      for (let index = baseReferenceSlotLimit; index < next.length; index += 1) {
+        if (next[index]) {
+          cleanupSlotPreview(next[index]);
+          next[index] = null;
+          mutated = true;
+        }
+      }
+      return mutated ? next : previous;
+    });
+  }, [baseReferenceSlotLimit]);
+
+  useEffect(() => {
+    if (!canCollapseReferenceSlots && areReferenceSlotsExpanded) {
+      setAreReferenceSlotsExpanded(false);
+    }
+  }, [areReferenceSlotsExpanded, canCollapseReferenceSlots]);
+
+  useEffect(() => {
+    if (!areReferenceSlotsExpanded && hasCollapsedReferenceContent) {
+      setAreReferenceSlotsExpanded(true);
+    }
+  }, [areReferenceSlotsExpanded, hasCollapsedReferenceContent]);
+
+  const showUnsupportedFormatError = useCallback(() => {
+    setError(
+      formatTemplate(resolvedCopy.errors.unsupportedFormat, {
+        formats: supportedReferenceFormatsLabel || 'JPG, JPEG, PNG, WEBP',
+      })
+    );
+  }, [resolvedCopy.errors.unsupportedFormat, setError, supportedReferenceFormatsLabel]);
+
+  const isSupportedReferenceAsset = useCallback(
+    (mime?: string | null, locator?: string | null) => {
+      if (!supportedReferenceFormats.length) return true;
+      const supportedByMime = isSupportedImageMime(supportedReferenceFormats, mime);
+      if (supportedByMime != null) {
+        return supportedByMime;
+      }
+      const inferredFormat = inferImageFormatFromUrl(locator);
+      if (!inferredFormat) {
+        return true;
+      }
+      return isSupportedImageFormat(supportedReferenceFormats, inferredFormat);
+    },
+    [supportedReferenceFormats]
+  );
+
+  const handleRemoveReferenceSlot = useCallback((index: number) => {
+    setReferenceSlots((previous) => {
+      const next = previous.slice();
+      cleanupSlotPreview(next[index]);
+      next[index] = null;
+      return next;
+    });
+  }, []);
+
+  const handleReferenceFile = useCallback(
+    async (index: number, file: File | null) => {
+      if (!file) {
+        return;
+      }
+      if (!file.type.startsWith('image/')) {
+        setError(resolvedCopy.errors.onlyImages);
+        return;
+      }
+      const tempUrl = URL.createObjectURL(file);
+      const slotId = crypto.randomUUID();
+      setReferenceSlots((previous) => {
+        const next = previous.slice();
+        cleanupSlotPreview(next[index]);
+        next[index] = {
+          id: slotId,
+          url: tempUrl,
+          previewUrl: tempUrl,
+          name: file.name,
+          status: 'uploading',
+          source: 'upload',
+        };
+        return next;
+      });
+      try {
+        const preparedFile = await prepareImageFileForUpload(file, {
+          maxBytes: DEFAULT_UPLOAD_LIMIT_MB * 1024 * 1024,
+        });
+        const formData = new FormData();
+        formData.append('file', preparedFile, preparedFile.name);
+        const response = await authFetch('/api/uploads/image', {
+          method: 'POST',
+          body: formData,
+        });
+        const payload = await response.json().catch(() => null);
+        if (!response.ok || !payload?.ok) {
+          const uploadError = new Error(
+            typeof payload?.error === 'string' ? payload.error : 'UPLOAD_FAILED'
+          ) as UploadFailure;
+          uploadError.code = typeof payload?.error === 'string' ? payload.error : 'UPLOAD_FAILED';
+          if (typeof payload?.maxMB === 'number') {
+            uploadError.maxMB = payload.maxMB;
+          }
+          throw uploadError;
+        }
+        const asset = payload.asset as {
+          id: string;
+          url: string;
+          width?: number | null;
+          height?: number | null;
+        };
+        setReferenceSlots((previous) => {
+          const next = previous.slice();
+          const current = next[index];
+          if (!current || current.id !== slotId) {
+            return previous;
+          }
+          next[index] = {
+            id: slotId,
+            url: asset.url,
+            previewUrl: asset.url,
+            name: file.name,
+            status: 'ready',
+            source: 'upload',
+            width: asset.width ?? null,
+            height: asset.height ?? null,
+          };
+          if (current.previewUrl && current.previewUrl !== asset.url) {
+            try {
+              URL.revokeObjectURL(current.previewUrl);
+            } catch {}
+          }
+          return next;
+        });
+      } catch (uploadError) {
+        console.error('[image-workspace] reference upload failed', uploadError);
+        setReferenceSlots((previous) => {
+          const next = previous.slice();
+          const current = next[index];
+          if (current?.previewUrl) {
+            try {
+              URL.revokeObjectURL(current.previewUrl);
+            } catch {}
+          }
+          next[index] = null;
+          return next;
+        });
+        const failure = uploadError as UploadFailure;
+        const code = failure?.code;
+        if (code === 'FILE_TOO_LARGE') {
+          const limit =
+            typeof failure?.maxMB === 'number' && Number.isFinite(failure.maxMB)
+              ? failure.maxMB
+              : DEFAULT_UPLOAD_LIMIT_MB;
+          setError(formatTemplate(resolvedCopy.errors.fileTooLarge, { maxMB: limit }));
+        } else if (code === 'UNAUTHORIZED') {
+          setError(resolvedCopy.errors.unauthorized);
+        } else {
+          setError(resolvedCopy.errors.uploadFailed);
+        }
+      }
+    },
+    [
+      resolvedCopy.errors.fileTooLarge,
+      resolvedCopy.errors.onlyImages,
+      resolvedCopy.errors.unauthorized,
+      resolvedCopy.errors.uploadFailed,
+      setError,
+    ]
+  );
+
+  const handleReferenceUrl = useCallback(
+    (index: number, url: string, source: ReferenceSlotValue['source']) => {
+      if (!url) return;
+      if (!isSupportedReferenceAsset(null, url)) {
+        showUnsupportedFormatError();
+        return;
+      }
+      setReferenceSlots((previous) => {
+        const next = previous.slice();
+        cleanupSlotPreview(next[index]);
+        next[index] = {
+          id: crypto.randomUUID(),
+          url,
+          previewUrl: url,
+          status: 'ready',
+          source: source ?? 'paste',
+        };
+        return next;
+      });
+    },
+    [isSupportedReferenceAsset, showUnsupportedFormatError]
+  );
+
+  const resolveTargetReferenceSlotIndex = useCallback(
+    (preferredIndex: number | null = null) => {
+      if (preferredIndex != null && preferredIndex >= 0 && preferredIndex < referenceSlotLimit) {
+        return preferredIndex;
+      }
+      const emptyIndex = referenceSlots.slice(0, referenceSlotLimit).findIndex((slot) => slot === null);
+      if (emptyIndex >= 0) {
+        return emptyIndex;
+      }
+      return Math.max(0, referenceSlotLimit - 1);
+    },
+    [referenceSlotLimit, referenceSlots]
+  );
+
+  const closeLibraryModal = useCallback(() => {
+    setLibraryModal({ open: false, slotIndex: null, selectionMode: 'reference', initialSource: 'all' });
+  }, []);
+
+  const openCharacterLibrary = useCallback(() => {
+    setLibraryModal({
+      open: true,
+      slotIndex: null,
+      selectionMode: 'character',
+      initialSource: 'character',
+    });
+  }, []);
+
+  const handleLibrarySelect = useCallback(
+    (asset: LibraryAsset) => {
+      if (!isSupportedReferenceAsset(asset.mime, asset.url)) {
+        showUnsupportedFormatError();
+        return;
+      }
+      const slotIndex = resolveTargetReferenceSlotIndex(libraryModal.slotIndex);
+      if (slotIndex >= referenceSlotLimit) {
+        closeLibraryModal();
+        return;
+      }
+      const index = slotIndex;
+      if (index >= DEFAULT_VISIBLE_REFERENCE_SLOTS && canCollapseReferenceSlots) {
+        setAreReferenceSlotsExpanded(true);
+      }
+      setReferenceSlots((previous) => {
+        const next = previous.slice();
+        cleanupSlotPreview(next[index]);
+        next[index] = {
+          id: asset.id,
+          url: asset.url,
+          previewUrl: asset.url,
+          status: 'ready',
+          source: 'library',
+          width: asset.width ?? null,
+          height: asset.height ?? null,
+        };
+        return next;
+      });
+      closeLibraryModal();
+    },
+    [
+      canCollapseReferenceSlots,
+      closeLibraryModal,
+      isSupportedReferenceAsset,
+      libraryModal.slotIndex,
+      referenceSlotLimit,
+      resolveTargetReferenceSlotIndex,
+      showUnsupportedFormatError,
+    ]
+  );
+
+  const openLibraryForSlot = useCallback((index: number) => {
+    setLibraryModal({ open: true, slotIndex: index, selectionMode: 'reference', initialSource: 'all' });
+  }, []);
+
+  const toggleCharacterReference = useCallback(
+    (reference: CharacterReferenceSelection) => {
+      if (!supportsCharacterReferences) {
+        return;
+      }
+      const existingIndex = referenceSlots.findIndex((slot) => slot?.characterReference?.id === reference.id);
+      if (existingIndex >= 0) {
+        setReferenceSlots((previous) => {
+          const next = previous.slice();
+          cleanupSlotPreview(next[existingIndex]);
+          next[existingIndex] = null;
+          return next;
+        });
+        return;
+      }
+      if (selectedCharacterReferences.length >= characterSelectionLimit) {
+        return;
+      }
+      const nextIndex = resolveTargetReferenceSlotIndex(libraryModal.slotIndex);
+      if (nextIndex >= referenceSlotLimit) {
+        return;
+      }
+      if (nextIndex >= DEFAULT_VISIBLE_REFERENCE_SLOTS && canCollapseReferenceSlots) {
+        setAreReferenceSlotsExpanded(true);
+      }
+      setReferenceSlots((previous) => {
+        const next = previous.slice();
+        cleanupSlotPreview(next[nextIndex]);
+        next[nextIndex] = createCharacterReferenceSlot(reference);
+        return next;
+      });
+    },
+    [
+      canCollapseReferenceSlots,
+      characterSelectionLimit,
+      libraryModal.slotIndex,
+      referenceSlotLimit,
+      referenceSlots,
+      resolveTargetReferenceSlotIndex,
+      selectedCharacterReferences.length,
+      supportsCharacterReferences,
+    ]
+  );
+
+  return {
+    canCollapseReferenceSlots,
+    characterSelectionLimit,
+    closeLibraryModal,
+    combinedReferenceUrls,
+    displayedReferenceSlotCount,
+    displayedReferenceSlots,
+    handleLibrarySelect,
+    handleReferenceFile,
+    handleReferenceUrl,
+    handleRemoveReferenceSlot,
+    hasAnyReferenceSelection,
+    libraryModal,
+    openCharacterLibrary,
+    openLibraryForSlot,
+    persistableReferenceSlots,
+    readyReferenceSizes,
+    readyReferenceUrls,
+    referenceHelperText,
+    referenceMinRequired,
+    referenceSizeSignature,
+    referenceSlotLimit,
+    referenceToggleLabel,
+    selectedCharacterReferences,
+    setAreReferenceSlotsExpanded,
+    setReferenceSlots,
+    supportsCharacterReferences,
+    toggleCharacterReference,
+  };
+}

--- a/tests/image-reference-slots-hook-contract.test.ts
+++ b/tests/image-reference-slots-hook-contract.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { readFileSync, statSync } from 'node:fs';
+import { test } from 'node:test';
+import path from 'node:path';
+
+const root = process.cwd();
+const imageDir = path.join(root, 'frontend/app/(core)/(workspace)/app/image');
+const workspacePath = path.join(imageDir, 'ImageWorkspace.tsx');
+const hookPath = path.join(imageDir, '_hooks/useImageReferenceSlots.ts');
+
+test('image reference slots are owned by a route-local hook', () => {
+  statSync(hookPath);
+
+  const workspaceSource = readFileSync(workspacePath, 'utf8');
+  const hookSource = readFileSync(hookPath, 'utf8');
+
+  assert.match(workspaceSource, /from '\.\/_hooks\/useImageReferenceSlots'/);
+  assert.match(workspaceSource, /useImageReferenceSlots\(/);
+
+  assert.doesNotMatch(workspaceSource, /const handleReferenceFile = useCallback/);
+  assert.doesNotMatch(workspaceSource, /const handleReferenceUrl = useCallback/);
+  assert.doesNotMatch(workspaceSource, /const handleLibrarySelect = useCallback/);
+  assert.doesNotMatch(workspaceSource, /const toggleCharacterReference = useCallback/);
+  assert.doesNotMatch(workspaceSource, /prepareImageFileForUpload/);
+
+  assert.match(hookSource, /handleReferenceFile/);
+  assert.match(hookSource, /handleReferenceUrl/);
+  assert.match(hookSource, /handleLibrarySelect/);
+  assert.match(hookSource, /toggleCharacterReference/);
+  assert.match(hookSource, /prepareImageFileForUpload/);
+});


### PR DESCRIPTION
## Summary
- Extract image reference slot state, derived limits, upload orchestration, pasted URL insertion, library selection, and character toggling into `useImageReferenceSlots`.
- Keep `ImageWorkspace.tsx` as the image route orchestrator while preserving storage hydration and snapshot application through the hook setter.
- Add a contract test so reference slot handlers stay out of the route component.

## Notes
- `ImageWorkspace.tsx` drops from roughly 2,400 lines after #63 to roughly 2,000 lines.
- Upload, auth, generation payload, pricing estimate, and persisted storage shape are intended to stay behavior-compatible.

## Test Plan
- `pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/image-reference-slots-hook-contract.test.ts tests/image-workspace-split-contract.test.ts tests/supabase-browser-session-cleanup.test.ts`
- `pnpm --prefix frontend exec tsc --noEmit`
- `npm --prefix frontend run lint`
- `npm run lint:exposure`
- `pnpm test:validate`
- `pnpm --prefix frontend run build`
