### PR TITLE
Split image preview actions

### DIFF
--- a/frontend/app/(core)/(workspace)/app/image/AGENTS.md
+++ b/frontend/app/(core)/(workspace)/app/image/AGENTS.md
@@ -16,6 +16,7 @@ This route owns the dedicated still-image generation workspace.
 - Keep character reference parsing, labels, and slot merging in `_lib/image-workspace-character-references.ts`.
 - Keep job-to-history and local active group builders in `_lib/image-workspace-history.ts`.
 - Keep reference slot state, upload orchestration, library selection, and character toggling in `_hooks/useImageReferenceSlots.ts`.
+- Keep preview copy/download actions and generated-library save/remove orchestration in `_hooks/useImagePreviewActions.ts`.
 - Keep browser-only library UI in `_components/ImageLibraryModal.tsx`.
 - Keep `ImageWorkspace.tsx` focused on orchestration; do not add new inline helper blocks or route-local modal implementations there.
 - Keep image composer storage keys and stored payload shape backward compatible.

--- a/frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx
+++ b/frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx
@@ -16,7 +16,6 @@ import { Composer, type AssetFieldConfig, type ComposerAttachment } from '@/comp
 import { ImageSettingsBar } from '@/components/ImageSettingsBar';
 import { ImageAdvancedSettings } from '@/components/ImageAdvancedSettings';
 import { runImageGeneration, useInfiniteJobs, saveImageToLibrary } from '@/lib/api';
-import { suggestDownloadFilename, triggerAppDownload } from '@/lib/download';
 import type {
   CharacterReferenceSelection,
   ImageGenerationMode,
@@ -61,6 +60,7 @@ import { groupJobsIntoSummaries } from '@/lib/job-groups';
 import { countResolvedVisualSlots } from '@/lib/group-progress';
 import { ImageLibraryModal } from './_components/ImageLibraryModal';
 import { useImageWorkspaceDesktopLayout } from './_hooks/useImageWorkspaceDesktopLayout';
+import { useImagePreviewActions } from './_hooks/useImagePreviewActions';
 import { useImageReferenceSlots } from './_hooks/useImageReferenceSlots';
 import {
   createCharacterReferenceSlot,
@@ -91,10 +91,8 @@ import {
   IMAGE_COMPOSER_STORAGE_VERSION,
   MAX_REFERENCE_SLOTS,
   QUICK_IMAGE_COUNT_OPTIONS,
-  type AssetsResponse,
   type HistoryEntry,
   type ImageEngineOption,
-  type LibraryAsset,
   type PersistedImageComposerState,
   type ReferenceSlotValue,
   type PricingEstimateResponse,
@@ -152,9 +150,6 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
   const isDesktopLayout = useImageWorkspaceDesktopLayout();
   const [error, setError] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
-  const [isSavingToLibrary, setIsSavingToLibrary] = useState(false);
-  const [isRemovingFromLibrary, setIsRemovingFromLibrary] = useState(false);
-  const [copiedUrl, setCopiedUrl] = useState<string | null>(null);
   const [viewerGroup, setViewerGroup] = useState<VideoGroup | null>(null);
   const [authModalOpen, setAuthModalOpen] = useState(false);
   const [
@@ -1263,24 +1258,6 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
     ]
   );
 
-  const handleCopy = useCallback((url: string) => {
-    if (!navigator?.clipboard) {
-      setCopiedUrl(url);
-      return;
-    }
-    navigator.clipboard
-      .writeText(url)
-      .then(() => {
-        setCopiedUrl(url);
-        setTimeout(() => setCopiedUrl(null), 2000);
-      })
-      .catch(() => setCopiedUrl(null));
-  }, []);
-
-  const handleDownload = useCallback((url: string) => {
-    triggerAppDownload(url, suggestDownloadFilename(url, 'image-generation'));
-  }, []);
-
   const historyEntries = combinedHistory;
 
   const handleSelectGalleryGroup = useCallback(
@@ -1413,31 +1390,31 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
     return historyEntries[0];
   })();
   const canUseWorkspace = Boolean(selectedEngine && selectedEngineCaps);
-  const selectedPreviewUrl = previewEntry?.images?.[selectedPreviewImageIndex]?.url ?? null;
-  const savedAssetKey =
-    canUseWorkspace && selectedPreviewUrl
-      ? `/api/user-assets?limit=1&source=generated&originUrl=${encodeURIComponent(selectedPreviewUrl)}`
-      : null;
   const {
-    data: savedAssets,
-    mutate: mutateSavedAssets,
-  } = useSWR(savedAssetKey, async (url: string) => {
-    const response = await authFetch(url);
-    const payload = (await response.json().catch(() => null)) as AssetsResponse | null;
-    if (!response.ok || !payload?.ok) {
-      let message: string | undefined;
-      if (payload && typeof payload === 'object' && 'error' in payload) {
-        const maybeError = (payload as { error?: unknown }).error;
-        if (typeof maybeError === 'string') {
-          message = maybeError;
-        }
-      }
-      throw new Error(message ?? 'Failed to load library');
-    }
-    return payload.assets;
+    copiedUrl,
+    handleAddToLibrary,
+    handleCopy,
+    handleDownload,
+    handleRemoveFromLibrary,
+    isInLibrary,
+    isRemovingFromLibrary,
+    isSavingToLibrary,
+  } = useImagePreviewActions({
+    canUseWorkspace,
+    genericError: resolvedCopy.errors.generic,
+    previewEntry,
+    removedFromLibraryMessage: t(
+      'workspace.image.messages.removedFromLibrary',
+      DEFAULT_COPY.messages.removedFromLibrary
+    ) as string,
+    savedToLibraryMessage: t(
+      'workspace.image.messages.savedToLibrary',
+      DEFAULT_COPY.messages.savedToLibrary
+    ) as string,
+    selectedPreviewImageIndex,
+    setError,
+    setStatusMessage,
   });
-  const savedAsset = (savedAssets?.[0] as LibraryAsset | undefined) ?? null;
-  const isInLibrary = Boolean(savedAsset?.id);
 
   const inProgressMessage = useMemo(() => {
     const count = pendingGroups.length;
@@ -1628,64 +1605,8 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
                 onOpenModal={previewEntry ? () => handleOpenHistoryEntry(previewEntry) : undefined}
                 onDownload={handleDownload}
                 onCopyLink={handleCopy}
-                onAddToLibrary={(url) => {
-                  if (!previewEntry?.id) return;
-                  if (isSavingToLibrary) return;
-                  if (isRemovingFromLibrary) return;
-                  setIsSavingToLibrary(true);
-                  setError(null);
-                  setStatusMessage(null);
-                  void saveImageToLibrary({
-                    url,
-                    jobId: previewEntry.jobId ?? previewEntry.id,
-                    label: previewEntry.prompt ?? undefined,
-                  })
-                    .then(() => {
-                      const savedMessage = t(
-                        'workspace.image.messages.savedToLibrary',
-                        DEFAULT_COPY.messages.savedToLibrary
-                      ) as string;
-                      setStatusMessage(savedMessage);
-                      void mutateSavedAssets();
-                    })
-                    .catch((error) => {
-                      setError(error instanceof Error ? error.message : resolvedCopy.errors.generic);
-                    })
-                    .finally(() => {
-                      setIsSavingToLibrary(false);
-                    });
-                }}
-                onRemoveFromLibrary={() => {
-                  if (!savedAsset?.id) return;
-                  if (isRemovingFromLibrary) return;
-                  if (isSavingToLibrary) return;
-                  setIsRemovingFromLibrary(true);
-                  setError(null);
-                  setStatusMessage(null);
-                  void authFetch('/api/user-assets', {
-                    method: 'DELETE',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ id: savedAsset.id }),
-                  })
-                    .then(async (response) => {
-                      const payload = (await response.json().catch(() => null)) as { ok?: boolean; error?: string } | null;
-                      if (!response.ok || !payload?.ok) {
-                        throw new Error(payload?.error ?? 'Failed to remove from library');
-                      }
-                      const removedMessage = t(
-                        'workspace.image.messages.removedFromLibrary',
-                        DEFAULT_COPY.messages.removedFromLibrary
-                      ) as string;
-                      setStatusMessage(removedMessage);
-                      void mutateSavedAssets();
-                    })
-                    .catch((error) => {
-                      setError(error instanceof Error ? error.message : resolvedCopy.errors.generic);
-                    })
-                    .finally(() => {
-                      setIsRemovingFromLibrary(false);
-                    });
-                }}
+                onAddToLibrary={handleAddToLibrary}
+                onRemoveFromLibrary={handleRemoveFromLibrary}
                 isInLibrary={isInLibrary}
                 isSavingToLibrary={isSavingToLibrary}
                 isRemovingFromLibrary={isRemovingFromLibrary}

--- a/frontend/app/(core)/(workspace)/app/image/_hooks/useImagePreviewActions.ts
+++ b/frontend/app/(core)/(workspace)/app/image/_hooks/useImagePreviewActions.ts
@@ -1,0 +1,163 @@
+import { useCallback, useState, type Dispatch, type SetStateAction } from 'react';
+import useSWR from 'swr';
+import { saveImageToLibrary } from '@/lib/api';
+import { authFetch } from '@/lib/authFetch';
+import { suggestDownloadFilename, triggerAppDownload } from '@/lib/download';
+import type {
+  AssetsResponse,
+  HistoryEntry,
+  LibraryAsset,
+} from '../_lib/image-workspace-types';
+
+type UseImagePreviewActionsParams = {
+  canUseWorkspace: boolean;
+  genericError: string;
+  previewEntry: HistoryEntry | undefined;
+  removedFromLibraryMessage: string;
+  savedToLibraryMessage: string;
+  selectedPreviewImageIndex: number;
+  setError: Dispatch<SetStateAction<string | null>>;
+  setStatusMessage: Dispatch<SetStateAction<string | null>>;
+};
+
+export function useImagePreviewActions({
+  canUseWorkspace,
+  genericError,
+  previewEntry,
+  removedFromLibraryMessage,
+  savedToLibraryMessage,
+  selectedPreviewImageIndex,
+  setError,
+  setStatusMessage,
+}: UseImagePreviewActionsParams) {
+  const [isSavingToLibrary, setIsSavingToLibrary] = useState(false);
+  const [isRemovingFromLibrary, setIsRemovingFromLibrary] = useState(false);
+  const [copiedUrl, setCopiedUrl] = useState<string | null>(null);
+  const selectedPreviewUrl = previewEntry?.images?.[selectedPreviewImageIndex]?.url ?? null;
+  const savedAssetLookupKey =
+    canUseWorkspace && selectedPreviewUrl
+      ? `/api/user-assets?limit=1&source=generated&originUrl=${encodeURIComponent(selectedPreviewUrl)}`
+      : null;
+  const {
+    data: savedAssets,
+    mutate: mutateSavedAssets,
+  } = useSWR(savedAssetLookupKey, async (url: string) => {
+    const response = await authFetch(url);
+    const payload = (await response.json().catch(() => null)) as AssetsResponse | null;
+    if (!response.ok || !payload?.ok) {
+      let message: string | undefined;
+      if (payload && typeof payload === 'object' && 'error' in payload) {
+        const maybeError = (payload as { error?: unknown }).error;
+        if (typeof maybeError === 'string') {
+          message = maybeError;
+        }
+      }
+      throw new Error(message ?? 'Failed to load library');
+    }
+    return payload.assets;
+  });
+  const savedAsset = (savedAssets?.[0] as LibraryAsset | undefined) ?? null;
+  const isInLibrary = Boolean(savedAsset?.id);
+
+  const handleCopy = useCallback((url: string) => {
+    if (!navigator?.clipboard) {
+      setCopiedUrl(url);
+      return;
+    }
+    navigator.clipboard
+      .writeText(url)
+      .then(() => {
+        setCopiedUrl(url);
+        setTimeout(() => setCopiedUrl(null), 2000);
+      })
+      .catch(() => setCopiedUrl(null));
+  }, []);
+
+  const handleDownload = useCallback((url: string) => {
+    triggerAppDownload(url, suggestDownloadFilename(url, 'image-generation'));
+  }, []);
+
+  const handleAddToLibrary = useCallback(
+    (url: string) => {
+      if (!previewEntry?.id) return;
+      if (isSavingToLibrary) return;
+      if (isRemovingFromLibrary) return;
+      setIsSavingToLibrary(true);
+      setError(null);
+      setStatusMessage(null);
+      void saveImageToLibrary({
+        url,
+        jobId: previewEntry.jobId ?? previewEntry.id,
+        label: previewEntry.prompt ?? undefined,
+      })
+        .then(() => {
+          setStatusMessage(savedToLibraryMessage);
+          void mutateSavedAssets();
+        })
+        .catch((error) => {
+          setError(error instanceof Error ? error.message : genericError);
+        })
+        .finally(() => {
+          setIsSavingToLibrary(false);
+        });
+    },
+    [
+      genericError,
+      isRemovingFromLibrary,
+      isSavingToLibrary,
+      mutateSavedAssets,
+      previewEntry,
+      savedToLibraryMessage,
+      setError,
+      setStatusMessage,
+    ]
+  );
+
+  const handleRemoveFromLibrary = useCallback(() => {
+    if (!savedAsset?.id) return;
+    if (isRemovingFromLibrary) return;
+    if (isSavingToLibrary) return;
+    setIsRemovingFromLibrary(true);
+    setError(null);
+    setStatusMessage(null);
+    void authFetch('/api/user-assets', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: savedAsset.id }),
+    })
+      .then(async (response) => {
+        const payload = (await response.json().catch(() => null)) as { ok?: boolean; error?: string } | null;
+        if (!response.ok || !payload?.ok) {
+          throw new Error(payload?.error ?? 'Failed to remove from library');
+        }
+        setStatusMessage(removedFromLibraryMessage);
+        void mutateSavedAssets();
+      })
+      .catch((error) => {
+        setError(error instanceof Error ? error.message : genericError);
+      })
+      .finally(() => {
+        setIsRemovingFromLibrary(false);
+      });
+  }, [
+    genericError,
+    isRemovingFromLibrary,
+    isSavingToLibrary,
+    mutateSavedAssets,
+    removedFromLibraryMessage,
+    savedAsset?.id,
+    setError,
+    setStatusMessage,
+  ]);
+
+  return {
+    copiedUrl,
+    handleAddToLibrary,
+    handleCopy,
+    handleDownload,
+    handleRemoveFromLibrary,
+    isInLibrary,
+    isRemovingFromLibrary,
+    isSavingToLibrary,
+  };
+}

--- a/tests/image-preview-actions-hook-contract.test.ts
+++ b/tests/image-preview-actions-hook-contract.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { readFileSync, statSync } from 'node:fs';
+import { test } from 'node:test';
+import path from 'node:path';
+
+const root = process.cwd();
+const imageDir = path.join(root, 'frontend/app/(core)/(workspace)/app/image');
+const workspacePath = path.join(imageDir, 'ImageWorkspace.tsx');
+const hookPath = path.join(imageDir, '_hooks/useImagePreviewActions.ts');
+
+test('image preview library actions are owned by a route-local hook', () => {
+  statSync(hookPath);
+
+  const workspaceSource = readFileSync(workspacePath, 'utf8');
+  const hookSource = readFileSync(hookPath, 'utf8');
+
+  assert.match(workspaceSource, /from '\.\/_hooks\/useImagePreviewActions'/);
+  assert.match(workspaceSource, /useImagePreviewActions\(/);
+
+  assert.doesNotMatch(workspaceSource, /const handleCopy = useCallback/);
+  assert.doesNotMatch(workspaceSource, /const handleDownload = useCallback/);
+  assert.doesNotMatch(workspaceSource, /savedAssetKey/);
+  assert.doesNotMatch(workspaceSource, /onAddToLibrary=\{\(url\) =>/);
+  assert.doesNotMatch(workspaceSource, /onRemoveFromLibrary=\{\(\) =>/);
+
+  assert.match(hookSource, /handleCopy/);
+  assert.match(hookSource, /handleDownload/);
+  assert.match(hookSource, /handleAddToLibrary/);
+  assert.match(hookSource, /handleRemoveFromLibrary/);
+  assert.match(hookSource, /saveImageToLibrary/);
+});


### PR DESCRIPTION
## Summary
- Extract image preview copy/download and generated-library save/remove actions into `useImagePreviewActions`.
- Move saved generated asset lookup and save/remove pending state out of `ImageWorkspace.tsx`.
- Add a contract test and image route guide rule to keep preview actions out of the route component.

## Notes
- Behavior-compatible refactor; no intended upload/generation/pricing/storage changes.
- `ImageWorkspace.tsx` is now 1920 lines; the extracted hook is 163 lines.

## Test Plan
- `pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/image-preview-actions-hook-contract.test.ts tests/image-reference-slots-hook-contract.test.ts tests/image-workspace-split-contract.test.ts`
- `pnpm test:validate`
- `pnpm --prefix frontend exec tsc --noEmit`
- `npm --prefix frontend run lint`
- `npm run lint:exposure`
- `git diff --check`
- `pnpm --prefix frontend run build`