### PR TITLE
Split audio generated picker UI

### DIFF
--- a/frontend/app/(core)/(workspace)/app/audio/AudioWorkspace.tsx
+++ b/frontend/app/(core)/(workspace)/app/audio/AudioWorkspace.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-/* eslint-disable @next/next/no-img-element */
-
 import deepmerge from 'deepmerge';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
@@ -60,6 +58,7 @@ import {
   type AudioVoiceProfile,
 } from '@/lib/audio-generation';
 import AudioLatestRendersRail from './AudioLatestRendersRail';
+import { AudioGeneratedVideoPickerModal } from './_components/audio-generated-video-picker';
 import { AudioModePicker, AudioSelectControl, ToggleRow } from './_components/audio-workspace-controls';
 import {
   AUDIO_VOICE_GENDER_VALUES,
@@ -74,7 +73,6 @@ import {
   fetchJobDetail,
   formatCopy,
   formatCurrency,
-  formatDateTime,
   inferOutputKind,
   probeVideoDuration,
   resolveProviderLabel,
@@ -1128,88 +1126,16 @@ export default function AudioWorkspace() {
         <AudioLatestRendersRail activeJobId={activeJob?.jobId ?? result?.jobId ?? null} onSelectJob={handleSelectLatestJob} />
       </aside>
 
-      {generatedPickerOpen ? (
-        <div className="fixed inset-0 z-[1200] flex items-center justify-center bg-surface-on-media-dark-55 px-4">
-          <div className="absolute inset-0" role="presentation" onClick={() => setGeneratedPickerOpen(false)} />
-          <div className="relative z-10 flex max-h-[80vh] w-full max-w-4xl flex-col overflow-hidden rounded-card border border-border bg-surface shadow-float">
-            <div className="flex items-center justify-between border-b border-border px-5 py-4">
-              <div>
-                <h2 className="text-lg font-semibold text-text-primary">{copy.picker.title}</h2>
-                <p className="mt-1 text-sm text-text-secondary">{copy.picker.description}</p>
-              </div>
-              <Button type="button" variant="ghost" size="sm" onClick={() => setGeneratedPickerOpen(false)}>
-                {copy.picker.close}
-              </Button>
-            </div>
-            <div className="overflow-y-auto p-5">
-              {generatedVideosError ? (
-                <div className="rounded-card border border-warning-border bg-warning-bg p-4 text-sm text-warning">
-                  {generatedVideosError}
-                </div>
-              ) : null}
-              {!generatedVideosError && !generatedVideos.length && isGeneratedVideosLoading ? (
-                <div className="grid gap-4 md:grid-cols-2">
-                  {Array.from({ length: 4 }).map((_, index) => (
-                    <div key={`generated-source-skeleton-${index}`} className="overflow-hidden rounded-card border border-border bg-surface shadow-card" aria-hidden>
-                      <div className="aspect-[16/9] w-full bg-skeleton" />
-                      <div className="space-y-2 px-4 py-4">
-                        <div className="h-4 w-36 rounded-full bg-skeleton" />
-                        <div className="h-3 w-28 rounded-full bg-skeleton" />
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              ) : null}
-              {!generatedVideosError && !generatedVideos.length && !isGeneratedVideosLoading ? (
-                <div className="rounded-card border border-border bg-bg p-5 text-sm text-text-secondary">
-                  {copy.picker.empty}
-                </div>
-              ) : null}
-              {generatedVideos.length ? (
-                <div className="grid gap-4 md:grid-cols-2">
-                  {generatedVideos.map((video) => (
-                    <button
-                      key={video.jobId}
-                      type="button"
-                      className="overflow-hidden rounded-card border border-border bg-surface text-left shadow-card transition hover:border-border-hover hover:bg-surface-hover"
-                      onClick={() => {
-                        void handleSelectGeneratedVideo(video);
-                      }}
-                    >
-                      <div className="relative aspect-[16/9] w-full overflow-hidden bg-bg">
-                        <video
-                          src={video.url}
-                          poster={video.thumbUrl ?? undefined}
-                          className="h-full w-full object-cover"
-                          muted
-                          playsInline
-                          loop
-                          autoPlay
-                          preload="metadata"
-                        />
-                      </div>
-                      <div className="space-y-2 px-4 py-4">
-                        <div className="flex items-start justify-between gap-3">
-                          <p className="min-w-0 truncate text-sm font-semibold text-text-primary">{video.label}</p>
-                          {video.hasAudio ? (
-                            <span className="rounded-full border border-border bg-bg px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">
-                              {copy.picker.audioBadge}
-                            </span>
-                          ) : null}
-                        </div>
-                        <p className="text-xs text-text-secondary">
-                          {video.durationSec ? formatAudioDurationLabel(video.durationSec) : copy.source.durationPending}{video.aspectRatio ? ` • ${video.aspectRatio}` : ''}
-                        </p>
-                        <p className="text-xs text-text-muted">{formatDateTime(video.createdAt, locale)}</p>
-                      </div>
-                    </button>
-                  ))}
-                </div>
-              ) : null}
-            </div>
-          </div>
-        </div>
-      ) : null}
+      <AudioGeneratedVideoPickerModal
+        open={generatedPickerOpen}
+        videos={generatedVideos}
+        isLoading={isGeneratedVideosLoading}
+        error={generatedVideosError}
+        locale={locale}
+        copy={copy}
+        onClose={() => setGeneratedPickerOpen(false)}
+        onSelect={handleSelectGeneratedVideo}
+      />
     </div>
   );
 }

--- a/frontend/app/(core)/(workspace)/app/audio/_components/audio-generated-video-picker.tsx
+++ b/frontend/app/(core)/(workspace)/app/audio/_components/audio-generated-video-picker.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { Button } from '@/components/ui/Button';
+import { formatAudioDurationLabel } from '@/lib/audio-generation';
+import { formatDateTime } from '../_lib/audio-workspace-helpers';
+import type { GeneratedSourceVideo } from '../_lib/audio-workspace-types';
+import type { AudioWorkspaceCopy } from '../copy';
+
+export function AudioGeneratedVideoPickerModal({
+  open,
+  videos,
+  isLoading,
+  error,
+  locale,
+  copy,
+  onClose,
+  onSelect,
+}: {
+  open: boolean;
+  videos: GeneratedSourceVideo[];
+  isLoading: boolean;
+  error: string | null;
+  locale: string;
+  copy: AudioWorkspaceCopy;
+  onClose: () => void;
+  onSelect: (video: GeneratedSourceVideo) => void | Promise<void>;
+}) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[1200] flex items-center justify-center bg-surface-on-media-dark-55 px-4">
+      <div className="absolute inset-0" role="presentation" onClick={onClose} />
+      <div className="relative z-10 flex max-h-[80vh] w-full max-w-4xl flex-col overflow-hidden rounded-card border border-border bg-surface shadow-float">
+        <div className="flex items-center justify-between border-b border-border px-5 py-4">
+          <div>
+            <h2 className="text-lg font-semibold text-text-primary">{copy.picker.title}</h2>
+            <p className="mt-1 text-sm text-text-secondary">{copy.picker.description}</p>
+          </div>
+          <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+            {copy.picker.close}
+          </Button>
+        </div>
+        <div className="overflow-y-auto p-5">
+          {error ? (
+            <div className="rounded-card border border-warning-border bg-warning-bg p-4 text-sm text-warning">
+              {error}
+            </div>
+          ) : null}
+          {!error && !videos.length && isLoading ? (
+            <div className="grid gap-4 md:grid-cols-2">
+              {Array.from({ length: 4 }).map((_, index) => (
+                <div key={`generated-source-skeleton-${index}`} className="overflow-hidden rounded-card border border-border bg-surface shadow-card" aria-hidden>
+                  <div className="aspect-[16/9] w-full bg-skeleton" />
+                  <div className="space-y-2 px-4 py-4">
+                    <div className="h-4 w-36 rounded-full bg-skeleton" />
+                    <div className="h-3 w-28 rounded-full bg-skeleton" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : null}
+          {!error && !videos.length && !isLoading ? (
+            <div className="rounded-card border border-border bg-bg p-5 text-sm text-text-secondary">
+              {copy.picker.empty}
+            </div>
+          ) : null}
+          {videos.length ? (
+            <div className="grid gap-4 md:grid-cols-2">
+              {videos.map((video) => (
+                <button
+                  key={video.jobId}
+                  type="button"
+                  className="overflow-hidden rounded-card border border-border bg-surface text-left shadow-card transition hover:border-border-hover hover:bg-surface-hover"
+                  onClick={() => {
+                    void onSelect(video);
+                  }}
+                >
+                  <div className="relative aspect-[16/9] w-full overflow-hidden bg-bg">
+                    <video
+                      src={video.url}
+                      poster={video.thumbUrl ?? undefined}
+                      className="h-full w-full object-cover"
+                      muted
+                      playsInline
+                      loop
+                      autoPlay
+                      preload="metadata"
+                    />
+                  </div>
+                  <div className="space-y-2 px-4 py-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <p className="min-w-0 truncate text-sm font-semibold text-text-primary">{video.label}</p>
+                      {video.hasAudio ? (
+                        <span className="rounded-full border border-border bg-bg px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">
+                          {copy.picker.audioBadge}
+                        </span>
+                      ) : null}
+                    </div>
+                    <p className="text-xs text-text-secondary">
+                      {video.durationSec ? formatAudioDurationLabel(video.durationSec) : copy.source.durationPending}{video.aspectRatio ? ` • ${video.aspectRatio}` : ''}
+                    </p>
+                    <p className="text-xs text-text-muted">{formatDateTime(video.createdAt, locale)}</p>
+                  </div>
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tests/audio-workspace-architecture.test.ts
+++ b/tests/audio-workspace-architecture.test.ts
@@ -7,6 +7,7 @@ const root = process.cwd();
 const audioDir = join(root, 'frontend/app/(core)/(workspace)/app/audio');
 const workspacePath = join(audioDir, 'AudioWorkspace.tsx');
 const controlsPath = join(audioDir, '_components/audio-workspace-controls.tsx');
+const generatedPickerPath = join(audioDir, '_components/audio-generated-video-picker.tsx');
 const helpersPath = join(audioDir, '_lib/audio-workspace-helpers.ts');
 const typesPath = join(audioDir, '_lib/audio-workspace-types.ts');
 
@@ -14,10 +15,12 @@ const workspaceSource = readFileSync(workspacePath, 'utf8');
 
 test('audio workspace delegates local controls, helpers, and contracts', () => {
   assert.ok(existsSync(controlsPath), 'audio control components should live in a route-local component module');
+  assert.ok(existsSync(generatedPickerPath), 'generated video picker should live in a route-local component module');
   assert.ok(existsSync(helpersPath), 'audio browser/API helpers should live in a route-local helper module');
   assert.ok(existsSync(typesPath), 'audio local contracts should live in a route-local type module');
 
   assert.match(workspaceSource, /from '\.\/_components\/audio-workspace-controls'/);
+  assert.match(workspaceSource, /from '\.\/_components\/audio-generated-video-picker'/);
   assert.match(workspaceSource, /from '\.\/_lib\/audio-workspace-helpers'/);
   assert.match(workspaceSource, /from '\.\/_lib\/audio-workspace-types'/);
 });
@@ -30,13 +33,16 @@ test('audio workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /async function uploadAsset\(/, 'upload helper belongs in _lib/audio-workspace-helpers.ts');
   assert.doesNotMatch(workspaceSource, /function AudioModePicker\(/, 'audio controls belong in _components/audio-workspace-controls.tsx');
   assert.doesNotMatch(workspaceSource, /function AudioSelectControl\(/, 'audio controls belong in _components/audio-workspace-controls.tsx');
+  assert.doesNotMatch(workspaceSource, /generated-source-skeleton/, 'generated video picker UI belongs in _components/audio-generated-video-picker.tsx');
+  assert.doesNotMatch(workspaceSource, /copy\.picker\.audioBadge/, 'generated video picker card UI belongs in _components/audio-generated-video-picker.tsx');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 1230, `AudioWorkspace should stay below 1230 lines after helper extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 1160, `AudioWorkspace should stay below 1160 lines after generated picker extraction, got ${lineCount}`);
 });
 
 test('audio helper modules expose the expected workspace contract', () => {
   const controlsSource = readFileSync(controlsPath, 'utf8');
+  const generatedPickerSource = readFileSync(generatedPickerPath, 'utf8');
   const helpersSource = readFileSync(helpersPath, 'utf8');
   const typesSource = readFileSync(typesPath, 'utf8');
 
@@ -47,6 +53,12 @@ test('audio helper modules expose the expected workspace contract', () => {
   ]) {
     assert.match(controlsSource, new RegExp(`export function ${exportName}`), `${exportName} should be exported`);
   }
+
+  assert.match(
+    generatedPickerSource,
+    /export function AudioGeneratedVideoPickerModal/,
+    'AudioGeneratedVideoPickerModal should be exported'
+  );
 
   for (const exportName of [
     'DEFAULT_PACK',


### PR DESCRIPTION
## Summary
- extract the generated video picker modal from AudioWorkspace into a route-local component
- keep AudioWorkspace responsible for state, loading, and selection orchestration
- extend the audio architecture contract to keep picker card/modal UI out of the workspace file

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/audio-workspace-architecture.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build