### PR TITLE
Split generate attachment reference helpers

### DIFF
--- a/frontend/app/api/generate/_lib/attachment-references.ts
+++ b/frontend/app/api/generate/_lib/attachment-references.ts
@@ -1,0 +1,118 @@
+import type { Mode } from '@/types/engines';
+import type { NormalizedAttachment } from './attachments';
+
+type AttachmentReferenceParams = {
+  attachments: NormalizedAttachment[];
+  engineId: string;
+  mode: Mode;
+  soraImageUrl?: string;
+  imageUrl?: unknown;
+  image_url?: unknown;
+  referenceImages?: unknown;
+  reference_images?: unknown;
+  rawAudioUrl?: string | null;
+};
+
+type AttachmentReferenceResult = {
+  maxUploadedBytes: number;
+  firstFrameUrl: string | undefined;
+  lastFrameUrl: string | undefined;
+  requestedPrimaryImageUrl: string | undefined;
+  normalizedReferenceImages: string[];
+  videoUrls: string[];
+  audioUrls: string[];
+  resolvedAudioUrl: string | undefined;
+  initialImageUrl: string | undefined;
+  resolvedFirstFrameUrl: string | undefined;
+  sourceInputVideoUrl: string | undefined;
+};
+
+function trimString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length ? value.trim() : undefined;
+}
+
+function normalizeStringList(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value
+        .map((entry) => trimString(entry) ?? '')
+        .filter((entry): entry is string => entry.length > 0)
+    : [];
+}
+
+function uniqueNonEmpty(values: string[]): string[] {
+  return values.filter((url, index, self) => url.length > 0 && self.indexOf(url) === index);
+}
+
+export function deriveGenerationAttachmentReferences(params: AttachmentReferenceParams): AttachmentReferenceResult {
+  const maxUploadedBytes =
+    params.attachments.reduce((max, attachment) => Math.max(max, attachment.size ?? 0), 0) ?? 0;
+  const firstFrameUrl =
+    params.attachments.find((attachment) => attachment.slotId === 'first_frame_url')?.url?.trim() ?? undefined;
+  const lastFrameUrl =
+    params.attachments.find((attachment) => attachment.slotId === 'last_frame_url')?.url?.trim() ?? undefined;
+  const attachmentPrimaryImageUrl =
+    params.attachments.find((attachment) => {
+      if (attachment.kind !== 'image' || typeof attachment.url !== 'string') return false;
+      return (
+        attachment.slotId === 'image_url' ||
+        attachment.slotId === 'input_image' ||
+        attachment.slotId === 'image'
+      );
+    })?.url?.trim() ?? undefined;
+  const requestedPrimaryImageUrl =
+    params.soraImageUrl ?? trimString(params.imageUrl) ?? trimString(params.image_url) ?? attachmentPrimaryImageUrl;
+  const referenceImagesInput = Array.isArray(params.referenceImages)
+    ? params.referenceImages
+    : Array.isArray(params.reference_images)
+      ? params.reference_images
+      : null;
+  const attachmentReferenceImageUrls = params.attachments
+    .filter((attachment) => {
+      if (attachment.kind !== 'image' || typeof attachment.url !== 'string') return false;
+      if (params.engineId === 'happy-horse-1-0') {
+        if (params.mode === 'v2v') return attachment.slotId === 'reference_image_urls';
+        if (params.mode === 'ref2v') return attachment.slotId === 'image_urls' || attachment.slotId === 'reference_images';
+      }
+      return (
+        attachment.slotId === 'image_urls' ||
+        attachment.slotId === 'reference_images' ||
+        attachment.slotId === 'reference_image_urls'
+      );
+    })
+    .map((attachment) => attachment.url!.trim())
+    .filter((url) => url.length > 0);
+  const normalizedReferenceImages = Array.from(
+    new Set([...normalizeStringList(referenceImagesInput), ...attachmentReferenceImageUrls])
+  );
+  const videoUrls = uniqueNonEmpty(
+    params.attachments
+      .filter((attachment) => attachment.kind === 'video' && typeof attachment.url === 'string')
+      .map((attachment) => attachment.url!.trim())
+  );
+  const audioUrls = uniqueNonEmpty(
+    params.attachments
+      .filter((attachment) => attachment.kind === 'audio' && typeof attachment.url === 'string')
+      .map((attachment) => attachment.url!.trim())
+  );
+  const resolvedAudioUrl = params.rawAudioUrl ?? audioUrls[0] ?? undefined;
+  const initialImageUrl =
+    params.mode === 'i2v' || params.mode === 'i2i' || params.mode === 'v2v' || params.mode === 'reframe'
+      ? requestedPrimaryImageUrl
+      : undefined;
+  const resolvedFirstFrameUrl = params.mode === 'fl2v' ? firstFrameUrl ?? requestedPrimaryImageUrl : firstFrameUrl;
+  const sourceInputVideoUrl = videoUrls[0];
+
+  return {
+    maxUploadedBytes,
+    firstFrameUrl,
+    lastFrameUrl,
+    requestedPrimaryImageUrl,
+    normalizedReferenceImages,
+    videoUrls,
+    audioUrls,
+    resolvedAudioUrl,
+    initialImageUrl,
+    resolvedFirstFrameUrl,
+    sourceInputVideoUrl,
+  };
+}

--- a/frontend/app/api/generate/route.ts
+++ b/frontend/app/api/generate/route.ts
@@ -22,6 +22,7 @@ import {
 } from './_lib/fal-error-handling';
 import { validateExtraInputValues } from './_lib/extra-input-values';
 import { processGenerationAttachments } from './_lib/attachments';
+import { deriveGenerationAttachmentReferences } from './_lib/attachment-references';
 import {
   buildResponseFromExistingVideoJob,
   createAtomicInitialVideoJob,
@@ -804,76 +805,27 @@ export async function POST(req: NextRequest) {
   }
   const processedAttachments = attachmentProcessing.attachments;
 
-  const maxUploadedBytes =
-    processedAttachments.reduce((max, attachment) => Math.max(max, attachment.size ?? 0), 0) ?? 0;
-  const firstFrameUrl =
-    processedAttachments.find((attachment) => attachment.slotId === 'first_frame_url')?.url?.trim() ?? undefined;
-  const lastFrameUrl =
-    processedAttachments.find((attachment) => attachment.slotId === 'last_frame_url')?.url?.trim() ?? undefined;
-  const attachmentPrimaryImageUrl =
-    processedAttachments.find((attachment) => {
-      if (attachment.kind !== 'image' || typeof attachment.url !== 'string') return false;
-      return (
-        attachment.slotId === 'image_url' ||
-        attachment.slotId === 'input_image' ||
-        attachment.slotId === 'image'
-      );
-    })?.url?.trim() ?? undefined;
-  const requestedPrimaryImageUrl =
-    soraRequest?.mode === 'i2v'
-      ? soraRequest.image_url
-      : typeof body.imageUrl === 'string' && body.imageUrl.trim().length
-        ? body.imageUrl.trim()
-        : typeof body.image_url === 'string' && body.image_url.trim().length
-          ? body.image_url.trim()
-          : attachmentPrimaryImageUrl;
-  const referenceImagesInput = Array.isArray(body.referenceImages)
-    ? body.referenceImages
-    : Array.isArray(body.reference_images)
-      ? body.reference_images
-      : null;
-  const attachmentReferenceImageUrls = processedAttachments
-    .filter((attachment) => {
-      if (attachment.kind !== 'image' || typeof attachment.url !== 'string') return false;
-      if (engine.id === 'happy-horse-1-0') {
-        if (mode === 'v2v') return attachment.slotId === 'reference_image_urls';
-        if (mode === 'ref2v') return attachment.slotId === 'image_urls' || attachment.slotId === 'reference_images';
-      }
-      return (
-        attachment.slotId === 'image_urls' ||
-        attachment.slotId === 'reference_images' ||
-        attachment.slotId === 'reference_image_urls'
-      );
-    })
-    .map((attachment) => attachment.url!.trim())
-    .filter((url) => url.length > 0);
-  const normalizedReferenceImages = Array.from(
-    new Set(
-      [
-        ...(Array.isArray(referenceImagesInput)
-          ? referenceImagesInput
-              .map((value: unknown) => (typeof value === 'string' ? value.trim() : ''))
-              .filter((value): value is string => value.length > 0)
-          : []),
-        ...attachmentReferenceImageUrls,
-      ]
-    )
-  );
-  const videoUrls = processedAttachments
-    .filter((attachment) => attachment.kind === 'video' && typeof attachment.url === 'string')
-    .map((attachment) => attachment.url!.trim())
-    .filter((url, index, self) => url.length > 0 && self.indexOf(url) === index);
-  const audioUrls = processedAttachments
-    .filter((attachment) => attachment.kind === 'audio' && typeof attachment.url === 'string')
-    .map((attachment) => attachment.url!.trim())
-    .filter((url, index, self) => url.length > 0 && self.indexOf(url) === index);
-  const resolvedAudioUrl = rawAudioUrl ?? audioUrls[0] ?? undefined;
-  const initialImageUrl =
-    mode === 'i2v' || mode === 'i2i' || mode === 'v2v' || mode === 'reframe'
-      ? requestedPrimaryImageUrl
-      : undefined;
-  const resolvedFirstFrameUrl = mode === 'fl2v' ? firstFrameUrl ?? requestedPrimaryImageUrl : firstFrameUrl;
-  const sourceInputVideoUrl = videoUrls[0];
+  const {
+    maxUploadedBytes,
+    lastFrameUrl,
+    normalizedReferenceImages,
+    videoUrls,
+    audioUrls,
+    resolvedAudioUrl,
+    initialImageUrl,
+    resolvedFirstFrameUrl,
+    sourceInputVideoUrl,
+  } = deriveGenerationAttachmentReferences({
+    attachments: processedAttachments,
+    engineId: engine.id,
+    mode,
+    soraImageUrl: soraRequest?.mode === 'i2v' ? soraRequest.image_url : undefined,
+    imageUrl: body.imageUrl,
+    image_url: body.image_url,
+    referenceImages: body.referenceImages,
+    reference_images: body.reference_images,
+    rawAudioUrl,
+  });
   const validationPayload: Record<string, unknown> = {};
   if (prompt.length > 0) {
     validationPayload.prompt = prompt;

--- a/tests/generate-attachment-references.test.ts
+++ b/tests/generate-attachment-references.test.ts
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { deriveGenerationAttachmentReferences } from '../frontend/app/api/generate/_lib/attachment-references';
+import type { NormalizedAttachment } from '../frontend/app/api/generate/_lib/attachments';
+
+const root = process.cwd();
+const routePath = join(root, 'frontend/app/api/generate/route.ts');
+const helperPath = join(root, 'frontend/app/api/generate/_lib/attachment-references.ts');
+
+const routeSource = readFileSync(routePath, 'utf8');
+const helperSource = readFileSync(helperPath, 'utf8');
+
+const attachment = (overrides: Partial<NormalizedAttachment>): NormalizedAttachment => ({
+  name: 'asset',
+  type: 'application/octet-stream',
+  size: 0,
+  ...overrides,
+});
+
+test('generate route delegates attachment reference derivation', () => {
+  assert.ok(existsSync(helperPath), 'attachment reference derivation should live in the generate route _lib folder');
+  assert.match(routeSource, /from '\.\/_lib\/attachment-references'/);
+  assert.doesNotMatch(routeSource, /attachmentPrimaryImageUrl/, 'primary image derivation belongs in attachment-references.ts');
+  assert.doesNotMatch(routeSource, /requestedPrimaryImageUrl/, 'requested primary image fallback belongs in attachment-references.ts');
+  assert.doesNotMatch(routeSource, /referenceImagesInput/, 'reference image input selection belongs in attachment-references.ts');
+  assert.doesNotMatch(routeSource, /attachmentReferenceImageUrls/, 'attachment reference image selection belongs in attachment-references.ts');
+  assert.doesNotMatch(routeSource, /const firstFrameUrl\s*=/, 'first frame selection belongs in attachment-references.ts');
+  assert.doesNotMatch(routeSource, /const sourceInputVideoUrl\s*=/, 'source video selection belongs in attachment-references.ts');
+
+  const lineCount = routeSource.split('\n').length;
+  assert.ok(lineCount <= 2200, `/api/generate route should stay below 2200 lines after attachment reference extraction, got ${lineCount}`);
+});
+
+test('attachment reference helper exposes the route contract', () => {
+  assert.match(helperSource, /export function deriveGenerationAttachmentReferences/, 'deriveGenerationAttachmentReferences should be exported');
+  assert.match(helperSource, /function normalizeStringList/, 'reference list normalization should stay private');
+  assert.match(helperSource, /function uniqueNonEmpty/, 'URL dedupe should stay private');
+});
+
+test('attachment reference helper derives primary image, media lists, and frame fallbacks', () => {
+  const result = deriveGenerationAttachmentReferences({
+    engineId: 'generic-engine',
+    mode: 'fl2v',
+    imageUrl: ' https://cdn.maxvideoai.com/body-image.png ',
+    referenceImages: [' https://cdn.maxvideoai.com/ref-a.png ', '', 'https://cdn.maxvideoai.com/ref-a.png'],
+    rawAudioUrl: null,
+    attachments: [
+      attachment({ kind: 'image', slotId: 'image_url', url: 'https://cdn.maxvideoai.com/primary.png', size: 20 }),
+      attachment({ kind: 'image', slotId: 'last_frame_url', url: 'https://cdn.maxvideoai.com/last.png', size: 40 }),
+      attachment({ kind: 'image', slotId: 'reference_images', url: 'https://cdn.maxvideoai.com/ref-b.png' }),
+      attachment({ kind: 'video', slotId: 'video_url', url: 'https://cdn.maxvideoai.com/source.mp4' }),
+      attachment({ kind: 'audio', slotId: 'audio_url', url: 'https://cdn.maxvideoai.com/audio.mp3' }),
+    ],
+  });
+
+  assert.deepEqual(result, {
+    maxUploadedBytes: 40,
+    firstFrameUrl: undefined,
+    lastFrameUrl: 'https://cdn.maxvideoai.com/last.png',
+    requestedPrimaryImageUrl: 'https://cdn.maxvideoai.com/body-image.png',
+    normalizedReferenceImages: ['https://cdn.maxvideoai.com/ref-a.png', 'https://cdn.maxvideoai.com/ref-b.png'],
+    videoUrls: ['https://cdn.maxvideoai.com/source.mp4'],
+    audioUrls: ['https://cdn.maxvideoai.com/audio.mp3'],
+    resolvedAudioUrl: 'https://cdn.maxvideoai.com/audio.mp3',
+    initialImageUrl: undefined,
+    resolvedFirstFrameUrl: 'https://cdn.maxvideoai.com/body-image.png',
+    sourceInputVideoUrl: 'https://cdn.maxvideoai.com/source.mp4',
+  });
+});
+
+test('attachment reference helper preserves Happy Horse slot routing', () => {
+  const attachments: NormalizedAttachment[] = [
+    attachment({ kind: 'image', slotId: 'image_urls', url: 'https://cdn.maxvideoai.com/ref2v-only.png' }),
+    attachment({ kind: 'image', slotId: 'reference_image_urls', url: 'https://cdn.maxvideoai.com/v2v-only.png' }),
+  ];
+
+  assert.deepEqual(
+    deriveGenerationAttachmentReferences({
+      engineId: 'happy-horse-1-0',
+      mode: 'ref2v',
+      attachments,
+      rawAudioUrl: null,
+    }).normalizedReferenceImages,
+    ['https://cdn.maxvideoai.com/ref2v-only.png']
+  );
+
+  assert.deepEqual(
+    deriveGenerationAttachmentReferences({
+      engineId: 'happy-horse-1-0',
+      mode: 'v2v',
+      attachments,
+      rawAudioUrl: null,
+    }).normalizedReferenceImages,
+    ['https://cdn.maxvideoai.com/v2v-only.png']
+  );
+});


### PR DESCRIPTION
## Summary
- Move media reference derivation from normalized attachments out of /api/generate
- Keep the route consuming derived first/last frame, primary image, reference image, video, and audio URLs for validation, payloads, and snapshots
- Add architecture and behavior coverage for frame fallbacks, dedupe, audio/video references, max uploaded bytes, and Happy Horse slot routing

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-attachment-references.test.ts tests/generate-attachments.test.ts tests/generate-extra-input-values.test.ts tests/generate-payment-rollback-architecture.test.ts tests/generate-initial-video-job-architecture.test.ts tests/generate-fal-error-handling.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build