### PR TITLE
Split audio workspace helpers

### DIFF
--- a/docs/superpowers/plans/2026-05-07-workspace-architecture-wave-2.md
+++ b/docs/superpowers/plans/2026-05-07-workspace-architecture-wave-2.md
@@ -1,0 +1,111 @@
+# Workspace Architecture Wave 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship three focused architecture PRs that keep large workspace files moving toward route orchestration instead of owning copy, UI primitives, browser helpers, and data orchestration inline.
+
+**Architecture:** Continue the existing feature-local split style: route/client files remain orchestrators, while colocated `_components`, `_hooks`, and `_lib` modules own reusable UI, browser helpers, and local contracts. Each PR adds or extends a contract test so the extracted responsibility does not drift back into the workspace file.
+
+**Tech Stack:** Next.js App Router, React client components, TypeScript, Node `node:test` contract checks, existing npm/pnpm verification commands.
+
+---
+
+### Task 1: Audio Workspace Helper And Component Split
+
+**Files:**
+- Modify: `frontend/app/(core)/(workspace)/app/audio/AudioWorkspace.tsx`
+- Create: `frontend/app/(core)/(workspace)/app/audio/_components/audio-workspace-controls.tsx`
+- Create: `frontend/app/(core)/(workspace)/app/audio/_lib/audio-workspace-helpers.ts`
+- Create: `frontend/app/(core)/(workspace)/app/audio/_lib/audio-workspace-types.ts`
+- Create: `tests/audio-workspace-architecture.test.ts`
+
+- [ ] **Step 1: Add a contract test**
+
+Create `tests/audio-workspace-architecture.test.ts` asserting that the workspace imports the new `_components` and `_lib` modules, that top-level helper/component ownership no longer lives inline, and that key exports exist.
+
+- [ ] **Step 2: Move local audio contracts**
+
+Move `SourceVideoState`, `GeneratedSourceVideo`, `AudioJobSettingsSnapshot`, `AudioJobDetail`, `ActiveAudioJobState`, and `AudioResultState` into `audio-workspace-types.ts`.
+
+- [ ] **Step 3: Move audio defaults and browser/API helpers**
+
+Move default pack constants, voice gender values, provider metadata, formatting helpers, duration probing, upload, and job-detail fetch into `audio-workspace-helpers.ts`.
+
+- [ ] **Step 4: Move audio control components**
+
+Move `AudioModePicker`, `AudioModeCard`, `AudioInlineSelectLabel`, `AudioSelectControl`, and `ToggleRow` into `audio-workspace-controls.tsx`.
+
+- [ ] **Step 5: Verify and commit**
+
+Run:
+`pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/audio-workspace-architecture.test.ts`
+`pnpm --prefix frontend exec tsc --noEmit --pretty false`
+`npm --prefix frontend run lint`
+`npm run lint:exposure`
+`git diff --check`
+`pnpm --prefix frontend run build`
+
+Commit: `Split audio workspace helpers`
+
+### Task 2: Image Workspace Route Orchestration Split
+
+**Files:**
+- Modify: `frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx`
+- Create: `frontend/app/(core)/(workspace)/app/image/_hooks/useImageWorkspacePricing.ts`
+- Create: `frontend/app/(core)/(workspace)/app/image/_hooks/useImageWorkspaceHistory.ts`
+- Modify: `tests/image-workspace-split-contract.test.ts`
+
+- [ ] **Step 1: Extend the image split contract**
+
+Assert that image pricing/history orchestration lives in route-local hooks and that `ImageWorkspace.tsx` imports those hooks.
+
+- [ ] **Step 2: Extract pricing SWR orchestration**
+
+Move the `/api/images/estimate` SWR key/request logic into `useImageWorkspacePricing`.
+
+- [ ] **Step 3: Extract history and gallery group orchestration**
+
+Move image job filtering, remote history mapping, pending group resolution, and polling into `useImageWorkspaceHistory`.
+
+- [ ] **Step 4: Verify and commit**
+
+Run:
+`pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/image-workspace-split-contract.test.ts`
+`pnpm --prefix frontend exec tsc --noEmit --pretty false`
+`npm --prefix frontend run lint`
+`npm run lint:exposure`
+`git diff --check`
+`pnpm --prefix frontend run build`
+
+Commit: `Split image workspace orchestration hooks`
+
+### Task 3: Character Builder UI Component Split
+
+**Files:**
+- Modify: `frontend/src/components/tools/CharacterBuilderWorkspace.tsx`
+- Create: `frontend/src/components/tools/character-builder/_components/character-builder-workspace-components.tsx`
+- Modify: `tests/character-builder-workspace-architecture.test.ts`
+
+- [ ] **Step 1: Extend the character builder contract**
+
+Assert that visual cards, sticky dock, editors, controls, reference modal, and result rail components live in the colocated component module.
+
+- [ ] **Step 2: Move visual/control components**
+
+Move pre-page UI components and presentation constants out of `CharacterBuilderWorkspace.tsx`, preserving their props and behavior.
+
+- [ ] **Step 3: Keep page-level state and side effects in the workspace**
+
+Keep `CharacterBuilderWorkspace.tsx` responsible for route state, auth, persistence, job orchestration, and rendering composition only.
+
+- [ ] **Step 4: Verify and commit**
+
+Run:
+`pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/character-builder-workspace-architecture.test.ts`
+`pnpm --prefix frontend exec tsc --noEmit --pretty false`
+`npm --prefix frontend run lint`
+`npm run lint:exposure`
+`git diff --check`
+`pnpm --prefix frontend run build`
+
+Commit: `Split character builder workspace components`

--- a/frontend/app/(core)/(workspace)/app/audio/AudioWorkspace.tsx
+++ b/frontend/app/(core)/(workspace)/app/audio/AudioWorkspace.tsx
@@ -7,23 +7,19 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import {
   AudioLines,
-  Check,
   CheckCircle2,
   ChevronDown,
-  Clapperboard,
   Clock3,
   Coins,
   FileVideo,
   Gauge,
   Languages,
   Mic2,
-  Music2,
   Play,
   SlidersHorizontal,
   Sparkles,
   Upload,
   Video,
-  type LucideIcon,
 } from 'lucide-react';
 
 import { useRequireAuth } from '@/hooks/useRequireAuth';
@@ -33,7 +29,6 @@ import { useI18n } from '@/lib/i18n/I18nProvider';
 import type { Job } from '@/types/jobs';
 import { Button, ButtonLink } from '@/components/ui/Button';
 import { Textarea } from '@/components/ui/Input';
-import { SelectMenu } from '@/components/ui/SelectMenu';
 import { UIIcon } from '@/components/ui/UIIcon';
 import {
   AUDIO_INTENSITY_VALUES,
@@ -65,377 +60,39 @@ import {
   type AudioVoiceProfile,
 } from '@/lib/audio-generation';
 import AudioLatestRendersRail from './AudioLatestRendersRail';
+import { AudioModePicker, AudioSelectControl, ToggleRow } from './_components/audio-workspace-controls';
+import {
+  AUDIO_VOICE_GENDER_VALUES,
+  DEFAULT_INTENSITY,
+  DEFAULT_LANGUAGE,
+  DEFAULT_MANUAL_DURATION_SEC,
+  DEFAULT_MOOD,
+  DEFAULT_PACK,
+  DEFAULT_VOICE_DELIVERY,
+  DEFAULT_VOICE_GENDER,
+  DEFAULT_VOICE_PROFILE,
+  fetchJobDetail,
+  formatCopy,
+  formatCurrency,
+  formatDateTime,
+  inferOutputKind,
+  probeVideoDuration,
+  resolveProviderLabel,
+  resolveUiErrorMessage,
+  uploadAsset,
+} from './_lib/audio-workspace-helpers';
+import type {
+  ActiveAudioJobState,
+  AudioResultState,
+  GeneratedSourceVideo,
+  SourceVideoState,
+} from './_lib/audio-workspace-types';
 import {
   buildAudioModeOptions,
   DEFAULT_AUDIO_WORKSPACE_COPY,
   formatAudioOutputKind,
   type AudioWorkspaceCopy,
 } from './copy';
-
-type SourceVideoState = {
-  url: string;
-  jobId?: string | null;
-  thumbUrl?: string | null;
-  durationSec?: number | null;
-  aspectRatio?: string | null;
-  label: string;
-};
-
-type GeneratedSourceVideo = {
-  jobId: string;
-  url: string;
-  thumbUrl: string | null;
-  durationSec: number | null;
-  aspectRatio: string | null;
-  label: string;
-  createdAt: string;
-  hasAudio: boolean;
-};
-
-type AudioJobSettingsSnapshot = {
-  pack?: string | null;
-  prompt?: string | null;
-  mood?: string | null;
-  intensity?: string | null;
-  durationSec?: number | null;
-  script?: string | null;
-  musicEnabled?: boolean | null;
-  exportAudioFile?: boolean | null;
-  voiceGender?: string | null;
-  voiceProfile?: string | null;
-  voiceDelivery?: string | null;
-  language?: string | null;
-  outputKind?: AudioOutputKind | null;
-  sourceJobId?: string | null;
-  sourceVideoUrl?: string | null;
-  refs?: {
-    sourceVideoUrl?: string | null;
-    voiceSampleUrl?: string | null;
-  } | null;
-};
-
-type AudioJobDetail = {
-  ok?: boolean;
-  error?: string;
-  jobId: string;
-  surface?: string;
-  status?: 'pending' | 'running' | 'completed' | 'failed' | null;
-  progress?: number | null;
-  message?: string | null;
-  videoUrl?: string | null;
-  audioUrl?: string | null;
-  thumbUrl?: string | null;
-  aspectRatio?: string | null;
-  engineLabel?: string | null;
-  durationSec?: number | null;
-  settingsSnapshot?: AudioJobSettingsSnapshot | null;
-};
-
-type ActiveAudioJobState = {
-  jobId: string;
-  status: 'pending' | 'running' | 'completed' | 'failed';
-  progress: number;
-  message: string | null;
-  videoUrl: string | null;
-  audioUrl: string | null;
-  thumbUrl: string | null;
-  outputKind: AudioOutputKind;
-};
-
-type AudioResultState = {
-  jobId: string;
-  videoUrl: string | null;
-  audioUrl: string | null;
-  thumbUrl: string | null;
-  outputKind: AudioOutputKind;
-};
-
-const DEFAULT_PACK: AudioPackId = 'cinematic';
-const DEFAULT_MOOD: AudioMood = 'epic';
-const DEFAULT_INTENSITY: AudioIntensity = 'standard';
-const DEFAULT_VOICE_GENDER: AudioVoiceGender = 'female';
-const DEFAULT_VOICE_PROFILE: AudioVoiceProfile = 'balanced';
-const DEFAULT_VOICE_DELIVERY: AudioVoiceDelivery = 'cinematic';
-const DEFAULT_LANGUAGE: AudioLanguage = 'auto';
-const DEFAULT_MANUAL_DURATION_SEC = 8;
-const AUDIO_VOICE_GENDER_VALUES = ['female', 'male', 'neutral'] as const;
-const AUDIO_MODE_META: Record<
-  AudioPackId,
-  {
-    icon: LucideIcon;
-    providerKey: keyof AudioWorkspaceCopy['controls']['providers'];
-  }
-> = {
-  music_only: {
-    icon: Music2,
-    providerKey: 'music',
-  },
-  voice_only: {
-    icon: Mic2,
-    providerKey: 'voice',
-  },
-  cinematic: {
-    icon: Clapperboard,
-    providerKey: 'sfx',
-  },
-  cinematic_voice: {
-    icon: AudioLines,
-    providerKey: 'mix',
-  },
-};
-
-function resolveProviderLabel(copy: AudioWorkspaceCopy, pack: AudioPackId): string {
-  return copy.controls.providers[AUDIO_MODE_META[pack].providerKey];
-}
-
-function formatDateTime(value: string, locale?: string): string {
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) return value;
-  return new Intl.DateTimeFormat(locale, {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  }).format(parsed);
-}
-
-function formatCopy(template: string, values: Record<string, string | number>): string {
-  return Object.entries(values).reduce((resolved, [key, value]) => {
-    return resolved.split(`{${key}}`).join(String(value));
-  }, template);
-}
-
-function formatCurrency(amountCents?: number | null, currency = 'USD', locale?: string): string {
-  if (typeof amountCents !== 'number') return '-';
-  try {
-    return new Intl.NumberFormat(locale, {
-      style: 'currency',
-      currency,
-    }).format(amountCents / 100);
-  } catch {
-    return `${currency} ${(amountCents / 100).toFixed(2)}`;
-  }
-}
-
-function resolveUiErrorMessage(
-  error: unknown,
-  fallback: string,
-  genericMessages: string[] = []
-): string {
-  if (!(error instanceof Error) || !error.message.trim().length) {
-    return fallback;
-  }
-  return genericMessages.includes(error.message) ? fallback : error.message;
-}
-
-function inferOutputKind(detail: {
-  outputKind?: AudioOutputKind | null;
-  videoUrl?: string | null;
-  audioUrl?: string | null;
-}): AudioOutputKind {
-  if (detail.outputKind) return detail.outputKind;
-  if (detail.videoUrl && detail.audioUrl) return 'both';
-  if (detail.audioUrl) return 'audio';
-  return 'video';
-}
-
-async function probeVideoDuration(url: string): Promise<number | null> {
-  return new Promise((resolve) => {
-    const video = document.createElement('video');
-    const cleanup = () => {
-      video.pause();
-      video.removeAttribute('src');
-      video.load();
-    };
-    const finish = (value: number | null) => {
-      cleanup();
-      resolve(value);
-    };
-
-    video.preload = 'metadata';
-    video.muted = true;
-    video.onloadedmetadata = () => {
-      finish(Number.isFinite(video.duration) ? Math.round(video.duration) : null);
-    };
-    video.onerror = () => finish(null);
-    video.src = url;
-  });
-}
-
-async function uploadAsset(file: File, kind: 'video' | 'audio'): Promise<{ url: string; name: string }> {
-  const formData = new FormData();
-  formData.append('file', file, file.name);
-  const response = await authFetch(kind === 'video' ? '/api/uploads/video' : '/api/uploads/audio', {
-    method: 'POST',
-    body: formData,
-  });
-  const payload = (await response.json().catch(() => null)) as
-    | { ok?: boolean; error?: string; asset?: { url?: string; name?: string } }
-    | null;
-  if (!response.ok || !payload?.ok || !payload.asset?.url) {
-    throw new Error(payload?.error ?? 'Upload failed');
-  }
-  return {
-    url: payload.asset.url,
-    name: payload.asset.name ?? file.name,
-  };
-}
-
-async function fetchJobDetail(jobId: string): Promise<AudioJobDetail> {
-  const response = await authFetch(`/api/jobs/${encodeURIComponent(jobId)}`);
-  const payload = (await response.json().catch(() => null)) as AudioJobDetail | null;
-  if (!response.ok || !payload?.jobId) {
-    throw new Error(payload?.error ?? 'Unable to load job.');
-  }
-  return payload;
-}
-
-function AudioModePicker({
-  value,
-  options,
-  onChange,
-}: {
-  value: AudioPackId;
-  options: Array<{ id: AudioPackId; label: string; description: string }>;
-  onChange: (pack: AudioPackId) => void;
-}) {
-  return (
-    <div className="grid gap-2 md:grid-cols-2 2xl:grid-cols-4">
-      {options.map((mode) => (
-        <AudioModeCard
-          key={mode.id}
-          mode={mode}
-          active={value === mode.id}
-          onClick={() => onChange(mode.id)}
-        />
-      ))}
-    </div>
-  );
-}
-
-function AudioModeCard({
-  mode,
-  active,
-  onClick,
-}: {
-  mode: { id: AudioPackId; label: string; description: string };
-  active: boolean;
-  onClick: () => void;
-}) {
-  const Icon = AUDIO_MODE_META[mode.id].icon;
-
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-pressed={active}
-      className={[
-        'group relative min-h-[86px] overflow-hidden rounded-[10px] border px-3.5 py-3 text-left transition duration-200',
-        active
-          ? 'border-brand bg-brand-soft shadow-[0_14px_34px_rgba(46,99,216,0.12)] ring-1 ring-brand/25'
-          : 'border-hairline bg-surface hover:border-brand/45 hover:bg-surface-hover hover:shadow-card',
-      ].join(' ')}
-    >
-      <div className="flex items-start gap-3">
-        <span
-          className={[
-            'flex h-10 w-10 shrink-0 items-center justify-center rounded-[9px] transition',
-            active
-              ? 'bg-brand text-on-brand shadow-[0_10px_28px_rgba(46,99,216,0.22)]'
-              : 'bg-brand-soft text-brand group-hover:bg-brand-soft-hover',
-          ].join(' ')}
-        >
-          <UIIcon icon={Icon} size={21} strokeWidth={1.9} />
-        </span>
-        <span className="min-w-0 flex-1">
-          <span className="block text-sm font-semibold text-text-primary">{mode.label}</span>
-          <span className="mt-1 block text-xs leading-5 text-text-secondary">{mode.description}</span>
-        </span>
-        <span
-          className={[
-            'flex h-6 w-6 shrink-0 items-center justify-center rounded-full border transition',
-            active
-              ? 'border-brand bg-brand text-on-brand'
-              : 'border-hairline bg-surface text-transparent group-hover:border-brand/45',
-          ].join(' ')}
-          aria-hidden
-        >
-          {active ? <Check className="h-3.5 w-3.5" /> : null}
-        </span>
-      </div>
-    </button>
-  );
-}
-
-function AudioInlineSelectLabel({ icon, label }: { icon: LucideIcon; label: string }) {
-  return (
-    <span className="inline-flex min-w-0 items-center gap-2">
-      <UIIcon icon={icon} size={15} strokeWidth={1.8} />
-      <span className="truncate">{label}</span>
-    </span>
-  );
-}
-
-function AudioSelectControl({
-  label,
-  value,
-  options,
-  icon,
-  onChange,
-}: {
-  label: string;
-  value: string | number | boolean;
-  options: Array<{ value: string | number | boolean; label: string; disabled?: boolean }>;
-  icon: LucideIcon;
-  onChange: (next: string | number | boolean) => void;
-}) {
-  return (
-    <div className="min-w-0">
-      <span className="mb-2 block text-sm font-semibold text-text-primary">{label}</span>
-      <SelectMenu
-        options={options.map((option) => ({
-          ...option,
-          label: <AudioInlineSelectLabel icon={icon} label={option.label} />,
-        }))}
-        value={value}
-        onChange={(next) => onChange(String(next))}
-        className="min-w-0"
-        buttonClassName="min-h-0 h-10 rounded-full border-border bg-surface px-3 py-0 text-[12px] font-medium shadow-none dark:border-white/10 dark:bg-surface dark:text-white/92 dark:hover:border-white/16 dark:hover:bg-surface-hover"
-        menuClassName="min-w-[180px]"
-        menuPlacement="top"
-      />
-    </div>
-  );
-}
-
-function ToggleRow({
-  label,
-  description,
-  checked,
-  onChange,
-}: {
-  label: string;
-  description: string;
-  checked: boolean;
-  onChange: (next: boolean) => void;
-}) {
-  return (
-    <label className="flex items-start justify-between gap-4 rounded-[10px] border border-hairline bg-surface px-4 py-3 shadow-sm">
-      <div className="min-w-0">
-        <p className="text-sm font-semibold text-text-primary">{label}</p>
-        {description ? <p className="mt-1 text-sm text-text-secondary">{description}</p> : null}
-      </div>
-      <span className="relative mt-1 inline-flex h-6 w-11 shrink-0 items-center">
-        <input
-          type="checkbox"
-          checked={checked}
-          onChange={(event) => onChange(event.target.checked)}
-          className="peer sr-only"
-        />
-        <span className="absolute inset-0 rounded-full bg-border transition peer-checked:bg-brand" />
-        <span className="absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-white shadow transition peer-checked:translate-x-5" />
-      </span>
-    </label>
-  );
-}
 
 export default function AudioWorkspace() {
   const searchParams = useSearchParams();

--- a/frontend/app/(core)/(workspace)/app/audio/_components/audio-workspace-controls.tsx
+++ b/frontend/app/(core)/(workspace)/app/audio/_components/audio-workspace-controls.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { Check, type LucideIcon } from 'lucide-react';
+
+import { SelectMenu } from '@/components/ui/SelectMenu';
+import { UIIcon } from '@/components/ui/UIIcon';
+import type { AudioPackId } from '@/lib/audio-generation';
+import { AUDIO_MODE_META } from '../_lib/audio-workspace-helpers';
+
+export function AudioModePicker({
+  value,
+  options,
+  onChange,
+}: {
+  value: AudioPackId;
+  options: Array<{ id: AudioPackId; label: string; description: string }>;
+  onChange: (pack: AudioPackId) => void;
+}) {
+  return (
+    <div className="grid gap-2 md:grid-cols-2 2xl:grid-cols-4">
+      {options.map((mode) => (
+        <AudioModeCard
+          key={mode.id}
+          mode={mode}
+          active={value === mode.id}
+          onClick={() => onChange(mode.id)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function AudioModeCard({
+  mode,
+  active,
+  onClick,
+}: {
+  mode: { id: AudioPackId; label: string; description: string };
+  active: boolean;
+  onClick: () => void;
+}) {
+  const Icon = AUDIO_MODE_META[mode.id].icon;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={[
+        'group relative min-h-[86px] overflow-hidden rounded-[10px] border px-3.5 py-3 text-left transition duration-200',
+        active
+          ? 'border-brand bg-brand-soft shadow-[0_14px_34px_rgba(46,99,216,0.12)] ring-1 ring-brand/25'
+          : 'border-hairline bg-surface hover:border-brand/45 hover:bg-surface-hover hover:shadow-card',
+      ].join(' ')}
+    >
+      <div className="flex items-start gap-3">
+        <span
+          className={[
+            'flex h-10 w-10 shrink-0 items-center justify-center rounded-[9px] transition',
+            active
+              ? 'bg-brand text-on-brand shadow-[0_10px_28px_rgba(46,99,216,0.22)]'
+              : 'bg-brand-soft text-brand group-hover:bg-brand-soft-hover',
+          ].join(' ')}
+        >
+          <UIIcon icon={Icon} size={21} strokeWidth={1.9} />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block text-sm font-semibold text-text-primary">{mode.label}</span>
+          <span className="mt-1 block text-xs leading-5 text-text-secondary">{mode.description}</span>
+        </span>
+        <span
+          className={[
+            'flex h-6 w-6 shrink-0 items-center justify-center rounded-full border transition',
+            active
+              ? 'border-brand bg-brand text-on-brand'
+              : 'border-hairline bg-surface text-transparent group-hover:border-brand/45',
+          ].join(' ')}
+          aria-hidden
+        >
+          {active ? <Check className="h-3.5 w-3.5" /> : null}
+        </span>
+      </div>
+    </button>
+  );
+}
+
+function AudioInlineSelectLabel({ icon, label }: { icon: LucideIcon; label: string }) {
+  return (
+    <span className="inline-flex min-w-0 items-center gap-2">
+      <UIIcon icon={icon} size={15} strokeWidth={1.8} />
+      <span className="truncate">{label}</span>
+    </span>
+  );
+}
+
+export function AudioSelectControl({
+  label,
+  value,
+  options,
+  icon,
+  onChange,
+}: {
+  label: string;
+  value: string | number | boolean;
+  options: Array<{ value: string | number | boolean; label: string; disabled?: boolean }>;
+  icon: LucideIcon;
+  onChange: (next: string | number | boolean) => void;
+}) {
+  return (
+    <div className="min-w-0">
+      <span className="mb-2 block text-sm font-semibold text-text-primary">{label}</span>
+      <SelectMenu
+        options={options.map((option) => ({
+          ...option,
+          label: <AudioInlineSelectLabel icon={icon} label={option.label} />,
+        }))}
+        value={value}
+        onChange={(next) => onChange(String(next))}
+        className="min-w-0"
+        buttonClassName="min-h-0 h-10 rounded-full border-border bg-surface px-3 py-0 text-[12px] font-medium shadow-none dark:border-white/10 dark:bg-surface dark:text-white/92 dark:hover:border-white/16 dark:hover:bg-surface-hover"
+        menuClassName="min-w-[180px]"
+        menuPlacement="top"
+      />
+    </div>
+  );
+}
+
+export function ToggleRow({
+  label,
+  description,
+  checked,
+  onChange,
+}: {
+  label: string;
+  description: string;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  return (
+    <label className="flex items-start justify-between gap-4 rounded-[10px] border border-hairline bg-surface px-4 py-3 shadow-sm">
+      <div className="min-w-0">
+        <p className="text-sm font-semibold text-text-primary">{label}</p>
+        {description ? <p className="mt-1 text-sm text-text-secondary">{description}</p> : null}
+      </div>
+      <span className="relative mt-1 inline-flex h-6 w-11 shrink-0 items-center">
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(event) => onChange(event.target.checked)}
+          className="peer sr-only"
+        />
+        <span className="absolute inset-0 rounded-full bg-border transition peer-checked:bg-brand" />
+        <span className="absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-white shadow transition peer-checked:translate-x-5" />
+      </span>
+    </label>
+  );
+}

--- a/frontend/app/(core)/(workspace)/app/audio/_lib/audio-workspace-helpers.ts
+++ b/frontend/app/(core)/(workspace)/app/audio/_lib/audio-workspace-helpers.ts
@@ -1,0 +1,160 @@
+import {
+  AudioLines,
+  Clapperboard,
+  Mic2,
+  Music2,
+  type LucideIcon,
+} from 'lucide-react';
+
+import { authFetch } from '@/lib/authFetch';
+import type {
+  AudioIntensity,
+  AudioLanguage,
+  AudioMood,
+  AudioOutputKind,
+  AudioPackId,
+  AudioVoiceDelivery,
+  AudioVoiceGender,
+  AudioVoiceProfile,
+} from '@/lib/audio-generation';
+import type { AudioWorkspaceCopy } from '../copy';
+import type { AudioJobDetail } from './audio-workspace-types';
+
+export const DEFAULT_PACK: AudioPackId = 'cinematic';
+export const DEFAULT_MOOD: AudioMood = 'epic';
+export const DEFAULT_INTENSITY: AudioIntensity = 'standard';
+export const DEFAULT_VOICE_GENDER: AudioVoiceGender = 'female';
+export const DEFAULT_VOICE_PROFILE: AudioVoiceProfile = 'balanced';
+export const DEFAULT_VOICE_DELIVERY: AudioVoiceDelivery = 'cinematic';
+export const DEFAULT_LANGUAGE: AudioLanguage = 'auto';
+export const DEFAULT_MANUAL_DURATION_SEC = 8;
+export const AUDIO_VOICE_GENDER_VALUES = ['female', 'male', 'neutral'] as const;
+
+export const AUDIO_MODE_META: Record<
+  AudioPackId,
+  {
+    icon: LucideIcon;
+    providerKey: keyof AudioWorkspaceCopy['controls']['providers'];
+  }
+> = {
+  music_only: {
+    icon: Music2,
+    providerKey: 'music',
+  },
+  voice_only: {
+    icon: Mic2,
+    providerKey: 'voice',
+  },
+  cinematic: {
+    icon: Clapperboard,
+    providerKey: 'sfx',
+  },
+  cinematic_voice: {
+    icon: AudioLines,
+    providerKey: 'mix',
+  },
+};
+
+export function resolveProviderLabel(copy: AudioWorkspaceCopy, pack: AudioPackId): string {
+  return copy.controls.providers[AUDIO_MODE_META[pack].providerKey];
+}
+
+export function formatDateTime(value: string, locale?: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return new Intl.DateTimeFormat(locale, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(parsed);
+}
+
+export function formatCopy(template: string, values: Record<string, string | number>): string {
+  return Object.entries(values).reduce((resolved, [key, value]) => {
+    return resolved.split(`{${key}}`).join(String(value));
+  }, template);
+}
+
+export function formatCurrency(amountCents?: number | null, currency = 'USD', locale?: string): string {
+  if (typeof amountCents !== 'number') return '-';
+  try {
+    return new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency,
+    }).format(amountCents / 100);
+  } catch {
+    return `${currency} ${(amountCents / 100).toFixed(2)}`;
+  }
+}
+
+export function resolveUiErrorMessage(
+  error: unknown,
+  fallback: string,
+  genericMessages: string[] = []
+): string {
+  if (!(error instanceof Error) || !error.message.trim().length) {
+    return fallback;
+  }
+  return genericMessages.includes(error.message) ? fallback : error.message;
+}
+
+export function inferOutputKind(detail: {
+  outputKind?: AudioOutputKind | null;
+  videoUrl?: string | null;
+  audioUrl?: string | null;
+}): AudioOutputKind {
+  if (detail.outputKind) return detail.outputKind;
+  if (detail.videoUrl && detail.audioUrl) return 'both';
+  if (detail.audioUrl) return 'audio';
+  return 'video';
+}
+
+export async function probeVideoDuration(url: string): Promise<number | null> {
+  return new Promise((resolve) => {
+    const video = document.createElement('video');
+    const cleanup = () => {
+      video.pause();
+      video.removeAttribute('src');
+      video.load();
+    };
+    const finish = (value: number | null) => {
+      cleanup();
+      resolve(value);
+    };
+
+    video.preload = 'metadata';
+    video.muted = true;
+    video.onloadedmetadata = () => {
+      finish(Number.isFinite(video.duration) ? Math.round(video.duration) : null);
+    };
+    video.onerror = () => finish(null);
+    video.src = url;
+  });
+}
+
+export async function uploadAsset(file: File, kind: 'video' | 'audio'): Promise<{ url: string; name: string }> {
+  const formData = new FormData();
+  formData.append('file', file, file.name);
+  const response = await authFetch(kind === 'video' ? '/api/uploads/video' : '/api/uploads/audio', {
+    method: 'POST',
+    body: formData,
+  });
+  const payload = (await response.json().catch(() => null)) as
+    | { ok?: boolean; error?: string; asset?: { url?: string; name?: string } }
+    | null;
+  if (!response.ok || !payload?.ok || !payload.asset?.url) {
+    throw new Error(payload?.error ?? 'Upload failed');
+  }
+  return {
+    url: payload.asset.url,
+    name: payload.asset.name ?? file.name,
+  };
+}
+
+export async function fetchJobDetail(jobId: string): Promise<AudioJobDetail> {
+  const response = await authFetch(`/api/jobs/${encodeURIComponent(jobId)}`);
+  const payload = (await response.json().catch(() => null)) as AudioJobDetail | null;
+  if (!response.ok || !payload?.jobId) {
+    throw new Error(payload?.error ?? 'Unable to load job.');
+  }
+  return payload;
+}

--- a/frontend/app/(core)/(workspace)/app/audio/_lib/audio-workspace-types.ts
+++ b/frontend/app/(core)/(workspace)/app/audio/_lib/audio-workspace-types.ts
@@ -1,0 +1,79 @@
+import type { AudioOutputKind } from '@/lib/audio-generation';
+
+export type SourceVideoState = {
+  url: string;
+  jobId?: string | null;
+  thumbUrl?: string | null;
+  durationSec?: number | null;
+  aspectRatio?: string | null;
+  label: string;
+};
+
+export type GeneratedSourceVideo = {
+  jobId: string;
+  url: string;
+  thumbUrl: string | null;
+  durationSec: number | null;
+  aspectRatio: string | null;
+  label: string;
+  createdAt: string;
+  hasAudio: boolean;
+};
+
+export type AudioJobSettingsSnapshot = {
+  pack?: string | null;
+  prompt?: string | null;
+  mood?: string | null;
+  intensity?: string | null;
+  durationSec?: number | null;
+  script?: string | null;
+  musicEnabled?: boolean | null;
+  exportAudioFile?: boolean | null;
+  voiceGender?: string | null;
+  voiceProfile?: string | null;
+  voiceDelivery?: string | null;
+  language?: string | null;
+  outputKind?: AudioOutputKind | null;
+  sourceJobId?: string | null;
+  sourceVideoUrl?: string | null;
+  refs?: {
+    sourceVideoUrl?: string | null;
+    voiceSampleUrl?: string | null;
+  } | null;
+};
+
+export type AudioJobDetail = {
+  ok?: boolean;
+  error?: string;
+  jobId: string;
+  surface?: string;
+  status?: 'pending' | 'running' | 'completed' | 'failed' | null;
+  progress?: number | null;
+  message?: string | null;
+  videoUrl?: string | null;
+  audioUrl?: string | null;
+  thumbUrl?: string | null;
+  aspectRatio?: string | null;
+  engineLabel?: string | null;
+  durationSec?: number | null;
+  settingsSnapshot?: AudioJobSettingsSnapshot | null;
+};
+
+export type ActiveAudioJobState = {
+  jobId: string;
+  status: 'pending' | 'running' | 'completed' | 'failed';
+  progress: number;
+  message: string | null;
+  videoUrl: string | null;
+  audioUrl: string | null;
+  thumbUrl: string | null;
+  outputKind: AudioOutputKind;
+};
+
+export type AudioResultState = {
+  jobId: string;
+  videoUrl: string | null;
+  audioUrl: string | null;
+  thumbUrl: string | null;
+  outputKind: AudioOutputKind;
+};

--- a/tests/audio-workspace-architecture.test.ts
+++ b/tests/audio-workspace-architecture.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const root = process.cwd();
+const audioDir = join(root, 'frontend/app/(core)/(workspace)/app/audio');
+const workspacePath = join(audioDir, 'AudioWorkspace.tsx');
+const controlsPath = join(audioDir, '_components/audio-workspace-controls.tsx');
+const helpersPath = join(audioDir, '_lib/audio-workspace-helpers.ts');
+const typesPath = join(audioDir, '_lib/audio-workspace-types.ts');
+
+const workspaceSource = readFileSync(workspacePath, 'utf8');
+
+test('audio workspace delegates local controls, helpers, and contracts', () => {
+  assert.ok(existsSync(controlsPath), 'audio control components should live in a route-local component module');
+  assert.ok(existsSync(helpersPath), 'audio browser/API helpers should live in a route-local helper module');
+  assert.ok(existsSync(typesPath), 'audio local contracts should live in a route-local type module');
+
+  assert.match(workspaceSource, /from '\.\/_components\/audio-workspace-controls'/);
+  assert.match(workspaceSource, /from '\.\/_lib\/audio-workspace-helpers'/);
+  assert.match(workspaceSource, /from '\.\/_lib\/audio-workspace-types'/);
+});
+
+test('audio workspace does not regain extracted ownership', () => {
+  assert.doesNotMatch(workspaceSource, /type SourceVideoState =/, 'source video contract belongs in _lib/audio-workspace-types.ts');
+  assert.doesNotMatch(workspaceSource, /type AudioJobDetail =/, 'job detail contract belongs in _lib/audio-workspace-types.ts');
+  assert.doesNotMatch(workspaceSource, /const DEFAULT_PACK:/, 'default audio settings belong in _lib/audio-workspace-helpers.ts');
+  assert.doesNotMatch(workspaceSource, /function probeVideoDuration\(/, 'browser duration probing belongs in _lib/audio-workspace-helpers.ts');
+  assert.doesNotMatch(workspaceSource, /async function uploadAsset\(/, 'upload helper belongs in _lib/audio-workspace-helpers.ts');
+  assert.doesNotMatch(workspaceSource, /function AudioModePicker\(/, 'audio controls belong in _components/audio-workspace-controls.tsx');
+  assert.doesNotMatch(workspaceSource, /function AudioSelectControl\(/, 'audio controls belong in _components/audio-workspace-controls.tsx');
+
+  const lineCount = workspaceSource.split('\n').length;
+  assert.ok(lineCount <= 1230, `AudioWorkspace should stay below 1230 lines after helper extraction, got ${lineCount}`);
+});
+
+test('audio helper modules expose the expected workspace contract', () => {
+  const controlsSource = readFileSync(controlsPath, 'utf8');
+  const helpersSource = readFileSync(helpersPath, 'utf8');
+  const typesSource = readFileSync(typesPath, 'utf8');
+
+  for (const exportName of [
+    'AudioModePicker',
+    'AudioSelectControl',
+    'ToggleRow',
+  ]) {
+    assert.match(controlsSource, new RegExp(`export function ${exportName}`), `${exportName} should be exported`);
+  }
+
+  for (const exportName of [
+    'DEFAULT_PACK',
+    'DEFAULT_MOOD',
+    'DEFAULT_INTENSITY',
+    'AUDIO_VOICE_GENDER_VALUES',
+    'resolveProviderLabel',
+    'formatDateTime',
+    'formatCopy',
+    'formatCurrency',
+    'resolveUiErrorMessage',
+    'inferOutputKind',
+    'probeVideoDuration',
+    'uploadAsset',
+    'fetchJobDetail',
+  ]) {
+    assert.match(helpersSource, new RegExp(`export (const|function|async function) ${exportName}`), `${exportName} should be exported`);
+  }
+
+  for (const typeName of [
+    'SourceVideoState',
+    'GeneratedSourceVideo',
+    'AudioJobSettingsSnapshot',
+    'AudioJobDetail',
+    'ActiveAudioJobState',
+    'AudioResultState',
+  ]) {
+    assert.match(typesSource, new RegExp(`export type ${typeName}`), `${typeName} should be exported`);
+  }
+});


### PR DESCRIPTION
## Summary
- move Audio workspace local types into a route-local _lib contract module
- move browser/API helpers and audio defaults into _lib/audio-workspace-helpers
- move mode/select/toggle controls into _components/audio-workspace-controls
- add a contract test for the Audio workspace split

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/audio-workspace-architecture.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build