### PR TITLE
Split generate Fal error helpers

### DIFF
--- a/frontend/app/api/generate/_lib/fal-error-handling.ts
+++ b/frontend/app/api/generate/_lib/fal-error-handling.ts
@@ -1,0 +1,237 @@
+import { FalGenerationError } from '@/lib/fal';
+
+const TRANSIENT_FAL_STATUS_CODES = new Set([404, 408, 409, 410, 412, 425, 500, 502, 503, 504, 522, 524, 598]);
+const CONSTRAINT_ERROR_CODES = new Set([
+  'engine_constraint',
+  'invalid_input',
+  'input_invalid',
+  'validation_error',
+  'unsupported',
+  'payload_invalid',
+  'flagged_content',
+  'content_flagged',
+  'policy_violation',
+  'policy_denied',
+  'safety_violation',
+  'safety',
+]);
+
+const FAL_ERROR_FIELDS = [
+  'error_message',
+  'errorMessage',
+  'message',
+  'detail',
+  'error',
+  'reason',
+  'status_message',
+  'statusMessage',
+  'status_reason',
+  'statusReason',
+  'status_detail',
+  'statusDetail',
+  'status_description',
+  'statusDescription',
+  'description',
+  'failure',
+  'failureReason',
+  'cause',
+];
+
+export class FalTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'FalTimeoutError';
+  }
+}
+
+export function withFalTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<T>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new FalTimeoutError(`Fal request timed out after ${timeoutMs}ms`)), timeoutMs);
+  });
+
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }) as Promise<T>;
+}
+
+function normalizeFalErrorValue(value: unknown): string | null {
+  if (value == null) return null;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed.length) return null;
+    if (/^(error|failed|null|undefined)$/i.test(trimmed)) return null;
+    return trimmed;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (value instanceof Error) {
+    return normalizeFalErrorValue(value.message);
+  }
+  return null;
+}
+
+export function extractFalProviderMessage(payload: unknown): string | null {
+  if (!payload || (typeof payload !== 'object' && typeof payload !== 'string')) {
+    return normalizeFalErrorValue(payload);
+  }
+
+  const visited = new Set<unknown>();
+  const stack: unknown[] = [payload];
+
+  while (stack.length) {
+    const current = stack.pop();
+    const directText = normalizeFalErrorValue(current);
+    if (directText) return directText;
+    if (!current || typeof current !== 'object') continue;
+    if (visited.has(current)) continue;
+    visited.add(current);
+
+    const record = current as Record<string, unknown>;
+    for (const key of FAL_ERROR_FIELDS) {
+      if (key in record) {
+        const candidate = normalizeFalErrorValue(record[key]);
+        if (candidate) return candidate;
+      }
+    }
+
+    for (const value of Object.values(record)) {
+      if (value && typeof value === 'object') {
+        stack.push(value);
+      } else {
+        const candidate = normalizeFalErrorValue(value);
+        if (candidate) return candidate;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function condenseFalErrorMessage(message: string | null | undefined): string | null {
+  if (!message) return null;
+  const condensed = message.replace(/\s+/g, ' ').trim();
+  if (!condensed.length) return null;
+  return condensed.length > 400 ? `${condensed.slice(0, 400)}...` : condensed;
+}
+
+function isConstraintDetail(detail: unknown): boolean {
+  if (!detail) return false;
+  if (typeof detail === 'string') {
+    const normalized = detail.trim().toLowerCase();
+    if (!normalized.length) return false;
+    return /support|only|must|should|allowed|invalid|exceed|limit|policy|prohibit|safety|flagged|duration/.test(normalized);
+  }
+  if (Array.isArray(detail)) {
+    return (detail as unknown[]).some((entry) => isConstraintDetail(entry));
+  }
+  if (typeof detail !== 'object') return false;
+  const record = detail as Record<string, unknown>;
+  const codes: Array<unknown> = [
+    record.code,
+    record.error_code,
+    record.errorCode,
+    record.status_code,
+    record.statusCode,
+  ];
+  for (const candidate of codes) {
+    if (typeof candidate !== 'string') continue;
+    const normalized = candidate.trim().toLowerCase();
+    if (CONSTRAINT_ERROR_CODES.has(normalized)) {
+      return true;
+    }
+  }
+  if (Array.isArray(record.errors) && record.errors.length) return true;
+  if ('field' in record || 'allowed' in record || 'allowed_values' in record) return true;
+  return false;
+}
+
+function isSafetyMessage(message: string | null | undefined): boolean {
+  if (!message) return false;
+  const normalized = message.trim().toLowerCase();
+  if (!normalized) return false;
+  return (
+    normalized.includes('content could not be processed') ||
+    normalized.includes('flagged by a content checker') ||
+    normalized.includes('policy violation') ||
+    normalized.includes('safety system') ||
+    normalized.includes('not allowed') ||
+    normalized.includes('violates') ||
+    normalized.includes('prohibited')
+  );
+}
+
+function isConstraintMessage(message: string | null | undefined): boolean {
+  if (!message) return false;
+  const normalized = message.trim().toLowerCase();
+  if (!normalized.length) return false;
+  return (
+    normalized.includes('not supported') ||
+    normalized.includes('unsupported') ||
+    normalized.includes('only supported') ||
+    normalized.includes('only support') ||
+    normalized.includes('must be') ||
+    normalized.includes('should be') ||
+    normalized.includes('must provide') ||
+    normalized.includes('allowed values') ||
+    normalized.includes('invalid value') ||
+    normalized.includes('duration') ||
+    normalized.includes('exceeds')
+  );
+}
+
+type FalErrorMetadata = {
+  error: unknown;
+  status?: number | null;
+  detail?: unknown;
+  providerMessage?: string | null;
+  providerJobId?: string | null;
+  attempt?: number;
+  maxAttempts?: number;
+};
+
+export function shouldDeferFalError(meta: FalErrorMetadata): boolean {
+  if (!(meta.error instanceof FalGenerationError)) {
+    return false;
+  }
+
+  const providerJobId = meta.providerJobId ?? meta.error.providerJobId ?? null;
+  if (!providerJobId) return false;
+
+  const status = typeof meta.status === 'number' ? meta.status : meta.error.status;
+  if (status === 429 || status === 401 || status === 403) {
+    return false;
+  }
+
+  const fallbackProviderMessage =
+    meta.providerMessage ?? (meta.error instanceof Error ? meta.error.message : null);
+  const message = condenseFalErrorMessage(normalizeFalErrorValue(fallbackProviderMessage));
+  if (isSafetyMessage(message)) {
+    return false;
+  }
+
+  if (status === 422) {
+    if (isConstraintDetail(meta.detail) || isConstraintMessage(message)) {
+      return false;
+    }
+    if (message && /timeout|timed out|try again|queued|in progress|pending|not ready|still processing|rate limited/i.test(message)) {
+      return true;
+    }
+    return false;
+  }
+
+  if (typeof status === 'number' && (TRANSIENT_FAL_STATUS_CODES.has(status) || status === 422 || status === 404)) {
+    return true;
+  }
+
+  if (message) {
+    return /timeout|timed out|try again|queued|in progress|pending|not ready|still processing|rate limited/i.test(
+      message
+    );
+  }
+
+  return false;
+}

--- a/frontend/app/api/generate/route.ts
+++ b/frontend/app/api/generate/route.ts
@@ -14,6 +14,13 @@ import { reserveWalletChargeInExecutor } from '@/lib/wallet';
 import { normalizeMediaUrl } from '@/lib/media';
 import type { Mode } from '@/types/engines';
 import { validateRequest } from './_lib/validate';
+import {
+  condenseFalErrorMessage,
+  extractFalProviderMessage,
+  FalTimeoutError,
+  shouldDeferFalError,
+  withFalTimeout,
+} from './_lib/fal-error-handling';
 import { uploadImageToStorage, isAllowedAssetHost, probeImageUrl, recordUserAsset } from '@/server/storage';
 import {
   buildNextProviderVideoCopyState,
@@ -78,29 +85,6 @@ const FAL_RETRY_DELAYS_MS = [5_000, 15_000, 30_000];
 const FAL_HARD_TIMEOUT_MS = 400_000;
 const FAL_PROGRESS_FLOOR = 10;
 
-const TRANSIENT_FAL_STATUS_CODES = new Set([404, 408, 409, 410, 412, 425, 500, 502, 503, 504, 522, 524, 598]);
-const CONSTRAINT_ERROR_CODES = new Set([
-  'engine_constraint',
-  'invalid_input',
-  'input_invalid',
-  'validation_error',
-  'unsupported',
-  'payload_invalid',
-  'flagged_content',
-  'content_flagged',
-  'policy_violation',
-  'policy_denied',
-  'safety_violation',
-  'safety',
-]);
-
-class FalTimeoutError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'FalTimeoutError';
-  }
-}
-
 class VideoInitialJobError extends Error {
   status: number;
   body: Record<string, unknown>;
@@ -126,19 +110,6 @@ class VideoInitialJobError extends Error {
     this.metricCode = options.metricCode;
     this.metricMeta = options.metricMeta;
   }
-}
-
-function withFalTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  let timeoutId: ReturnType<typeof setTimeout> | null = null;
-  const timeoutPromise = new Promise<T>((_, reject) => {
-    timeoutId = setTimeout(() => reject(new FalTimeoutError(`Fal request timed out after ${timeoutMs}ms`)), timeoutMs);
-  });
-
-  return Promise.race([promise, timeoutPromise]).finally(() => {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-    }
-  }) as Promise<T>;
 }
 
 function isVideoMode(value: unknown): value is VideoMode {
@@ -196,81 +167,6 @@ async function resolveUserId(req?: NextRequest): Promise<string | null> {
   return null;
 }
 
-const FAL_ERROR_FIELDS = [
-  'error_message',
-  'errorMessage',
-  'message',
-  'detail',
-  'error',
-  'reason',
-  'status_message',
-  'statusMessage',
-  'status_reason',
-  'statusReason',
-  'status_detail',
-  'statusDetail',
-  'status_description',
-  'statusDescription',
-  'description',
-  'failure',
-  'failureReason',
-  'cause',
-];
-
-function normalizeFalErrorValue(value: unknown): string | null {
-  if (value == null) return null;
-  if (typeof value === 'string') {
-    const trimmed = value.trim();
-    if (!trimmed.length) return null;
-    if (/^(error|failed|null|undefined)$/i.test(trimmed)) return null;
-    return trimmed;
-  }
-  if (typeof value === 'number' || typeof value === 'boolean') {
-    return String(value);
-  }
-  if (value instanceof Error) {
-    return normalizeFalErrorValue(value.message);
-  }
-  return null;
-}
-
-function extractFalProviderMessage(payload: unknown): string | null {
-  if (!payload || (typeof payload !== 'object' && typeof payload !== 'string')) {
-    return normalizeFalErrorValue(payload);
-  }
-
-  const visited = new Set<unknown>();
-  const stack: unknown[] = [payload];
-
-  while (stack.length) {
-    const current = stack.pop();
-    const directText = normalizeFalErrorValue(current);
-    if (directText) return directText;
-    if (!current || typeof current !== 'object') continue;
-    if (visited.has(current)) continue;
-    visited.add(current);
-
-    const record = current as Record<string, unknown>;
-    for (const key of FAL_ERROR_FIELDS) {
-      if (key in record) {
-        const candidate = normalizeFalErrorValue(record[key]);
-        if (candidate) return candidate;
-      }
-    }
-
-    for (const value of Object.values(record)) {
-      if (value && typeof value === 'object') {
-        stack.push(value);
-      } else {
-        const candidate = normalizeFalErrorValue(value);
-        if (candidate) return candidate;
-      }
-    }
-  }
-
-  return null;
-}
-
 function buildReceiptSnapshot(pricing: PricingSnapshot): Record<string, unknown> {
   const snapshot: Record<string, unknown> = {
     totalCents: pricing.totalCents,
@@ -300,131 +196,6 @@ function buildReceiptSnapshot(pricing: PricingSnapshot): Record<string, unknown>
   }
 
   return snapshot;
-}
-
-function condenseFalErrorMessage(message: string | null | undefined): string | null {
-  if (!message) return null;
-  const condensed = message.replace(/\s+/g, ' ').trim();
-  if (!condensed.length) return null;
-  return condensed.length > 400 ? `${condensed.slice(0, 400)}...` : condensed;
-}
-
-function isConstraintDetail(detail: unknown): boolean {
-  if (!detail) return false;
-  if (typeof detail === 'string') {
-    const normalized = detail.trim().toLowerCase();
-    if (!normalized.length) return false;
-    return /support|only|must|should|allowed|invalid|exceed|limit|policy|prohibit|safety|flagged|duration/.test(normalized);
-  }
-  if (Array.isArray(detail)) {
-    return (detail as unknown[]).some((entry) => isConstraintDetail(entry));
-  }
-  if (typeof detail !== 'object') return false;
-  const record = detail as Record<string, unknown>;
-  const codes: Array<unknown> = [
-    record.code,
-    record.error_code,
-    record.errorCode,
-    record.status_code,
-    record.statusCode,
-  ];
-  for (const candidate of codes) {
-    if (typeof candidate !== 'string') continue;
-    const normalized = candidate.trim().toLowerCase();
-    if (CONSTRAINT_ERROR_CODES.has(normalized)) {
-      return true;
-    }
-  }
-  if (Array.isArray(record.errors) && record.errors.length) return true;
-  if ('field' in record || 'allowed' in record || 'allowed_values' in record) return true;
-  return false;
-}
-
-function isSafetyMessage(message: string | null | undefined): boolean {
-  if (!message) return false;
-  const normalized = message.trim().toLowerCase();
-  if (!normalized) return false;
-  return (
-    normalized.includes('content could not be processed') ||
-    normalized.includes('flagged by a content checker') ||
-    normalized.includes('policy violation') ||
-    normalized.includes('safety system') ||
-    normalized.includes('not allowed') ||
-    normalized.includes('violates') ||
-    normalized.includes('prohibited')
-  );
-}
-
-function isConstraintMessage(message: string | null | undefined): boolean {
-  if (!message) return false;
-  const normalized = message.trim().toLowerCase();
-  if (!normalized.length) return false;
-  return (
-    normalized.includes('not supported') ||
-    normalized.includes('unsupported') ||
-    normalized.includes('only supported') ||
-    normalized.includes('only support') ||
-    normalized.includes('must be') ||
-    normalized.includes('should be') ||
-    normalized.includes('must provide') ||
-    normalized.includes('allowed values') ||
-    normalized.includes('invalid value') ||
-    normalized.includes('duration') ||
-    normalized.includes('exceeds')
-  );
-}
-
-type FalErrorMetadata = {
-  error: unknown;
-  status?: number | null;
-  detail?: unknown;
-  providerMessage?: string | null;
-  providerJobId?: string | null;
-  attempt?: number;
-  maxAttempts?: number;
-};
-
-function shouldDeferFalError(meta: FalErrorMetadata): boolean {
-  if (!(meta.error instanceof FalGenerationError)) {
-    return false;
-  }
-
-  const providerJobId = meta.providerJobId ?? meta.error.providerJobId ?? null;
-  if (!providerJobId) return false;
-
-  const status = typeof meta.status === 'number' ? meta.status : meta.error.status;
-  if (status === 429 || status === 401 || status === 403) {
-    return false;
-  }
-
-  const fallbackProviderMessage =
-    meta.providerMessage ?? (meta.error instanceof Error ? meta.error.message : null);
-  const message = condenseFalErrorMessage(normalizeFalErrorValue(fallbackProviderMessage));
-  if (isSafetyMessage(message)) {
-    return false;
-  }
-
-  if (status === 422) {
-    if (isConstraintDetail(meta.detail) || isConstraintMessage(message)) {
-      return false;
-    }
-    if (message && /timeout|timed out|try again|queued|in progress|pending|not ready|still processing|rate limited/i.test(message)) {
-      return true;
-    }
-    return false;
-  }
-
-  if (typeof status === 'number' && (TRANSIENT_FAL_STATUS_CODES.has(status) || status === 422 || status === 404)) {
-    return true;
-  }
-
-  if (message) {
-    return /timeout|timed out|try again|queued|in progress|pending|not ready|still processing|rate limited/i.test(
-      message
-    );
-  }
-
-  return false;
 }
 
 async function markJobAwaitingFal(params: {

--- a/tests/generate-fal-error-handling.test.ts
+++ b/tests/generate-fal-error-handling.test.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { FalGenerationError } from '../frontend/src/lib/fal';
+import {
+  condenseFalErrorMessage,
+  extractFalProviderMessage,
+  FalTimeoutError,
+  shouldDeferFalError,
+  withFalTimeout,
+} from '../frontend/app/api/generate/_lib/fal-error-handling';
+
+const root = process.cwd();
+const routePath = join(root, 'frontend/app/api/generate/route.ts');
+const helperPath = join(root, 'frontend/app/api/generate/_lib/fal-error-handling.ts');
+
+const routeSource = readFileSync(routePath, 'utf8');
+const helperSource = readFileSync(helperPath, 'utf8');
+
+test('generate route delegates Fal error handling helpers', () => {
+  assert.ok(existsSync(helperPath), 'Fal error helpers should live in the generate route _lib folder');
+  assert.match(routeSource, /from '\.\/_lib\/fal-error-handling'/);
+
+  for (const implementationName of [
+    'normalizeFalErrorValue',
+    'extractFalProviderMessage',
+    'condenseFalErrorMessage',
+    'isConstraintDetail',
+    'isSafetyMessage',
+    'isConstraintMessage',
+    'shouldDeferFalError',
+    'withFalTimeout',
+  ]) {
+    assert.doesNotMatch(
+      routeSource,
+      new RegExp(`function ${implementationName}\\(`),
+      `${implementationName} belongs in fal-error-handling.ts`
+    );
+  }
+
+  assert.doesNotMatch(routeSource, /class FalTimeoutError/, 'Fal timeout error belongs in fal-error-handling.ts');
+  assert.doesNotMatch(routeSource, /FAL_ERROR_FIELDS/, 'Fal provider error field mapping belongs in fal-error-handling.ts');
+  assert.doesNotMatch(routeSource, /CONSTRAINT_ERROR_CODES/, 'constraint code mapping belongs in fal-error-handling.ts');
+  assert.doesNotMatch(routeSource, /TRANSIENT_FAL_STATUS_CODES/, 'transient status mapping belongs in fal-error-handling.ts');
+
+  const lineCount = routeSource.split('\n').length;
+  assert.ok(lineCount <= 3000, `/api/generate route should stay below 3000 lines after error helper extraction, got ${lineCount}`);
+});
+
+test('Fal error helper module exposes the route contract', () => {
+  for (const exportName of [
+    'withFalTimeout',
+    'extractFalProviderMessage',
+    'condenseFalErrorMessage',
+    'shouldDeferFalError',
+  ]) {
+    assert.match(
+      helperSource,
+      new RegExp(`export function ${exportName}`),
+      `${exportName} should be exported by fal-error-handling.ts`
+    );
+  }
+
+  assert.match(helperSource, /export class FalTimeoutError/, 'FalTimeoutError should be exported by fal-error-handling.ts');
+  assert.match(helperSource, /const FAL_ERROR_FIELDS/, 'provider message key mapping should live with extraction');
+  assert.match(helperSource, /const TRANSIENT_FAL_STATUS_CODES/, 'transient Fal status mapping should live with deferral logic');
+  assert.match(helperSource, /const CONSTRAINT_ERROR_CODES/, 'constraint code mapping should live with deferral logic');
+});
+
+test('Fal provider message extraction and deferral behavior stays intact', async () => {
+  assert.equal(
+    extractFalProviderMessage({ response: { errors: [{ detail: 'Provider is still processing the request' }] } }),
+    'Provider is still processing the request'
+  );
+  assert.equal(condenseFalErrorMessage('  one\n\n two\tthree  '), 'one two three');
+  assert.equal(condenseFalErrorMessage('x'.repeat(450)), `${'x'.repeat(400)}...`);
+
+  const transientError = new FalGenerationError('Fal request failed', {
+    status: 500,
+    providerJobId: 'fal_job_123',
+  });
+  assert.equal(
+    shouldDeferFalError({
+      error: transientError,
+      status: 500,
+      providerMessage: 'still processing',
+      providerJobId: 'fal_job_123',
+    }),
+    true
+  );
+
+  const constraintError = new FalGenerationError('Fal request failed', {
+    status: 422,
+    body: { code: 'invalid_input' },
+    providerJobId: 'fal_job_123',
+  });
+  assert.equal(
+    shouldDeferFalError({
+      error: constraintError,
+      status: 422,
+      detail: { code: 'invalid_input' },
+      providerMessage: 'invalid input',
+      providerJobId: 'fal_job_123',
+    }),
+    false
+  );
+
+  await assert.rejects(
+    () => withFalTimeout(new Promise(() => undefined), 1),
+    FalTimeoutError
+  );
+});


### PR DESCRIPTION
## Summary
- Move Fal timeout, provider error message extraction, error message condensation, and deferred Fal error classification out of the 3k-line /api/generate route
- Keep /api/generate focused on request orchestration while preserving existing Fal timeout/defer behavior
- Add architecture and behavior coverage for the new helper boundary

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-fal-error-handling.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build