### PR TITLE
Split angle server request helpers

### DIFF
--- a/frontend/src/server/tools/angle-request-utils.ts
+++ b/frontend/src/server/tools/angle-request-utils.ts
@@ -1,0 +1,248 @@
+import { ValidationError } from '@fal-ai/client';
+import { normalizeMediaUrl } from '@/lib/media';
+import { mapTiltForEngine, normalizeRotation } from '@/lib/tools-angle';
+import type {
+  AngleToolEngineDefinition,
+  AngleToolEngineId,
+  AngleToolOutput,
+  AngleToolRequest,
+} from '@/types/tools-angle';
+
+export const ANGLE_SURFACE = 'angle' as const;
+export const ANGLE_MULTI_OUTPUT_COUNT = 4;
+
+export function getAngleBillingProductKeyForEngine(engineId: AngleToolEngineId, generateBestAngles: boolean): string {
+  const family = engineId === 'qwen-multiple-angles' ? 'qwen' : 'flux';
+  return `angle-${family}-${generateBestAngles ? 'multi' : 'single'}`;
+}
+
+export function buildAnglePromptSummary(params: { rotation: number; tilt: number; zoom: number }, outputCount: number): string {
+  return `Angle tool · rotation ${Math.round(params.rotation)}° · tilt ${Math.round(params.tilt)}° · zoom ${params.zoom.toFixed(1)} · ${outputCount} output${outputCount > 1 ? 's' : ''}`;
+}
+
+export function buildAngleSettingsSnapshot(args: {
+  engine: AngleToolEngineDefinition;
+  imageUrl: string;
+  requested: AngleToolRequest['params'];
+  applied: AngleToolRequest['params'] & { safeMode: boolean; safeApplied: boolean };
+  generateBestAngles: boolean;
+  outputCount: number;
+  billingProductKey: string;
+}): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    surface: ANGLE_SURFACE,
+    billingProductKey: args.billingProductKey,
+    engineId: args.engine.id,
+    engineLabel: args.engine.label,
+    inputMode: 'i2i',
+    prompt: buildAnglePromptSummary(args.applied, args.outputCount),
+    source: {
+      imageUrl: args.imageUrl,
+    },
+    controls: {
+      requested: args.requested,
+      applied: args.applied,
+      generateBestAngles: args.generateBestAngles,
+      outputCount: args.outputCount,
+    },
+  };
+}
+
+function normalizeFalUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return trimmed;
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+  const normalized = trimmed.replace(/^\.?\/+/, '');
+  return `https://fal.media/files/${normalized}`;
+}
+
+function toAngleOutput(entry: Record<string, unknown>): AngleToolOutput | null {
+  const urlRaw =
+    typeof entry.url === 'string'
+      ? entry.url
+      : typeof entry.image_url === 'string'
+        ? entry.image_url
+        : typeof entry.path === 'string'
+          ? entry.path
+          : null;
+  if (!urlRaw) return null;
+
+  const width = typeof entry.width === 'number' ? entry.width : null;
+  const height = typeof entry.height === 'number' ? entry.height : null;
+  const mimeType =
+    typeof entry.content_type === 'string'
+      ? entry.content_type
+      : typeof entry.mimetype === 'string'
+        ? entry.mimetype
+        : typeof entry.mime === 'string'
+          ? entry.mime
+          : null;
+
+  const url = normalizeFalUrl(urlRaw);
+  return {
+    url: normalizeMediaUrl(url) ?? url,
+    width,
+    height,
+    mimeType,
+  };
+}
+
+export function extractAngleOutputs(payload: unknown): AngleToolOutput[] {
+  const roots: unknown[] = [];
+  if (payload && typeof payload === 'object') {
+    const record = payload as Record<string, unknown>;
+    roots.push(record);
+    if (record.output && typeof record.output === 'object') roots.push(record.output);
+    if (record.response && typeof record.response === 'object') roots.push(record.response);
+    if (record.data && typeof record.data === 'object') roots.push(record.data);
+  }
+
+  for (const root of roots) {
+    if (!root || typeof root !== 'object') continue;
+    const record = root as Record<string, unknown>;
+
+    if (Array.isArray(record.images)) {
+      const mapped = record.images
+        .map((entry) => (entry && typeof entry === 'object' ? toAngleOutput(entry as Record<string, unknown>) : null))
+        .filter((entry): entry is AngleToolOutput => Boolean(entry));
+      if (mapped.length) return mapped;
+    }
+
+    if (record.image && typeof record.image === 'object') {
+      const single = toAngleOutput(record.image as Record<string, unknown>);
+      if (single) return [single];
+    }
+
+    if (typeof record.url === 'string') {
+      const single = toAngleOutput(record);
+      if (single) return [single];
+    }
+  }
+
+  return [];
+}
+
+export function parseAngleRequestId(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== 'object') return undefined;
+  const record = payload as Record<string, unknown>;
+  const direct = typeof record.request_id === 'string' ? record.request_id : undefined;
+  if (direct) return direct;
+  if (typeof record.id === 'string') return record.id;
+  if (record.response && typeof record.response === 'object') {
+    const responseRecord = record.response as Record<string, unknown>;
+    if (typeof responseRecord.request_id === 'string') return responseRecord.request_id;
+    if (typeof responseRecord.id === 'string') return responseRecord.id;
+  }
+  if (record.output && typeof record.output === 'object') {
+    const outputRecord = record.output as Record<string, unknown>;
+    if (typeof outputRecord.request_id === 'string') return outputRecord.request_id;
+    if (typeof outputRecord.id === 'string') return outputRecord.id;
+  }
+  return undefined;
+}
+
+export function extractAngleActualCostUsd(payload: unknown): number | null {
+  const queue: Array<{ value: unknown; depth: number }> = [{ value: payload, depth: 0 }];
+  const candidates: number[] = [];
+
+  const isCostKey = (rawKey: string): boolean => {
+    const key = rawKey.toLowerCase();
+    if (key.includes('zoom_amount')) return false;
+    return (
+      key === 'cost' ||
+      key === 'price' ||
+      key.includes('cost_usd') ||
+      key.includes('price_usd') ||
+      key.includes('actual_cost') ||
+      key.includes('estimated_cost') ||
+      key.endsWith('_usd') ||
+      key.endsWith('usd')
+    );
+  };
+
+  while (queue.length) {
+    const current = queue.shift();
+    if (!current) continue;
+    const { value, depth } = current;
+    if (depth > 5 || value == null) continue;
+
+    if (typeof value === 'string') {
+      const cleaned = value.trim();
+      const dollarMatch = cleaned.match(/\$\s*([0-9]+(?:\.[0-9]+)?)/);
+      if (dollarMatch) {
+        const parsed = Number(dollarMatch[1]);
+        if (Number.isFinite(parsed) && parsed > 0) candidates.push(parsed);
+      }
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      value.slice(0, 20).forEach((entry) => queue.push({ value: entry, depth: depth + 1 }));
+      continue;
+    }
+
+    if (typeof value === 'object') {
+      const record = value as Record<string, unknown>;
+      Object.entries(record).forEach(([key, field]) => {
+        const costLike = isCostKey(key);
+
+        if (costLike && typeof field === 'number' && Number.isFinite(field) && field > 0 && field < 10_000) {
+          candidates.push(field);
+          return;
+        }
+
+        if (costLike && typeof field === 'string') {
+          const parsed = Number(field.replace(/[^0-9.]+/g, ''));
+          if (Number.isFinite(parsed) && parsed > 0) {
+            candidates.push(parsed);
+            return;
+          }
+        }
+
+        queue.push({ value: field, depth: depth + 1 });
+      });
+    }
+  }
+
+  if (!candidates.length) return null;
+  const costCandidate = candidates.find((value) => value <= 100) ?? candidates[0];
+  return Number(costCandidate.toFixed(6));
+}
+
+export function buildAngleFalInput(
+  engine: AngleToolEngineDefinition,
+  imageUrl: string,
+  params: { rotation: number; tilt: number; zoom: number }
+) {
+  const horizontalAngle = Math.round(normalizeRotation(params.rotation));
+  const verticalAngle = Math.round(mapTiltForEngine(engine.id, params.tilt));
+  const zoomAmount = Number(params.zoom.toFixed(1));
+
+  return {
+    image_urls: [imageUrl],
+    horizontal_angle: horizontalAngle,
+    vertical_angle: verticalAngle,
+    zoom_amount: zoomAmount,
+    num_images: 1,
+  };
+}
+
+export function toAngleValidationMessage(error: ValidationError): string {
+  const messages = error.fieldErrors
+    .map((entry) => {
+      const loc = Array.isArray(entry.loc) ? entry.loc.filter((part) => part !== 'body') : [];
+      const path = loc.length ? loc.join('.') : null;
+      const msg = typeof entry.msg === 'string' ? entry.msg.trim() : '';
+      if (!msg) return null;
+      return path ? `${path}: ${msg}` : msg;
+    })
+    .filter((entry): entry is string => Boolean(entry));
+
+  if (!messages.length) {
+    return error.message || 'Validation failed';
+  }
+  return messages.slice(0, 3).join(' · ');
+}

--- a/frontend/src/server/tools/angle.ts
+++ b/frontend/src/server/tools/angle.ts
@@ -3,7 +3,6 @@ import { ApiError, ValidationError } from '@fal-ai/client';
 import { getAngleToolEngine } from '@/config/tools-angle-engines';
 import { isDatabaseConfigured, query, type QueryExecutor, withDbTransaction } from '@/lib/db';
 import { getFalClient } from '@/lib/fal-client';
-import { normalizeMediaUrl } from '@/lib/media';
 import { getResultProviderMode } from '@/lib/result-provider';
 import { ensureBillingSchema } from '@/lib/schema';
 import { computeBillingProductSnapshot } from '@/lib/billing-products';
@@ -18,24 +17,31 @@ import { ensureReusableAsset, upsertLegacyJobOutputs } from '@/server/media-libr
 import {
   applyCinemaSafeParams,
   buildBestAngleVariantParams,
-  mapTiltForEngine,
-  normalizeRotation,
   resolveAngleEngineForParams,
   sanitizeAngleParams,
 } from '@/lib/tools-angle';
 import type {
-  AngleToolEngineDefinition,
   AngleToolOutput,
   AngleToolRequest,
   AngleToolResponse,
   AngleToolEngineId,
 } from '@/types/tools-angle';
 import type { PricingSnapshot } from '@/types/engines';
+import {
+  ANGLE_MULTI_OUTPUT_COUNT,
+  ANGLE_SURFACE,
+  buildAngleFalInput,
+  buildAnglePromptSummary,
+  buildAngleSettingsSnapshot,
+  extractAngleActualCostUsd,
+  extractAngleOutputs,
+  getAngleBillingProductKeyForEngine,
+  parseAngleRequestId,
+  toAngleValidationMessage,
+} from './angle-request-utils';
 
 const TOOL_EVENT_NAME = 'tool_angle_generate';
 const PLACEHOLDER_THUMB = '/assets/frames/thumb-1x1.svg';
-const ANGLE_SURFACE = 'angle' as const;
-const ANGLE_MULTI_OUTPUT_COUNT = 4;
 
 function usdToCredits(value: number | null | undefined): number | null {
   if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return null;
@@ -105,44 +111,6 @@ type CreateAngleInitialJobParams = {
   settingsSnapshotJson: string;
   preferredCurrency: Currency | null;
 };
-
-function getAngleBillingProductKeyForEngine(engineId: AngleToolEngineId, generateBestAngles: boolean): string {
-  const family = engineId === 'qwen-multiple-angles' ? 'qwen' : 'flux';
-  return `angle-${family}-${generateBestAngles ? 'multi' : 'single'}`;
-}
-
-function buildAnglePromptSummary(params: { rotation: number; tilt: number; zoom: number }, outputCount: number): string {
-  return `Angle tool · rotation ${Math.round(params.rotation)}° · tilt ${Math.round(params.tilt)}° · zoom ${params.zoom.toFixed(1)} · ${outputCount} output${outputCount > 1 ? 's' : ''}`;
-}
-
-function buildAngleSettingsSnapshot(args: {
-  engine: AngleToolEngineDefinition;
-  imageUrl: string;
-  requested: AngleToolRequest['params'];
-  applied: AngleToolRequest['params'] & { safeMode: boolean; safeApplied: boolean };
-  generateBestAngles: boolean;
-  outputCount: number;
-  billingProductKey: string;
-}): Record<string, unknown> {
-  return {
-    schemaVersion: 1,
-    surface: ANGLE_SURFACE,
-    billingProductKey: args.billingProductKey,
-    engineId: args.engine.id,
-    engineLabel: args.engine.label,
-    inputMode: 'i2i',
-    prompt: buildAnglePromptSummary(args.applied, args.outputCount),
-    source: {
-      imageUrl: args.imageUrl,
-    },
-    controls: {
-      requested: args.requested,
-      applied: args.applied,
-      generateBestAngles: args.generateBestAngles,
-      outputCount: args.outputCount,
-    },
-  };
-}
 
 async function recordAngleRefundReceipt(receipt: PendingAngleReceipt, label: string, priceOnly: boolean) {
   try {
@@ -310,186 +278,6 @@ async function createAtomicInitialAngleJob(params: CreateAngleInitialJobParams):
   }
 }
 
-function normalizeFalUrl(value: string): string {
-  const trimmed = value.trim();
-  if (!trimmed) return trimmed;
-  if (/^https?:\/\//i.test(trimmed)) {
-    return trimmed;
-  }
-  const normalized = trimmed.replace(/^\.?\/+/, '');
-  return `https://fal.media/files/${normalized}`;
-}
-
-function toAngleOutput(entry: Record<string, unknown>): AngleToolOutput | null {
-  const urlRaw =
-    typeof entry.url === 'string'
-      ? entry.url
-      : typeof entry.image_url === 'string'
-        ? entry.image_url
-        : typeof entry.path === 'string'
-          ? entry.path
-          : null;
-  if (!urlRaw) return null;
-
-  const width = typeof entry.width === 'number' ? entry.width : null;
-  const height = typeof entry.height === 'number' ? entry.height : null;
-  const mimeType =
-    typeof entry.content_type === 'string'
-      ? entry.content_type
-      : typeof entry.mimetype === 'string'
-        ? entry.mimetype
-        : typeof entry.mime === 'string'
-          ? entry.mime
-          : null;
-
-  return {
-    url: normalizeMediaUrl(normalizeFalUrl(urlRaw)) ?? normalizeFalUrl(urlRaw),
-    width,
-    height,
-    mimeType,
-  };
-}
-
-function extractOutputs(payload: unknown): AngleToolOutput[] {
-  const roots: unknown[] = [];
-  if (payload && typeof payload === 'object') {
-    const record = payload as Record<string, unknown>;
-    roots.push(record);
-    if (record.output && typeof record.output === 'object') roots.push(record.output);
-    if (record.response && typeof record.response === 'object') roots.push(record.response);
-    if (record.data && typeof record.data === 'object') roots.push(record.data);
-  }
-
-  for (const root of roots) {
-    if (!root || typeof root !== 'object') continue;
-    const record = root as Record<string, unknown>;
-
-    if (Array.isArray(record.images)) {
-      const mapped = record.images
-        .map((entry) => (entry && typeof entry === 'object' ? toAngleOutput(entry as Record<string, unknown>) : null))
-        .filter((entry): entry is AngleToolOutput => Boolean(entry));
-      if (mapped.length) return mapped;
-    }
-
-    if (record.image && typeof record.image === 'object') {
-      const single = toAngleOutput(record.image as Record<string, unknown>);
-      if (single) return [single];
-    }
-
-    if (typeof record.url === 'string') {
-      const single = toAngleOutput(record);
-      if (single) return [single];
-    }
-  }
-
-  return [];
-}
-
-function parseRequestId(payload: unknown): string | undefined {
-  if (!payload || typeof payload !== 'object') return undefined;
-  const record = payload as Record<string, unknown>;
-  const direct = typeof record.request_id === 'string' ? record.request_id : undefined;
-  if (direct) return direct;
-  if (typeof record.id === 'string') return record.id;
-  if (record.response && typeof record.response === 'object') {
-    const responseRecord = record.response as Record<string, unknown>;
-    if (typeof responseRecord.request_id === 'string') return responseRecord.request_id;
-    if (typeof responseRecord.id === 'string') return responseRecord.id;
-  }
-  if (record.output && typeof record.output === 'object') {
-    const outputRecord = record.output as Record<string, unknown>;
-    if (typeof outputRecord.request_id === 'string') return outputRecord.request_id;
-    if (typeof outputRecord.id === 'string') return outputRecord.id;
-  }
-  return undefined;
-}
-
-function extractActualCostUsd(payload: unknown): number | null {
-  const queue: Array<{ value: unknown; depth: number }> = [{ value: payload, depth: 0 }];
-  const candidates: number[] = [];
-
-  const isCostKey = (rawKey: string): boolean => {
-    const key = rawKey.toLowerCase();
-    if (key.includes('zoom_amount')) return false;
-    return (
-      key === 'cost' ||
-      key === 'price' ||
-      key.includes('cost_usd') ||
-      key.includes('price_usd') ||
-      key.includes('actual_cost') ||
-      key.includes('estimated_cost') ||
-      key.endsWith('_usd') ||
-      key.endsWith('usd')
-    );
-  };
-
-  while (queue.length) {
-    const current = queue.shift();
-    if (!current) continue;
-    const { value, depth } = current;
-    if (depth > 5 || value == null) continue;
-
-    if (typeof value === 'string') {
-      const cleaned = value.trim();
-      const dollarMatch = cleaned.match(/\$\s*([0-9]+(?:\.[0-9]+)?)/);
-      if (dollarMatch) {
-        const parsed = Number(dollarMatch[1]);
-        if (Number.isFinite(parsed) && parsed > 0) candidates.push(parsed);
-      }
-      continue;
-    }
-
-    if (Array.isArray(value)) {
-      value.slice(0, 20).forEach((entry) => queue.push({ value: entry, depth: depth + 1 }));
-      continue;
-    }
-
-    if (typeof value === 'object') {
-      const record = value as Record<string, unknown>;
-      Object.entries(record).forEach(([key, field]) => {
-        const costLike = isCostKey(key);
-
-        if (costLike && typeof field === 'number' && Number.isFinite(field) && field > 0 && field < 10_000) {
-          candidates.push(field);
-          return;
-        }
-
-        if (costLike && typeof field === 'string') {
-          const parsed = Number(field.replace(/[^0-9.]+/g, ''));
-          if (Number.isFinite(parsed) && parsed > 0) {
-            candidates.push(parsed);
-            return;
-          }
-        }
-
-        queue.push({ value: field, depth: depth + 1 });
-      });
-    }
-  }
-
-  if (!candidates.length) return null;
-  const costCandidate = candidates.find((value) => value <= 100) ?? candidates[0];
-  return Number(costCandidate.toFixed(6));
-}
-
-function buildFalInput(
-  engine: AngleToolEngineDefinition,
-  imageUrl: string,
-  params: { rotation: number; tilt: number; zoom: number }
-) {
-  const horizontalAngle = Math.round(normalizeRotation(params.rotation));
-  const verticalAngle = Math.round(mapTiltForEngine(engine.id, params.tilt));
-  const zoomAmount = Number(params.zoom.toFixed(1));
-
-  return {
-    image_urls: [imageUrl],
-    horizontal_angle: horizontalAngle,
-    vertical_angle: verticalAngle,
-    zoom_amount: zoomAmount,
-    num_images: 1,
-  };
-}
-
 async function insertToolEvent(params: {
   jobId: string;
   engineId: AngleToolEngineId;
@@ -632,23 +420,6 @@ async function persistAngleOutputs(params: {
   );
 }
 
-function toValidationMessage(error: ValidationError): string {
-  const messages = error.fieldErrors
-    .map((entry) => {
-      const loc = Array.isArray(entry.loc) ? entry.loc.filter((part) => part !== 'body') : [];
-      const path = loc.length ? loc.join('.') : null;
-      const msg = typeof entry.msg === 'string' ? entry.msg.trim() : '';
-      if (!msg) return null;
-      return path ? `${path}: ${msg}` : msg;
-    })
-    .filter((entry): entry is string => Boolean(entry));
-
-  if (!messages.length) {
-    return error.message || 'Validation failed';
-  }
-  return messages.slice(0, 3).join(' · ');
-}
-
 export async function runAngleTool(input: RunAngleToolInput): Promise<AngleToolResponse> {
   const requested = sanitizeAngleParams(input.params);
   const safeMode = input.safeMode !== false;
@@ -741,8 +512,8 @@ export async function runAngleTool(input: RunAngleToolInput): Promise<AngleToolR
   });
 
   const falInputs = generateBestAngles
-    ? buildBestAngleVariantParams(applied).map((variant) => buildFalInput(engine, input.imageUrl, variant))
-    : [buildFalInput(engine, input.imageUrl, applied)];
+    ? buildBestAngleVariantParams(applied).map((variant) => buildAngleFalInput(engine, input.imageUrl, variant))
+    : [buildAngleFalInput(engine, input.imageUrl, applied)];
   const falClient = getFalClient();
   let providerJobId: string | null = null;
   let lastQueueUpdate: unknown = null;
@@ -768,8 +539,8 @@ export async function runAngleTool(input: RunAngleToolInput): Promise<AngleToolR
         },
       });
       results.push(result);
-      outputs.push(...extractOutputs(result.data));
-      const providerCostUsd = extractActualCostUsd(result.data) ?? extractActualCostUsd(lastQueueUpdate) ?? 0;
+      outputs.push(...extractAngleOutputs(result.data));
+      const providerCostUsd = extractAngleActualCostUsd(result.data) ?? extractAngleActualCostUsd(lastQueueUpdate) ?? 0;
       providerCostUsdTotal += providerCostUsd;
     }
 
@@ -783,7 +554,7 @@ export async function runAngleTool(input: RunAngleToolInput): Promise<AngleToolR
     const latencyMs = Date.now() - startedAt;
     const finalResult = results[results.length - 1] ?? null;
     const providerCostUsd = providerCostUsdTotal > 0 ? Number(providerCostUsdTotal.toFixed(6)) : null;
-    const requestId = providerJobId ?? (finalResult ? parseRequestId(finalResult.data) ?? finalResult.requestId ?? null : null);
+    const requestId = providerJobId ?? (finalResult ? parseAngleRequestId(finalResult.data) ?? finalResult.requestId ?? null : null);
     const persistedOutputs = await persistAngleOutputs({
       outputs,
       userId: input.userId,
@@ -943,7 +714,7 @@ export async function runAngleTool(input: RunAngleToolInput): Promise<AngleToolR
       detail = error.detail;
       code = error.code;
     } else if (error instanceof ValidationError) {
-      message = toValidationMessage(error);
+      message = toAngleValidationMessage(error);
       status = 422;
       detail = error.fieldErrors;
       code = 'validation_error';

--- a/tests/angle-server-architecture.test.ts
+++ b/tests/angle-server-architecture.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const root = process.cwd();
+const serverPath = join(root, 'frontend/src/server/tools/angle.ts');
+const requestUtilsPath = join(root, 'frontend/src/server/tools/angle-request-utils.ts');
+
+const serverSource = readFileSync(serverPath, 'utf8');
+const requestUtilsSource = readFileSync(requestUtilsPath, 'utf8');
+
+test('angle server delegates request and provider normalization helpers', () => {
+  assert.ok(existsSync(requestUtilsPath), 'angle request helpers should live in a server-local utility module');
+  assert.match(
+    serverSource,
+    /from '\.\/angle-request-utils'/,
+    'angle server orchestration should import request/provider helpers'
+  );
+
+  for (const implementationName of [
+    'getAngleBillingProductKeyForEngine',
+    'buildAnglePromptSummary',
+    'buildAngleSettingsSnapshot',
+    'normalizeFalUrl',
+    'toAngleOutput',
+    'extractOutputs',
+    'parseRequestId',
+    'extractActualCostUsd',
+    'buildFalInput',
+    'toValidationMessage',
+  ]) {
+    assert.doesNotMatch(
+      serverSource,
+      new RegExp(`function ${implementationName}\\(`),
+      `${implementationName} belongs in angle-request-utils.ts`
+    );
+  }
+
+  assert.doesNotMatch(serverSource, /normalizeMediaUrl/, 'Fal output URL normalization belongs in angle-request-utils.ts');
+
+  const lineCount = serverSource.split('\n').length;
+  assert.ok(lineCount <= 820, `angle server orchestrator should stay below 820 lines after helper extraction, got ${lineCount}`);
+});
+
+test('angle request utils expose the expected pure helper contract', () => {
+  for (const exportName of [
+    'ANGLE_SURFACE',
+    'ANGLE_MULTI_OUTPUT_COUNT',
+    'getAngleBillingProductKeyForEngine',
+    'buildAnglePromptSummary',
+    'buildAngleSettingsSnapshot',
+    'extractAngleOutputs',
+    'parseAngleRequestId',
+    'extractAngleActualCostUsd',
+    'buildAngleFalInput',
+    'toAngleValidationMessage',
+  ]) {
+    assert.match(
+      requestUtilsSource,
+      new RegExp(`export (const|function) ${exportName}`),
+      `${exportName} should be exported by angle-request-utils.ts`
+    );
+  }
+
+  assert.match(requestUtilsSource, /function normalizeFalUrl\(/, 'Fal URL normalization should be private to request helpers');
+  assert.match(requestUtilsSource, /function toAngleOutput\(/, 'provider output mapping should be private to request helpers');
+});


### PR DESCRIPTION
## Summary
- Move Angle billing key, prompt/settings snapshot, provider output parsing, request id parsing, cost extraction, Fal payload building, and validation message formatting into a server-local helper module
- Keep frontend/src/server/tools/angle.ts focused on billing, wallet, storage, persistence, and Fal orchestration
- Add an architecture contract to lock the new boundary

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/angle-server-architecture.test.ts tests/angle-atomic.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build