### PR TITLE
Split login page helpers

### DIFF
--- a/frontend/app/(core)/login/_lib/login-copy.ts
+++ b/frontend/app/(core)/login/_lib/login-copy.ts
@@ -1,0 +1,15 @@
+import enMessages from '@/messages/en.json';
+import esMessages from '@/messages/es.json';
+import frMessages from '@/messages/fr.json';
+
+export type AuthMode = 'signin' | 'signup' | 'reset';
+
+export const AUTH_COPY = {
+  en: enMessages.auth,
+  fr: frMessages.auth,
+  es: esMessages.auth,
+} as const;
+
+export type Locale = keyof typeof AUTH_COPY;
+
+export const LOCALE_OPTIONS: Locale[] = ['en', 'fr', 'es'];

--- a/frontend/app/(core)/login/_lib/login-helpers.ts
+++ b/frontend/app/(core)/login/_lib/login-helpers.ts
@@ -1,0 +1,83 @@
+import { LOCALE_OPTIONS, type Locale } from './login-copy';
+
+export const DEFAULT_NEXT_PATH = '/generate';
+export const NEXT_PATH_PREFIXES = ['/app', '/generate', '/dashboard', '/jobs', '/billing', '/settings', '/admin', '/connect'];
+export const PENDING_GOOGLE_LOGIN_STORAGE_KEY = 'mvai.pending-google-login.v1';
+export const PENDING_GOOGLE_LOGIN_TTL_MS = 10 * 60 * 1000;
+
+export function detectLocale(): Locale {
+  if (typeof document !== 'undefined') {
+    const attr = document.documentElement.lang?.slice(0, 2).toLowerCase();
+    if (attr && LOCALE_OPTIONS.includes(attr as Locale)) {
+      return attr as Locale;
+    }
+    const match = document.cookie.match(/(?:NEXT_LOCALE|mvid_locale)=([a-z]{2})/i);
+    if (match && LOCALE_OPTIONS.includes(match[1].toLowerCase() as Locale)) {
+      return match[1].toLowerCase() as Locale;
+    }
+  }
+  return 'en';
+}
+
+export function formatTemplate(template: string, replacements: Record<string, string>): string {
+  return Object.entries(replacements).reduce((text, [key, value]) => text.replace(`{${key}}`, value), template);
+}
+
+export function sanitizeNextPath(candidate: string | null | undefined): string {
+  if (typeof candidate !== 'string') return DEFAULT_NEXT_PATH;
+  const trimmed = candidate.trim();
+  if (!trimmed.startsWith('/')) return DEFAULT_NEXT_PATH;
+  if (trimmed === '/' || trimmed.startsWith('/login') || trimmed.startsWith('/api') || trimmed.startsWith('/_next')) {
+    return DEFAULT_NEXT_PATH;
+  }
+  const pathname = trimmed.split(/[?#]/)[0] ?? trimmed;
+  const isAllowed = NEXT_PATH_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
+  return isAllowed ? trimmed : DEFAULT_NEXT_PATH;
+}
+
+export function getBrowserAuthRedirectOrigin(): string {
+  if (typeof window === 'undefined') return '';
+  return window.location.origin;
+}
+
+export function buildAuthCallbackRedirect(origin: string, nextPath: string): string | undefined {
+  const trimmed = origin.trim();
+  if (!trimmed) return undefined;
+  const base = trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed;
+  return `${base}/auth/callback?next=${encodeURIComponent(sanitizeNextPath(nextPath))}`;
+}
+
+export function markPendingGoogleLogin() {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(
+      PENDING_GOOGLE_LOGIN_STORAGE_KEY,
+      JSON.stringify({ createdAt: Date.now() })
+    );
+  } catch {
+    // ignore storage failures
+  }
+}
+
+export function clearPendingGoogleLogin() {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.removeItem(PENDING_GOOGLE_LOGIN_STORAGE_KEY);
+  } catch {
+    // ignore storage failures
+  }
+}
+
+export function consumePendingGoogleLogin(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    const raw = window.sessionStorage.getItem(PENDING_GOOGLE_LOGIN_STORAGE_KEY);
+    window.sessionStorage.removeItem(PENDING_GOOGLE_LOGIN_STORAGE_KEY);
+    if (!raw) return false;
+    const parsed = JSON.parse(raw) as { createdAt?: number } | null;
+    if (!parsed || typeof parsed.createdAt !== 'number') return false;
+    return Date.now() - parsed.createdAt <= PENDING_GOOGLE_LOGIN_TTL_MS;
+  } catch {
+    return false;
+  }
+}

--- a/frontend/app/(core)/login/page.tsx
+++ b/frontend/app/(core)/login/page.tsx
@@ -16,110 +16,25 @@ import {
 import { canonicalizeBrowserAuthOrigin } from '@/lib/siteOrigin';
 import { startOAuthCookieRedirectFallback } from './_lib/oauth-cookie-fallback';
 import clsx from 'clsx';
-import enMessages from '@/messages/en.json';
-import frMessages from '@/messages/fr.json';
-import esMessages from '@/messages/es.json';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
+import { AUTH_COPY, type AuthMode, type Locale } from './_lib/login-copy';
+import {
+  buildAuthCallbackRedirect,
+  clearPendingGoogleLogin,
+  consumePendingGoogleLogin,
+  DEFAULT_NEXT_PATH,
+  detectLocale,
+  formatTemplate,
+  getBrowserAuthRedirectOrigin,
+  markPendingGoogleLogin,
+  sanitizeNextPath,
+} from './_lib/login-helpers';
 
 export const dynamic = 'force-dynamic';
 
-type AuthMode = 'signin' | 'signup' | 'reset';
-
 const MIN_AGE_ENV = Number.parseInt(process.env.NEXT_PUBLIC_LEGAL_MIN_AGE ?? '15', 10);
 const LEGAL_MIN_AGE = Number.isNaN(MIN_AGE_ENV) ? 15 : MIN_AGE_ENV;
-
-const DEFAULT_NEXT_PATH = '/generate';
-const NEXT_PATH_PREFIXES = ['/app', '/generate', '/dashboard', '/jobs', '/billing', '/settings', '/admin', '/connect'];
-const PENDING_GOOGLE_LOGIN_STORAGE_KEY = 'mvai.pending-google-login.v1';
-const PENDING_GOOGLE_LOGIN_TTL_MS = 10 * 60 * 1000;
-
-const AUTH_COPY = {
-  en: enMessages.auth,
-  fr: frMessages.auth,
-  es: esMessages.auth,
-} as const;
-
-type Locale = keyof typeof AUTH_COPY;
-
-const LOCALE_OPTIONS: Locale[] = ['en', 'fr', 'es'];
-
-function detectLocale(): Locale {
-  if (typeof document !== 'undefined') {
-    const attr = document.documentElement.lang?.slice(0, 2).toLowerCase();
-    if (attr && LOCALE_OPTIONS.includes(attr as Locale)) {
-      return attr as Locale;
-    }
-    const match = document.cookie.match(/(?:NEXT_LOCALE|mvid_locale)=([a-z]{2})/i);
-    if (match && LOCALE_OPTIONS.includes(match[1].toLowerCase() as Locale)) {
-      return match[1].toLowerCase() as Locale;
-    }
-  }
-  return 'en';
-}
-
-function formatTemplate(template: string, replacements: Record<string, string>): string {
-  return Object.entries(replacements).reduce((text, [key, value]) => text.replace(`{${key}}`, value), template);
-}
-
-function sanitizeNextPath(candidate: string | null | undefined): string {
-  if (typeof candidate !== 'string') return DEFAULT_NEXT_PATH;
-  const trimmed = candidate.trim();
-  if (!trimmed.startsWith('/')) return DEFAULT_NEXT_PATH;
-  if (trimmed === '/' || trimmed.startsWith('/login') || trimmed.startsWith('/api') || trimmed.startsWith('/_next')) {
-    return DEFAULT_NEXT_PATH;
-  }
-  const pathname = trimmed.split(/[?#]/)[0] ?? trimmed;
-  const isAllowed = NEXT_PATH_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
-  return isAllowed ? trimmed : DEFAULT_NEXT_PATH;
-}
-
-function getBrowserAuthRedirectOrigin(): string {
-  if (typeof window === 'undefined') return '';
-  return window.location.origin;
-}
-
-function buildAuthCallbackRedirect(origin: string, nextPath: string): string | undefined {
-  const trimmed = origin.trim();
-  if (!trimmed) return undefined;
-  const base = trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed;
-  return `${base}/auth/callback?next=${encodeURIComponent(sanitizeNextPath(nextPath))}`;
-}
-
-function markPendingGoogleLogin() {
-  if (typeof window === 'undefined') return;
-  try {
-    window.sessionStorage.setItem(
-      PENDING_GOOGLE_LOGIN_STORAGE_KEY,
-      JSON.stringify({ createdAt: Date.now() })
-    );
-  } catch {
-    // ignore storage failures
-  }
-}
-
-function clearPendingGoogleLogin() {
-  if (typeof window === 'undefined') return;
-  try {
-    window.sessionStorage.removeItem(PENDING_GOOGLE_LOGIN_STORAGE_KEY);
-  } catch {
-    // ignore storage failures
-  }
-}
-
-function consumePendingGoogleLogin(): boolean {
-  if (typeof window === 'undefined') return false;
-  try {
-    const raw = window.sessionStorage.getItem(PENDING_GOOGLE_LOGIN_STORAGE_KEY);
-    window.sessionStorage.removeItem(PENDING_GOOGLE_LOGIN_STORAGE_KEY);
-    if (!raw) return false;
-    const parsed = JSON.parse(raw) as { createdAt?: number } | null;
-    if (!parsed || typeof parsed.createdAt !== 'number') return false;
-    return Date.now() - parsed.createdAt <= PENDING_GOOGLE_LOGIN_TTL_MS;
-  } catch {
-    return false;
-  }
-}
 
 export default function LoginPage() {
   const router = useRouter();

--- a/tests/auth-callback-redirect.test.ts
+++ b/tests/auth-callback-redirect.test.ts
@@ -5,6 +5,7 @@ import test from 'node:test';
 const authCallbackSource = readFileSync('frontend/app/auth/callback/route.ts', 'utf8');
 const middlewareSource = readFileSync('frontend/middleware.ts', 'utf8');
 const loginPageSource = readFileSync('frontend/app/(core)/login/page.tsx', 'utf8');
+const loginHelpersSource = readFileSync('frontend/app/(core)/login/_lib/login-helpers.ts', 'utf8');
 const siteOriginSource = readFileSync('frontend/lib/siteOrigin.ts', 'utf8');
 
 test('OAuth callback exchanges PKCE on the server before using the browser fallback', () => {
@@ -55,7 +56,7 @@ test('login page can consume a PKCE OAuth code directly', () => {
     'the login page should exchange direct OAuth codes with the browser Supabase client'
   );
   assert.match(
-    loginPageSource,
+    loginHelpersSource,
     /return `\$\{base\}\/auth\/callback\?next=\$\{encodeURIComponent\(sanitizeNextPath\(nextPath\)\)\}`/,
     'Google OAuth should use the existing allowlisted callback before forwarding the code to browser-side exchange'
   );

--- a/tests/login-page-architecture.test.ts
+++ b/tests/login-page-architecture.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const root = process.cwd();
+const pagePath = join(root, 'frontend/app/(core)/login/page.tsx');
+const copyPath = join(root, 'frontend/app/(core)/login/_lib/login-copy.ts');
+const helpersPath = join(root, 'frontend/app/(core)/login/_lib/login-helpers.ts');
+
+const pageSource = readFileSync(pagePath, 'utf8');
+
+test('login page delegates localized copy and browser helpers to route-local modules', () => {
+  assert.ok(existsSync(copyPath), 'login localized copy should stay in a route-local copy module');
+  assert.ok(existsSync(helpersPath), 'login browser helpers should stay in a route-local helper module');
+
+  assert.match(
+    pageSource,
+    /from '\.\/_lib\/login-copy'/,
+    'login page should import auth copy and auth mode types from the route-local copy module'
+  );
+  assert.match(
+    pageSource,
+    /from '\.\/_lib\/login-helpers'/,
+    'login page should import auth path and OAuth helpers from the route-local helper module'
+  );
+});
+
+test('login page does not regain auth copy or browser helper ownership', () => {
+  assert.doesNotMatch(pageSource, /const AUTH_COPY =/, 'localized auth copy belongs in _lib/login-copy.ts');
+  assert.doesNotMatch(pageSource, /function sanitizeNextPath\(/, 'next path validation belongs in _lib/login-helpers.ts');
+  assert.doesNotMatch(
+    pageSource,
+    /PENDING_GOOGLE_LOGIN_STORAGE_KEY/,
+    'pending Google OAuth storage details belong in _lib/login-helpers.ts'
+  );
+
+  const lineCount = pageSource.split('\n').length;
+  assert.ok(lineCount <= 1060, `login page should stay below 1060 lines after helper extraction, got ${lineCount}`);
+});
+
+test('login helper modules expose the expected route contract', () => {
+  const copySource = readFileSync(copyPath, 'utf8');
+  const helpersSource = readFileSync(helpersPath, 'utf8');
+
+  assert.match(copySource, /export const AUTH_COPY =/, 'copy module should export the auth copy dictionary');
+  assert.match(copySource, /export type AuthMode =/, 'copy module should export the auth mode type');
+  assert.match(copySource, /export type Locale =/, 'copy module should export the locale type derived from auth copy');
+
+  for (const helperName of [
+    'detectLocale',
+    'formatTemplate',
+    'sanitizeNextPath',
+    'getBrowserAuthRedirectOrigin',
+    'buildAuthCallbackRedirect',
+    'markPendingGoogleLogin',
+    'clearPendingGoogleLogin',
+    'consumePendingGoogleLogin',
+  ]) {
+    assert.match(helpersSource, new RegExp(`export function ${helperName}\\(`), `${helperName} should be exported`);
+  }
+});


### PR DESCRIPTION
## Summary
- move login localized auth copy and auth mode/locale types into route-local _lib/login-copy
- move next path sanitation, redirect URL building, locale detection, and pending Google OAuth storage helpers into _lib/login-helpers
- add a login page architecture contract and update the auth callback contract to follow the extracted helper

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/login-page-architecture.test.ts tests/login-hydration-contract.test.ts tests/login-metadata.test.ts tests/login-oauth-cookie-fallback.test.ts tests/auth-callback-redirect.test.ts tests/auth-hash-session-contract.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build