### PR TITLE
Split generate receipt snapshot helper

### DIFF
--- a/frontend/app/api/generate/_lib/receipt-snapshot.ts
+++ b/frontend/app/api/generate/_lib/receipt-snapshot.ts
@@ -1,0 +1,43 @@
+import type { PricingSnapshot } from '@/types/engines';
+
+type DiscountCandidate = {
+  amountCents?: number;
+  percentApplied?: number;
+  label?: string;
+};
+
+type TaxCandidate = {
+  amountCents?: number;
+  label?: string;
+};
+
+export function buildReceiptSnapshot(pricing: PricingSnapshot): Record<string, unknown> {
+  const snapshot: Record<string, unknown> = {
+    totalCents: pricing.totalCents,
+    currency: pricing.currency,
+  };
+
+  const discountCandidate = (pricing as unknown as { discount?: DiscountCandidate }).discount;
+  if (discountCandidate && typeof discountCandidate.amountCents === 'number' && discountCandidate.amountCents > 0) {
+    snapshot.discount = {
+      amountCents: discountCandidate.amountCents,
+      percentApplied: discountCandidate.percentApplied ?? null,
+      label: discountCandidate.label ?? null,
+    };
+  }
+
+  const taxesCandidate = (pricing as unknown as { taxes?: TaxCandidate[] }).taxes;
+  if (Array.isArray(taxesCandidate)) {
+    const taxes = taxesCandidate
+      .filter((tax) => tax && typeof tax.amountCents === 'number' && tax.amountCents > 0)
+      .map((tax) => ({
+        amountCents: tax.amountCents!,
+        label: tax.label ?? null,
+      }));
+    if (taxes.length) {
+      snapshot.taxes = taxes;
+    }
+  }
+
+  return snapshot;
+}

--- a/frontend/app/api/generate/route.ts
+++ b/frontend/app/api/generate/route.ts
@@ -8,7 +8,6 @@ import { computePricingSnapshot, getPlatformFeeCents } from '@/lib/pricing';
 import { getConfiguredEngine, getConfiguredEngineIncludingHidden } from '@/server/engines';
 import Stripe from 'stripe';
 import { ENV, receiptsPriceOnlyEnabled } from '@/lib/env';
-import type { PricingSnapshot } from '@/types/engines';
 import { ensureBillingSchema } from '@/lib/schema';
 import { normalizeMediaUrl } from '@/lib/media';
 import type { Mode } from '@/types/engines';
@@ -23,6 +22,7 @@ import {
 import { validateExtraInputValues } from './_lib/extra-input-values';
 import { processGenerationAttachments } from './_lib/attachments';
 import { deriveGenerationAttachmentReferences } from './_lib/attachment-references';
+import { buildReceiptSnapshot } from './_lib/receipt-snapshot';
 import {
   buildResponseFromExistingVideoJob,
   createAtomicInitialVideoJob,
@@ -127,37 +127,6 @@ async function resolveUserId(req?: NextRequest): Promise<string | null> {
     return localAdminUserId;
   }
   return null;
-}
-
-function buildReceiptSnapshot(pricing: PricingSnapshot): Record<string, unknown> {
-  const snapshot: Record<string, unknown> = {
-    totalCents: pricing.totalCents,
-    currency: pricing.currency,
-  };
-
-  const discountCandidate = (pricing as unknown as { discount?: { amountCents?: number; percentApplied?: number; label?: string } }).discount;
-  if (discountCandidate && typeof discountCandidate.amountCents === 'number' && discountCandidate.amountCents > 0) {
-    snapshot.discount = {
-      amountCents: discountCandidate.amountCents,
-      percentApplied: discountCandidate.percentApplied ?? null,
-      label: discountCandidate.label ?? null,
-    };
-  }
-
-  const taxesCandidate = (pricing as unknown as { taxes?: Array<{ amountCents?: number; label?: string }> }).taxes;
-  if (Array.isArray(taxesCandidate)) {
-    const taxes = taxesCandidate
-      .filter((tax) => tax && typeof tax.amountCents === 'number' && tax.amountCents > 0)
-      .map((tax) => ({
-        amountCents: tax.amountCents!,
-        label: tax.label ?? null,
-      }));
-    if (taxes.length) {
-      snapshot.taxes = taxes;
-    }
-  }
-
-  return snapshot;
 }
 
 async function markJobAwaitingFal(params: {

--- a/tests/generate-receipt-snapshot.test.ts
+++ b/tests/generate-receipt-snapshot.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { buildReceiptSnapshot } from '../frontend/app/api/generate/_lib/receipt-snapshot';
+
+const root = process.cwd();
+const routePath = join(root, 'frontend/app/api/generate/route.ts');
+const helperPath = join(root, 'frontend/app/api/generate/_lib/receipt-snapshot.ts');
+
+const routeSource = readFileSync(routePath, 'utf8');
+const helperSource = readFileSync(helperPath, 'utf8');
+
+test('generate route delegates receipt snapshot building', () => {
+  assert.ok(existsSync(helperPath), 'receipt snapshot building should live in the generate route _lib folder');
+  assert.match(routeSource, /from '\.\/_lib\/receipt-snapshot'/);
+  assert.doesNotMatch(routeSource, /function buildReceiptSnapshot/, 'receipt snapshot construction belongs in receipt-snapshot.ts');
+  assert.doesNotMatch(routeSource, /discountCandidate/, 'discount pruning belongs in receipt-snapshot.ts');
+  assert.doesNotMatch(routeSource, /taxesCandidate/, 'tax pruning belongs in receipt-snapshot.ts');
+
+  const lineCount = routeSource.split('\n').length;
+  assert.ok(lineCount <= 2130, `/api/generate route should stay below 2130 lines after receipt snapshot extraction, got ${lineCount}`);
+});
+
+test('receipt snapshot helper exposes the route contract', () => {
+  assert.match(helperSource, /export function buildReceiptSnapshot/, 'buildReceiptSnapshot should be exported');
+  assert.match(helperSource, /type DiscountCandidate/, 'discount shape should stay with receipt snapshot logic');
+  assert.match(helperSource, /type TaxCandidate/, 'tax shape should stay with receipt snapshot logic');
+});
+
+test('receipt snapshot helper keeps price-only receipt fields and prunes empty adjustments', () => {
+  const snapshot = buildReceiptSnapshot({
+    totalCents: 1200,
+    currency: 'USD',
+    discount: {
+      amountCents: 300,
+      percentApplied: 20,
+      label: 'Launch',
+    },
+    taxes: [
+      { amountCents: 0, label: 'Ignored' },
+      { amountCents: 75, label: 'VAT' },
+      { amountCents: 25 },
+    ],
+  } as never);
+
+  assert.deepEqual(snapshot, {
+    totalCents: 1200,
+    currency: 'USD',
+    discount: {
+      amountCents: 300,
+      percentApplied: 20,
+      label: 'Launch',
+    },
+    taxes: [
+      { amountCents: 75, label: 'VAT' },
+      { amountCents: 25, label: null },
+    ],
+  });
+});
+
+test('receipt snapshot helper omits non-positive discount and tax details', () => {
+  const snapshot = buildReceiptSnapshot({
+    totalCents: 900,
+    currency: 'EUR',
+    discount: {
+      amountCents: 0,
+      percentApplied: 0,
+      label: 'None',
+    },
+    taxes: [{ amountCents: -10, label: 'Invalid' }],
+  } as never);
+
+  assert.deepEqual(snapshot, {
+    totalCents: 900,
+    currency: 'EUR',
+  });
+});


### PR DESCRIPTION
## Summary
- Move price-only receipt snapshot shaping out of /api/generate
- Keep discount and tax pruning behavior in a focused route-local helper
- Add architecture and behavior coverage for receipt snapshot output

## Local verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-receipt-snapshot.test.ts tests/generate-attachment-references.test.ts tests/generate-attachments.test.ts tests/generate-extra-input-values.test.ts tests/generate-payment-rollback-architecture.test.ts tests/generate-initial-video-job-architecture.test.ts tests/generate-fal-error-handling.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build