### PR TITLE
Fix blog language switch slugs

### DIFF
--- a/frontend/components/marketing/LanguageToggle.tsx
+++ b/frontend/components/marketing/LanguageToggle.tsx
@@ -9,6 +9,7 @@ import { useI18n } from '@/lib/i18n/I18nProvider';
 import type { Locale } from '@/lib/i18n/types';
 import { LOCALE_COOKIE } from '@/lib/i18n/constants';
 import localizedSlugConfig from '@/config/localized-slugs.json';
+import { resolveBlogCanonicalSlug, resolveLocalizedBlogSlug } from '@/config/blog-slugs';
 import { Button } from '@/components/ui/Button';
 import { UIIcon } from '@/components/ui/UIIcon';
 
@@ -35,6 +36,14 @@ const LOCALIZED_SEGMENT_TO_EN: Record<string, string> = Object.values(localizedS
 function shouldBypassLocale(pathname: string | null | undefined) {
   if (!pathname) return false;
   return LOCALE_BYPASS_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
+
+function decodePathSegment(value: string) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }
 
 type LanguageToggleVariant = 'select' | 'icon';
@@ -81,11 +90,22 @@ export function LanguageToggle({ variant = 'select' }: { variant?: LanguageToggl
       const isComparePage = typeof rawPathname === 'string'
         ? /^\/(?:en|fr|es)?\/(?:ai-video-engines|comparatif|comparativa)\/[^\/?#]+/i.test(rawPathname)
         : false;
+      const isBlogPage = typeof rawPathname === 'string'
+        ? /^\/(?:en|fr|es)?\/blog\/[^\/?#]+/i.test(rawPathname)
+        : false;
       if (!slugValue && typeof rawPathname === 'string') {
         const m = rawPathname.match(
-          /^\/(?:en|fr|es)?\/(?:models|modeles|modelos|ai-video-engines|comparatif|comparativa)\/([^\/?#]+)/i
+          /^\/(?:en|fr|es)?\/(?:models|modeles|modelos|ai-video-engines|comparatif|comparativa|blog)\/([^\/?#]+)/i
         );
         if (m && m[1]) slugValue = m[1];
+      }
+      if (slugValue && isBlogPage) {
+        const decodedSlug = decodePathSegment(slugValue);
+        const canonicalSlug =
+          resolveBlogCanonicalSlug(locale as Locale, decodedSlug) ?? resolveBlogCanonicalSlug('en', decodedSlug) ?? decodedSlug;
+        const targetSlug = resolveLocalizedBlogSlug(canonicalSlug, value) ?? canonicalSlug;
+        router.replace({ pathname: '/blog/[slug]', params: { slug: targetSlug } }, { locale: value });
+        return;
       }
       if (slugValue && isComparePage) {
         router.replace({ pathname: '/ai-video-engines/[slug]', params: { slug: slugValue } }, { locale: value });
@@ -132,6 +152,11 @@ function resolveEnglishPath(pathname: string, currentLocale: Locale): string {
   }
   const [first, ...rest] = segments;
   const englishFirst = LOCALIZED_SEGMENT_TO_EN[first] ?? first;
+  if (englishFirst === 'blog' && rest.length > 0) {
+    const localizedSlug = decodePathSegment(rest[0]);
+    const englishSlug = resolveBlogCanonicalSlug(currentLocale, localizedSlug) ?? localizedSlug;
+    return `/${[englishFirst, englishSlug, ...rest.slice(1)].join('/')}`;
+  }
   return `/${[englishFirst, ...rest].join('/')}`;
 }
 

--- a/frontend/config/blog-slugs.ts
+++ b/frontend/config/blog-slugs.ts
@@ -1,0 +1,58 @@
+export type BlogSlugLocale = 'en' | 'fr' | 'es';
+
+export const BLOG_SLUGS_BY_CANONICAL = {
+  'access-sora-2-without-invite': {
+    en: 'access-sora-2-without-invite',
+    fr: 'acceder-a-sora-2-sans-invitation',
+    es: 'accede-a-sora-2-sin-invitacion',
+  },
+  'ai-character-sheet-generator': {
+    en: 'ai-character-sheet-generator',
+    fr: 'generateur-de-fiche-personnage-ia',
+    es: 'generador-de-fichas-de-personaje-con-ia',
+  },
+  'change-camera-angle-with-ai': {
+    en: 'change-camera-angle-with-ai',
+    fr: 'lia-peut-elle-changer-langle-de-camera-dune-photo',
+    es: 'la-ia-puede-cambiar-el-angulo-de-camara-de-una-foto',
+  },
+  'compare-ai-video-engines': {
+    en: 'compare-ai-video-engines',
+    fr: 'comment-comparer-les-mod\u00e8les-video-dia-sora-vs-veo-vs-pika',
+    es: 'como-comparar-motores-de-video-con-ia-sora-vs-veo-vs-pika',
+  },
+  'how-to-create-consistent-ai-characters': {
+    en: 'how-to-create-consistent-ai-characters',
+    fr: 'comment-creer-des-personnages-ia-coherents-dans-les-images-et-la-video',
+    es: 'como-crear-personajes-de-ia-coherentes-en-imagenes-y-video',
+  },
+  'multiple-camera-angles-from-one-image': {
+    en: 'multiple-camera-angles-from-one-image',
+    fr: 'explorer-plusieurs-angles-de-camera-a-partir-dune-image-approuvee',
+    es: 'como-explorar-multiples-angulos-de-camara-desde-una-imagen-aprobada',
+  },
+  'sora-2-sequenced-prompts': {
+    en: 'sora-2-sequenced-prompts',
+    fr: 'invites-sequencees-sora-2-avec-son-et-image-de-marque',
+    es: 'indicaciones-secuenciadas-de-sora-2-con-sonido-e-identidad-de-marca',
+  },
+  'veo-3-updates': {
+    en: 'veo-3-updates',
+    fr: 'les-mises-a-jour-de-veo-3-apportent-des-controles-cinematographiques',
+    es: 'las-actualizaciones-de-veo-3-traen-controles-cinematograficos',
+  },
+} as const satisfies Record<string, Record<BlogSlugLocale, string>>;
+
+export function resolveBlogCanonicalSlug(locale: BlogSlugLocale, slug: string): string | null {
+  for (const [canonicalSlug, localizedSlugs] of Object.entries(BLOG_SLUGS_BY_CANONICAL)) {
+    if (localizedSlugs[locale] === slug) {
+      return canonicalSlug;
+    }
+  }
+
+  return null;
+}
+
+export function resolveLocalizedBlogSlug(canonicalSlug: string, locale: BlogSlugLocale): string | null {
+  return BLOG_SLUGS_BY_CANONICAL[canonicalSlug as keyof typeof BLOG_SLUGS_BY_CANONICAL]?.[locale] ?? null;
+}

--- a/frontend/lib/i18n/I18nProvider.tsx
+++ b/frontend/lib/i18n/I18nProvider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { NextIntlClientProvider } from 'next-intl';
-import { createContext, useContext, useMemo } from 'react';
+import { createContext, useContext, useEffect, useMemo } from 'react';
 import type { Dictionary, Locale } from '@/lib/i18n/types';
 
 type TranslateFn = <T = unknown>(path: string, fallback?: T) => T | undefined;
@@ -33,6 +33,10 @@ interface I18nProviderProps {
 }
 
 export function I18nProvider({ locale, dictionary, fallback, children }: I18nProviderProps) {
+  useEffect(() => {
+    document.documentElement.lang = locale;
+  }, [locale]);
+
   const value = useMemo<I18nContextValue>(() => {
     const translate: TranslateFn = (path, defaultValue) => {
       const primary = resolvePath(dictionary as unknown as Record<string, unknown>, path);

--- a/tests/blog-language-switch.test.ts
+++ b/tests/blog-language-switch.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  BLOG_SLUGS_BY_CANONICAL,
+  resolveBlogCanonicalSlug,
+  resolveLocalizedBlogSlug,
+  type BlogSlugLocale,
+} from '../frontend/config/blog-slugs.ts';
+
+const locales: BlogSlugLocale[] = ['en', 'fr', 'es'];
+
+function readFrontMatterValue(source: string, key: string): string | null {
+  const match = source.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
+  return match?.[1]?.trim().replace(/^['"]|['"]$/g, '') ?? null;
+}
+
+test('blog language switch resolves localized article slugs across locales', () => {
+  const canonical = resolveBlogCanonicalSlug(
+    'fr',
+    'comment-creer-des-personnages-ia-coherents-dans-les-images-et-la-video'
+  );
+
+  assert.equal(canonical, 'how-to-create-consistent-ai-characters');
+  assert.equal(resolveLocalizedBlogSlug(canonical, 'en'), 'how-to-create-consistent-ai-characters');
+  assert.equal(
+    resolveLocalizedBlogSlug(canonical, 'es'),
+    'como-crear-personajes-de-ia-coherentes-en-imagenes-y-video'
+  );
+});
+
+test('blog slug switch map covers every localized blog frontmatter slug', () => {
+  for (const locale of locales) {
+    const dir = path.join(process.cwd(), 'content', locale, 'blog');
+    const files = readdirSync(dir).filter((file) => file.endsWith('.mdx'));
+
+    for (const file of files) {
+      const source = readFileSync(path.join(dir, file), 'utf8');
+      const slug = readFrontMatterValue(source, 'slug');
+      const canonicalSlug = readFrontMatterValue(source, 'canonicalSlug') ?? slug;
+
+      assert.ok(slug, `${file} should define a slug`);
+      assert.ok(canonicalSlug, `${file} should define or derive a canonicalSlug`);
+      assert.equal(
+        BLOG_SLUGS_BY_CANONICAL[canonicalSlug]?.[locale],
+        slug,
+        `${locale}/${file} should be present in BLOG_SLUGS_BY_CANONICAL`
+      );
+    }
+  }
+});
+
+test('marketing language toggle handles blog dynamic routes before generic locale replacement', () => {
+  const source = readFileSync('frontend/components/marketing/LanguageToggle.tsx', 'utf8');
+
+  assert.match(source, /resolveBlogCanonicalSlug/);
+  assert.match(source, /resolveLocalizedBlogSlug/);
+  assert.match(source, /pathname: '\/blog\/\[slug\]'/);
+});
+
+test('client i18n provider keeps the document language in sync after locale switches', () => {
+  const source = readFileSync('frontend/lib/i18n/I18nProvider.tsx', 'utf8');
+
+  assert.match(source, /document\.documentElement\.lang = locale/);
+});


### PR DESCRIPTION
## Summary
- Fixes blog article language switching so localized article slugs resolve back to the canonical English slug and across FR/ES.
- Adds a browser-safe blog slug map plus contract coverage against localized blog frontmatter.
- Syncs document html lang on client-side locale switches so SPA transitions update accessibility metadata immediately.

## Root cause
The server metadata already exposed the correct canonical and hreflang URLs, but the client LanguageToggle only translated localized route segments. On localized blog detail pages it reused the current article slug when switching to English, which left the French slug under the default English /blog route.

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/blog-language-switch.test.ts
- pnpm --prefix frontend exec tsc --noEmit
- npm --prefix frontend run lint
- npm run lint:exposure
- pnpm test:validate
- pnpm --prefix frontend run build
- Playwright production-local smoke on http://localhost:3100/fr/blog/comment-creer-des-personnages-ia-coherents-dans-les-images-et-la-video: FR -> EN, EN -> FR, FR -> ES desktop all land on the expected localized slugs, h1/title/canonical/hreflang update, html lang updates, no relevant app 4xx/5xx. Mobile initial FR page renders with correct metadata; header language button is present but hidden at 390px, so no mobile interaction was exercised.