### PR TITLE
Split generate extra input validation

### DIFF
--- a/frontend/app/api/generate/_lib/extra-input-values.ts
+++ b/frontend/app/api/generate/_lib/extra-input-values.ts
@@ -1,0 +1,157 @@
+import type { EngineCaps, EngineInputField, Mode } from '@/types/engines';
+
+type ExtraInputField = {
+  id: string;
+  type: Extract<EngineInputField['type'], 'text' | 'number' | 'enum'>;
+  required: boolean;
+  values?: Array<string | number>;
+};
+
+type ExtraInputValidationErrorBody = {
+  ok: false;
+  error: 'INVALID_EXTRA_FIELD' | 'MISSING_EXTRA_FIELD';
+  field: string;
+  message: string;
+};
+
+type ExtraInputValidationResult =
+  | {
+      ok: true;
+      values: Record<string, unknown>;
+    }
+  | {
+      ok: false;
+      status: 400;
+      body: ExtraInputValidationErrorBody;
+    };
+
+function normalizeFieldId(value: string | undefined): string {
+  return (value ?? '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+const STANDARD_INPUT_FIELD_IDS = new Set([
+  'prompt',
+  'negativeprompt',
+  'duration',
+  'durationseconds',
+  'resolution',
+  'aspectratio',
+  'fps',
+  'generateaudio',
+  'seed',
+  'camerafixed',
+  'enablesafetychecker',
+  'cfgscale',
+  'loop',
+]);
+
+function getApplicableExtraInputFields(engine: Pick<EngineCaps, 'inputSchema'>, mode: Mode): ExtraInputField[] {
+  const schema = engine.inputSchema;
+  if (!schema) return [];
+
+  return [...(schema.required ?? []), ...(schema.optional ?? [])]
+    .filter((field) => !field.modes || field.modes.includes(mode))
+    .filter(
+      (field): field is EngineInputField & { type: 'text' | 'number' | 'enum' } =>
+        field.type === 'text' || field.type === 'number' || field.type === 'enum'
+    )
+    .filter((field) => !STANDARD_INPUT_FIELD_IDS.has(normalizeFieldId(field.id)))
+    .map((field) => ({
+      id: field.id,
+      type: field.type,
+      required: Boolean(field.requiredInModes ? field.requiredInModes.includes(mode) : (schema.required ?? []).includes(field)),
+      values: field.values,
+    }));
+}
+
+export function validateExtraInputValues(params: {
+  engine: Pick<EngineCaps, 'inputSchema'>;
+  mode: Mode;
+  rawExtraInputValues: Record<string, unknown> | null;
+}): ExtraInputValidationResult {
+  const applicableSchemaFields = getApplicableExtraInputFields(params.engine, params.mode);
+  const applicableFieldMap = new Map(applicableSchemaFields.map((field) => [field.id, field]));
+  const validatedExtraInputValues: Record<string, unknown> = {};
+
+  if (params.rawExtraInputValues) {
+    for (const [key, rawValue] of Object.entries(params.rawExtraInputValues)) {
+      const schemaField = applicableFieldMap.get(key);
+      if (!schemaField) {
+        return {
+          ok: false,
+          status: 400,
+          body: {
+            ok: false,
+            error: 'INVALID_EXTRA_FIELD',
+            field: key,
+            message: `Unsupported input field "${key}" for this mode.`,
+          },
+        };
+      }
+
+      if (schemaField.type === 'number') {
+        const parsed =
+          typeof rawValue === 'number'
+            ? rawValue
+            : typeof rawValue === 'string' && rawValue.trim().length
+              ? Number(rawValue.trim())
+              : Number.NaN;
+        if (!Number.isFinite(parsed)) {
+          return {
+            ok: false,
+            status: 400,
+            body: { ok: false, error: 'INVALID_EXTRA_FIELD', field: key, message: `${key} must be a number.` },
+          };
+        }
+        validatedExtraInputValues[key] = parsed;
+        continue;
+      }
+
+      if (schemaField.type === 'enum') {
+        const parsed = typeof rawValue === 'number' ? rawValue : typeof rawValue === 'string' ? rawValue.trim() : '';
+        if (parsed === '') {
+          continue;
+        }
+        if (Array.isArray(schemaField.values) && !schemaField.values.some((value) => String(value) === String(parsed))) {
+          return {
+            ok: false,
+            status: 400,
+            body: {
+              ok: false,
+              error: 'INVALID_EXTRA_FIELD',
+              field: key,
+              message: `${key} must be one of ${(schemaField.values ?? []).join(', ')}.`,
+            },
+          };
+        }
+        validatedExtraInputValues[key] = parsed;
+        continue;
+      }
+
+      if (schemaField.type === 'text') {
+        const parsed = typeof rawValue === 'string' ? rawValue.trim() : '';
+        if (!parsed) {
+          continue;
+        }
+        validatedExtraInputValues[key] = parsed;
+      }
+    }
+  }
+
+  for (const field of applicableSchemaFields) {
+    if (field.required && validatedExtraInputValues[field.id] == null) {
+      return {
+        ok: false,
+        status: 400,
+        body: {
+          ok: false,
+          error: 'MISSING_EXTRA_FIELD',
+          field: field.id,
+          message: `${field.id} is required for this mode.`,
+        },
+      };
+    }
+  }
+
+  return { ok: true, values: validatedExtraInputValues };
+}

--- a/frontend/app/api/generate/route.ts
+++ b/frontend/app/api/generate/route.ts
@@ -20,6 +20,7 @@ import {
   shouldDeferFalError,
   withFalTimeout,
 } from './_lib/fal-error-handling';
+import { validateExtraInputValues } from './_lib/extra-input-values';
 import {
   buildResponseFromExistingVideoJob,
   createAtomicInitialVideoJob,
@@ -107,26 +108,6 @@ function isVideoMode(value: unknown): value is VideoMode {
     value === 'reframe'
   );
 }
-
-function normalizeFieldId(value: string | undefined): string {
-  return (value ?? '').toLowerCase().replace(/[^a-z0-9]/g, '');
-}
-
-const STANDARD_INPUT_FIELD_IDS = new Set([
-  'prompt',
-  'negativeprompt',
-  'duration',
-  'durationseconds',
-  'resolution',
-  'aspectratio',
-  'fps',
-  'generateaudio',
-  'seed',
-  'camerafixed',
-  'enablesafetychecker',
-  'cfgscale',
-  'loop',
-]);
 
 async function resolveUserId(req?: NextRequest): Promise<string | null> {
   try {
@@ -810,85 +791,11 @@ export async function POST(req: NextRequest) {
   let stripeChargeId: string | null = null;
   let walletChargeReserved = false;
 
-  const applicableSchemaFields = (() => {
-    const schema = engine.inputSchema;
-    if (!schema) return [] as Array<{ id: string; type: string; required: boolean; values?: Array<string | number> }>;
-    return [...(schema.required ?? []), ...(schema.optional ?? [])]
-      .filter((field) => !field.modes || field.modes.includes(mode))
-      .filter((field) => field.type === 'text' || field.type === 'number' || field.type === 'enum')
-      .filter((field) => !STANDARD_INPUT_FIELD_IDS.has(normalizeFieldId(field.id)))
-      .map((field) => ({
-        id: field.id,
-        type: field.type,
-        required: Boolean(field.requiredInModes ? field.requiredInModes.includes(mode) : (schema.required ?? []).includes(field)),
-        values: field.values,
-      }));
-  })();
-
-  const applicableFieldMap = new Map(applicableSchemaFields.map((field) => [field.id, field]));
-  const validatedExtraInputValues: Record<string, unknown> = {};
-  if (rawExtraInputValues) {
-    for (const [key, rawValue] of Object.entries(rawExtraInputValues)) {
-      const schemaField = applicableFieldMap.get(key);
-      if (!schemaField) {
-        return NextResponse.json(
-          { ok: false, error: 'INVALID_EXTRA_FIELD', field: key, message: `Unsupported input field "${key}" for this mode.` },
-          { status: 400 }
-        );
-      }
-      if (schemaField.type === 'number') {
-        const parsed =
-          typeof rawValue === 'number'
-            ? rawValue
-            : typeof rawValue === 'string' && rawValue.trim().length
-              ? Number(rawValue.trim())
-              : Number.NaN;
-        if (!Number.isFinite(parsed)) {
-          return NextResponse.json(
-            { ok: false, error: 'INVALID_EXTRA_FIELD', field: key, message: `${key} must be a number.` },
-            { status: 400 }
-          );
-        }
-        validatedExtraInputValues[key] = parsed;
-        continue;
-      }
-      if (schemaField.type === 'enum') {
-        const parsed = typeof rawValue === 'number' ? rawValue : typeof rawValue === 'string' ? rawValue.trim() : '';
-        if (parsed === '') {
-          continue;
-        }
-        if (Array.isArray(schemaField.values) && !schemaField.values.some((value) => String(value) === String(parsed))) {
-          return NextResponse.json(
-            {
-              ok: false,
-              error: 'INVALID_EXTRA_FIELD',
-              field: key,
-              message: `${key} must be one of ${(schemaField.values ?? []).join(', ')}.`,
-            },
-            { status: 400 }
-          );
-        }
-        validatedExtraInputValues[key] = parsed;
-        continue;
-      }
-      if (schemaField.type === 'text') {
-        const parsed = typeof rawValue === 'string' ? rawValue.trim() : '';
-        if (!parsed) {
-          continue;
-        }
-        validatedExtraInputValues[key] = parsed;
-      }
-    }
+  const extraInputValidation = validateExtraInputValues({ engine, mode, rawExtraInputValues });
+  if (!extraInputValidation.ok) {
+    return NextResponse.json(extraInputValidation.body, { status: extraInputValidation.status });
   }
-
-  for (const field of applicableSchemaFields) {
-    if (field.required && validatedExtraInputValues[field.id] == null) {
-      return NextResponse.json(
-        { ok: false, error: 'MISSING_EXTRA_FIELD', field: field.id, message: `${field.id} is required for this mode.` },
-        { status: 400 }
-      );
-    }
-  }
+  const validatedExtraInputValues = extraInputValidation.values;
 
   let generationResult: Awaited<ReturnType<typeof generateVideo>> | null = null;
   type NormalizedAttachment = {

--- a/tests/generate-extra-input-values.test.ts
+++ b/tests/generate-extra-input-values.test.ts
@@ -1,0 +1,162 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { validateExtraInputValues } from '../frontend/app/api/generate/_lib/extra-input-values';
+
+const root = process.cwd();
+const routePath = join(root, 'frontend/app/api/generate/route.ts');
+const helperPath = join(root, 'frontend/app/api/generate/_lib/extra-input-values.ts');
+
+const routeSource = readFileSync(routePath, 'utf8');
+const helperSource = readFileSync(helperPath, 'utf8');
+
+const engineWithExtraFields = {
+  inputSchema: {
+    required: [
+      { id: 'prompt', type: 'text', label: 'Prompt' },
+      { id: 'style_strength', type: 'number', label: 'Style strength', requiredInModes: ['t2v'] },
+    ],
+    optional: [
+      { id: 'camera_style', type: 'enum', label: 'Camera style', values: ['cinematic', 'handheld'] },
+      { id: 'director_note', type: 'text', label: 'Director note' },
+      { id: 'aspect_ratio', type: 'enum', label: 'Aspect ratio', values: ['16:9', '9:16'] },
+    ],
+  },
+} as const;
+
+test('generate route delegates extra input validation', () => {
+  assert.ok(existsSync(helperPath), 'extra input validation should live in the generate route _lib folder');
+  assert.match(routeSource, /from '\.\/_lib\/extra-input-values'/);
+  assert.doesNotMatch(routeSource, /function normalizeFieldId\(/, 'field id normalization belongs in extra-input-values.ts');
+  assert.doesNotMatch(routeSource, /STANDARD_INPUT_FIELD_IDS/, 'standard input exclusion belongs in extra-input-values.ts');
+  assert.doesNotMatch(routeSource, /applicableSchemaFields/, 'extra schema field selection belongs in extra-input-values.ts');
+  assert.doesNotMatch(routeSource, /applicableFieldMap/, 'extra schema field map belongs in extra-input-values.ts');
+
+  const lineCount = routeSource.split('\n').length;
+  assert.ok(lineCount <= 2400, `/api/generate route should stay below 2400 lines after extra input extraction, got ${lineCount}`);
+});
+
+test('extra input helper exposes the route contract', () => {
+  assert.match(helperSource, /export function validateExtraInputValues/, 'validateExtraInputValues should be exported');
+  assert.match(helperSource, /const STANDARD_INPUT_FIELD_IDS/, 'standard field exclusions should stay with extra input validation');
+  assert.match(helperSource, /function normalizeFieldId/, 'field id normalization should stay with extra input validation');
+});
+
+test('extra input helper validates and normalizes schema-driven values', () => {
+  const result = validateExtraInputValues({
+    engine: engineWithExtraFields,
+    mode: 't2v',
+    rawExtraInputValues: {
+      style_strength: '0.72',
+      camera_style: 'cinematic',
+      director_note: '  close camera  ',
+    },
+  });
+
+  assert.deepEqual(result, {
+    ok: true,
+    values: {
+      style_strength: 0.72,
+      camera_style: 'cinematic',
+      director_note: 'close camera',
+    },
+  });
+});
+
+test('extra input helper rejects unsupported, invalid, and missing fields', () => {
+  assert.deepEqual(
+    validateExtraInputValues({
+      engine: engineWithExtraFields,
+      mode: 't2v',
+      rawExtraInputValues: { unknown: 'value', style_strength: '0.5' },
+    }),
+    {
+      ok: false,
+      status: 400,
+      body: {
+        ok: false,
+        error: 'INVALID_EXTRA_FIELD',
+        field: 'unknown',
+        message: 'Unsupported input field "unknown" for this mode.',
+      },
+    }
+  );
+
+  assert.deepEqual(
+    validateExtraInputValues({
+      engine: engineWithExtraFields,
+      mode: 't2v',
+      rawExtraInputValues: { style_strength: 'nope' },
+    }),
+    {
+      ok: false,
+      status: 400,
+      body: {
+        ok: false,
+        error: 'INVALID_EXTRA_FIELD',
+        field: 'style_strength',
+        message: 'style_strength must be a number.',
+      },
+    }
+  );
+
+  assert.deepEqual(
+    validateExtraInputValues({
+      engine: engineWithExtraFields,
+      mode: 't2v',
+      rawExtraInputValues: { style_strength: '0.5', camera_style: 'wrong' },
+    }),
+    {
+      ok: false,
+      status: 400,
+      body: {
+        ok: false,
+        error: 'INVALID_EXTRA_FIELD',
+        field: 'camera_style',
+        message: 'camera_style must be one of cinematic, handheld.',
+      },
+    }
+  );
+
+  assert.deepEqual(
+    validateExtraInputValues({
+      engine: engineWithExtraFields,
+      mode: 't2v',
+      rawExtraInputValues: null,
+    }),
+    {
+      ok: false,
+      status: 400,
+      body: {
+        ok: false,
+        error: 'MISSING_EXTRA_FIELD',
+        field: 'style_strength',
+        message: 'style_strength is required for this mode.',
+      },
+    }
+  );
+});
+
+test('extra input helper excludes standard route fields from the extra field contract', () => {
+  const result = validateExtraInputValues({
+    engine: engineWithExtraFields,
+    mode: 't2v',
+    rawExtraInputValues: {
+      style_strength: 0.5,
+      aspect_ratio: '16:9',
+    },
+  });
+
+  assert.deepEqual(result, {
+    ok: false,
+    status: 400,
+    body: {
+      ok: false,
+      error: 'INVALID_EXTRA_FIELD',
+      field: 'aspect_ratio',
+      message: 'Unsupported input field "aspect_ratio" for this mode.',
+    },
+  });
+});


### PR DESCRIPTION
## Summary
- Move schema-driven extraInputValues field selection, standard field exclusion, and value normalization out of /api/generate
- Keep the route responsible only for converting helper validation failures into NextResponse JSON
- Add architecture and behavior coverage for unsupported, invalid, missing, and standard-excluded fields

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-extra-input-values.test.ts tests/generate-payment-rollback-architecture.test.ts tests/generate-initial-video-job-architecture.test.ts tests/generate-fal-error-handling.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build