### PR TITLE
Split generate Fal request builders

### DIFF
--- a/frontend/app/api/generate/_lib/fal-request.ts
+++ b/frontend/app/api/generate/_lib/fal-request.ts
@@ -1,0 +1,177 @@
+import type { GenerateAttachment, GeneratePayload } from '@/lib/fal';
+import type { SoraRequest } from '@/lib/sora';
+import type { Mode } from '@/types/engines';
+import type { NormalizedAttachment } from './attachments';
+
+export type FalInputSummary = {
+  primaryImageUrl: string | null;
+  primaryAudioUrl: string | null;
+  referenceImageCount: number;
+  referenceVideoCount: number;
+  referenceAudioCount: number;
+  hasFirstFrame: boolean;
+  hasLastFrame: boolean;
+  inputSlots: Array<{
+    slotId: string | null;
+    kind: NormalizedAttachment['kind'] | null;
+    hasUrl: boolean;
+  }>;
+};
+
+type MultiPromptEntry = {
+  prompt: string;
+  duration: number;
+};
+
+type GenerationElement = {
+  frontalImageUrl?: string;
+  referenceImageUrls?: string[];
+  videoUrl?: string;
+};
+
+export type FalRequestParts = {
+  falInputs: GenerateAttachment[] | undefined;
+  falInputSummary: FalInputSummary;
+  falDurationOption: number | string | null;
+  clampedFps: number | undefined;
+  falPayload: GeneratePayload;
+};
+
+export function buildFalInputs(attachments: NormalizedAttachment[]): GenerateAttachment[] | undefined {
+  return attachments.length > 0
+    ? attachments.map((attachment) => ({
+        name: attachment.name,
+        type: attachment.type,
+        size: attachment.size,
+        kind: attachment.kind,
+        slotId: attachment.slotId,
+        label: attachment.label,
+        url: attachment.url,
+        width: attachment.width ?? undefined,
+        height: attachment.height ?? undefined,
+        assetId: attachment.assetId,
+      }))
+    : undefined;
+}
+
+export function buildFalRequestParts(params: {
+  attachments: NormalizedAttachment[];
+  engineId: string;
+  prompt: string;
+  mode: Mode;
+  apiKey: unknown;
+  jobId: string;
+  localKey: string | null;
+  needsImage: boolean;
+  needsFirstLastFrames: boolean;
+  initialImageUrl: string | undefined;
+  resolvedFirstFrameUrl: string | undefined;
+  lastFrameUrl: string | undefined;
+  resolvedAudioUrl: string | undefined;
+  normalizedReferenceImages: string[];
+  videoUrls: string[];
+  audioUrls: string[];
+  soraRequest: SoraRequest | null;
+  isLumaRay2: boolean;
+  loop: boolean;
+  multiPrompt: MultiPromptEntry[] | null;
+  shotType: 'customize' | 'intelligent' | null;
+  seed: number | null;
+  cameraFixed: boolean | null;
+  safetyChecker: boolean | null;
+  voiceIds: string[];
+  elements: GenerationElement[] | null;
+  endImageUrl: string | null;
+  extraInputValues: Record<string, unknown>;
+  supportsDuration: boolean;
+  durationSec: number;
+  durationOption: number | string | null;
+  numFrames: number | null;
+  supportsAspectRatio: boolean;
+  aspectRatio: string | null;
+  supportsResolution: boolean;
+  resolution: string;
+  audioEnabled: boolean | undefined;
+  supportsFps: boolean;
+  fps: unknown;
+  cfgScale: unknown;
+}): FalRequestParts {
+  const falInputs = buildFalInputs(params.attachments);
+  const falInputSummary: FalInputSummary = {
+    primaryImageUrl: params.initialImageUrl ?? params.resolvedFirstFrameUrl ?? null,
+    primaryAudioUrl: params.resolvedAudioUrl ?? null,
+    referenceImageCount: params.normalizedReferenceImages.length,
+    referenceVideoCount: params.videoUrls.length,
+    referenceAudioCount: params.audioUrls.length,
+    hasFirstFrame: Boolean(params.resolvedFirstFrameUrl),
+    hasLastFrame: Boolean(params.lastFrameUrl),
+    inputSlots:
+      falInputs?.map((attachment) => ({
+        slotId: attachment.slotId ?? null,
+        kind: attachment.kind ?? null,
+        hasUrl: Boolean(attachment.url),
+      })) ?? [],
+  };
+
+  const isLtxFastLong = (params.engineId === 'ltx-2-fast' || params.engineId === 'ltx-2-3-fast') && params.durationSec > 10;
+  let clampedFps =
+    typeof params.fps === 'number' && Number.isFinite(params.fps) && params.fps > 0
+      ? Math.trunc(params.fps)
+      : undefined;
+  if (isLtxFastLong) {
+    clampedFps = 25;
+  }
+
+  const falPayload: GeneratePayload = {
+    engineId: params.engineId,
+    prompt: params.prompt,
+    mode: params.mode,
+    apiKey: typeof params.apiKey === 'string' ? params.apiKey : undefined,
+    idempotencyKey: params.jobId,
+    imageUrl:
+      params.needsImage || params.mode === 'v2v' || params.mode === 'reframe'
+        ? params.initialImageUrl
+        : params.needsFirstLastFrames
+          ? params.resolvedFirstFrameUrl
+          : undefined,
+    audioUrl: params.resolvedAudioUrl,
+    referenceImages: params.normalizedReferenceImages.length ? params.normalizedReferenceImages : undefined,
+    inputs: falInputs,
+    soraRequest: params.soraRequest ?? undefined,
+    jobId: params.jobId,
+    localKey: params.localKey,
+    loop: params.isLumaRay2 ? params.loop : undefined,
+    multiPrompt: params.multiPrompt ?? undefined,
+    shotType: params.mode === 'i2v' ? 'customize' : params.shotType ?? undefined,
+    seed: typeof params.seed === 'number' ? params.seed : undefined,
+    cameraFixed: typeof params.cameraFixed === 'boolean' ? params.cameraFixed : undefined,
+    safetyChecker: typeof params.safetyChecker === 'boolean' ? params.safetyChecker : undefined,
+    voiceIds: params.voiceIds.length ? params.voiceIds : undefined,
+    elements: params.elements ?? undefined,
+    endImageUrl: params.endImageUrl ?? undefined,
+    extraInputValues: Object.keys(params.extraInputValues).length ? params.extraInputValues : undefined,
+    ...(params.supportsDuration
+      ? { durationSec: params.durationSec, durationOption: params.durationOption, numFrames: params.numFrames }
+      : {}),
+    ...(params.supportsAspectRatio ? { aspectRatio: params.aspectRatio ?? undefined } : {}),
+    ...(params.supportsResolution ? { resolution: params.resolution } : {}),
+  };
+
+  if (typeof params.audioEnabled === 'boolean') {
+    falPayload.audio = params.audioEnabled;
+  }
+  if (params.supportsFps && typeof clampedFps === 'number') {
+    falPayload.fps = clampedFps;
+  }
+  if (typeof params.cfgScale === 'number' && Number.isFinite(params.cfgScale)) {
+    falPayload.cfgScale = params.cfgScale;
+  }
+
+  return {
+    falInputs,
+    falInputSummary,
+    falDurationOption: params.durationOption,
+    clampedFps,
+    falPayload,
+  };
+}

--- a/frontend/app/api/generate/route.ts
+++ b/frontend/app/api/generate/route.ts
@@ -24,6 +24,7 @@ import { processGenerationAttachments } from './_lib/attachments';
 import { deriveGenerationAttachmentReferences } from './_lib/attachment-references';
 import { buildReceiptSnapshot } from './_lib/receipt-snapshot';
 import { createGenerateMetricLogger } from './_lib/metric-logger';
+import { buildFalRequestParts } from './_lib/fal-request';
 import {
   buildResponseFromExistingVideoJob,
   createAtomicInitialVideoJob,
@@ -1037,85 +1038,54 @@ export async function POST(req: NextRequest) {
         ? '/assets/frames/thumb-1x1.svg'
         : '/assets/frames/thumb-16x9.svg';
 
-  const falInputs =
-    processedAttachments.length > 0
-      ? processedAttachments.map((attachment) => ({
-          name: attachment.name,
-          type: attachment.type,
-          size: attachment.size,
-          kind: attachment.kind,
-          slotId: attachment.slotId,
-          label: attachment.label,
-          url: attachment.url,
-          width: attachment.width ?? undefined,
-          height: attachment.height ?? undefined,
-          assetId: attachment.assetId,
-        }))
-      : undefined;
-  const falInputSummary = {
-    primaryImageUrl: initialImageUrl ?? resolvedFirstFrameUrl ?? null,
-    primaryAudioUrl: resolvedAudioUrl ?? null,
-    referenceImageCount: Array.isArray(normalizedReferenceImages) ? normalizedReferenceImages.length : 0,
-    referenceVideoCount: videoUrls.length,
-    referenceAudioCount: audioUrls.length,
-    hasFirstFrame: Boolean(resolvedFirstFrameUrl),
-    hasLastFrame: Boolean(lastFrameUrl),
-    inputSlots:
-      falInputs?.map((attachment) => ({
-        slotId: attachment.slotId ?? null,
-        kind: attachment.kind ?? null,
-        hasUrl: Boolean(attachment.url),
-      })) ?? [],
-  };
-
-  const falDurationOption = lumaDurationInfo?.label ?? rawDurationLabel ?? rawDurationOption ?? null;
-  const isLtxFastLong = (engine.id === 'ltx-2-fast' || engine.id === 'ltx-2-3-fast') && durationSec > 10;
-  let clampedFps =
-    typeof body.fps === 'number' && Number.isFinite(body.fps) && body.fps > 0 ? Math.trunc(body.fps) : undefined;
-  if (isLtxFastLong) {
-    clampedFps = 25;
-  }
-  const falPayload: Parameters<typeof generateVideo>[0] = {
+  const {
+    falInputs,
+    falInputSummary,
+    falDurationOption,
+    clampedFps,
+    falPayload,
+  } = buildFalRequestParts({
+    attachments: processedAttachments,
     engineId: engine.id,
-    prompt: prompt,
+    prompt,
     mode,
-    apiKey: typeof body.apiKey === 'string' ? body.apiKey : undefined,
-    idempotencyKey: jobId,
-    imageUrl:
-      needsImage || mode === 'v2v' || mode === 'reframe'
-        ? initialImageUrl
-        : needsFirstLastFrames
-          ? resolvedFirstFrameUrl
-          : undefined,
-    audioUrl: resolvedAudioUrl,
-    referenceImages: normalizedReferenceImages.length ? normalizedReferenceImages : undefined,
-    inputs: falInputs,
-    soraRequest: soraRequest ?? undefined,
+    apiKey: body.apiKey,
     jobId,
     localKey,
-    loop: isLumaRay2 ? loop : undefined,
-    multiPrompt: multiPrompt ?? undefined,
-    shotType: mode === 'i2v' ? 'customize' : shotType ?? undefined,
-    seed: typeof seed === 'number' ? seed : undefined,
-    cameraFixed: typeof cameraFixed === 'boolean' ? cameraFixed : undefined,
-    safetyChecker: typeof safetyChecker === 'boolean' ? safetyChecker : undefined,
-    voiceIds: voiceIds.length ? voiceIds : undefined,
-    elements: elements ?? undefined,
-    endImageUrl: endImageUrl ?? undefined,
-    extraInputValues: Object.keys(validatedExtraInputValues).length ? validatedExtraInputValues : undefined,
-    ...(supportsDuration ? { durationSec, durationOption: falDurationOption, numFrames } : {}),
-    ...(supportsAspectRatio ? { aspectRatio: aspectRatio ?? undefined } : {}),
-    ...(supportsResolution ? { resolution: effectiveResolution } : {}),
-  };
-  if (typeof audioEnabled === 'boolean') {
-    falPayload.audio = audioEnabled;
-  }
-  if (supportsFps && typeof clampedFps === 'number') {
-    falPayload.fps = clampedFps;
-  }
-  if (typeof body.cfgScale === 'number' && Number.isFinite(body.cfgScale)) {
-    falPayload.cfgScale = body.cfgScale;
-  }
+    needsImage,
+    needsFirstLastFrames,
+    initialImageUrl,
+    resolvedFirstFrameUrl,
+    lastFrameUrl,
+    resolvedAudioUrl,
+    normalizedReferenceImages,
+    videoUrls,
+    audioUrls,
+    soraRequest,
+    isLumaRay2,
+    loop,
+    multiPrompt,
+    shotType,
+    seed,
+    cameraFixed,
+    safetyChecker,
+    voiceIds,
+    elements,
+    endImageUrl,
+    extraInputValues: validatedExtraInputValues,
+    supportsDuration,
+    durationSec,
+    durationOption: lumaDurationInfo?.label ?? rawDurationLabel ?? rawDurationOption ?? null,
+    numFrames,
+    supportsAspectRatio,
+    aspectRatio,
+    supportsResolution,
+    resolution: effectiveResolution,
+    audioEnabled,
+    supportsFps,
+    fps: body.fps,
+    cfgScale: body.cfgScale,
+  });
 
   const negativePrompt =
     typeof body.negativePrompt === 'string' && body.negativePrompt.trim().length ? body.negativePrompt.trim() : null;

--- a/tests/generate-fal-request.test.ts
+++ b/tests/generate-fal-request.test.ts
@@ -1,0 +1,216 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { buildFalInputs, buildFalRequestParts } from '../frontend/app/api/generate/_lib/fal-request';
+import type { NormalizedAttachment } from '../frontend/app/api/generate/_lib/attachments';
+
+const root = process.cwd();
+const routePath = join(root, 'frontend/app/api/generate/route.ts');
+const helperPath = join(root, 'frontend/app/api/generate/_lib/fal-request.ts');
+
+const routeSource = readFileSync(routePath, 'utf8');
+const helperSource = readFileSync(helperPath, 'utf8');
+
+const attachment = (overrides: Partial<NormalizedAttachment>): NormalizedAttachment => ({
+  name: 'asset',
+  type: 'application/octet-stream',
+  size: 0,
+  ...overrides,
+});
+
+function baseFalRequest(overrides: Partial<Parameters<typeof buildFalRequestParts>[0]> = {}) {
+  return buildFalRequestParts({
+    attachments: [],
+    engineId: 'generic-engine',
+    prompt: 'Generate a cinematic shot',
+    mode: 't2v',
+    apiKey: undefined,
+    jobId: 'job_123',
+    localKey: null,
+    needsImage: false,
+    needsFirstLastFrames: false,
+    initialImageUrl: undefined,
+    resolvedFirstFrameUrl: undefined,
+    lastFrameUrl: undefined,
+    resolvedAudioUrl: undefined,
+    normalizedReferenceImages: [],
+    videoUrls: [],
+    audioUrls: [],
+    soraRequest: null,
+    isLumaRay2: false,
+    loop: false,
+    multiPrompt: null,
+    shotType: null,
+    seed: null,
+    cameraFixed: null,
+    safetyChecker: null,
+    voiceIds: [],
+    elements: null,
+    endImageUrl: null,
+    extraInputValues: {},
+    supportsDuration: true,
+    durationSec: 8,
+    durationOption: '8',
+    numFrames: null,
+    supportsAspectRatio: true,
+    aspectRatio: '16:9',
+    supportsResolution: true,
+    resolution: '1080p',
+    audioEnabled: undefined,
+    supportsFps: true,
+    fps: undefined,
+    cfgScale: undefined,
+    ...overrides,
+  });
+}
+
+test('generate route delegates Fal request building', () => {
+  assert.ok(existsSync(helperPath), 'Fal request building should live in the generate route _lib folder');
+  assert.match(routeSource, /from '\.\/_lib\/fal-request'/);
+  assert.doesNotMatch(routeSource, /const falInputs\s*=/, 'Fal attachment mapping belongs in fal-request.ts');
+  assert.doesNotMatch(routeSource, /const falInputSummary\s*=/, 'Fal input summary belongs in fal-request.ts');
+  assert.doesNotMatch(routeSource, /isLtxFastLong/, 'LTX FPS clamping belongs in fal-request.ts');
+  assert.doesNotMatch(routeSource, /Parameters<typeof generateVideo>\[0\]/, 'Fal payload typing belongs in fal-request.ts');
+
+  const lineCount = routeSource.split('\n').length;
+  assert.ok(lineCount <= 2060, `/api/generate route should stay below 2060 lines after Fal request extraction, got ${lineCount}`);
+});
+
+test('Fal request helper exposes the route contract', () => {
+  assert.match(helperSource, /export type FalInputSummary/, 'Fal input summary type should be exported');
+  assert.match(helperSource, /export function buildFalInputs/, 'buildFalInputs should be exported');
+  assert.match(helperSource, /export function buildFalRequestParts/, 'buildFalRequestParts should be exported');
+});
+
+test('Fal request helper maps normalized attachments to provider inputs', () => {
+  assert.deepEqual(
+    buildFalInputs([
+      attachment({
+        name: 'source',
+        type: 'video/mp4',
+        size: 42,
+        kind: 'video',
+        slotId: 'video_url',
+        label: 'Source clip',
+        url: 'https://cdn.maxvideoai.com/source.mp4',
+        width: null,
+        height: 720,
+        assetId: 'asset_123',
+      }),
+    ]),
+    [
+      {
+        name: 'source',
+        type: 'video/mp4',
+        size: 42,
+        kind: 'video',
+        slotId: 'video_url',
+        label: 'Source clip',
+        url: 'https://cdn.maxvideoai.com/source.mp4',
+        width: undefined,
+        height: 720,
+        assetId: 'asset_123',
+      },
+    ]
+  );
+
+  assert.equal(buildFalInputs([]), undefined);
+});
+
+test('Fal request helper builds payload, input summary, and LTX long FPS clamp', () => {
+  const result = baseFalRequest({
+    attachments: [
+      attachment({ kind: 'image', slotId: 'image_url', url: 'https://cdn.maxvideoai.com/image.png' }),
+      attachment({ kind: 'audio', slotId: 'audio_url', url: 'https://cdn.maxvideoai.com/audio.mp3' }),
+    ],
+    engineId: 'ltx-2-fast',
+    mode: 'i2v',
+    apiKey: 'secret',
+    localKey: 'local_123',
+    needsImage: true,
+    initialImageUrl: 'https://cdn.maxvideoai.com/image.png',
+    resolvedAudioUrl: 'https://cdn.maxvideoai.com/audio.mp3',
+    normalizedReferenceImages: ['https://cdn.maxvideoai.com/ref.png'],
+    audioUrls: ['https://cdn.maxvideoai.com/audio.mp3'],
+    durationSec: 12,
+    durationOption: 12,
+    audioEnabled: false,
+    fps: 12,
+    cfgScale: 5.5,
+    multiPrompt: [{ prompt: 'Shot one', duration: 6 }],
+    shotType: 'intelligent',
+    seed: 123,
+    cameraFixed: true,
+    safetyChecker: false,
+    voiceIds: ['voice_1'],
+    elements: [{ frontalImageUrl: 'https://cdn.maxvideoai.com/face.png' }],
+    endImageUrl: 'https://cdn.maxvideoai.com/end.png',
+    extraInputValues: { style_strength: 0.6 },
+  });
+
+  assert.equal(result.clampedFps, 25);
+  assert.equal(result.falDurationOption, 12);
+  assert.deepEqual(result.falInputSummary, {
+    primaryImageUrl: 'https://cdn.maxvideoai.com/image.png',
+    primaryAudioUrl: 'https://cdn.maxvideoai.com/audio.mp3',
+    referenceImageCount: 1,
+    referenceVideoCount: 0,
+    referenceAudioCount: 1,
+    hasFirstFrame: false,
+    hasLastFrame: false,
+    inputSlots: [
+      { slotId: 'image_url', kind: 'image', hasUrl: true },
+      { slotId: 'audio_url', kind: 'audio', hasUrl: true },
+    ],
+  });
+  assert.deepEqual(result.falPayload, {
+    engineId: 'ltx-2-fast',
+    prompt: 'Generate a cinematic shot',
+    mode: 'i2v',
+    apiKey: 'secret',
+    idempotencyKey: 'job_123',
+    imageUrl: 'https://cdn.maxvideoai.com/image.png',
+    audioUrl: 'https://cdn.maxvideoai.com/audio.mp3',
+    referenceImages: ['https://cdn.maxvideoai.com/ref.png'],
+    inputs: result.falInputs,
+    soraRequest: undefined,
+    jobId: 'job_123',
+    localKey: 'local_123',
+    loop: undefined,
+    multiPrompt: [{ prompt: 'Shot one', duration: 6 }],
+    shotType: 'customize',
+    seed: 123,
+    cameraFixed: true,
+    safetyChecker: false,
+    voiceIds: ['voice_1'],
+    elements: [{ frontalImageUrl: 'https://cdn.maxvideoai.com/face.png' }],
+    endImageUrl: 'https://cdn.maxvideoai.com/end.png',
+    extraInputValues: { style_strength: 0.6 },
+    durationSec: 12,
+    durationOption: 12,
+    numFrames: null,
+    aspectRatio: '16:9',
+    resolution: '1080p',
+    audio: false,
+    fps: 25,
+    cfgScale: 5.5,
+  });
+});
+
+test('Fal request helper uses first frame URL for first-last-frame payloads', () => {
+  const result = baseFalRequest({
+    mode: 'fl2v',
+    needsFirstLastFrames: true,
+    resolvedFirstFrameUrl: 'https://cdn.maxvideoai.com/first.png',
+    lastFrameUrl: 'https://cdn.maxvideoai.com/last.png',
+    supportsFps: false,
+    fps: 24,
+  });
+
+  assert.equal(result.falPayload.imageUrl, 'https://cdn.maxvideoai.com/first.png');
+  assert.equal(result.falPayload.fps, undefined);
+  assert.equal(result.falInputSummary.hasFirstFrame, true);
+  assert.equal(result.falInputSummary.hasLastFrame, true);
+});


### PR DESCRIPTION
## Summary
- Move Fal provider input mapping, input summary, duration option, FPS clamping, and payload construction out of /api/generate
- Keep the route focused on orchestration while settings snapshots and provider submission consume the derived request parts
- Add architecture and behavior coverage for provider inputs, LTX FPS clamping, i2v shot type handling, first/last frame payloads, and payload options

## Local verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-fal-request.test.ts tests/generate-metric-logger.test.ts tests/generate-receipt-snapshot.test.ts tests/generate-attachment-references.test.ts tests/generate-attachments.test.ts tests/generate-extra-input-values.test.ts tests/generate-payment-rollback-architecture.test.ts tests/generate-initial-video-job-architecture.test.ts tests/generate-fal-error-handling.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build