### PR TITLE
Add architecture audit tooling

### DIFF
--- a/docs/engineering/llm-working-guide.md
+++ b/docs/engineering/llm-working-guide.md
@@ -11,6 +11,18 @@ Read these files before changing architecture or route structure:
 - `docs/engineering/page-architecture.md`
 - `docs/engineering/refactor-roadmap.md`
 
+Then run the large-file audit when choosing a cleanup target:
+
+```bash
+npm run architecture:audit -- --min-lines 900
+```
+
+Use JSON when another tool or agent needs to rank candidates:
+
+```bash
+npm run architecture:audit -- --json --min-lines 900
+```
+
 For a focused task, inspect the nearest route-local `AGENTS.md` if one exists.
 
 ## Working Rules
@@ -65,7 +77,8 @@ npm --prefix frontend run build
 
 ## Current Architecture Notes
 
-- The model detail route has already been split into route-local `_components` and `_lib`.
-- The dashboard route has already been split into route-local panels and helpers.
-- The next large cleanup candidates are the workspace app client, image/audio workspaces, tool workspaces, and older `ai-video-engines` marketing pages.
+- The comparison detail route, admin insights route, and billing route have route-local architecture contract tests.
+- The model detail route has route-local `_components` and `_lib`, but supporting files such as `model-page-specs.ts` can still be large.
+- The dashboard route has route-local panels and helpers, but workspace app/image/audio routes and tool workspaces remain major cleanup candidates.
+- Before proposing a new architecture PR, run `npm run architecture:audit -- --min-lines 900` and use the roadmap to separate low-risk route splits from high-blast-radius provider/API work.
 - Root-level browser screenshots and `.playwright-mcp/` files are local QA artifacts and should stay untracked.

--- a/docs/engineering/page-architecture.md
+++ b/docs/engineering/page-architecture.md
@@ -120,6 +120,7 @@ Keep serialization centralized to avoid inconsistent escaping.
 
 Before moving code:
 
+- run `npm run architecture:audit -- --min-lines 900` if you are choosing the next cleanup target
 - identify behavior that must not change
 - find route params, redirects, and metadata coupling
 - check whether the file is server or client
@@ -132,4 +133,3 @@ After moving code:
 - smoke-test the route
 - compare important generated metadata/JSON-LD if the route is public
 - confirm localized paths still resolve
-

--- a/docs/engineering/refactor-roadmap.md
+++ b/docs/engineering/refactor-roadmap.md
@@ -1,176 +1,78 @@
 # Refactor Roadmap
 
-This roadmap turns the current large-page problem into small, testable work.
+This roadmap turns large-file cleanup into small, testable PRs.
 
-## Current Signals
+## Audit Command
 
-The largest route files are:
+Run the current large-file audit before choosing a refactor target:
 
-| File | Lines | Risk |
+```bash
+npm run architecture:audit -- --min-lines 900
+```
+
+For scripts or Codex context, use JSON:
+
+```bash
+npm run architecture:audit -- --json --min-lines 900
+```
+
+The audit scans `frontend` source files, ignores build/generated folders, and sorts files by line count.
+
+## Recently Completed
+
+The first architecture cleanup wave has landed:
+
+- Comparison detail page: split copy, helpers, overrides, types, and media/spec components.
+- Admin insights page: split route-local types, helpers, and panels.
+- Billing page: split route server wrapper, client orchestrator, wallet top-up panel, receipts panel, copy, types, helpers, Stripe Express Checkout, Turnstile, and analytics.
+
+These areas now have contract tests:
+
+```txt
+tests/compare-page-architecture.test.ts
+tests/admin-insights-architecture.test.ts
+tests/billing-page-architecture.test.ts
+```
+
+## Current High-Signal Candidates
+
+Snapshot from `npm run architecture:audit -- --min-lines 900` after the first cleanup wave:
+
+| File | Lines | Recommended approach |
 | --- | ---: | --- |
-| `frontend/app/(localized)/[locale]/(marketing)/models/[slug]/page.tsx` | 4936 | Very high maintainability risk. Server-side, but mixes route, SEO, pricing, schemas, and rendering. |
-| `frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/page.tsx` | 3572 | Very high maintainability risk. Comparison logic and rendering are tightly coupled. |
-| `frontend/app/(core)/dashboard/page.tsx` | 2284 | High client-side complexity. This should be split before adding dashboard behavior. |
-| `frontend/app/(core)/admin/insights/page.tsx` | 1939 | High maintainability risk. Good candidate for extracting charts/tables/builders. |
-| `frontend/app/(core)/billing/page.tsx` | 1597 | Client-side page; likely worth extracting panels and hooks. |
+| `frontend/src/config/falEngines.ts` | 7677 | Split only with strong model-registry tests. High blast radius. |
+| `frontend/src/components/tools/CharacterBuilderWorkspace.tsx` | 3962 | Split into tool-local hooks, panels, preview/runtime modules. |
+| `frontend/app/api/generate/route.ts` | 3203 | Split request parsing, auth/preflight, provider dispatch, response projection. High blast radius. |
+| `frontend/app/(localized)/[locale]/(marketing)/models/ModelsCatalogPage.tsx` | 1934 | Split catalog copy, filters, cards, and SEO-oriented sections. |
+| `frontend/src/components/tools/AngleWorkspace.tsx` | 1833 | Split tool state, canvas/runtime, prompt form, examples/results panels. |
+| `frontend/src/server/images/execute-image-generation.ts` | 1813 | Split validation, provider payloads, persistence, polling/projection. |
+| `frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/best-for/[usecase]/page.tsx` | 1609 | Split localized copy, ranking builders, schema helpers, route sections. |
+| `frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx` | 1660 | Continue route-local hook/component extraction with contract tests. |
+| `frontend/app/(core)/(workspace)/app/audio/AudioWorkspace.tsx` | 1559 | Split audio form state, provider options, uploads, preview/progress surfaces. |
+| `frontend/app/(core)/login/page.tsx` | 1135 | Low-risk next split: copy and auth/browser helpers first. |
+| `frontend/app/(core)/admin/pricing/page.tsx` | 921 | Low-risk next split: types, helpers, and card components. |
 
-## Phase 1: Documentation and Guardrails
+Line counts change over time. Treat the table as a dated snapshot, not source of truth.
 
-Goal: make the target structure explicit before large moves.
+## Next Cleanup Sequence
 
-- Add `AGENTS.md`.
-- Add `docs/engineering/project-structure.md`.
-- Add `docs/engineering/page-architecture.md`.
-- Add this roadmap.
-- Link these guides from `README.md` and `CONTRIBUTING.md`.
+Prefer this order unless product work changes the risk profile:
 
-Expected result: future work has a shared standard.
+1. Login page helpers and copy.
+2. Admin pricing cards/helpers.
+3. Tool workspace split, starting with Angle or Character Builder.
+4. Best-for usecase marketing page split.
+5. API/generate split with broader regression coverage.
+6. `falEngines.ts` registry split after a dedicated model-registry plan.
 
-## Phase 2: Dashboard Split
+## Definition Of Done
 
-Goal: reduce the largest client page without changing behavior.
-
-Target files:
-
-```txt
-frontend/app/(core)/dashboard/
-  page.tsx
-  _components/
-    CreateHero.tsx
-    InProgressList.tsx
-    RecentGrid.tsx
-    InsightsPanel.tsx
-    ToolsPanel.tsx
-  _hooks/
-    useDashboardSelections.ts
-    useDashboardTemplates.ts
-  _lib/
-    dashboard-storage.ts
-    dashboard-media.ts
-    dashboard-formatters.ts
-```
-
-Order:
-
-1. Move browser storage helpers into `_lib/dashboard-storage.ts`.
-2. Move media/lightbox helper functions into `_lib/dashboard-media.ts`.
-3. Move formatting helpers into `_lib/dashboard-formatters.ts`.
-4. Move visual sections into `_components`.
-5. Move selection/template state into hooks only after the helper extraction is stable.
-
-Verification:
-
-```bash
-npm --prefix frontend run lint
-```
-
-Manual smoke test:
-
-- open `/dashboard` or the route that maps to it
-- confirm auth/loading state
-- confirm create video/image actions
-- confirm recent grid opens media lightbox
-- confirm template/remix actions still route correctly
-
-## Phase 3: Model Detail Page Split
-
-Goal: turn the model detail page into route orchestration plus named builders/sections.
-
-Target files:
-
-```txt
-frontend/app/(localized)/[locale]/(marketing)/models/[slug]/
-  page.tsx
-  _components/
-    ModelHeroSection.tsx
-    ModelSpecSections.tsx
-    ModelPricingSection.tsx
-    ModelExamplesSection.tsx
-    ModelFaqSection.tsx
-  _lib/
-    model-page-data.ts
-    model-page-pricing.ts
-    model-page-specs.ts
-    model-page-schema.ts
-    model-page-links.ts
-```
-
-Order:
-
-1. Move schema helpers.
-2. Move pricing/spec helpers.
-3. Move link/canonical helpers.
-4. Move small rendering sections.
-5. Move hero and examples only after props are stable.
-
-Verification:
-
-```bash
-npm --prefix frontend run lint
-```
-
-Manual smoke test:
-
-- `/models/veo-3-1`
-- localized variants for French and Spanish
-- legacy redirects such as `veo-3-1-first-last`
-- JSON-LD script output
-- canonical and hreflang output
-
-## Phase 4: Comparison Detail Page Split
-
-Goal: isolate comparison data preparation from comparison rendering.
-
-Target files:
-
-```txt
-frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/
-  page.tsx
-  _components/
-    CompareHero.tsx
-    CompareScoreSummary.tsx
-    CompareSpecTable.tsx
-    CompareMediaShowdown.tsx
-    CompareFaq.tsx
-  _lib/
-    compare-page-data.ts
-    compare-page-schema.ts
-    compare-page-specs.ts
-    compare-page-routing.ts
-```
-
-Verification should cover canonical order, reversed slugs, excluded redirects, and localized copy.
-
-## Phase 5: Admin Insights Split
-
-Goal: keep the admin page server-driven while extracting chart/table surfaces.
-
-Target files:
-
-```txt
-frontend/app/(core)/admin/insights/
-  page.tsx
-  _components/
-    PrioritySignalPanel.tsx
-    WindowPulseGrid.tsx
-    ComparisonChart.tsx
-    RevenueBoardTable.tsx
-    HealthPanel.tsx
-  _lib/
-    insights-builders.ts
-    insights-formatters.ts
-```
-
-Verification should cover range/focus search params and admin access behavior.
-
-## Definition of Done
-
-A refactor phase is complete when:
+A cleanup PR is complete when:
 
 - behavior is unchanged
-- route file is materially shorter
+- the route or feature owner file is materially shorter
 - extracted files have clear names and responsibilities
-- lint passes
-- manual smoke checks pass
-- the roadmap is updated if the actual structure differs from this plan
-
+- a contract test guards the architectural boundary
+- focused tests pass
+- `npm --prefix frontend run lint`, `npm run lint:exposure`, `pnpm --prefix frontend exec tsc --noEmit --pretty false`, and `git diff --check` pass
+- a full build passes before merge when the PR touches routes, app-level components, or provider logic

--- a/docs/superpowers/plans/2026-05-07-next-three-architecture-prs.md
+++ b/docs/superpowers/plans/2026-05-07-next-three-architecture-prs.md
@@ -1,0 +1,161 @@
+# Next Three Architecture PRs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the next three maintainability PRs after the compare/admin/billing cleanup wave.
+
+**Architecture:** Keep each PR independently reviewable and mergeable. First add objective guardrails for future cleanup, then split two route-heavy client/admin surfaces without changing behavior.
+
+**Tech Stack:** Next.js App Router, TypeScript, Node test runner, ESLint, existing route-local `_components`, `_hooks`, and `_lib` conventions.
+
+---
+
+## File Structure
+
+### PR 1: Architecture Audit Tooling
+
+- Create `scripts/audit-large-files.mjs`: lists large TS/TSX/JS/JSX files with configurable threshold and JSON output.
+- Create `tests/architecture-audit.test.ts`: verifies the audit script reports known large files and supports `--json`.
+- Modify `package.json`: add `architecture:audit`.
+- Modify `docs/engineering/refactor-roadmap.md`: refresh completed work and next candidates.
+- Modify `docs/engineering/llm-working-guide.md`: document the audit command.
+
+### PR 2: Login Page Split
+
+- Modify `frontend/app/(core)/login/page.tsx`: keep page-level auth flow, state, and rendering orchestration.
+- Create `frontend/app/(core)/login/_lib/login-copy.ts`: locale copy, locale type, and locale options.
+- Create `frontend/app/(core)/login/_lib/login-helpers.ts`: next-path sanitization, redirect origin/callback helpers, locale detection, pending Google login storage helpers.
+- Create `tests/login-page-architecture.test.ts`: guard the route-local split and page size.
+
+### PR 3: Admin Pricing Page Split
+
+- Modify `frontend/app/(core)/admin/pricing/page.tsx`: keep SWR loading, mutation handlers, and route orchestration.
+- Create `frontend/app/(core)/admin/pricing/_lib/pricing-admin-types.ts`: pricing rule, membership, product, and form types.
+- Create `frontend/app/(core)/admin/pricing/_lib/pricing-admin-helpers.ts`: formatters, legacy product helper, subtitle helper, overview builder, form conversion helpers.
+- Create `frontend/app/(core)/admin/pricing/_components/PricingRuleCard.tsx`: existing rule card and field rendering.
+- Create `frontend/app/(core)/admin/pricing/_components/BillingProductCard.tsx`: billing product card.
+- Create `frontend/app/(core)/admin/pricing/_components/NewPricingRuleCard.tsx`: create-rule form.
+- Create `tests/admin-pricing-architecture.test.ts`: guard the route-local split and page size.
+
+---
+
+## Task 1: Architecture Audit Tooling PR
+
+**Branch:** `codex/architecture-audit-tooling`
+
+- [ ] **Step 1: Add static audit test**
+
+Create `tests/architecture-audit.test.ts` with assertions that `scripts/audit-large-files.mjs --json --min-lines 900` outputs JSON rows containing `frontend/src/config/falEngines.ts` and that `--help` documents `--min-lines`.
+
+- [ ] **Step 2: Add audit script**
+
+Create `scripts/audit-large-files.mjs`. It should:
+
+```txt
+node scripts/audit-large-files.mjs --min-lines 900
+node scripts/audit-large-files.mjs --json --min-lines 900
+```
+
+Expected behavior: scan `frontend`, ignore generated/build folders, count lines, sort descending, and print either a table or JSON.
+
+- [ ] **Step 3: Wire npm script and docs**
+
+Add `"architecture:audit": "node scripts/audit-large-files.mjs"` to `package.json`. Update `docs/engineering/refactor-roadmap.md` and `docs/engineering/llm-working-guide.md` so future Codex work starts from the audit command.
+
+- [ ] **Step 4: Verify**
+
+Run:
+
+```bash
+pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/architecture-audit.test.ts
+npm run architecture:audit -- --min-lines 900
+npm --prefix frontend run lint
+npm run lint:exposure
+git diff --check
+```
+
+- [ ] **Step 5: Commit, push, PR, wait for checks, merge**
+
+Commit message: `Add architecture audit tooling`.
+
+---
+
+## Task 2: Login Page Split PR
+
+**Branch:** `codex/login-page-split`
+
+- [ ] **Step 1: Add architecture contract**
+
+Create `tests/login-page-architecture.test.ts` requiring:
+
+- `_lib/login-copy.ts` exists and exports `AUTH_COPY`.
+- `_lib/login-helpers.ts` exists and exports `sanitizeNextPath`, `buildAuthCallbackRedirect`, and pending Google helpers.
+- `page.tsx` imports both route-local modules.
+- `page.tsx` does not define `AUTH_COPY` or `sanitizeNextPath`.
+
+- [ ] **Step 2: Move copy and helpers**
+
+Move locale copy and pure/browser helper functions from `frontend/app/(core)/login/page.tsx` into route-local `_lib` files. Preserve all names or update imports mechanically.
+
+- [ ] **Step 3: Verify auth tests**
+
+Run:
+
+```bash
+pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/login-page-architecture.test.ts tests/login-hydration-contract.test.ts tests/login-metadata.test.ts tests/login-oauth-cookie-fallback.test.ts tests/auth-callback-redirect.test.ts tests/auth-hash-session-contract.test.ts
+pnpm --prefix frontend exec tsc --noEmit --pretty false
+npm --prefix frontend run lint
+npm run lint:exposure
+git diff --check
+```
+
+- [ ] **Step 4: Build and smoke**
+
+Run `pnpm --prefix frontend run build`. If feasible, start `next start` on a temporary port and verify `/login` returns 200.
+
+- [ ] **Step 5: Commit, push, PR, wait for checks, merge**
+
+Commit message: `Split login page helpers`.
+
+---
+
+## Task 3: Admin Pricing Page Split PR
+
+**Branch:** `codex/admin-pricing-page-split`
+
+- [ ] **Step 1: Add architecture contract**
+
+Create `tests/admin-pricing-architecture.test.ts` requiring route-local `_components` and `_lib` files, ensuring `page.tsx` imports them and no longer defines `BillingProductCard`, `PricingRuleCard`, `NewPricingRuleCard`, or formatter helpers.
+
+- [ ] **Step 2: Move types and helpers**
+
+Move pricing types and helper functions from `frontend/app/(core)/admin/pricing/page.tsx` into `_lib/pricing-admin-types.ts` and `_lib/pricing-admin-helpers.ts`.
+
+- [ ] **Step 3: Move cards**
+
+Move `BillingProductCard`, `PricingRuleCard`, `Field`, and `NewPricingRuleCard` into route-local `_components`. Preserve props and behavior.
+
+- [ ] **Step 4: Verify**
+
+Run:
+
+```bash
+pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/admin-pricing-architecture.test.ts tests/pricing-definition.test.ts tests/checkout-report.test.ts tests/wallet-checkout-session.test.ts
+pnpm --prefix frontend exec tsc --noEmit --pretty false
+npm --prefix frontend run lint
+npm run lint:exposure
+git diff --check
+pnpm --prefix frontend run build
+```
+
+- [ ] **Step 5: Commit, push, PR, wait for checks, merge**
+
+Commit message: `Split admin pricing page modules`.
+
+---
+
+## Self-Review
+
+- Spec coverage: three PRs are defined, each with branch, files, verification, and merge gates.
+- Placeholder scan: no `TBD`, `TODO`, or unspecified tests are required.
+- Type consistency: route-local names match the planned import paths.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "model:scaffold": "npm --prefix frontend run models:scaffold --",
     "model:setup": "node scripts/model-setup.mjs",
     "models:audit": "node scripts/models-audit.mjs",
+    "architecture:audit": "node scripts/audit-large-files.mjs",
     "db:migrate:neon": "bash scripts/apply-neon-migrations.sh",
     "audit:premerge": "rm -rf frontend/.next && pnpm --prefix frontend run build && pnpm test:validate && pnpm --prefix frontend run i18n:check && pnpm --prefix frontend run seo:check && pnpm model:check && pnpm models:audit",
     "sources:check": "node scripts/sources-check.mjs",

--- a/scripts/audit-large-files.mjs
+++ b/scripts/audit-large-files.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const DEFAULT_ROOT = 'frontend';
+const DEFAULT_MIN_LINES = 500;
+const SOURCE_EXTENSIONS = new Set(['.js', '.jsx', '.ts', '.tsx']);
+const IGNORED_SEGMENTS = new Set([
+  '.git',
+  '.next',
+  'coverage',
+  'dist',
+  'node_modules',
+  'out',
+  'playwright-report',
+  'test-results',
+]);
+
+function printHelp() {
+  console.log(`Usage: node scripts/audit-large-files.mjs [options]
+
+Options:
+  --root <path>       Directory to scan. Defaults to frontend.
+  --min-lines <n>    Only include files with at least n lines. Defaults to 500.
+  --json             Emit machine-readable JSON.
+  --help             Show this help text.
+
+Examples:
+  node scripts/audit-large-files.mjs --min-lines 900
+  node scripts/audit-large-files.mjs --json --min-lines 900
+`);
+}
+
+function parseArgs(argv) {
+  const options = {
+    root: DEFAULT_ROOT,
+    minLines: DEFAULT_MIN_LINES,
+    json: false,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+    if (arg === '--json') {
+      options.json = true;
+      continue;
+    }
+    if (arg === '--root') {
+      const next = argv[index + 1];
+      if (!next) throw new Error('--root requires a path');
+      options.root = next;
+      index += 1;
+      continue;
+    }
+    if (arg === '--min-lines') {
+      const next = argv[index + 1];
+      if (!next) throw new Error('--min-lines requires a number');
+      const parsed = Number.parseInt(next, 10);
+      if (!Number.isFinite(parsed) || parsed < 1) {
+        throw new Error('--min-lines must be a positive integer');
+      }
+      options.minLines = parsed;
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  return options;
+}
+
+function shouldIgnore(filePath) {
+  return filePath.split(path.sep).some((segment) => IGNORED_SEGMENTS.has(segment));
+}
+
+function collectSourceFiles(root) {
+  const files = [];
+
+  function walk(currentPath) {
+    if (shouldIgnore(currentPath)) return;
+    const stats = statSync(currentPath);
+    if (stats.isDirectory()) {
+      for (const entry of readdirSync(currentPath)) {
+        walk(path.join(currentPath, entry));
+      }
+      return;
+    }
+    if (!stats.isFile()) return;
+    if (!SOURCE_EXTENSIONS.has(path.extname(currentPath))) return;
+    files.push(currentPath);
+  }
+
+  walk(root);
+  return files;
+}
+
+function countLines(filePath) {
+  const source = readFileSync(filePath, 'utf8');
+  return source.length === 0 ? 0 : source.split('\n').length;
+}
+
+function auditLargeFiles({ root, minLines }) {
+  return collectSourceFiles(root)
+    .map((filePath) => ({
+      file: path.relative(process.cwd(), filePath),
+      lines: countLines(filePath),
+      bytes: statSync(filePath).size,
+    }))
+    .filter((row) => row.lines >= minLines)
+    .sort((a, b) => b.lines - a.lines || a.file.localeCompare(b.file));
+}
+
+function printTable(rows, minLines) {
+  if (rows.length === 0) {
+    console.log(`No source files found at or above ${minLines} lines.`);
+    return;
+  }
+
+  console.log(`Large source files (>= ${minLines} lines)`);
+  console.log('');
+  console.log('Lines  Bytes    File');
+  console.log('-----  -------  ----');
+  for (const row of rows) {
+    console.log(`${String(row.lines).padStart(5)}  ${String(row.bytes).padStart(7)}  ${row.file}`);
+  }
+}
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const root = path.resolve(process.cwd(), options.root);
+  const rows = auditLargeFiles({ root, minLines: options.minLines });
+  if (options.json) {
+    console.log(JSON.stringify(rows, null, 2));
+  } else {
+    printTable(rows, options.minLines);
+  }
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`architecture audit failed: ${message}`);
+  process.exit(1);
+}

--- a/tests/architecture-audit.test.ts
+++ b/tests/architecture-audit.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import test from 'node:test';
+
+const scriptPath = 'scripts/audit-large-files.mjs';
+
+test('large file audit emits JSON rows sorted by size', () => {
+  const output = execFileSync('node', [scriptPath, '--json', '--min-lines', '900'], {
+    encoding: 'utf8',
+  });
+  const rows = JSON.parse(output) as Array<{ file: string; lines: number }>;
+
+  assert.ok(rows.length > 0);
+  assert.equal(rows.some((row) => row.file === 'frontend/src/config/falEngines.ts'), true);
+  assert.equal(rows.every((row) => row.lines >= 900), true);
+  assert.deepEqual(
+    rows.map((row) => row.lines),
+    [...rows.map((row) => row.lines)].sort((a, b) => b - a)
+  );
+});
+
+test('large file audit help documents threshold and JSON output', () => {
+  const output = execFileSync('node', [scriptPath, '--help'], {
+    encoding: 'utf8',
+  });
+
+  assert.match(output, /--min-lines/);
+  assert.match(output, /--json/);
+});


### PR DESCRIPTION
## Summary
- add a reproducible large-file audit script with table and JSON output
- add an architecture audit contract test
- refresh the refactor roadmap and LLM/page architecture guides around the new audit workflow

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/architecture-audit.test.ts
- npm run architecture:audit -- --min-lines 900
- npm --prefix frontend run lint
- npm run lint:exposure
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- git diff --check