### PR TITLE
Split generate attachment processing

### DIFF
--- a/frontend/app/api/generate/_lib/attachments.ts
+++ b/frontend/app/api/generate/_lib/attachments.ts
@@ -1,0 +1,207 @@
+import { uploadImageToStorage, isAllowedAssetHost, probeImageUrl, recordUserAsset } from '@/server/storage';
+
+export type NormalizedAttachment = {
+  name: string;
+  type: string;
+  size: number;
+  kind?: 'image' | 'video' | 'audio';
+  slotId?: string;
+  label?: string;
+  url?: string;
+  width?: number | null;
+  height?: number | null;
+  assetId?: string;
+};
+
+type AttachmentProcessingErrorBody =
+  | {
+      ok: false;
+      error: 'INVALID_VIDEO_ASSET' | 'INVALID_AUDIO_ASSET' | 'INLINE_ASSET_UNSUPPORTED' | 'IMAGE_UPLOAD_FAILED';
+      message?: string;
+    }
+  | {
+      ok: false;
+      error: 'IMAGE_HOST_NOT_ALLOWED' | 'IMAGE_UNREACHABLE';
+      url: string;
+    };
+
+type AttachmentProcessingResult =
+  | {
+      ok: true;
+      attachments: NormalizedAttachment[];
+    }
+  | {
+      ok: false;
+      status: 400 | 422 | 500;
+      body: AttachmentProcessingErrorBody;
+    };
+
+function decodeDataUrl(value: string): { buffer: Buffer; mime: string } {
+  const match = /^data:([^;,]+);base64,(.+)$/i.exec(value);
+  if (!match) {
+    throw new Error('Invalid data URL');
+  }
+  const [, mime, base64] = match;
+  return {
+    mime,
+    buffer: Buffer.from(base64, 'base64'),
+  };
+}
+
+export async function processGenerationAttachments(params: {
+  rawInputs: unknown;
+  userId: string;
+}): Promise<AttachmentProcessingResult> {
+  const rawAttachments = Array.isArray(params.rawInputs) ? params.rawInputs : [];
+  const processedAttachments: NormalizedAttachment[] = [];
+
+  for (const entry of rawAttachments) {
+    if (!entry || typeof entry !== 'object') continue;
+    const candidate = entry as Record<string, unknown>;
+    const base: NormalizedAttachment = {
+      name: typeof candidate.name === 'string' ? candidate.name : 'attachment',
+      type: typeof candidate.type === 'string' ? candidate.type : 'application/octet-stream',
+      size: typeof candidate.size === 'number' ? candidate.size : 0,
+      kind:
+        candidate.kind === 'image' || candidate.kind === 'video' || candidate.kind === 'audio'
+          ? (candidate.kind as 'image' | 'video' | 'audio')
+          : undefined,
+      slotId: typeof candidate.slotId === 'string' ? candidate.slotId : undefined,
+      label: typeof candidate.label === 'string' ? candidate.label : undefined,
+    };
+
+    const urlCandidate = typeof candidate.url === 'string' ? candidate.url.trim() : null;
+    const dataUrlCandidate = typeof candidate.dataUrl === 'string' ? candidate.dataUrl.trim() : null;
+    const width = typeof candidate.width === 'number' ? candidate.width : null;
+    const height = typeof candidate.height === 'number' ? candidate.height : null;
+    const assetId = typeof candidate.assetId === 'string' ? candidate.assetId : undefined;
+    const declaredMimeType = base.type.trim().toLowerCase();
+
+    if (
+      base.kind === 'video' &&
+      declaredMimeType &&
+      declaredMimeType !== 'application/octet-stream' &&
+      !declaredMimeType.startsWith('video/')
+    ) {
+      return {
+        ok: false,
+        status: 422,
+        body: {
+          ok: false,
+          error: 'INVALID_VIDEO_ASSET',
+          message: 'The selected source is not a video. Choose an MP4/MOV clip and try again.',
+        },
+      };
+    }
+
+    if (
+      base.kind === 'audio' &&
+      declaredMimeType &&
+      declaredMimeType !== 'application/octet-stream' &&
+      !declaredMimeType.startsWith('audio/')
+    ) {
+      return {
+        ok: false,
+        status: 422,
+        body: {
+          ok: false,
+          error: 'INVALID_AUDIO_ASSET',
+          message: 'The selected source is not an audio file. Choose an audio clip and try again.',
+        },
+      };
+    }
+
+    if (urlCandidate) {
+      if (!isAllowedAssetHost(urlCandidate)) {
+        return {
+          ok: false,
+          status: 422,
+          body: { ok: false, error: 'IMAGE_HOST_NOT_ALLOWED', url: urlCandidate },
+        };
+      }
+
+      let sizeBytes = base.size;
+      let mimeType = base.type;
+      if (base.kind === 'image' && (!sizeBytes || !mimeType || mimeType === 'application/octet-stream')) {
+        const probe = await probeImageUrl(urlCandidate);
+        if (!probe.ok) {
+          return {
+            ok: false,
+            status: 422,
+            body: { ok: false, error: 'IMAGE_UNREACHABLE', url: urlCandidate },
+          };
+        }
+        sizeBytes = sizeBytes || probe.size || 0;
+        mimeType = mimeType === 'application/octet-stream' && probe.mime ? probe.mime : mimeType;
+      }
+
+      processedAttachments.push({
+        ...base,
+        type: mimeType,
+        size: sizeBytes,
+        url: urlCandidate,
+        width,
+        height,
+        assetId,
+      });
+      continue;
+    }
+
+    if (dataUrlCandidate && dataUrlCandidate.startsWith('data:')) {
+      if (base.kind && base.kind !== 'image') {
+        return {
+          ok: false,
+          status: 400,
+          body: {
+            ok: false,
+            error: 'INLINE_ASSET_UNSUPPORTED',
+            message: 'Inline audio/video uploads are not supported.',
+          },
+        };
+      }
+
+      const { buffer, mime } = decodeDataUrl(dataUrlCandidate);
+      let uploadResult;
+      try {
+        uploadResult = await uploadImageToStorage({
+          data: buffer,
+          mime,
+          userId: params.userId,
+          fileName: base.name,
+          prefix: 'inline',
+        });
+      } catch (error) {
+        console.error('[generate] failed to upload inline attachment', error);
+        return { ok: false, status: 500, body: { ok: false, error: 'IMAGE_UPLOAD_FAILED' } };
+      }
+
+      try {
+        const assetIdCreated = await recordUserAsset({
+          userId: params.userId,
+          url: uploadResult.url,
+          mime: uploadResult.mime,
+          width: uploadResult.width,
+          height: uploadResult.height,
+          size: uploadResult.size,
+          source: 'inline',
+          metadata: { originalName: base.name, kind: 'image' },
+        });
+
+        processedAttachments.push({
+          ...base,
+          type: uploadResult.mime,
+          size: uploadResult.size,
+          url: uploadResult.url,
+          width: uploadResult.width,
+          height: uploadResult.height,
+          assetId: assetIdCreated,
+        });
+      } catch (error) {
+        console.error('[generate] failed to record inline asset', error);
+      }
+      continue;
+    }
+  }
+
+  return { ok: true, attachments: processedAttachments };
+}

--- a/frontend/app/api/generate/route.ts
+++ b/frontend/app/api/generate/route.ts
@@ -21,6 +21,7 @@ import {
   withFalTimeout,
 } from './_lib/fal-error-handling';
 import { validateExtraInputValues } from './_lib/extra-input-values';
+import { processGenerationAttachments } from './_lib/attachments';
 import {
   buildResponseFromExistingVideoJob,
   createAtomicInitialVideoJob,
@@ -30,7 +31,6 @@ import {
   type PendingReceipt,
 } from './_lib/initial-video-job';
 import { rollbackPendingPayment } from './_lib/payment-rollback';
-import { uploadImageToStorage, isAllowedAssetHost, probeImageUrl, recordUserAsset } from '@/server/storage';
 import {
   buildNextProviderVideoCopyState,
   buildSafeProviderMediaLog,
@@ -798,158 +798,11 @@ export async function POST(req: NextRequest) {
   const validatedExtraInputValues = extraInputValidation.values;
 
   let generationResult: Awaited<ReturnType<typeof generateVideo>> | null = null;
-  type NormalizedAttachment = {
-    name: string;
-    type: string;
-    size: number;
-    kind?: 'image' | 'video' | 'audio';
-    slotId?: string;
-    label?: string;
-    url?: string;
-    width?: number | null;
-    height?: number | null;
-    assetId?: string;
-  };
-
-  const rawAttachments = Array.isArray(body.inputs) ? (body.inputs as unknown[]) : [];
-  const processedAttachments: NormalizedAttachment[] = [];
-
-  const decodeDataUrl = (value: string): { buffer: Buffer; mime: string } => {
-    const match = /^data:([^;,]+);base64,(.+)$/i.exec(value);
-    if (!match) {
-      throw new Error('Invalid data URL');
-    }
-    const [, mime, base64] = match;
-    return {
-      mime,
-      buffer: Buffer.from(base64, 'base64'),
-    };
-  };
-
-  for (const entry of rawAttachments) {
-    if (!entry || typeof entry !== 'object') continue;
-    const candidate = entry as Record<string, unknown>;
-    const base: NormalizedAttachment = {
-      name: typeof candidate.name === 'string' ? candidate.name : 'attachment',
-      type: typeof candidate.type === 'string' ? candidate.type : 'application/octet-stream',
-      size: typeof candidate.size === 'number' ? candidate.size : 0,
-      kind:
-        candidate.kind === 'image' || candidate.kind === 'video' || candidate.kind === 'audio'
-          ? (candidate.kind as 'image' | 'video' | 'audio')
-          : undefined,
-      slotId: typeof candidate.slotId === 'string' ? candidate.slotId : undefined,
-      label: typeof candidate.label === 'string' ? candidate.label : undefined,
-    };
-
-    const urlCandidate = typeof candidate.url === 'string' ? candidate.url.trim() : null;
-    const dataUrlCandidate = typeof candidate.dataUrl === 'string' ? candidate.dataUrl.trim() : null;
-    const width = typeof candidate.width === 'number' ? candidate.width : null;
-    const height = typeof candidate.height === 'number' ? candidate.height : null;
-    const assetId = typeof candidate.assetId === 'string' ? candidate.assetId : undefined;
-    const declaredMimeType = base.type.trim().toLowerCase();
-
-    if (base.kind === 'video' && declaredMimeType && declaredMimeType !== 'application/octet-stream' && !declaredMimeType.startsWith('video/')) {
-      return NextResponse.json(
-        {
-          ok: false,
-          error: 'INVALID_VIDEO_ASSET',
-          message: 'The selected source is not a video. Choose an MP4/MOV clip and try again.',
-        },
-        { status: 422 }
-      );
-    }
-
-    if (base.kind === 'audio' && declaredMimeType && declaredMimeType !== 'application/octet-stream' && !declaredMimeType.startsWith('audio/')) {
-      return NextResponse.json(
-        {
-          ok: false,
-          error: 'INVALID_AUDIO_ASSET',
-          message: 'The selected source is not an audio file. Choose an audio clip and try again.',
-        },
-        { status: 422 }
-      );
-    }
-
-    if (urlCandidate) {
-      if (!isAllowedAssetHost(urlCandidate)) {
-        return NextResponse.json(
-          { ok: false, error: 'IMAGE_HOST_NOT_ALLOWED', url: urlCandidate },
-          { status: 422 }
-        );
-      }
-
-      let sizeBytes = base.size;
-      let mimeType = base.type;
-      if (base.kind === 'image' && (!sizeBytes || !mimeType || mimeType === 'application/octet-stream')) {
-        const probe = await probeImageUrl(urlCandidate);
-        if (!probe.ok) {
-          return NextResponse.json({ ok: false, error: 'IMAGE_UNREACHABLE', url: urlCandidate }, { status: 422 });
-        }
-        sizeBytes = sizeBytes || probe.size || 0;
-        mimeType = mimeType === 'application/octet-stream' && probe.mime ? probe.mime : mimeType;
-      }
-
-      processedAttachments.push({
-        ...base,
-        type: mimeType,
-        size: sizeBytes,
-        url: urlCandidate,
-        width,
-        height,
-        assetId,
-      });
-      continue;
-    }
-
-    if (dataUrlCandidate && dataUrlCandidate.startsWith('data:')) {
-      if (base.kind && base.kind !== 'image') {
-        return NextResponse.json(
-          { ok: false, error: 'INLINE_ASSET_UNSUPPORTED', message: 'Inline audio/video uploads are not supported.' },
-          { status: 400 }
-        );
-      }
-      const { buffer, mime } = decodeDataUrl(dataUrlCandidate);
-      let uploadResult;
-      try {
-        uploadResult = await uploadImageToStorage({
-          data: buffer,
-          mime,
-          userId,
-          fileName: base.name,
-          prefix: 'inline',
-        });
-      } catch (error) {
-        console.error('[generate] failed to upload inline attachment', error);
-        return NextResponse.json({ ok: false, error: 'IMAGE_UPLOAD_FAILED' }, { status: 500 });
-      }
-
-      try {
-        const assetIdCreated = await recordUserAsset({
-          userId,
-          url: uploadResult.url,
-          mime: uploadResult.mime,
-          width: uploadResult.width,
-          height: uploadResult.height,
-          size: uploadResult.size,
-          source: 'inline',
-          metadata: { originalName: base.name, kind: 'image' },
-        });
-
-        processedAttachments.push({
-          ...base,
-          type: uploadResult.mime,
-          size: uploadResult.size,
-          url: uploadResult.url,
-          width: uploadResult.width,
-          height: uploadResult.height,
-          assetId: assetIdCreated,
-        });
-      } catch (error) {
-        console.error('[generate] failed to record inline asset', error);
-      }
-      continue;
-    }
+  const attachmentProcessing = await processGenerationAttachments({ rawInputs: body.inputs, userId });
+  if (!attachmentProcessing.ok) {
+    return NextResponse.json(attachmentProcessing.body, { status: attachmentProcessing.status });
   }
+  const processedAttachments = attachmentProcessing.attachments;
 
   const maxUploadedBytes =
     processedAttachments.reduce((max, attachment) => Math.max(max, attachment.size ?? 0), 0) ?? 0;

--- a/tests/generate-attachments.test.ts
+++ b/tests/generate-attachments.test.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { processGenerationAttachments } from '../frontend/app/api/generate/_lib/attachments';
+
+const root = process.cwd();
+const routePath = join(root, 'frontend/app/api/generate/route.ts');
+const helperPath = join(root, 'frontend/app/api/generate/_lib/attachments.ts');
+
+const routeSource = readFileSync(routePath, 'utf8');
+const helperSource = readFileSync(helperPath, 'utf8');
+
+test('generate route delegates attachment normalization and inline uploads', () => {
+  assert.ok(existsSync(helperPath), 'attachment processing should live in the generate route _lib folder');
+  assert.match(routeSource, /from '\.\/_lib\/attachments'/);
+  assert.doesNotMatch(routeSource, /type NormalizedAttachment =/, 'attachment type belongs in attachments.ts');
+  assert.doesNotMatch(routeSource, /function decodeDataUrl\(/, 'data URL decoding belongs in attachments.ts');
+  assert.doesNotMatch(routeSource, /uploadImageToStorage/, 'inline upload belongs in attachments.ts');
+  assert.doesNotMatch(routeSource, /recordUserAsset/, 'inline asset recording belongs in attachments.ts');
+  assert.doesNotMatch(routeSource, /probeImageUrl/, 'image URL probing belongs in attachments.ts');
+  assert.doesNotMatch(routeSource, /isAllowedAssetHost/, 'asset host allow-list checks belong in attachments.ts');
+
+  const lineCount = routeSource.split('\n').length;
+  assert.ok(lineCount <= 2250, `/api/generate route should stay below 2250 lines after attachment extraction, got ${lineCount}`);
+});
+
+test('attachment helper exposes the route contract', () => {
+  assert.match(helperSource, /export type NormalizedAttachment =/, 'NormalizedAttachment should be exported');
+  assert.match(helperSource, /export async function processGenerationAttachments/, 'processGenerationAttachments should be exported');
+  assert.match(helperSource, /function decodeDataUrl/, 'data URL decoding should stay private');
+  assert.match(helperSource, /uploadImageToStorage/, 'inline upload should stay with attachment processing');
+  assert.match(helperSource, /recordUserAsset/, 'inline asset recording should stay with attachment processing');
+});
+
+test('attachment helper accepts existing allowed-host video URLs', async () => {
+  const result = await processGenerationAttachments({
+    userId: 'user_123',
+    rawInputs: [
+      {
+        name: 'clip.mp4',
+        kind: 'video',
+        type: 'video/mp4',
+        size: 1234,
+        slotId: 'video_url',
+        label: undefined,
+        url: 'https://cdn.maxvideoai.com/uploads/clip.mp4',
+        width: 1280,
+        height: 720,
+        assetId: 'asset_123',
+      },
+    ],
+  });
+
+  assert.deepEqual(result, {
+    ok: true,
+    attachments: [
+      {
+        name: 'clip.mp4',
+        kind: 'video',
+        type: 'video/mp4',
+        size: 1234,
+        slotId: 'video_url',
+        label: undefined,
+        url: 'https://cdn.maxvideoai.com/uploads/clip.mp4',
+        width: 1280,
+        height: 720,
+        assetId: 'asset_123',
+      },
+    ],
+  });
+});
+
+test('attachment helper preserves route validation failures', async () => {
+  assert.deepEqual(
+    await processGenerationAttachments({
+      userId: 'user_123',
+      rawInputs: [{ kind: 'video', type: 'image/png', name: 'not-video.png' }],
+    }),
+    {
+      ok: false,
+      status: 422,
+      body: {
+        ok: false,
+        error: 'INVALID_VIDEO_ASSET',
+        message: 'The selected source is not a video. Choose an MP4/MOV clip and try again.',
+      },
+    }
+  );
+
+  assert.deepEqual(
+    await processGenerationAttachments({
+      userId: 'user_123',
+      rawInputs: [{ kind: 'audio', type: 'audio/mpeg', dataUrl: 'data:audio/mpeg;base64,AAAA' }],
+    }),
+    {
+      ok: false,
+      status: 400,
+      body: {
+        ok: false,
+        error: 'INLINE_ASSET_UNSUPPORTED',
+        message: 'Inline audio/video uploads are not supported.',
+      },
+    }
+  );
+
+  assert.deepEqual(
+    await processGenerationAttachments({
+      userId: 'user_123',
+      rawInputs: [{ kind: 'video', type: 'video/mp4', url: 'https://example.com/clip.mp4' }],
+    }),
+    {
+      ok: false,
+      status: 422,
+      body: {
+        ok: false,
+        error: 'IMAGE_HOST_NOT_ALLOWED',
+        url: 'https://example.com/clip.mp4',
+      },
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- Move attachment normalization, host validation, image probing, inline image upload, and inline asset recording out of /api/generate
- Keep the route responsible for consuming normalized attachments and returning helper validation failures
- Add architecture and behavior coverage for allowed video URLs, invalid MIME types, unsupported inline audio/video, and blocked hosts

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-attachments.test.ts tests/generate-extra-input-values.test.ts tests/generate-payment-rollback-architecture.test.ts tests/generate-initial-video-job-architecture.test.ts tests/generate-fal-error-handling.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build