### PR TITLE
Split generate metric logger helper

### DIFF
--- a/frontend/app/api/generate/_lib/metric-logger.ts
+++ b/frontend/app/api/generate/_lib/metric-logger.ts
@@ -1,0 +1,67 @@
+import type { Mode } from '@/types/engines';
+import { recordGenerateMetric, type GenerateMetricInput } from '@/server/generate-metrics';
+
+export type GenerateRouteMetricState = {
+  engineId: string | null;
+  engineLabel: string | null;
+  mode: Mode | null;
+  userId: string | null;
+  jobId: string | null;
+  durationSec: number | null;
+  resolution: string | null;
+};
+
+export type GenerateRouteMetricStatus = 'accepted' | 'rejected' | 'completed' | 'failed';
+
+export type GenerateRouteMetricOptions = {
+  errorCode?: string;
+  meta?: Record<string, unknown>;
+  durationMs?: number;
+  jobId?: string | null;
+};
+
+type RecordGenerateMetric = (input: GenerateMetricInput) => void | Promise<void>;
+
+export function createGenerateMetricLogger(params: {
+  requestStartedAt: number;
+  now?: () => number;
+  recordMetric?: RecordGenerateMetric;
+}): {
+  state: GenerateRouteMetricState;
+  log: (status: GenerateRouteMetricStatus, options?: GenerateRouteMetricOptions) => void;
+} {
+  const now = params.now ?? Date.now;
+  const recordMetric = params.recordMetric ?? recordGenerateMetric;
+  const state: GenerateRouteMetricState = {
+    engineId: null,
+    engineLabel: null,
+    mode: null,
+    userId: null,
+    jobId: null,
+    durationSec: null,
+    resolution: null,
+  };
+
+  const log = (status: GenerateRouteMetricStatus, options?: GenerateRouteMetricOptions) => {
+    if (!state.engineId) return;
+    const durationMs = options?.durationMs ?? now() - params.requestStartedAt;
+    const meta = {
+      durationSec: state.durationSec,
+      resolution: state.resolution,
+      ...(options?.meta ?? {}),
+    };
+    void recordMetric({
+      jobId: options?.jobId ?? state.jobId,
+      userId: state.userId,
+      engineId: state.engineId,
+      engineLabel: state.engineLabel ?? undefined,
+      mode: state.mode ?? undefined,
+      status,
+      durationMs,
+      errorCode: options?.errorCode,
+      meta,
+    });
+  };
+
+  return { state, log };
+}

--- a/frontend/app/api/generate/route.ts
+++ b/frontend/app/api/generate/route.ts
@@ -23,6 +23,7 @@ import { validateExtraInputValues } from './_lib/extra-input-values';
 import { processGenerationAttachments } from './_lib/attachments';
 import { deriveGenerationAttachmentReferences } from './_lib/attachment-references';
 import { buildReceiptSnapshot } from './_lib/receipt-snapshot';
+import { createGenerateMetricLogger } from './_lib/metric-logger';
 import {
   buildResponseFromExistingVideoJob,
   createAtomicInitialVideoJob,
@@ -60,7 +61,6 @@ import { ensureUserPreferredCurrency, getUserPreferredCurrency, resolveCurrency 
 import type { Currency } from '@/lib/currency';
 import { convertCents } from '@/lib/exchange';
 import { applyEngineVariantPricing, buildEngineAddonInput } from '@/lib/pricing-addons';
-import { recordGenerateMetric } from '@/server/generate-metrics';
 import { createSupabaseRouteClient } from '@/lib/supabase-ssr';
 import { AdminAuthError, requireAdmin, resolveLocalAdminBypassUserId } from '@/server/admin';
 import { buildRestrictedAccountPayload, getActiveAccountRestriction } from '@/server/fraud-cleanup';
@@ -186,46 +186,7 @@ async function markJobAwaitingFal(params: {
 
 export async function POST(req: NextRequest) {
   const requestStartedAt = Date.now();
-  const metricState: {
-    engineId: string | null;
-    engineLabel: string | null;
-    mode: Mode | null;
-    userId: string | null;
-    jobId: string | null;
-    durationSec: number | null;
-    resolution: string | null;
-  } = {
-    engineId: null,
-    engineLabel: null,
-    mode: null,
-    userId: null,
-    jobId: null,
-    durationSec: null,
-    resolution: null,
-  };
-  const logMetric = (
-    status: 'accepted' | 'rejected' | 'completed' | 'failed',
-    options?: { errorCode?: string; meta?: Record<string, unknown>; durationMs?: number; jobId?: string | null }
-  ) => {
-    if (!metricState.engineId) return;
-    const durationMs = options?.durationMs ?? Date.now() - requestStartedAt;
-    const meta = {
-      durationSec: metricState.durationSec,
-      resolution: metricState.resolution,
-      ...(options?.meta ?? {}),
-    };
-    void recordGenerateMetric({
-      jobId: options?.jobId ?? metricState.jobId,
-      userId: metricState.userId,
-      engineId: metricState.engineId,
-      engineLabel: metricState.engineLabel ?? undefined,
-      mode: metricState.mode ?? undefined,
-      status,
-      durationMs,
-      errorCode: options?.errorCode,
-      meta,
-    });
-  };
+  const { state: metricState, log: logMetric } = createGenerateMetricLogger({ requestStartedAt });
 
   const body = await req
     .json()

--- a/tests/generate-metric-logger.test.ts
+++ b/tests/generate-metric-logger.test.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { createGenerateMetricLogger } from '../frontend/app/api/generate/_lib/metric-logger';
+import type { GenerateMetricInput } from '../frontend/server/generate-metrics';
+
+const root = process.cwd();
+const routePath = join(root, 'frontend/app/api/generate/route.ts');
+const helperPath = join(root, 'frontend/app/api/generate/_lib/metric-logger.ts');
+
+const routeSource = readFileSync(routePath, 'utf8');
+const helperSource = readFileSync(helperPath, 'utf8');
+
+test('generate route delegates metric logging state', () => {
+  assert.ok(existsSync(helperPath), 'metric logging should live in the generate route _lib folder');
+  assert.match(routeSource, /from '\.\/_lib\/metric-logger'/);
+  assert.doesNotMatch(routeSource, /recordGenerateMetric/, 'metric recording belongs in metric-logger.ts');
+  assert.doesNotMatch(routeSource, /const metricState:\s*\{/, 'metric state shape belongs in metric-logger.ts');
+  assert.doesNotMatch(routeSource, /void recordMetric/, 'recording dispatch belongs in metric-logger.ts');
+
+  const lineCount = routeSource.split('\n').length;
+  assert.ok(lineCount <= 2100, `/api/generate route should stay below 2100 lines after metric logger extraction, got ${lineCount}`);
+});
+
+test('metric logger helper exposes the route contract', () => {
+  assert.match(helperSource, /export type GenerateRouteMetricState/, 'metric state type should be exported');
+  assert.match(helperSource, /export function createGenerateMetricLogger/, 'createGenerateMetricLogger should be exported');
+  assert.match(helperSource, /recordGenerateMetric/, 'default metric sink should remain in the helper');
+});
+
+test('metric logger skips records before an engine is known', () => {
+  const recorded: GenerateMetricInput[] = [];
+  const { log } = createGenerateMetricLogger({
+    requestStartedAt: 1000,
+    now: () => 1200,
+    recordMetric: (input) => {
+      recorded.push(input);
+    },
+  });
+
+  log('rejected', { errorCode: 'UNKNOWN_ENGINE' });
+
+  assert.deepEqual(recorded, []);
+});
+
+test('metric logger records state, duration, and merged metadata', () => {
+  const recorded: GenerateMetricInput[] = [];
+  const { state, log } = createGenerateMetricLogger({
+    requestStartedAt: 1000,
+    now: () => 1450,
+    recordMetric: (input) => {
+      recorded.push(input);
+    },
+  });
+
+  state.engineId = 'seedance-2-0';
+  state.engineLabel = 'Seedance 2.0';
+  state.mode = 'i2v';
+  state.userId = 'user_123';
+  state.jobId = 'job_123';
+  state.durationSec = 8;
+  state.resolution = '1080p';
+
+  log('accepted', {
+    jobId: 'job_override',
+    meta: {
+      paymentMode: 'wallet',
+    },
+  });
+
+  assert.deepEqual(recorded, [
+    {
+      jobId: 'job_override',
+      userId: 'user_123',
+      engineId: 'seedance-2-0',
+      engineLabel: 'Seedance 2.0',
+      mode: 'i2v',
+      status: 'accepted',
+      durationMs: 450,
+      errorCode: undefined,
+      meta: {
+        durationSec: 8,
+        resolution: '1080p',
+        paymentMode: 'wallet',
+      },
+    },
+  ]);
+});
+
+test('metric logger honors explicit duration and error code', () => {
+  const recorded: GenerateMetricInput[] = [];
+  const { state, log } = createGenerateMetricLogger({
+    requestStartedAt: 1000,
+    now: () => 1450,
+    recordMetric: (input) => {
+      recorded.push(input);
+    },
+  });
+
+  state.engineId = 'veo-3-1';
+  state.jobId = 'job_456';
+
+  log('failed', {
+    durationMs: 12,
+    errorCode: 'PROVIDER_ERROR',
+  });
+
+  assert.equal(recorded.length, 1);
+  assert.equal(recorded[0]?.durationMs, 12);
+  assert.equal(recorded[0]?.errorCode, 'PROVIDER_ERROR');
+  assert.equal(recorded[0]?.jobId, 'job_456');
+});


### PR DESCRIPTION
## Summary
- Move /api/generate metric state and dispatch into a focused route helper
- Keep the route mutating metric state while recordGenerateMetric stays out of route.ts
- Add architecture and behavior coverage for skipped metrics, duration, error code, and metadata merging

## Local verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-metric-logger.test.ts tests/generate-receipt-snapshot.test.ts tests/generate-attachment-references.test.ts tests/generate-attachments.test.ts tests/generate-extra-input-values.test.ts tests/generate-payment-rollback-architecture.test.ts tests/generate-initial-video-job-architecture.test.ts tests/generate-fal-error-handling.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build