### PR TITLE
Split image auth gate modal

### DIFF
--- a/frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx
+++ b/frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx
@@ -9,7 +9,7 @@ import { usePathname, useSearchParams } from 'next/navigation';
 import { Plus } from 'lucide-react';
 import type { FormEvent } from 'react';
 import { GalleryRail } from '@/components/GalleryRail';
-import { Button, ButtonLink } from '@/components/ui/Button';
+import { Button } from '@/components/ui/Button';
 import { EngineSelect } from '@/components/ui/EngineSelect';
 import { Composer, type AssetFieldConfig, type ComposerAttachment } from '@/components/Composer';
 import { ImageSettingsBar } from '@/components/ImageSettingsBar';
@@ -46,6 +46,7 @@ import { authFetch } from '@/lib/authFetch';
 import { readLastKnownUserId } from '@/lib/last-known';
 import { readBrowserSession } from '@/lib/supabase-auth-cleanup';
 import { hasSupabaseAuthCookie } from '@/lib/supabase-session-hint';
+import { ImageAuthGateModal } from './_components/ImageAuthGateModal';
 import { ImageLibraryModal } from './_components/ImageLibraryModal';
 import { useImageWorkspaceHistory } from './_hooks/useImageWorkspaceHistory';
 import { useImageWorkspacePricing } from './_hooks/useImageWorkspacePricing';
@@ -1424,42 +1425,12 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
         onSaveToLibrary={handleSaveVariantToLibrary}
       />
     ) : null}
-      {authModalOpen ? (
-      <div className="fixed inset-0 z-[10050] flex items-center justify-center bg-surface-on-media-dark-60 px-3 py-6 sm:px-6">
-        <div className="absolute inset-0" role="presentation" onClick={() => setAuthModalOpen(false)} />
-        <div className="relative z-10 w-full max-w-md rounded-modal border border-border bg-surface p-6 shadow-float">
-          <div className="flex items-start justify-between gap-4">
-            <div className="flex-1">
-              <h2 className="text-base font-semibold text-text-primary">{resolvedCopy.authGate.title}</h2>
-              <p className="mt-2 text-sm text-text-secondary">{resolvedCopy.authGate.body}</p>
-            </div>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => setAuthModalOpen(false)}
-              className="rounded-full border-hairline bg-surface-glass-80 px-3 py-1.5 text-sm text-text-muted hover:bg-surface-2"
-              aria-label={resolvedCopy.authGate.close}
-            >
-              {resolvedCopy.authGate.close}
-            </Button>
-          </div>
-          <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
-            <ButtonLink href={`/login?next=${encodeURIComponent(loginRedirectTarget)}`} size="sm" className="px-4">
-              {resolvedCopy.authGate.primary}
-            </ButtonLink>
-            <ButtonLink
-              href={`/login?mode=signin&next=${encodeURIComponent(loginRedirectTarget)}`}
-              variant="outline"
-              size="sm"
-              className="px-4"
-            >
-              {resolvedCopy.authGate.secondary}
-            </ButtonLink>
-          </div>
-        </div>
-      </div>
-    ) : null}
+      <ImageAuthGateModal
+        open={authModalOpen}
+        copy={resolvedCopy.authGate}
+        loginRedirectTarget={loginRedirectTarget}
+        onClose={() => setAuthModalOpen(false)}
+      />
       {libraryModal.open ? (
       <ImageLibraryModal
         open={libraryModal.open}

--- a/frontend/app/(core)/(workspace)/app/image/_components/ImageAuthGateModal.tsx
+++ b/frontend/app/(core)/(workspace)/app/image/_components/ImageAuthGateModal.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { Button, ButtonLink } from '@/components/ui/Button';
+import type { ImageWorkspaceCopy } from '../_lib/image-workspace-copy';
+
+export function ImageAuthGateModal({
+  open,
+  copy,
+  loginRedirectTarget,
+  onClose,
+}: {
+  open: boolean;
+  copy: ImageWorkspaceCopy['authGate'];
+  loginRedirectTarget: string;
+  onClose: () => void;
+}) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[10050] flex items-center justify-center bg-surface-on-media-dark-60 px-3 py-6 sm:px-6">
+      <div className="absolute inset-0" role="presentation" onClick={onClose} />
+      <div className="relative z-10 w-full max-w-md rounded-modal border border-border bg-surface p-6 shadow-float">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1">
+            <h2 className="text-base font-semibold text-text-primary">{copy.title}</h2>
+            <p className="mt-2 text-sm text-text-secondary">{copy.body}</p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onClose}
+            className="rounded-full border-hairline bg-surface-glass-80 px-3 py-1.5 text-sm text-text-muted hover:bg-surface-2"
+            aria-label={copy.close}
+          >
+            {copy.close}
+          </Button>
+        </div>
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
+          <ButtonLink href={`/login?next=${encodeURIComponent(loginRedirectTarget)}`} size="sm" className="px-4">
+            {copy.primary}
+          </ButtonLink>
+          <ButtonLink
+            href={`/login?mode=signin&next=${encodeURIComponent(loginRedirectTarget)}`}
+            variant="outline"
+            size="sm"
+            className="px-4"
+          >
+            {copy.secondary}
+          </ButtonLink>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tests/image-workspace-split-contract.test.ts
+++ b/tests/image-workspace-split-contract.test.ts
@@ -8,6 +8,7 @@ const imageDir = path.join(root, 'frontend/app/(core)/(workspace)/app/image');
 const workspacePath = path.join(imageDir, 'ImageWorkspace.tsx');
 
 const splitFiles = [
+  '_components/ImageAuthGateModal.tsx',
   '_components/ImageLibraryModal.tsx',
   '_hooks/useImageWorkspaceHistory.ts',
   '_hooks/useImageWorkspacePricing.ts',
@@ -32,6 +33,7 @@ test('image workspace foundations are split from the route orchestrator', () => 
   }
 
   assert.match(source, /from '\.\/_components\/ImageLibraryModal'/);
+  assert.match(source, /from '\.\/_components\/ImageAuthGateModal'/);
   assert.match(source, /from '\.\/_hooks\/useImageWorkspaceHistory'/);
   assert.match(source, /from '\.\/_hooks\/useImageWorkspacePricing'/);
   assert.match(source, /from '\.\/_hooks\/useImageWorkspaceDesktopLayout'/);
@@ -42,6 +44,8 @@ test('image workspace foundations are split from the route orchestrator', () => 
 
   assert.doesNotMatch(source, /const DEFAULT_COPY: ImageWorkspaceCopy =/);
   assert.doesNotMatch(source, /function ImageLibraryModal\(/);
+  assert.doesNotMatch(source, /function ImageAuthGateModal\(/);
+  assert.doesNotMatch(source, /resolvedCopy\.authGate\.primary/, 'auth gate modal UI belongs in ImageAuthGateModal');
   assert.doesNotMatch(source, /function parsePersistedImageComposerState\(/);
   assert.doesNotMatch(source, /function mapJobToHistoryEntry\(/);
   assert.doesNotMatch(source, /function buildPendingGroup\(/);
@@ -49,4 +53,7 @@ test('image workspace foundations are split from the route orchestrator', () => 
   assert.doesNotMatch(source, /useSWR\(/, 'pricing SWR orchestration belongs in useImageWorkspacePricing');
   assert.doesNotMatch(source, /useInfiniteJobs\(24, \{ surface: 'image' \}\)/, 'image job feed orchestration belongs in useImageWorkspaceHistory');
   assert.doesNotMatch(source, /const remoteImageJobs =/, 'remote image history derivation belongs in useImageWorkspaceHistory');
+
+  const lineCount = source.split('\n').length;
+  assert.ok(lineCount <= 1460, `ImageWorkspace should stay below 1460 lines after auth modal extraction, got ${lineCount}`);
 });


### PR DESCRIPTION
## Summary
- extract the image workspace auth gate modal into a route-local component
- keep ImageWorkspace focused on auth state and modal entry-point orchestration
- extend the image workspace split contract to keep auth modal UI out of the route file

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/image-workspace-split-contract.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build