### PR TITLE
Split image settings fields

### DIFF
--- a/frontend/app/(core)/(workspace)/app/image/AGENTS.md
+++ b/frontend/app/(core)/(workspace)/app/image/AGENTS.md
@@ -17,6 +17,7 @@ This route owns the dedicated still-image generation workspace.
 - Keep job-to-history and local active group builders in `_lib/image-workspace-history.ts`.
 - Keep reference slot state, upload orchestration, library selection, and character toggling in `_hooks/useImageReferenceSlots.ts`.
 - Keep preview copy/download actions and generated-library save/remove orchestration in `_hooks/useImagePreviewActions.ts`.
+- Keep image setting field derivation, select options, and schema-driven default resets in `_hooks/useImageSettingsFields.ts`.
 - Keep browser-only library UI in `_components/ImageLibraryModal.tsx`.
 - Keep `ImageWorkspace.tsx` focused on orchestration; do not add new inline helper blocks or route-local modal implementations there.
 - Keep image composer storage keys and stored payload shape backward compatible.

--- a/frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx
+++ b/frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx
@@ -27,19 +27,12 @@ import type { MediaLightboxEntry } from '@/components/MediaLightbox';
 import { ImageCompositePreviewDock, type ImageCompositePreviewEntry } from '@/components/groups/ImageCompositePreviewDock';
 import { buildVideoGroupFromImageRun } from '@/lib/image-groups';
 import { useI18n } from '@/lib/i18n/I18nProvider';
-import { formatAspectRatioLabel } from '@/lib/image/aspectRatios';
 import { FEATURES } from '@/content/feature-flags';
-import {
-  formatSupportedImageFormatsLabel,
-  getSupportedImageFormats,
-} from '@/lib/image/formats';
 import {
   clampRequestedImageCount,
   getAspectRatioOptions,
   getDefaultAspectRatio,
   getDefaultResolution,
-  getImageCountConstraints,
-  getImageFieldDefaultBoolean,
   getImageFieldDefaultNumber,
   getImageFieldDefaultString,
   getImageFieldValues,
@@ -59,6 +52,7 @@ import { normalizeJobSurface } from '@/lib/job-surface-normalize';
 import { groupJobsIntoSummaries } from '@/lib/job-groups';
 import { countResolvedVisualSlots } from '@/lib/group-progress';
 import { ImageLibraryModal } from './_components/ImageLibraryModal';
+import { useImageSettingsFields } from './_hooks/useImageSettingsFields';
 import { useImageWorkspaceDesktopLayout } from './_hooks/useImageWorkspaceDesktopLayout';
 import { useImagePreviewActions } from './_hooks/useImagePreviewActions';
 import { useImageReferenceSlots } from './_hooks/useImageReferenceSlots';
@@ -82,15 +76,12 @@ import { parsePersistedImageComposerState } from './_lib/image-workspace-persist
 import {
   buildCustomImageSize,
   findImageEngine,
-  formatImageSizeLabel,
-  formatQualityLabel,
 } from './_lib/image-workspace-utils';
 import {
   IMAGE_COMPOSER_STORAGE_DEBOUNCE_MS,
   IMAGE_COMPOSER_STORAGE_KEY,
   IMAGE_COMPOSER_STORAGE_VERSION,
   MAX_REFERENCE_SLOTS,
-  QUICK_IMAGE_COUNT_OPTIONS,
   type HistoryEntry,
   type ImageEngineOption,
   type PersistedImageComposerState,
@@ -168,53 +159,53 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
     selectedEngine && selectedEngine.modes.includes('t2i') && selectedEngine.modes.includes('i2i')
   );
   const selectedEngineCaps = selectedEngine?.engineCaps ?? engines[0]?.engineCaps;
-  const imageCountField = useMemo(
-    () => getImageInputField(selectedEngineCaps ?? null, 'num_images', mode),
-    [selectedEngineCaps, mode]
-  );
-  const imageCountConstraints = useMemo(
-    () => getImageCountConstraints(selectedEngineCaps ?? null, mode),
-    [selectedEngineCaps, mode]
-  );
-  const aspectRatioField = useMemo(
-    () => getImageInputField(selectedEngineCaps ?? null, 'aspect_ratio', mode),
-    [selectedEngineCaps, mode]
-  );
-  const aspectRatioOptions = useMemo(
-    () => getAspectRatioOptions(selectedEngineCaps ?? null, mode),
-    [selectedEngineCaps, mode]
-  );
-  const resolutionField = useMemo(
-    () => getImageInputField(selectedEngineCaps ?? null, 'resolution', mode),
-    [selectedEngineCaps, mode]
-  );
-  const customImageWidthField = useMemo(
-    () => getImageInputField(selectedEngineCaps ?? null, 'image_width', mode),
-    [selectedEngineCaps, mode]
-  );
-  const customImageHeightField = useMemo(
-    () => getImageInputField(selectedEngineCaps ?? null, 'image_height', mode),
-    [selectedEngineCaps, mode]
-  );
-  const resolutionOptions = useMemo(
-    () =>
-      getImageFieldValues(
-        selectedEngineCaps ?? null,
-        'resolution',
-        mode,
-        Array.isArray(selectedEngineCaps?.resolutions) ? [...selectedEngineCaps.resolutions] : []
-      ),
-    [selectedEngineCaps, mode]
-  );
-  const isResolutionLocked = Boolean(resolutionField && resolutionOptions.length === 1);
-  const supportedReferenceFormats = useMemo(
-    () => getSupportedImageFormats(selectedEngineCaps ?? null),
-    [selectedEngineCaps]
-  );
-  const supportedReferenceFormatsLabel = useMemo(
-    () => formatSupportedImageFormatsLabel(supportedReferenceFormats),
-    [supportedReferenceFormats]
-  );
+  const {
+    aspectRatioField,
+    aspectRatioSelectOptions,
+    booleanSelectOptions,
+    enableWebSearchField,
+    imageCountOptions,
+    isResolutionLocked,
+    limitGenerationsField,
+    maskUrlField,
+    outputFormatField,
+    outputFormatSelectOptions,
+    qualityField,
+    qualitySelectOptions,
+    resolutionSelectOptions,
+    seedField,
+    showAspectRatioControl,
+    showCustomImageSizeControl,
+    showEnableWebSearchControl,
+    showLimitGenerationsControl,
+    showNumImagesControl,
+    showOutputFormatControl,
+    showQualityControl,
+    showResolutionControl,
+    showSeedControl,
+    showThinkingLevelControl,
+    supportedReferenceFormats,
+    supportedReferenceFormatsLabel,
+    thinkingLevelField,
+    thinkingLevelSelectOptions,
+  } = useImageSettingsFields({
+    mode,
+    resolution,
+    resolvedCopy,
+    selectedEngineCaps,
+    setAspectRatio,
+    setCustomImageHeight,
+    setCustomImageWidth,
+    setEnableWebSearch,
+    setLimitGenerations,
+    setMaskUrl,
+    setNumImages,
+    setOutputFormat,
+    setQuality,
+    setResolution,
+    setSeed,
+    setThinkingLevel,
+  });
   const {
     canCollapseReferenceSlots,
     characterSelectionLimit,
@@ -253,180 +244,6 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
     supportedReferenceFormatsLabel,
     toolsEnabled,
   });
-  const outputFormatField = useMemo(
-    () => getImageInputField(selectedEngineCaps ?? null, 'output_format', mode),
-    [selectedEngineCaps, mode]
-  );
-  const outputFormatOptions = useMemo(
-    () => getImageFieldValues(selectedEngineCaps ?? null, 'output_format', mode),
-    [selectedEngineCaps, mode]
-  );
-  const qualityField = useMemo(
-    () => getImageInputField(selectedEngineCaps ?? null, 'quality', mode),
-    [selectedEngineCaps, mode]
-  );
-  const qualityOptions = useMemo(
-    () => getImageFieldValues(selectedEngineCaps ?? null, 'quality', mode),
-    [selectedEngineCaps, mode]
-  );
-  const maskUrlField = useMemo(
-    () => getImageInputField(selectedEngineCaps ?? null, 'mask_url', mode),
-    [selectedEngineCaps, mode]
-  );
-  const seedField = useMemo(
-    () => getImageInputField(selectedEngineCaps ?? null, 'seed', mode),
-    [selectedEngineCaps, mode]
-  );
-  const enableWebSearchField = useMemo(
-    () => getImageInputField(selectedEngineCaps ?? null, 'enable_web_search', mode),
-    [selectedEngineCaps, mode]
-  );
-  const thinkingLevelField = useMemo(
-    () => getImageInputField(selectedEngineCaps ?? null, 'thinking_level', mode),
-    [selectedEngineCaps, mode]
-  );
-  const thinkingLevelOptions = useMemo(
-    () => getImageFieldValues(selectedEngineCaps ?? null, 'thinking_level', mode),
-    [selectedEngineCaps, mode]
-  );
-  const limitGenerationsField = useMemo(
-    () => getImageInputField(selectedEngineCaps ?? null, 'limit_generations', mode),
-    [selectedEngineCaps, mode]
-  );
-  useEffect(() => {
-    setNumImages((previous) => clampRequestedImageCount(selectedEngineCaps ?? null, mode, previous));
-  }, [selectedEngineCaps, mode]);
-
-  useEffect(() => {
-    if (!aspectRatioField || !aspectRatioOptions.length) {
-      setAspectRatio(null);
-      return;
-    }
-    const defaultValue = getDefaultAspectRatio(selectedEngineCaps ?? null, mode);
-    setAspectRatio((previous) => {
-      if (previous && aspectRatioOptions.includes(previous)) {
-        return previous;
-      }
-      return defaultValue;
-    });
-  }, [aspectRatioField, aspectRatioOptions, selectedEngineCaps, mode]);
-
-  useEffect(() => {
-    if (!resolutionField || !resolutionOptions.length) {
-      setResolution(null);
-      return;
-    }
-    const defaultValue = getDefaultResolution(selectedEngineCaps ?? null, mode);
-    setResolution((previous) => {
-      if (previous && resolutionOptions.includes(previous)) {
-        return previous;
-      }
-      return defaultValue;
-    });
-  }, [resolutionField, resolutionOptions, selectedEngineCaps, mode]);
-
-  useEffect(() => {
-    if (!customImageWidthField || !customImageHeightField) {
-      setCustomImageWidth('');
-      setCustomImageHeight('');
-      return;
-    }
-    const defaultWidth =
-      getImageFieldDefaultNumber(selectedEngineCaps ?? null, 'image_width', mode) ??
-      GPT_IMAGE_2_SIZE_CONSTRAINTS.defaultWidth;
-    const defaultHeight =
-      getImageFieldDefaultNumber(selectedEngineCaps ?? null, 'image_height', mode) ??
-      GPT_IMAGE_2_SIZE_CONSTRAINTS.defaultHeight;
-    setCustomImageWidth((previous) => (previous.trim().length ? previous : String(defaultWidth)));
-    setCustomImageHeight((previous) => (previous.trim().length ? previous : String(defaultHeight)));
-  }, [customImageHeightField, customImageWidthField, selectedEngineCaps, mode]);
-
-  useEffect(() => {
-    if (!seedField) {
-      setSeed('');
-      return;
-    }
-    const defaultValue = getImageFieldDefaultNumber(selectedEngineCaps ?? null, 'seed', mode);
-    setSeed((previous) => {
-      if (previous.trim().length) {
-        const parsed = Number(previous);
-        if (Number.isFinite(parsed)) {
-          return String(Math.round(parsed));
-        }
-      }
-      return defaultValue == null ? '' : String(defaultValue);
-    });
-  }, [seedField, selectedEngineCaps, mode]);
-
-  useEffect(() => {
-    if (!outputFormatField || !outputFormatOptions.length) {
-      setOutputFormat(null);
-      return;
-    }
-    const defaultValue =
-      getImageFieldDefaultString(selectedEngineCaps ?? null, 'output_format', mode) ?? outputFormatOptions[0] ?? null;
-    setOutputFormat((previous) => {
-      if (previous && outputFormatOptions.includes(previous)) {
-        return previous;
-      }
-      return defaultValue;
-    });
-  }, [outputFormatField, outputFormatOptions, selectedEngineCaps, mode]);
-
-  useEffect(() => {
-    if (!qualityField || !qualityOptions.length) {
-      setQuality(null);
-      return;
-    }
-    const defaultValue =
-      getImageFieldDefaultString(selectedEngineCaps ?? null, 'quality', mode) ?? qualityOptions[0] ?? null;
-    setQuality((previous) => {
-      if (previous && qualityOptions.includes(previous)) {
-        return previous;
-      }
-      return defaultValue;
-    });
-  }, [qualityField, qualityOptions, selectedEngineCaps, mode]);
-
-  useEffect(() => {
-    if (!maskUrlField) {
-      setMaskUrl('');
-    }
-  }, [maskUrlField]);
-
-  useEffect(() => {
-    if (!enableWebSearchField) {
-      setEnableWebSearch(false);
-      return;
-    }
-    const defaultValue = getImageFieldDefaultBoolean(selectedEngineCaps ?? null, 'enable_web_search', mode);
-    setEnableWebSearch((previous) => previous ?? defaultValue ?? false);
-  }, [enableWebSearchField, selectedEngineCaps, mode]);
-
-  useEffect(() => {
-    if (!thinkingLevelField || !thinkingLevelOptions.length) {
-      setThinkingLevel(null);
-      return;
-    }
-    const defaultValue =
-      getImageFieldDefaultString(selectedEngineCaps ?? null, 'thinking_level', mode) ?? thinkingLevelOptions[0] ?? null;
-    setThinkingLevel((previous) => {
-      if (previous && thinkingLevelOptions.includes(previous)) {
-        return previous;
-      }
-      return defaultValue;
-    });
-  }, [thinkingLevelField, thinkingLevelOptions, selectedEngineCaps, mode]);
-
-  useEffect(() => {
-    if (!limitGenerationsField) {
-      setLimitGenerations(false);
-      return;
-    }
-    const defaultValue = getImageFieldDefaultBoolean(selectedEngineCaps ?? null, 'limit_generations', mode);
-    setLimitGenerations((previous) => previous ?? defaultValue ?? false);
-  }, [limitGenerationsField, selectedEngineCaps, mode]);
-
   useEffect(() => {
     if (!selectedEngine) return;
     setPriceEstimateKey([
@@ -1421,84 +1238,6 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
     if (count <= 0) return null;
     return formatTemplate(resolvedCopy.messages.generatingInProgress, { count });
   }, [pendingGroups.length, resolvedCopy.messages.generatingInProgress]);
-  const imageCountOptions = useMemo(
-    () => {
-      const options = Array.from(
-        new Set<number>([
-          ...QUICK_IMAGE_COUNT_OPTIONS.filter(
-            (option) => option >= imageCountConstraints.min && option <= imageCountConstraints.max
-          ),
-          imageCountConstraints.max,
-        ])
-      );
-      return options.map((option) => ({
-        value: option,
-        label: formatTemplate(resolvedCopy.composer.numImagesCount, {
-          count: option,
-          unit: option === 1 ? resolvedCopy.composer.numImagesUnit.singular : resolvedCopy.composer.numImagesUnit.plural,
-        }),
-      }));
-    },
-    [imageCountConstraints.max, imageCountConstraints.min, resolvedCopy.composer.numImagesCount, resolvedCopy.composer.numImagesUnit]
-  );
-  const aspectRatioSelectOptions = useMemo(
-    () =>
-      aspectRatioOptions.map((option) => ({
-        value: option,
-        label: formatAspectRatioLabel(option) ?? option,
-      })),
-    [aspectRatioOptions]
-  );
-  const resolutionSelectOptions = useMemo(
-    () =>
-      resolutionOptions.map((option) => ({
-        value: option,
-        label: formatImageSizeLabel(option),
-      })),
-    [resolutionOptions]
-  );
-  const qualitySelectOptions = useMemo(
-    () =>
-      qualityOptions.map((option) => ({
-        value: option,
-        label: formatQualityLabel(option),
-      })),
-    [qualityOptions]
-  );
-  const outputFormatSelectOptions = useMemo(
-    () =>
-      outputFormatOptions.map((option) => ({
-        value: option,
-        label: option.toUpperCase(),
-      })),
-    [outputFormatOptions]
-  );
-  const thinkingLevelSelectOptions = useMemo(
-    () =>
-      thinkingLevelOptions.map((option) => ({
-        value: option,
-        label: option === 'high' ? 'High' : option === 'minimal' ? 'Minimal' : option,
-      })),
-    [thinkingLevelOptions]
-  );
-  const booleanSelectOptions = useMemo(
-    () => [
-      { value: false, label: resolvedCopy.composer.toggleDisabled },
-      { value: true, label: resolvedCopy.composer.toggleEnabled },
-    ],
-    [resolvedCopy.composer.toggleDisabled, resolvedCopy.composer.toggleEnabled]
-  );
-  const showNumImagesControl = Boolean(imageCountField);
-  const showAspectRatioControl = Boolean(aspectRatioField) && aspectRatioSelectOptions.length > 0;
-  const showResolutionControl = Boolean(resolutionField) && resolutionSelectOptions.length > 0;
-  const showQualityControl = Boolean(qualityField) && qualitySelectOptions.length > 0;
-  const showSeedControl = Boolean(seedField);
-  const showOutputFormatControl = Boolean(outputFormatField) && outputFormatSelectOptions.length > 0;
-  const showCustomImageSizeControl =
-    Boolean(customImageWidthField && customImageHeightField) && resolution === 'custom';
-  const showEnableWebSearchControl = Boolean(enableWebSearchField);
-  const showThinkingLevelControl = Boolean(thinkingLevelField) && thinkingLevelSelectOptions.length > 0;
-  const showLimitGenerationsControl = Boolean(limitGenerationsField);
   const compositePreviewEntry: ImageCompositePreviewEntry | null = previewEntry
     ? {
         id: previewEntry.id,

--- a/frontend/app/(core)/(workspace)/app/image/_hooks/useImageSettingsFields.ts
+++ b/frontend/app/(core)/(workspace)/app/image/_hooks/useImageSettingsFields.ts
@@ -1,0 +1,416 @@
+import { useEffect, useMemo, type Dispatch, type SetStateAction } from 'react';
+import { formatAspectRatioLabel } from '@/lib/image/aspectRatios';
+import {
+  formatSupportedImageFormatsLabel,
+  getSupportedImageFormats,
+} from '@/lib/image/formats';
+import {
+  clampRequestedImageCount,
+  getAspectRatioOptions,
+  getDefaultAspectRatio,
+  getDefaultResolution,
+  getImageCountConstraints,
+  getImageFieldDefaultBoolean,
+  getImageFieldDefaultNumber,
+  getImageFieldDefaultString,
+  getImageFieldValues,
+  getImageInputField,
+} from '@/lib/image/inputSchema';
+import { GPT_IMAGE_2_SIZE_CONSTRAINTS } from '@/lib/image/gptImage2';
+import type { EngineCaps } from '@/types/engines';
+import type { ImageGenerationMode } from '@/types/image-generation';
+import { formatTemplate, type ImageWorkspaceCopy } from '../_lib/image-workspace-copy';
+import { QUICK_IMAGE_COUNT_OPTIONS } from '../_lib/image-workspace-types';
+import {
+  formatImageSizeLabel,
+  formatQualityLabel,
+} from '../_lib/image-workspace-utils';
+
+type UseImageSettingsFieldsParams = {
+  mode: ImageGenerationMode;
+  resolution: string | null;
+  resolvedCopy: ImageWorkspaceCopy;
+  selectedEngineCaps: EngineCaps | undefined;
+  setAspectRatio: Dispatch<SetStateAction<string | null>>;
+  setCustomImageHeight: Dispatch<SetStateAction<string>>;
+  setCustomImageWidth: Dispatch<SetStateAction<string>>;
+  setEnableWebSearch: Dispatch<SetStateAction<boolean>>;
+  setLimitGenerations: Dispatch<SetStateAction<boolean>>;
+  setMaskUrl: Dispatch<SetStateAction<string>>;
+  setNumImages: Dispatch<SetStateAction<number>>;
+  setOutputFormat: Dispatch<SetStateAction<string | null>>;
+  setQuality: Dispatch<SetStateAction<string | null>>;
+  setResolution: Dispatch<SetStateAction<string | null>>;
+  setSeed: Dispatch<SetStateAction<string>>;
+  setThinkingLevel: Dispatch<SetStateAction<string | null>>;
+};
+
+export function useImageSettingsFields({
+  mode,
+  resolution,
+  resolvedCopy,
+  selectedEngineCaps,
+  setAspectRatio,
+  setCustomImageHeight,
+  setCustomImageWidth,
+  setEnableWebSearch,
+  setLimitGenerations,
+  setMaskUrl,
+  setNumImages,
+  setOutputFormat,
+  setQuality,
+  setResolution,
+  setSeed,
+  setThinkingLevel,
+}: UseImageSettingsFieldsParams) {
+  const imageCountField = useMemo(
+    () => getImageInputField(selectedEngineCaps ?? null, 'num_images', mode),
+    [selectedEngineCaps, mode]
+  );
+  const imageCountConstraints = useMemo(
+    () => getImageCountConstraints(selectedEngineCaps ?? null, mode),
+    [selectedEngineCaps, mode]
+  );
+  const aspectRatioField = useMemo(
+    () => getImageInputField(selectedEngineCaps ?? null, 'aspect_ratio', mode),
+    [selectedEngineCaps, mode]
+  );
+  const aspectRatioOptions = useMemo(
+    () => getAspectRatioOptions(selectedEngineCaps ?? null, mode),
+    [selectedEngineCaps, mode]
+  );
+  const resolutionField = useMemo(
+    () => getImageInputField(selectedEngineCaps ?? null, 'resolution', mode),
+    [selectedEngineCaps, mode]
+  );
+  const customImageWidthField = useMemo(
+    () => getImageInputField(selectedEngineCaps ?? null, 'image_width', mode),
+    [selectedEngineCaps, mode]
+  );
+  const customImageHeightField = useMemo(
+    () => getImageInputField(selectedEngineCaps ?? null, 'image_height', mode),
+    [selectedEngineCaps, mode]
+  );
+  const resolutionOptions = useMemo(
+    () =>
+      getImageFieldValues(
+        selectedEngineCaps ?? null,
+        'resolution',
+        mode,
+        Array.isArray(selectedEngineCaps?.resolutions) ? [...selectedEngineCaps.resolutions] : []
+      ),
+    [selectedEngineCaps, mode]
+  );
+  const outputFormatField = useMemo(
+    () => getImageInputField(selectedEngineCaps ?? null, 'output_format', mode),
+    [selectedEngineCaps, mode]
+  );
+  const outputFormatOptions = useMemo(
+    () => getImageFieldValues(selectedEngineCaps ?? null, 'output_format', mode),
+    [selectedEngineCaps, mode]
+  );
+  const qualityField = useMemo(
+    () => getImageInputField(selectedEngineCaps ?? null, 'quality', mode),
+    [selectedEngineCaps, mode]
+  );
+  const qualityOptions = useMemo(
+    () => getImageFieldValues(selectedEngineCaps ?? null, 'quality', mode),
+    [selectedEngineCaps, mode]
+  );
+  const maskUrlField = useMemo(
+    () => getImageInputField(selectedEngineCaps ?? null, 'mask_url', mode),
+    [selectedEngineCaps, mode]
+  );
+  const seedField = useMemo(
+    () => getImageInputField(selectedEngineCaps ?? null, 'seed', mode),
+    [selectedEngineCaps, mode]
+  );
+  const enableWebSearchField = useMemo(
+    () => getImageInputField(selectedEngineCaps ?? null, 'enable_web_search', mode),
+    [selectedEngineCaps, mode]
+  );
+  const thinkingLevelField = useMemo(
+    () => getImageInputField(selectedEngineCaps ?? null, 'thinking_level', mode),
+    [selectedEngineCaps, mode]
+  );
+  const thinkingLevelOptions = useMemo(
+    () => getImageFieldValues(selectedEngineCaps ?? null, 'thinking_level', mode),
+    [selectedEngineCaps, mode]
+  );
+  const limitGenerationsField = useMemo(
+    () => getImageInputField(selectedEngineCaps ?? null, 'limit_generations', mode),
+    [selectedEngineCaps, mode]
+  );
+
+  const isResolutionLocked = Boolean(resolutionField && resolutionOptions.length === 1);
+  const supportedReferenceFormats = useMemo(
+    () => getSupportedImageFormats(selectedEngineCaps ?? null),
+    [selectedEngineCaps]
+  );
+  const supportedReferenceFormatsLabel = useMemo(
+    () => formatSupportedImageFormatsLabel(supportedReferenceFormats),
+    [supportedReferenceFormats]
+  );
+
+  useEffect(() => {
+    setNumImages((previous) => clampRequestedImageCount(selectedEngineCaps ?? null, mode, previous));
+  }, [selectedEngineCaps, mode, setNumImages]);
+
+  useEffect(() => {
+    if (!aspectRatioField || !aspectRatioOptions.length) {
+      setAspectRatio(null);
+      return;
+    }
+    const defaultValue = getDefaultAspectRatio(selectedEngineCaps ?? null, mode);
+    setAspectRatio((previous) => {
+      if (previous && aspectRatioOptions.includes(previous)) {
+        return previous;
+      }
+      return defaultValue;
+    });
+  }, [aspectRatioField, aspectRatioOptions, selectedEngineCaps, mode, setAspectRatio]);
+
+  useEffect(() => {
+    if (!resolutionField || !resolutionOptions.length) {
+      setResolution(null);
+      return;
+    }
+    const defaultValue = getDefaultResolution(selectedEngineCaps ?? null, mode);
+    setResolution((previous) => {
+      if (previous && resolutionOptions.includes(previous)) {
+        return previous;
+      }
+      return defaultValue;
+    });
+  }, [resolutionField, resolutionOptions, selectedEngineCaps, mode, setResolution]);
+
+  useEffect(() => {
+    if (!customImageWidthField || !customImageHeightField) {
+      setCustomImageWidth('');
+      setCustomImageHeight('');
+      return;
+    }
+    const defaultWidth =
+      getImageFieldDefaultNumber(selectedEngineCaps ?? null, 'image_width', mode) ??
+      GPT_IMAGE_2_SIZE_CONSTRAINTS.defaultWidth;
+    const defaultHeight =
+      getImageFieldDefaultNumber(selectedEngineCaps ?? null, 'image_height', mode) ??
+      GPT_IMAGE_2_SIZE_CONSTRAINTS.defaultHeight;
+    setCustomImageWidth((previous) => (previous.trim().length ? previous : String(defaultWidth)));
+    setCustomImageHeight((previous) => (previous.trim().length ? previous : String(defaultHeight)));
+  }, [
+    customImageHeightField,
+    customImageWidthField,
+    selectedEngineCaps,
+    mode,
+    setCustomImageHeight,
+    setCustomImageWidth,
+  ]);
+
+  useEffect(() => {
+    if (!seedField) {
+      setSeed('');
+      return;
+    }
+    const defaultValue = getImageFieldDefaultNumber(selectedEngineCaps ?? null, 'seed', mode);
+    setSeed((previous) => {
+      if (previous.trim().length) {
+        const parsed = Number(previous);
+        if (Number.isFinite(parsed)) {
+          return String(Math.round(parsed));
+        }
+      }
+      return defaultValue == null ? '' : String(defaultValue);
+    });
+  }, [seedField, selectedEngineCaps, mode, setSeed]);
+
+  useEffect(() => {
+    if (!outputFormatField || !outputFormatOptions.length) {
+      setOutputFormat(null);
+      return;
+    }
+    const defaultValue =
+      getImageFieldDefaultString(selectedEngineCaps ?? null, 'output_format', mode) ?? outputFormatOptions[0] ?? null;
+    setOutputFormat((previous) => {
+      if (previous && outputFormatOptions.includes(previous)) {
+        return previous;
+      }
+      return defaultValue;
+    });
+  }, [outputFormatField, outputFormatOptions, selectedEngineCaps, mode, setOutputFormat]);
+
+  useEffect(() => {
+    if (!qualityField || !qualityOptions.length) {
+      setQuality(null);
+      return;
+    }
+    const defaultValue =
+      getImageFieldDefaultString(selectedEngineCaps ?? null, 'quality', mode) ?? qualityOptions[0] ?? null;
+    setQuality((previous) => {
+      if (previous && qualityOptions.includes(previous)) {
+        return previous;
+      }
+      return defaultValue;
+    });
+  }, [qualityField, qualityOptions, selectedEngineCaps, mode, setQuality]);
+
+  useEffect(() => {
+    if (!maskUrlField) {
+      setMaskUrl('');
+    }
+  }, [maskUrlField, setMaskUrl]);
+
+  useEffect(() => {
+    if (!enableWebSearchField) {
+      setEnableWebSearch(false);
+      return;
+    }
+    const defaultValue = getImageFieldDefaultBoolean(selectedEngineCaps ?? null, 'enable_web_search', mode);
+    setEnableWebSearch((previous) => previous ?? defaultValue ?? false);
+  }, [enableWebSearchField, selectedEngineCaps, mode, setEnableWebSearch]);
+
+  useEffect(() => {
+    if (!thinkingLevelField || !thinkingLevelOptions.length) {
+      setThinkingLevel(null);
+      return;
+    }
+    const defaultValue =
+      getImageFieldDefaultString(selectedEngineCaps ?? null, 'thinking_level', mode) ?? thinkingLevelOptions[0] ?? null;
+    setThinkingLevel((previous) => {
+      if (previous && thinkingLevelOptions.includes(previous)) {
+        return previous;
+      }
+      return defaultValue;
+    });
+  }, [thinkingLevelField, thinkingLevelOptions, selectedEngineCaps, mode, setThinkingLevel]);
+
+  useEffect(() => {
+    if (!limitGenerationsField) {
+      setLimitGenerations(false);
+      return;
+    }
+    const defaultValue = getImageFieldDefaultBoolean(selectedEngineCaps ?? null, 'limit_generations', mode);
+    setLimitGenerations((previous) => previous ?? defaultValue ?? false);
+  }, [limitGenerationsField, selectedEngineCaps, mode, setLimitGenerations]);
+
+  const imageCountOptions = useMemo(
+    () => {
+      const options = Array.from(
+        new Set<number>([
+          ...QUICK_IMAGE_COUNT_OPTIONS.filter(
+            (option) => option >= imageCountConstraints.min && option <= imageCountConstraints.max
+          ),
+          imageCountConstraints.max,
+        ])
+      );
+      return options.map((option) => ({
+        value: option,
+        label: formatTemplate(resolvedCopy.composer.numImagesCount, {
+          count: option,
+          unit: option === 1 ? resolvedCopy.composer.numImagesUnit.singular : resolvedCopy.composer.numImagesUnit.plural,
+        }),
+      }));
+    },
+    [imageCountConstraints.max, imageCountConstraints.min, resolvedCopy.composer.numImagesCount, resolvedCopy.composer.numImagesUnit]
+  );
+  const aspectRatioSelectOptions = useMemo(
+    () =>
+      aspectRatioOptions.map((option) => ({
+        value: option,
+        label: formatAspectRatioLabel(option) ?? option,
+      })),
+    [aspectRatioOptions]
+  );
+  const resolutionSelectOptions = useMemo(
+    () =>
+      resolutionOptions.map((option) => ({
+        value: option,
+        label: formatImageSizeLabel(option),
+      })),
+    [resolutionOptions]
+  );
+  const qualitySelectOptions = useMemo(
+    () =>
+      qualityOptions.map((option) => ({
+        value: option,
+        label: formatQualityLabel(option),
+      })),
+    [qualityOptions]
+  );
+  const outputFormatSelectOptions = useMemo(
+    () =>
+      outputFormatOptions.map((option) => ({
+        value: option,
+        label: option.toUpperCase(),
+      })),
+    [outputFormatOptions]
+  );
+  const thinkingLevelSelectOptions = useMemo(
+    () =>
+      thinkingLevelOptions.map((option) => ({
+        value: option,
+        label: option === 'high' ? 'High' : option === 'minimal' ? 'Minimal' : option,
+      })),
+    [thinkingLevelOptions]
+  );
+  const booleanSelectOptions = useMemo(
+    () => [
+      { value: false, label: resolvedCopy.composer.toggleDisabled },
+      { value: true, label: resolvedCopy.composer.toggleEnabled },
+    ],
+    [resolvedCopy.composer.toggleDisabled, resolvedCopy.composer.toggleEnabled]
+  );
+
+  const showNumImagesControl = Boolean(imageCountField);
+  const showAspectRatioControl = Boolean(aspectRatioField) && aspectRatioSelectOptions.length > 0;
+  const showResolutionControl = Boolean(resolutionField) && resolutionSelectOptions.length > 0;
+  const showQualityControl = Boolean(qualityField) && qualitySelectOptions.length > 0;
+  const showSeedControl = Boolean(seedField);
+  const showOutputFormatControl = Boolean(outputFormatField) && outputFormatSelectOptions.length > 0;
+  const showCustomImageSizeControl =
+    Boolean(customImageWidthField && customImageHeightField) && resolution === 'custom';
+  const showEnableWebSearchControl = Boolean(enableWebSearchField);
+  const showThinkingLevelControl = Boolean(thinkingLevelField) && thinkingLevelSelectOptions.length > 0;
+  const showLimitGenerationsControl = Boolean(limitGenerationsField);
+
+  return {
+    aspectRatioField,
+    aspectRatioOptions,
+    aspectRatioSelectOptions,
+    booleanSelectOptions,
+    customImageHeightField,
+    customImageWidthField,
+    enableWebSearchField,
+    imageCountConstraints,
+    imageCountField,
+    imageCountOptions,
+    isResolutionLocked,
+    limitGenerationsField,
+    maskUrlField,
+    outputFormatField,
+    outputFormatOptions,
+    outputFormatSelectOptions,
+    qualityField,
+    qualityOptions,
+    qualitySelectOptions,
+    resolutionField,
+    resolutionOptions,
+    resolutionSelectOptions,
+    seedField,
+    showAspectRatioControl,
+    showCustomImageSizeControl,
+    showEnableWebSearchControl,
+    showLimitGenerationsControl,
+    showNumImagesControl,
+    showOutputFormatControl,
+    showQualityControl,
+    showResolutionControl,
+    showSeedControl,
+    showThinkingLevelControl,
+    supportedReferenceFormats,
+    supportedReferenceFormatsLabel,
+    thinkingLevelField,
+    thinkingLevelOptions,
+    thinkingLevelSelectOptions,
+  };
+}

--- a/tests/image-settings-fields-hook-contract.test.ts
+++ b/tests/image-settings-fields-hook-contract.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { readFileSync, statSync } from 'node:fs';
+import { test } from 'node:test';
+import path from 'node:path';
+
+const root = process.cwd();
+const imageDir = path.join(root, 'frontend/app/(core)/(workspace)/app/image');
+const workspacePath = path.join(imageDir, 'ImageWorkspace.tsx');
+const hookPath = path.join(imageDir, '_hooks/useImageSettingsFields.ts');
+
+test('image settings field derivation is owned by a route-local hook', () => {
+  statSync(hookPath);
+
+  const workspaceSource = readFileSync(workspacePath, 'utf8');
+  const hookSource = readFileSync(hookPath, 'utf8');
+
+  assert.match(workspaceSource, /from '\.\/_hooks\/useImageSettingsFields'/);
+  assert.match(workspaceSource, /useImageSettingsFields\(/);
+
+  assert.doesNotMatch(workspaceSource, /const imageCountField = useMemo/);
+  assert.doesNotMatch(workspaceSource, /const aspectRatioField = useMemo/);
+  assert.doesNotMatch(workspaceSource, /const outputFormatField = useMemo/);
+  assert.doesNotMatch(workspaceSource, /const imageCountOptions = useMemo/);
+  assert.doesNotMatch(workspaceSource, /const aspectRatioSelectOptions = useMemo/);
+  assert.doesNotMatch(workspaceSource, /const booleanSelectOptions = useMemo/);
+
+  assert.match(hookSource, /getImageInputField/);
+  assert.match(hookSource, /getImageFieldValues/);
+  assert.match(hookSource, /formatAspectRatioLabel/);
+  assert.match(hookSource, /formatSupportedImageFormatsLabel/);
+});


### PR DESCRIPTION
## Summary
- Extract image schema field derivation, select option builders, and schema-driven default resets into `useImageSettingsFields`.
- Keep `ImageWorkspace.tsx` focused on orchestration while preserving existing composer settings behavior.
- Add a contract test and route guide rule so settings field derivation stays out of the route component.

## Notes
- Behavior-compatible refactor; no intended generation, pricing, upload, or storage behavior change.
- `ImageWorkspace.tsx` is now 1659 lines; the extracted settings hook is 416 lines.

## Test Plan
- `pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/image-settings-fields-hook-contract.test.ts tests/image-preview-actions-hook-contract.test.ts tests/image-reference-slots-hook-contract.test.ts tests/image-workspace-split-contract.test.ts`
- `pnpm --prefix frontend exec tsc --noEmit`
- `npm --prefix frontend run lint`
- `npm run lint:exposure`
- `git diff --check`
- `pnpm test:validate`
- `pnpm --prefix frontend run build`