### PR TITLE
Split generate payment rollback helpers

### DIFF
--- a/frontend/app/api/generate/_lib/payment-rollback.ts
+++ b/frontend/app/api/generate/_lib/payment-rollback.ts
@@ -1,0 +1,109 @@
+import Stripe from 'stripe';
+
+import { query } from '@/lib/db';
+import { ENV, receiptsPriceOnlyEnabled } from '@/lib/env';
+import type { PendingReceipt } from './initial-video-job';
+
+export async function recordRefundReceipt(
+  receipt: PendingReceipt,
+  description: string,
+  stripeRefundId: string | null
+): Promise<void> {
+  const priceOnly = receiptsPriceOnlyEnabled();
+  if (!receipt.jobId) return;
+  try {
+    const existing = await query<{ id: string }>(
+      `SELECT id FROM app_receipts WHERE job_id = $1 AND type = 'refund' LIMIT 1`,
+      [receipt.jobId]
+    );
+    if (existing.length) return;
+  } catch (error) {
+    console.warn('[receipts] failed to check existing refund', error);
+    return;
+  }
+
+  try {
+    await query(
+      `INSERT INTO app_receipts (
+         user_id,
+         type,
+         amount_cents,
+         currency,
+         description,
+         job_id,
+         pricing_snapshot,
+         application_fee_cents,
+         vendor_account_id,
+         stripe_payment_intent_id,
+         stripe_charge_id,
+         stripe_refund_id,
+         platform_revenue_cents,
+         destination_acct
+       )
+       VALUES (
+         $1,'refund',$2,$3,$4,$5,$6::jsonb,$7,$8,$9,$10,$11,$12,$13
+       )
+       ON CONFLICT DO NOTHING`,
+      [
+        receipt.userId,
+        receipt.amountCents,
+        receipt.currency,
+        description,
+        receipt.jobId,
+        JSON.stringify(receipt.snapshot),
+        priceOnly ? null : 0,
+        priceOnly ? null : receipt.vendorAccountId,
+        receipt.stripePaymentIntentId ?? null,
+        receipt.stripeChargeId ?? null,
+        stripeRefundId ?? null,
+        priceOnly ? null : 0,
+        priceOnly ? null : receipt.vendorAccountId,
+      ]
+    );
+  } catch (error) {
+    console.warn('[receipts] failed to record refund', error);
+  }
+}
+
+async function issueStripeRefund(receipt: PendingReceipt): Promise<string | null> {
+  const refundReference = receipt.stripePaymentIntentId ?? receipt.stripeChargeId;
+  if (!refundReference) return null;
+  if (!ENV.STRIPE_SECRET_KEY) {
+    console.warn('[stripe] unable to refund: STRIPE_SECRET_KEY missing');
+    return null;
+  }
+  try {
+    const stripe = new Stripe(ENV.STRIPE_SECRET_KEY, { apiVersion: '2023-10-16' });
+    const params = receipt.stripePaymentIntentId
+      ? { payment_intent: receipt.stripePaymentIntentId }
+      : { charge: receipt.stripeChargeId! };
+    const idempotencyKey = receipt.jobId ? `job-refund-${receipt.jobId}` : undefined;
+    const refund = await stripe.refunds.create(
+      params,
+      idempotencyKey ? { idempotencyKey } : undefined
+    );
+    return refund?.id ?? null;
+  } catch (error) {
+    console.warn('[stripe] refund failed', error);
+    return null;
+  }
+}
+
+export async function rollbackPendingPayment(params: {
+  pendingReceipt: PendingReceipt | null;
+  walletChargeReserved: boolean;
+  refundDescription: string;
+}): Promise<void> {
+  const { pendingReceipt, walletChargeReserved, refundDescription } = params;
+  if (!pendingReceipt) return;
+  try {
+    if (walletChargeReserved) {
+      await recordRefundReceipt(pendingReceipt, refundDescription, null);
+      return;
+    }
+    const refundId = await issueStripeRefund(pendingReceipt);
+    await recordRefundReceipt(pendingReceipt, refundDescription, refundId);
+  } catch (error) {
+    console.warn('[payments] failed to rollback pending payment', error);
+  }
+}

--- a/frontend/app/api/generate/route.ts
+++ b/frontend/app/api/generate/route.ts
@@ -28,6 +28,7 @@ import {
   type PaymentMode,
   type PendingReceipt,
 } from './_lib/initial-video-job';
+import { rollbackPendingPayment } from './_lib/payment-rollback';
 import { uploadImageToStorage, isAllowedAssetHost, probeImageUrl, recordUserAsset } from '@/server/storage';
 import {
   buildNextProviderVideoCopyState,
@@ -802,110 +803,6 @@ export async function POST(req: NextRequest) {
   const applicationFeeCents = getPlatformFeeCents(pricing);
   const visibility: 'public' | 'private' = 'private';
   const indexable = false;
-
-async function recordRefundReceipt(
-  receipt: PendingReceipt,
-  description: string,
-  stripeRefundId: string | null
-): Promise<void> {
-  const priceOnly = receiptsPriceOnlyEnabled();
-  if (!receipt.jobId) return;
-  try {
-    const existing = await query<{ id: string }>(
-      `SELECT id FROM app_receipts WHERE job_id = $1 AND type = 'refund' LIMIT 1`,
-      [receipt.jobId]
-    );
-    if (existing.length) return;
-  } catch (error) {
-    console.warn('[receipts] failed to check existing refund', error);
-    return;
-  }
-
-  try {
-    await query(
-      `INSERT INTO app_receipts (
-         user_id,
-         type,
-         amount_cents,
-         currency,
-         description,
-         job_id,
-         pricing_snapshot,
-         application_fee_cents,
-         vendor_account_id,
-         stripe_payment_intent_id,
-         stripe_charge_id,
-         stripe_refund_id,
-         platform_revenue_cents,
-         destination_acct
-       )
-       VALUES (
-         $1,'refund',$2,$3,$4,$5,$6::jsonb,$7,$8,$9,$10,$11,$12,$13
-       )
-       ON CONFLICT DO NOTHING`,
-      [
-        receipt.userId,
-        receipt.amountCents,
-        receipt.currency,
-        description,
-        receipt.jobId,
-        JSON.stringify(receipt.snapshot),
-        priceOnly ? null : 0,
-        priceOnly ? null : receipt.vendorAccountId,
-        receipt.stripePaymentIntentId ?? null,
-        receipt.stripeChargeId ?? null,
-        stripeRefundId ?? null,
-        priceOnly ? null : 0,
-        priceOnly ? null : receipt.vendorAccountId,
-      ]
-    );
-  } catch (error) {
-    console.warn('[receipts] failed to record refund', error);
-  }
-}
-
-async function issueStripeRefund(receipt: PendingReceipt): Promise<string | null> {
-  const refundReference = receipt.stripePaymentIntentId ?? receipt.stripeChargeId;
-  if (!refundReference) return null;
-  if (!ENV.STRIPE_SECRET_KEY) {
-    console.warn('[stripe] unable to refund: STRIPE_SECRET_KEY missing');
-    return null;
-  }
-  try {
-    const stripe = new Stripe(ENV.STRIPE_SECRET_KEY, { apiVersion: '2023-10-16' });
-    const params = receipt.stripePaymentIntentId
-      ? { payment_intent: receipt.stripePaymentIntentId }
-      : { charge: receipt.stripeChargeId! };
-    const idempotencyKey = receipt.jobId ? `job-refund-${receipt.jobId}` : undefined;
-    const refund = await stripe.refunds.create(
-      params,
-      idempotencyKey ? { idempotencyKey } : undefined
-    );
-    return refund?.id ?? null;
-  } catch (error) {
-    console.warn('[stripe] refund failed', error);
-    return null;
-  }
-}
-
-async function rollbackPendingPayment(params: {
-  pendingReceipt: PendingReceipt | null;
-  walletChargeReserved: boolean;
-  refundDescription: string;
-}): Promise<void> {
-  const { pendingReceipt, walletChargeReserved, refundDescription } = params;
-  if (!pendingReceipt) return;
-  try {
-    if (walletChargeReserved) {
-      await recordRefundReceipt(pendingReceipt, refundDescription, null);
-      return;
-    }
-    const refundId = await issueStripeRefund(pendingReceipt);
-    await recordRefundReceipt(pendingReceipt, refundDescription, refundId);
-  } catch (error) {
-    console.warn('[payments] failed to rollback pending payment', error);
-  }
-}
 
   let pendingReceipt: PendingReceipt | null = null;
   let paymentStatus: string = 'platform';
@@ -2118,12 +2015,11 @@ async function rollbackPendingPayment(params: {
     }
 
     if (pendingReceipt && !isTimeoutError) {
-      if (walletChargeReserved) {
-        await recordRefundReceipt(pendingReceipt, refundDescription, null);
-      } else {
-        const refundId = await issueStripeRefund(pendingReceipt);
-        await recordRefundReceipt(pendingReceipt, refundDescription, refundId);
-      }
+      await rollbackPendingPayment({
+        pendingReceipt,
+        walletChargeReserved,
+        refundDescription,
+      });
     }
 
     if (status === 422) {
@@ -2252,12 +2148,11 @@ async function rollbackPendingPayment(params: {
 
     if (pendingReceipt) {
       const refundDescription = `Refund ${engine.label} - ${durationSec}s - missing provider_job_id`;
-      if (walletChargeReserved) {
-        await recordRefundReceipt(pendingReceipt, refundDescription, null);
-      } else {
-        const refundId = await issueStripeRefund(pendingReceipt);
-        await recordRefundReceipt(pendingReceipt, refundDescription, refundId);
-      }
+      await rollbackPendingPayment({
+        pendingReceipt,
+        walletChargeReserved,
+        refundDescription,
+      });
     }
 
     return NextResponse.json(

--- a/tests/generate-payment-rollback-architecture.test.ts
+++ b/tests/generate-payment-rollback-architecture.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const root = process.cwd();
+const routePath = join(root, 'frontend/app/api/generate/route.ts');
+const helperPath = join(root, 'frontend/app/api/generate/_lib/payment-rollback.ts');
+
+const routeSource = readFileSync(routePath, 'utf8');
+const helperSource = readFileSync(helperPath, 'utf8');
+
+test('generate route delegates payment rollback helpers', () => {
+  assert.ok(existsSync(helperPath), 'payment rollback helpers should live in the generate route _lib folder');
+  assert.match(routeSource, /from '\.\/_lib\/payment-rollback'/);
+
+  for (const implementationName of [
+    'recordRefundReceipt',
+    'issueStripeRefund',
+    'rollbackPendingPayment',
+  ]) {
+    assert.doesNotMatch(
+      routeSource,
+      new RegExp(`function ${implementationName}\\(`),
+      `${implementationName} belongs in payment-rollback.ts`
+    );
+  }
+
+  assert.doesNotMatch(routeSource, /stripe\.refunds\.create/, 'Stripe refund creation belongs in payment-rollback.ts');
+
+  const lineCount = routeSource.split('\n').length;
+  assert.ok(lineCount <= 2500, `/api/generate route should stay below 2500 lines after payment rollback extraction, got ${lineCount}`);
+});
+
+test('payment rollback helper exposes the route contract', () => {
+  assert.match(helperSource, /export async function recordRefundReceipt/, 'recordRefundReceipt should be exported');
+  assert.match(helperSource, /export async function rollbackPendingPayment/, 'rollbackPendingPayment should be exported');
+  assert.match(helperSource, /async function issueStripeRefund/, 'Stripe refund issue helper should stay private');
+  assert.match(helperSource, /receiptsPriceOnlyEnabled/, 'refund receipts should preserve price-only behavior');
+  assert.match(helperSource, /stripe\.refunds\.create/, 'Stripe refund creation should live with rollback');
+  assert.match(helperSource, /INSERT INTO app_receipts/, 'refund receipt insert should live with rollback');
+});


### PR DESCRIPTION
## Summary
- Move refund receipt persistence, Stripe refund creation, and pending payment rollback out of /api/generate into a route-local _lib helper
- Route Fal failure branches through rollbackPendingPayment instead of reaching into Stripe refund internals directly
- Add an architecture contract for the payment rollback boundary

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-payment-rollback-architecture.test.ts tests/generate-initial-video-job-architecture.test.ts tests/generate-fal-error-handling.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build