### PR TITLE
Fix angle tool canvas crash

### DIFF
--- a/frontend/app/api/media-proxy/route.ts
+++ b/frontend/app/api/media-proxy/route.ts
@@ -5,6 +5,7 @@ import { VISITOR_WORKSPACE_ENABLED } from '@/lib/visitor-access';
 export const runtime = 'nodejs';
 
 const PUBLIC_MEDIA_PROXY_HOSTS = new Set([
+  'media.maxvideoai.com',
   'videohub-uploads-us.s3.amazonaws.com',
   'v3b.fal.media',
   'fal.media',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,7 +50,6 @@
     "@maxvideoai/pricing": "file:../packages/pricing",
     "@react-email/components": "^0.5.7",
     "@react-email/render": "^1.4.0",
-    "@react-three/fiber": "^8.17.14",
     "@stripe/stripe-js": "^8.3.0",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.45.4",

--- a/frontend/src/components/tools/AngleOrbitCanvas.tsx
+++ b/frontend/src/components/tools/AngleOrbitCanvas.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { Canvas, useFrame, useThree } from '@react-three/fiber';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { buildBestAngleVariantParams } from '@/lib/tools-angle';
 import type { AngleToolNumericParams } from '@/types/tools-angle';
@@ -19,6 +18,24 @@ type AngleOrbitCanvasProps = {
   generateBestAngles: boolean;
 };
 
+type OrbitSceneState = {
+  renderer: THREE.WebGLRenderer;
+  scene: THREE.Scene;
+  camera: THREE.PerspectiveCamera;
+  frameMesh: THREE.Mesh<THREE.BoxGeometry, THREE.MeshStandardMaterial>;
+  imageMesh: THREE.Mesh<THREE.PlaneGeometry, THREE.MeshBasicMaterial>;
+  glossMesh: THREE.Mesh<THREE.PlaneGeometry, THREE.MeshStandardMaterial>;
+  guidesGroup: THREE.Group;
+  animationFrame: number | null;
+  resizeObserver: ResizeObserver | null;
+  texture: THREE.Texture | null;
+};
+
+const DEFAULT_ASPECT = 0.72;
+const MAX_CARD_WIDTH = 4.8;
+const MAX_CARD_HEIGHT = 3.15;
+const CAMERA_TARGET = new THREE.Vector3(0, 1.2, 0);
+
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
@@ -31,96 +48,76 @@ function buildTextureProxyUrl(url: string | null | undefined): string | null {
   return `/api/media-proxy?url=${encodeURIComponent(trimmed)}`;
 }
 
-function getTextureCandidates(sourceImage: OrbitSourceImage): string[] {
+function getTextureCandidates(sourceImage?: OrbitSourceImage | null): string[] {
+  if (!sourceImage) return [];
   return [buildTextureProxyUrl(sourceImage.previewUrl), buildTextureProxyUrl(sourceImage.url)]
     .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
     .filter((entry, index, array) => entry.length > 0 && array.indexOf(entry) === index);
 }
 
-function AngleCameraRig({ params }: { params: AngleToolNumericParams }) {
-  const { camera } = useThree();
-  const target = useRef(new THREE.Vector3(0, 1.2, 0));
-  const desiredPosition = useRef(new THREE.Vector3(0, 1.35, 7.9));
+function resolveCardSize(aspect: number): { width: number; height: number } {
+  const safeAspect = Number.isFinite(aspect) && aspect > 0 ? aspect : DEFAULT_ASPECT;
+  if (safeAspect >= 1) {
+    const width = MAX_CARD_WIDTH;
+    const height = Math.max(1.4, width / safeAspect);
+    return { width, height: Math.min(height, MAX_CARD_HEIGHT) };
+  }
 
-  useFrame(() => {
-    const yaw = (params.rotation * Math.PI) / 180;
-    const pitch = (params.tilt / 30) * (Math.PI / 5);
-    const distance = 8.3 - params.zoom * 0.46;
-    const planarDistance = Math.cos(pitch) * distance;
+  const height = MAX_CARD_HEIGHT;
+  const width = Math.max(1.4, height * safeAspect);
+  return { width: Math.min(width, MAX_CARD_WIDTH), height };
+}
 
-    desiredPosition.current.set(
-      Math.sin(yaw) * planarDistance,
-      1.15 + Math.sin(pitch) * distance * 1.1,
-      Math.cos(yaw) * planarDistance
-    );
+function disposeMaterial(material: THREE.Material | THREE.Material[]) {
+  if (Array.isArray(material)) {
+    material.forEach((entry) => entry.dispose());
+    return;
+  }
+  material.dispose();
+}
 
-    camera.position.lerp(desiredPosition.current, 0.16);
-    camera.lookAt(target.current);
-
-    if (camera instanceof THREE.PerspectiveCamera) {
-      const nextFov = clamp(32 - params.zoom * 0.72, 20, 32);
-      if (Math.abs(camera.fov - nextFov) > 0.01) {
-        camera.fov = nextFov;
-        camera.updateProjectionMatrix();
-      }
+function disposeObject(object: THREE.Object3D) {
+  object.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if (mesh.geometry) {
+      mesh.geometry.dispose();
+    }
+    if (mesh.material) {
+      disposeMaterial(mesh.material);
     }
   });
-
-  return null;
 }
 
-function AngleReferenceScene({
-  sourceImage,
-  generateBestAngles,
-  params,
-}: {
-  sourceImage?: OrbitSourceImage | null;
-  generateBestAngles: boolean;
-  params: AngleToolNumericParams;
-}) {
-  return (
-    <>
-      <group position={[0, -0.95, 0]}>
-        <mesh rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
-          <circleGeometry args={[6.6, 64]} />
-          <meshStandardMaterial color="#eef2f9" roughness={0.98} metalness={0.02} />
-        </mesh>
-      </group>
-
-      {generateBestAngles ? <AngleBestAnglesGuides params={params} /> : null}
-      {sourceImage?.url ? <AngleImageCard sourceImage={sourceImage} /> : null}
-    </>
-  );
+function setCardAspect(state: OrbitSceneState, aspect: number) {
+  const { width, height } = resolveCardSize(aspect);
+  state.frameMesh.scale.set(width + 0.18, height + 0.2, 0.1);
+  state.imageMesh.scale.set(width, height, 1);
+  state.glossMesh.scale.set(width + 0.02, height + 0.02, 1);
 }
 
-function AngleBestAnglesGuides({ params }: { params: AngleToolNumericParams }) {
+function setImageTexture(state: OrbitSceneState, texture: THREE.Texture | null) {
+  if (state.texture && state.texture !== texture) {
+    state.texture.dispose();
+  }
+  state.texture = texture;
+  state.imageMesh.material.map = texture ?? null;
+  state.imageMesh.material.color.set(texture ? '#ffffff' : '#c1d0e6');
+  state.imageMesh.material.needsUpdate = true;
+}
+
+function updateGuides(state: OrbitSceneState, params: AngleToolNumericParams, generateBestAngles: boolean) {
+  state.guidesGroup.children.forEach((child) => {
+    disposeObject(child);
+  });
+  state.guidesGroup.clear();
+
+  if (!generateBestAngles) return;
+
   const guideColor = '#97a8c2';
   const offsets = buildBestAngleVariantParams(params);
-  const target = useMemo(() => new THREE.Vector3(0, 1.2, 0), []);
-
-  return (
-    <group>
-      {offsets.map((offset, index) => (
-        <AngleGuideLine key={`best-angle-guide-${index}`} target={target} rotation={offset.rotation} tilt={offset.tilt} color={guideColor} />
-      ))}
-    </group>
-  );
-}
-
-function AngleGuideLine({
-  target,
-  rotation,
-  tilt,
-  color,
-}: {
-  target: THREE.Vector3;
-  rotation: number;
-  tilt: number;
-  color: string;
-}) {
-  const lineObject = useMemo(() => {
-    const yaw = (rotation * Math.PI) / 180;
-    const pitch = (tilt / 30) * (Math.PI / 5);
+  offsets.forEach((offset) => {
+    const yaw = (offset.rotation * Math.PI) / 180;
+    const pitch = (offset.tilt / 30) * (Math.PI / 5);
     const distance = 4.8;
     const planarDistance = Math.cos(pitch) * distance;
     const position = new THREE.Vector3(
@@ -128,46 +125,206 @@ function AngleGuideLine({
       1.2 + Math.sin(pitch) * distance * 1.05,
       Math.cos(yaw) * planarDistance
     );
-    const geometry = new THREE.BufferGeometry().setFromPoints([target.clone(), position]);
-    const material = new THREE.LineBasicMaterial({ color, transparent: true, opacity: 0.8 });
-    return new THREE.Line(geometry, material);
-  }, [color, rotation, target, tilt]);
-
-  useEffect(() => {
-    return () => {
-      lineObject.geometry.dispose();
-      const material = lineObject.material;
-      if (material instanceof THREE.Material) {
-        material.dispose();
-      }
-    };
-  }, [lineObject]);
-
-  return <primitive object={lineObject} />;
+    const geometry = new THREE.BufferGeometry().setFromPoints([CAMERA_TARGET.clone(), position]);
+    const material = new THREE.LineBasicMaterial({ color: guideColor, transparent: true, opacity: 0.8 });
+    state.guidesGroup.add(new THREE.Line(geometry, material));
+  });
 }
 
-function useSourceTexture(urls: Array<string | null | undefined>) {
-  const [texture, setTexture] = useState<THREE.Texture | null>(null);
+function updateCamera(camera: THREE.PerspectiveCamera, params: AngleToolNumericParams) {
+  const yaw = (params.rotation * Math.PI) / 180;
+  const pitch = (params.tilt / 30) * (Math.PI / 5);
+  const distance = 8.3 - params.zoom * 0.46;
+  const planarDistance = Math.cos(pitch) * distance;
+  const desiredPosition = new THREE.Vector3(
+    Math.sin(yaw) * planarDistance,
+    1.15 + Math.sin(pitch) * distance * 1.1,
+    Math.cos(yaw) * planarDistance
+  );
+
+  camera.position.lerp(desiredPosition, 0.16);
+  camera.lookAt(CAMERA_TARGET);
+
+  const nextFov = clamp(32 - params.zoom * 0.72, 20, 32);
+  if (Math.abs(camera.fov - nextFov) > 0.01) {
+    camera.fov = nextFov;
+    camera.updateProjectionMatrix();
+  }
+}
+
+function createScene(mount: HTMLDivElement): OrbitSceneState {
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color('#f6f8fc');
+  scene.fog = new THREE.Fog('#f6f8fc', 10, 22);
+
+  const camera = new THREE.PerspectiveCamera(32, 1, 0.1, 50);
+  camera.position.set(0, 1.35, 6.4);
+
+  const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
+  renderer.setClearColor('#f6f8fc', 1);
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+  renderer.domElement.className = 'block h-full w-full';
+  mount.appendChild(renderer.domElement);
+
+  const ground = new THREE.Mesh(
+    new THREE.CircleGeometry(6.6, 64),
+    new THREE.MeshStandardMaterial({ color: '#eef2f9', roughness: 0.98, metalness: 0.02 })
+  );
+  ground.rotation.x = -Math.PI / 2;
+  ground.position.y = -0.95;
+  ground.receiveShadow = true;
+  scene.add(ground);
+
+  const guidesGroup = new THREE.Group();
+  scene.add(guidesGroup);
+
+  const cardGroup = new THREE.Group();
+  cardGroup.position.set(0, 0.7, 0);
+  scene.add(cardGroup);
+
+  const frameMesh = new THREE.Mesh(
+    new THREE.BoxGeometry(1, 1, 1),
+    new THREE.MeshStandardMaterial({ color: '#dfe7f2', roughness: 0.9, metalness: 0.04 })
+  );
+  frameMesh.position.set(0, 0.92, -0.08);
+  frameMesh.castShadow = true;
+  frameMesh.receiveShadow = true;
+  cardGroup.add(frameMesh);
+
+  const imageMesh = new THREE.Mesh(
+    new THREE.PlaneGeometry(1, 1),
+    new THREE.MeshBasicMaterial({ color: '#c1d0e6', transparent: true, alphaTest: 0.04, side: THREE.DoubleSide })
+  );
+  imageMesh.position.set(0, 0.92, 0.065);
+  imageMesh.castShadow = true;
+  imageMesh.receiveShadow = true;
+  cardGroup.add(imageMesh);
+
+  const glossMesh = new THREE.Mesh(
+    new THREE.PlaneGeometry(1, 1),
+    new THREE.MeshStandardMaterial({
+      color: '#ffffff',
+      transparent: true,
+      opacity: 0.12,
+      roughness: 1,
+      metalness: 0,
+      side: THREE.DoubleSide,
+    })
+  );
+  glossMesh.position.set(0, 0.92, 0.085);
+  glossMesh.castShadow = true;
+  cardGroup.add(glossMesh);
+
+  scene.add(new THREE.AmbientLight('#ffffff', 1.3));
+  const mainLight = new THREE.DirectionalLight('#ffffff', 2.1);
+  mainLight.position.set(5, 6, 4);
+  scene.add(mainLight);
+  const fillLight = new THREE.DirectionalLight('#dbe6f7', 0.65);
+  fillLight.position.set(-3, 1.5, -4);
+  scene.add(fillLight);
+  const floorLight = new THREE.PointLight('#cddaf0', 0.16);
+  floorLight.position.set(0, -1.2, 0);
+  scene.add(floorLight);
+
+  const state: OrbitSceneState = {
+    renderer,
+    scene,
+    camera,
+    frameMesh,
+    imageMesh,
+    glossMesh,
+    guidesGroup,
+    animationFrame: null,
+    resizeObserver: null,
+    texture: null,
+  };
+  setCardAspect(state, DEFAULT_ASPECT);
+  return state;
+}
+
+export default function AngleOrbitCanvas({ params, sourceImage, generateBestAngles }: AngleOrbitCanvasProps) {
+  const mountRef = useRef<HTMLDivElement | null>(null);
+  const sceneRef = useRef<OrbitSceneState | null>(null);
+  const paramsRef = useRef(params);
+  const [webglUnavailable, setWebglUnavailable] = useState(false);
 
   useEffect(() => {
-    const candidates = urls
-      .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
-      .filter((entry, index, array) => entry.length > 0 && array.indexOf(entry) === index);
-    if (!candidates.length) {
-      setTexture(null);
+    paramsRef.current = params;
+  }, [params]);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return;
+
+    let state: OrbitSceneState;
+    try {
+      state = createScene(mount);
+    } catch {
+      setWebglUnavailable(true);
       return;
     }
 
-    let active = true;
-    let currentTexture: THREE.Texture | null = null;
+    sceneRef.current = state;
 
-    const tryLoad = (index: number) => {
+    const resize = () => {
+      const width = Math.max(1, mount.clientWidth);
+      const height = Math.max(1, mount.clientHeight);
+      state.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+      state.renderer.setSize(width, height, false);
+      state.camera.aspect = width / height;
+      state.camera.updateProjectionMatrix();
+    };
+
+    resize();
+    state.resizeObserver = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(resize);
+    state.resizeObserver?.observe(mount);
+
+    const render = () => {
+      updateCamera(state.camera, paramsRef.current);
+      state.renderer.render(state.scene, state.camera);
+      state.animationFrame = window.requestAnimationFrame(render);
+    };
+    render();
+
+    return () => {
+      if (state.animationFrame !== null) {
+        window.cancelAnimationFrame(state.animationFrame);
+      }
+      state.resizeObserver?.disconnect();
+      setImageTexture(state, null);
+      disposeObject(state.scene);
+      state.renderer.dispose();
+      state.renderer.domElement.remove();
+      sceneRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const state = sceneRef.current;
+    if (!state) return;
+    updateGuides(state, params, generateBestAngles);
+  }, [generateBestAngles, params]);
+
+  useEffect(() => {
+    const state = sceneRef.current;
+    if (!state) return;
+
+    let active = true;
+    const candidates = getTextureCandidates(sourceImage);
+    if (!candidates.length) {
+      setImageTexture(state, null);
+      setCardAspect(state, DEFAULT_ASPECT);
+      return;
+    }
+
+    const loadCandidate = (index: number) => {
       if (!active || index >= candidates.length) {
         if (active) {
-          setTexture(null);
+          setImageTexture(state, null);
         }
         return;
       }
+
       const loader = new THREE.TextureLoader();
       const candidate = candidates[index];
       if (!candidate.startsWith('blob:') && !candidate.startsWith('/')) {
@@ -176,108 +333,39 @@ function useSourceTexture(urls: Array<string | null | undefined>) {
 
       loader.load(
         candidate,
-        (nextTexture) => {
+        (texture) => {
           if (!active) {
-            nextTexture.dispose();
+            texture.dispose();
             return;
           }
-          if (currentTexture && currentTexture !== nextTexture) {
-            currentTexture.dispose();
-          }
-          nextTexture.colorSpace = THREE.SRGBColorSpace;
-          nextTexture.minFilter = THREE.LinearFilter;
-          nextTexture.magFilter = THREE.LinearFilter;
-          currentTexture = nextTexture;
-          setTexture(nextTexture);
+          texture.colorSpace = THREE.SRGBColorSpace;
+          texture.minFilter = THREE.LinearFilter;
+          texture.magFilter = THREE.LinearFilter;
+          setImageTexture(state, texture);
+          const image = texture.image as { width?: number; height?: number } | undefined;
+          const aspect =
+            sourceImage?.width && sourceImage.height
+              ? sourceImage.width / sourceImage.height
+              : image?.width && image.height
+                ? image.width / image.height
+                : DEFAULT_ASPECT;
+          setCardAspect(state, aspect);
         },
         undefined,
-        () => {
-          tryLoad(index + 1);
-        }
+        () => loadCandidate(index + 1)
       );
     };
 
-    tryLoad(0);
+    loadCandidate(0);
 
     return () => {
       active = false;
-      if (currentTexture) {
-        currentTexture.dispose();
-      }
     };
-  }, [urls]);
+  }, [sourceImage]);
 
-  return texture;
-}
+  if (webglUnavailable) {
+    return <div className="h-full w-full bg-[#f6f8fc]" aria-hidden="true" />;
+  }
 
-function AngleImageCard({ sourceImage }: { sourceImage: OrbitSourceImage }) {
-  const texture = useSourceTexture(getTextureCandidates(sourceImage));
-  const aspect = useMemo(() => {
-    if (sourceImage.width && sourceImage.height) {
-      return sourceImage.width / sourceImage.height;
-    }
-    const image = texture?.image as { width?: number; height?: number } | undefined;
-    if (image?.width && image?.height) {
-      return image.width / image.height;
-    }
-    return 0.72;
-  }, [sourceImage.height, sourceImage.width, texture]);
-  const maxCardWidth = 4.8;
-  const maxCardHeight = 3.15;
-  const { cardWidth, cardHeight } = useMemo(() => {
-    if (aspect >= 1) {
-      const width = maxCardWidth;
-      const height = Math.max(1.4, width / aspect);
-      return { cardWidth: width, cardHeight: Math.min(height, maxCardHeight) };
-    }
-
-    const height = maxCardHeight;
-    const width = Math.max(1.4, height * aspect);
-    return { cardWidth: Math.min(width, maxCardWidth), cardHeight: height };
-  }, [aspect]);
-  const frameZ = -0.08;
-  const imageZ = 0.065;
-  const glossZ = 0.085;
-
-  return (
-    <group position={[0, 0.7, 0]}>
-      <mesh position={[0, 0.92, frameZ]} castShadow receiveShadow>
-        <boxGeometry args={[cardWidth + 0.18, cardHeight + 0.2, 0.1]} />
-        <meshStandardMaterial color="#dfe7f2" roughness={0.9} metalness={0.04} />
-      </mesh>
-      <mesh position={[0, 0.92, imageZ]} castShadow receiveShadow>
-        <planeGeometry args={[cardWidth, cardHeight]} />
-        <meshBasicMaterial
-          map={texture ?? undefined}
-          color={texture ? '#ffffff' : '#c1d0e6'}
-          transparent
-          alphaTest={0.04}
-          side={THREE.DoubleSide}
-        />
-      </mesh>
-      <mesh position={[0, 0.92, glossZ]} castShadow>
-        <planeGeometry args={[cardWidth + 0.02, cardHeight + 0.02]} />
-        <meshStandardMaterial color="#ffffff" transparent opacity={0.12} roughness={1} metalness={0} side={THREE.DoubleSide} />
-      </mesh>
-    </group>
-  );
-}
-
-export default function AngleOrbitCanvas({ params, sourceImage, generateBestAngles }: AngleOrbitCanvasProps) {
-  return (
-    <Canvas
-      dpr={[1, 2]}
-      camera={{ position: [0, 1.35, 6.4], fov: 32, near: 0.1, far: 50 }}
-      gl={{ antialias: true, alpha: false }}
-    >
-      <color attach="background" args={['#f6f8fc']} />
-      <fog attach="fog" args={['#f6f8fc', 10, 22]} />
-      <ambientLight intensity={1.3} />
-      <directionalLight position={[5, 6, 4]} intensity={2.1} color="#ffffff" />
-      <directionalLight position={[-3, 1.5, -4]} intensity={0.65} color="#dbe6f7" />
-      <pointLight position={[0, -1.2, 0]} intensity={0.16} color="#cddaf0" />
-      <AngleCameraRig params={params} />
-      <AngleReferenceScene sourceImage={sourceImage} generateBestAngles={generateBestAngles} params={params} />
-    </Canvas>
-  );
+  return <div ref={mountRef} className="h-full w-full" data-angle-orbit-canvas="three" />;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,16 +80,13 @@ importers:
         version: 1.1.0
       '@maxvideoai/pricing':
         specifier: file:../packages/pricing
-        version: link:../packages/pricing
+        version: file:packages/pricing
       '@react-email/components':
         specifier: ^0.5.7
         version: 0.5.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-email/render':
         specifier: ^1.4.0
         version: 1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-three/fiber':
-        specifier: ^8.17.14
-        version: 8.17.14(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.183.2)
       '@stripe/stripe-js':
         specifier: ^8.3.0
         version: 8.3.0
@@ -431,10 +428,6 @@ packages:
   '@aws/lambda-invoke-store@0.2.4':
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
-
-  '@babel/runtime@7.29.2':
-    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
-    engines: {node: '>=6.9.0'}
 
   '@corex/deepmerge@4.0.43':
     resolution: {integrity: sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==}
@@ -1003,6 +996,10 @@ packages:
   '@lhci/utils@0.15.1':
     resolution: {integrity: sha512-WclJnUQJeOMY271JSuaOjCv/aA0pgvuHZS29NFNdIeI14id8eiFsjith85EGKYhljgoQhJ2SiW4PsVfFiakNNw==}
 
+  '@maxvideoai/pricing@file:packages/pricing':
+    resolution: {directory: packages/pricing, type: directory}
+    engines: {node: '>=18'}
+
   '@msgpack/msgpack@3.1.2':
     resolution: {integrity: sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==}
     engines: {node: '>= 18'}
@@ -1306,31 +1303,6 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
-
-  '@react-three/fiber@8.17.14':
-    resolution: {integrity: sha512-Al2Zdhn5vRefK0adJXNDputuM8hwRNh3goH8MCzf06gezZBbEsdmjt5IrHQQ8Rpr7l/znx/ipLUQuhiiVhxifQ==}
-    peerDependencies:
-      expo: '>=43.0'
-      expo-asset: '>=8.4'
-      expo-file-system: '>=11.0'
-      expo-gl: '>=11.0'
-      react: '>=18 <19'
-      react-dom: '>=18 <19'
-      react-native: '>=0.64'
-      three: '>=0.133'
-    peerDependenciesMeta:
-      expo:
-        optional: true
-      expo-asset:
-        optional: true
-      expo-file-system:
-        optional: true
-      expo-gl:
-        optional: true
-      react-dom:
-        optional: true
-      react-native:
-        optional: true
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -1749,14 +1721,6 @@ packages:
     resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
     peerDependencies:
       '@types/react': ^18.0.0
-
-  '@types/react-reconciler@0.26.7':
-    resolution: {integrity: sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==}
-
-  '@types/react-reconciler@0.28.9':
-    resolution: {integrity: sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==}
-    peerDependencies:
-      '@types/react': '*'
 
   '@types/react@18.3.26':
     resolution: {integrity: sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==}
@@ -2189,9 +2153,6 @@ packages:
   bare-url@2.3.2:
     resolution: {integrity: sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==}
 
-  base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
@@ -2228,9 +2189,6 @@ packages:
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
-
-  buffer@6.0.3:
-    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bufferutil@4.0.9:
     resolution: {integrity: sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==}
@@ -3108,9 +3066,6 @@ packages:
   icu-minify@4.11.0:
     resolution: {integrity: sha512-XRvblCwLqWXio5ZLcmDqXvJv7alSACK6UjXuuMOdQWB//d25AQX6xlVlI1FEbc3Q6iPLXXo6HaVLn8LcAFhn1Q==}
 
-  ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -3336,11 +3291,6 @@ packages:
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
-
-  its-fine@1.2.5:
-    resolution: {integrity: sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==}
-    peerDependencies:
-      react: '>=18.0'
 
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
@@ -4203,21 +4153,6 @@ packages:
   react-promise-suspense@0.3.4:
     resolution: {integrity: sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==}
 
-  react-reconciler@0.27.0:
-    resolution: {integrity: sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==}
-    engines: {node: '>=0.10.0'}
-    peerDependencies:
-      react: ^18.0.0
-
-  react-use-measure@2.1.7:
-    resolution: {integrity: sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==}
-    peerDependencies:
-      react: '>=16.13'
-      react-dom: '>=16.13'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
-
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -4330,9 +4265,6 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-
-  scheduler@0.21.0:
-    resolution: {integrity: sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -4602,11 +4534,6 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-
-  suspend-react@0.1.3:
-    resolution: {integrity: sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==}
-    peerDependencies:
-      react: '>=17.0'
 
   swr@2.3.6:
     resolution: {integrity: sha512-wfHRmHWk/isGNMwlLGlZX5Gzz/uTgo0o2IRuTMcf4CPuPFJZlq0rDaKUx+ozB5nBOReNV1kiOyzMfj+MBMikLw==}
@@ -4964,15 +4891,6 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
-  zustand@3.7.2:
-    resolution: {integrity: sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==}
-    engines: {node: '>=12.7.0'}
-    peerDependencies:
-      react: '>=16.8'
-    peerDependenciesMeta:
-      react:
-        optional: true
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -5446,8 +5364,6 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.2.4': {}
 
-  '@babel/runtime@7.29.2': {}
-
   '@corex/deepmerge@4.0.43': {}
 
   '@dimforge/rapier3d-compat@0.12.0': {}
@@ -5902,6 +5818,8 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@maxvideoai/pricing@file:packages/pricing': {}
+
   '@msgpack/msgpack@3.1.2': {}
 
   '@napi-rs/wasm-runtime@0.2.12':
@@ -6154,26 +6072,6 @@ snapshots:
   '@react-email/text@0.1.5(react@18.3.1)':
     dependencies:
       react: 18.3.1
-
-  '@react-three/fiber@8.17.14(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.183.2)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@types/react-reconciler': 0.26.7
-      '@types/webxr': 0.5.24
-      base64-js: 1.5.1
-      buffer: 6.0.3
-      its-fine: 1.2.5(@types/react@18.3.26)(react@18.3.1)
-      react: 18.3.1
-      react-reconciler: 0.27.0(react@18.3.1)
-      react-use-measure: 2.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      scheduler: 0.21.0
-      suspend-react: 0.1.3(react@18.3.1)
-      three: 0.183.2
-      zustand: 3.7.2(react@18.3.1)
-    optionalDependencies:
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
 
   '@rtsao/scc@1.1.0': {}
 
@@ -6721,14 +6619,6 @@ snapshots:
     dependencies:
       '@types/react': 18.3.26
 
-  '@types/react-reconciler@0.26.7':
-    dependencies:
-      '@types/react': 18.3.26
-
-  '@types/react-reconciler@0.28.9(@types/react@18.3.26)':
-    dependencies:
-      '@types/react': 18.3.26
-
   '@types/react@18.3.26':
     dependencies:
       '@types/prop-types': 15.7.15
@@ -7128,8 +7018,6 @@ snapshots:
       bare-path: 3.0.0
     optional: true
 
-  base64-js@1.5.1: {}
-
   baseline-browser-mapping@2.9.19: {}
 
   basic-ftp@5.3.1: {}
@@ -7177,11 +7065,6 @@ snapshots:
       update-browserslist-db: 1.1.3(browserslist@4.26.3)
 
   buffer-crc32@0.2.13: {}
-
-  buffer@6.0.3:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
 
   bufferutil@4.0.9:
     dependencies:
@@ -8297,8 +8180,6 @@ snapshots:
     dependencies:
       '@formatjs/icu-messageformat-parser': 3.5.6
 
-  ieee754@1.2.1: {}
-
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -8526,13 +8407,6 @@ snapshots:
       get-proto: 1.0.1
       has-symbols: 1.1.0
       set-function-name: 2.0.2
-
-  its-fine@1.2.5(@types/react@18.3.26)(react@18.3.1):
-    dependencies:
-      '@types/react-reconciler': 0.28.9(@types/react@18.3.26)
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@types/react'
 
   jiti@1.21.7: {}
 
@@ -9564,18 +9438,6 @@ snapshots:
     dependencies:
       fast-deep-equal: 2.0.1
 
-  react-reconciler@0.27.0(react@18.3.1):
-    dependencies:
-      loose-envify: 1.4.0
-      react: 18.3.1
-      scheduler: 0.21.0
-
-  react-use-measure@2.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      react: 18.3.1
-    optionalDependencies:
-      react-dom: 18.3.1(react@18.3.1)
-
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -9725,10 +9587,6 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
-
-  scheduler@0.21.0:
-    dependencies:
-      loose-envify: 1.4.0
 
   scheduler@0.23.2:
     dependencies:
@@ -10097,10 +9955,6 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
-
-  suspend-react@0.1.3(react@18.3.1):
-    dependencies:
-      react: 18.3.1
 
   swr@2.3.6(react@18.3.1):
     dependencies:
@@ -10555,9 +10409,5 @@ snapshots:
   yocto-queue@1.2.1: {}
 
   zod@3.25.76: {}
-
-  zustand@3.7.2(react@18.3.1):
-    optionalDependencies:
-      react: 18.3.1
 
   zwitch@2.0.4: {}

--- a/tests/angle-orbit-canvas-contract.test.ts
+++ b/tests/angle-orbit-canvas-contract.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import path from 'node:path';
+
+const root = process.cwd();
+const canvasPath = path.join(root, 'frontend/src/components/tools/AngleOrbitCanvas.tsx');
+
+test('angle orbit canvas avoids react-three-fiber reconciler in the app route bundle', () => {
+  const source = readFileSync(canvasPath, 'utf8');
+
+  assert.doesNotMatch(source, /@react-three\/fiber/);
+  assert.doesNotMatch(source, /useFrame/);
+  assert.doesNotMatch(source, /useThree/);
+  assert.match(source, /import \* as THREE from 'three'/);
+  assert.match(source, /new THREE\.WebGLRenderer/);
+});

--- a/tests/media-proxy-public-hosts-contract.test.ts
+++ b/tests/media-proxy-public-hosts-contract.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const mediaProxyRoutePath = path.join(repoRoot, 'frontend/app/api/media-proxy/route.ts');
+
+test('visitor media proxy allows MaxVideoAI CDN assets used by public tool demos', () => {
+  const source = readFileSync(mediaProxyRoutePath, 'utf8');
+
+  assert.match(source, /PUBLIC_MEDIA_PROXY_HOSTS[\s\S]*'media\.maxvideoai\.com'/);
+});


### PR DESCRIPTION
## Summary
- Replace the Angle tool 3D picker renderer with direct Three.js instead of @react-three/fiber/react-reconciler.
- Remove the unused @react-three/fiber dependency from the frontend bundle.
- Allow public MaxVideoAI CDN demo assets through the visitor media proxy so the Angle canvas can render the source image.
- Add contract tests to keep the app route bundle off react-three-fiber and preserve public demo media proxy coverage.

## Root cause
Production /app/tools/angle was loading an @react-three/fiber chunk that pulled react-reconciler into this Next/React app route bundle and crashed client-side with `Cannot read properties of undefined (reading ReactCurrentBatchConfig)`.

## Validation
- `pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/angle-orbit-canvas-contract.test.ts tests/angle-atomic.test.ts tests/media-proxy-public-hosts-contract.test.ts`
- `pnpm --prefix frontend exec tsc --noEmit`
- `npm --prefix frontend run lint`
- `npm run lint:exposure`
- `pnpm test:validate`
- `pnpm install --frozen-lockfile`
- `pnpm --prefix frontend run build`
- Playwright local prod smoke on `http://localhost:3100/app/tools/angle` desktop/mobile: no error boundary, canvas exists, WebGL pixel samples nonblank, rotation slider updates from 8 to 42 degrees.

## Notes
- Local `next start` still reports expected unauth/legal and local Vercel analytics script errors; no page errors and no media-proxy 401 after this patch.