### PR TITLE
Split generate settings snapshot helper

### DIFF
--- a/frontend/app/api/generate/_lib/settings-snapshot.ts
+++ b/frontend/app/api/generate/_lib/settings-snapshot.ts
@@ -1,0 +1,108 @@
+import type { GenerateAttachment } from '@/lib/fal';
+import type { Mode } from '@/types/engines';
+
+type MultiPromptEntry = {
+  prompt: string;
+  duration: number;
+};
+
+type GenerationElement = {
+  frontalImageUrl?: string;
+  referenceImageUrls?: string[];
+  videoUrl?: string;
+};
+
+export type GenerationSettingsSnapshot = Record<string, unknown>;
+
+function trimmedStringOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length ? value.trim() : null;
+}
+
+export function buildGenerationSettingsSnapshot(params: {
+  engineId: string;
+  engineLabel: string;
+  mode: Mode;
+  prompt: string;
+  negativePrompt: unknown;
+  membershipTier: unknown;
+  durationSec: number;
+  durationOption: number | string | null;
+  numFrames: number | null;
+  aspectRatio: string | null;
+  resolution: string;
+  clampedFps: number | undefined;
+  rawFps: unknown;
+  iterationCount: number | null;
+  audioEnabled: boolean | undefined;
+  cfgScale: unknown;
+  isLumaRay2: boolean;
+  loop: boolean;
+  shotType: 'customize' | 'intelligent' | null;
+  seed: number | null;
+  cameraFixed: boolean | null;
+  safetyChecker: boolean | null;
+  voiceIds: string[];
+  voiceControl: boolean;
+  multiPrompt: MultiPromptEntry[] | null;
+  extraInputValues: Record<string, unknown>;
+  initialImageUrl: string | undefined;
+  resolvedFirstFrameUrl: string | undefined;
+  resolvedAudioUrl: string | undefined;
+  normalizedReferenceImages: string[];
+  videoUrls: string[];
+  lastFrameUrl: string | undefined;
+  endImageUrl: string | null;
+  elements: GenerationElement[] | null;
+  falInputs: GenerateAttachment[] | undefined;
+}): GenerationSettingsSnapshot {
+  return {
+    schemaVersion: 1,
+    surface: 'video',
+    engineId: params.engineId,
+    engineLabel: params.engineLabel,
+    inputMode: params.mode,
+    prompt: params.prompt,
+    negativePrompt: trimmedStringOrNull(params.negativePrompt),
+    core: {
+      durationSec: params.durationSec,
+      durationOption: params.durationOption,
+      numFrames: params.numFrames ?? null,
+      aspectRatio: params.aspectRatio,
+      resolution: params.resolution,
+      fps:
+        typeof params.clampedFps === 'number'
+          ? params.clampedFps
+          : typeof params.rawFps === 'number'
+            ? Math.trunc(params.rawFps)
+            : null,
+      iterationCount: params.iterationCount ?? null,
+      audio: typeof params.audioEnabled === 'boolean' ? params.audioEnabled : null,
+    },
+    advanced: {
+      cfgScale: typeof params.cfgScale === 'number' && Number.isFinite(params.cfgScale) ? params.cfgScale : null,
+      loop: params.isLumaRay2 ? Boolean(params.loop) : null,
+      shotType: params.shotType ?? null,
+      seed: typeof params.seed === 'number' ? params.seed : null,
+      cameraFixed: typeof params.cameraFixed === 'boolean' ? params.cameraFixed : null,
+      safetyChecker: typeof params.safetyChecker === 'boolean' ? params.safetyChecker : null,
+      voiceIds: params.voiceIds.length ? params.voiceIds : null,
+      voiceControl: params.voiceControl ? true : null,
+      multiPrompt: params.multiPrompt ?? null,
+      extraInputValues: Object.keys(params.extraInputValues).length ? params.extraInputValues : null,
+    },
+    refs: {
+      imageUrl: params.initialImageUrl ?? params.resolvedFirstFrameUrl ?? null,
+      audioUrl: params.resolvedAudioUrl ?? null,
+      referenceImages: params.normalizedReferenceImages ?? null,
+      videoUrls: params.videoUrls.length ? params.videoUrls : null,
+      firstFrameUrl: params.resolvedFirstFrameUrl ?? null,
+      lastFrameUrl: params.lastFrameUrl ?? null,
+      endImageUrl: params.endImageUrl ?? null,
+      elements: params.elements ?? null,
+      inputs: params.falInputs ?? null,
+    },
+    meta: {
+      memberTier: trimmedStringOrNull(params.membershipTier),
+    },
+  };
+}

--- a/frontend/app/api/generate/route.ts
+++ b/frontend/app/api/generate/route.ts
@@ -25,6 +25,7 @@ import { deriveGenerationAttachmentReferences } from './_lib/attachment-referenc
 import { buildReceiptSnapshot } from './_lib/receipt-snapshot';
 import { createGenerateMetricLogger } from './_lib/metric-logger';
 import { buildFalRequestParts } from './_lib/fal-request';
+import { buildGenerationSettingsSnapshot } from './_lib/settings-snapshot';
 import {
   buildResponseFromExistingVideoJob,
   createAtomicInitialVideoJob,
@@ -1087,55 +1088,43 @@ export async function POST(req: NextRequest) {
     cfgScale: body.cfgScale,
   });
 
-  const negativePrompt =
-    typeof body.negativePrompt === 'string' && body.negativePrompt.trim().length ? body.negativePrompt.trim() : null;
-  const membershipTier =
-    typeof body.membershipTier === 'string' && body.membershipTier.trim().length ? body.membershipTier.trim() : null;
-  const settingsSnapshot = {
-    schemaVersion: 1,
-    surface: 'video',
+  const settingsSnapshot = buildGenerationSettingsSnapshot({
     engineId: engine.id,
     engineLabel: engine.label,
-    inputMode: mode,
+    mode,
     prompt,
-    negativePrompt,
-    core: {
-      durationSec,
-      durationOption: falDurationOption,
-      numFrames: numFrames ?? null,
-      aspectRatio,
-      resolution: effectiveResolution,
-      fps: typeof clampedFps === 'number' ? clampedFps : typeof body.fps === 'number' ? Math.trunc(body.fps) : null,
-      iterationCount: iterationCount ?? null,
-      audio: typeof audioEnabled === 'boolean' ? audioEnabled : null,
-    },
-    advanced: {
-      cfgScale: typeof body.cfgScale === 'number' && Number.isFinite(body.cfgScale) ? body.cfgScale : null,
-      loop: isLumaRay2 ? Boolean(loop) : null,
-      shotType: shotType ?? null,
-      seed: typeof seed === 'number' ? seed : null,
-      cameraFixed: typeof cameraFixed === 'boolean' ? cameraFixed : null,
-      safetyChecker: typeof safetyChecker === 'boolean' ? safetyChecker : null,
-      voiceIds: voiceIds.length ? voiceIds : null,
-      voiceControl: voiceControl ? true : null,
-      multiPrompt: multiPrompt ?? null,
-      extraInputValues: Object.keys(validatedExtraInputValues).length ? validatedExtraInputValues : null,
-    },
-    refs: {
-      imageUrl: initialImageUrl ?? resolvedFirstFrameUrl ?? null,
-      audioUrl: resolvedAudioUrl ?? null,
-      referenceImages: normalizedReferenceImages ?? null,
-      videoUrls: videoUrls.length ? videoUrls : null,
-      firstFrameUrl: resolvedFirstFrameUrl ?? null,
-      lastFrameUrl: lastFrameUrl ?? null,
-      endImageUrl: endImageUrl ?? null,
-      elements: elements ?? null,
-      inputs: falInputs ?? null,
-    },
-    meta: {
-      memberTier: membershipTier,
-    },
-  };
+    negativePrompt: body.negativePrompt,
+    membershipTier: body.membershipTier,
+    durationSec,
+    durationOption: falDurationOption,
+    numFrames,
+    aspectRatio,
+    resolution: effectiveResolution,
+    clampedFps,
+    rawFps: body.fps,
+    iterationCount,
+    audioEnabled,
+    cfgScale: body.cfgScale,
+    isLumaRay2,
+    loop,
+    shotType,
+    seed,
+    cameraFixed,
+    safetyChecker,
+    voiceIds,
+    voiceControl,
+    multiPrompt,
+    extraInputValues: validatedExtraInputValues,
+    initialImageUrl,
+    resolvedFirstFrameUrl,
+    resolvedAudioUrl,
+    normalizedReferenceImages,
+    videoUrls,
+    lastFrameUrl,
+    endImageUrl,
+    elements,
+    falInputs,
+  });
   let settingsSnapshotJson = JSON.stringify(settingsSnapshot);
 
   let lastProviderJobId: string | null = null;

--- a/tests/generate-settings-snapshot.test.ts
+++ b/tests/generate-settings-snapshot.test.ts
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { buildGenerationSettingsSnapshot } from '../frontend/app/api/generate/_lib/settings-snapshot';
+
+const root = process.cwd();
+const routePath = join(root, 'frontend/app/api/generate/route.ts');
+const helperPath = join(root, 'frontend/app/api/generate/_lib/settings-snapshot.ts');
+
+const routeSource = readFileSync(routePath, 'utf8');
+const helperSource = readFileSync(helperPath, 'utf8');
+
+test('generate route delegates settings snapshot building', () => {
+  assert.ok(existsSync(helperPath), 'settings snapshot building should live in the generate route _lib folder');
+  assert.match(routeSource, /from '\.\/_lib\/settings-snapshot'/);
+  assert.doesNotMatch(routeSource, /schemaVersion:\s*1/, 'settings schema version belongs in settings-snapshot.ts');
+  assert.doesNotMatch(routeSource, /negativePrompt\s*=/, 'negative prompt normalization belongs in settings-snapshot.ts');
+  assert.doesNotMatch(routeSource, /memberTier/, 'membership tier snapshot belongs in settings-snapshot.ts');
+
+  const lineCount = routeSource.split('\n').length;
+  assert.ok(lineCount <= 2050, `/api/generate route should stay below 2050 lines after settings snapshot extraction, got ${lineCount}`);
+});
+
+test('settings snapshot helper exposes the route contract', () => {
+  assert.match(helperSource, /export type GenerationSettingsSnapshot/, 'settings snapshot type should be exported');
+  assert.match(helperSource, /export function buildGenerationSettingsSnapshot/, 'buildGenerationSettingsSnapshot should be exported');
+  assert.match(helperSource, /function trimmedStringOrNull/, 'string trimming should stay private');
+});
+
+test('settings snapshot helper builds core, advanced, refs, and meta snapshots', () => {
+  const snapshot = buildGenerationSettingsSnapshot({
+    engineId: 'seedance-2-0',
+    engineLabel: 'Seedance 2.0',
+    mode: 'i2v',
+    prompt: 'Create a shot',
+    negativePrompt: '  blur  ',
+    membershipTier: ' pro ',
+    durationSec: 8,
+    durationOption: '8',
+    numFrames: null,
+    aspectRatio: '16:9',
+    resolution: '1080p',
+    clampedFps: 25,
+    rawFps: 12,
+    iterationCount: 2,
+    audioEnabled: true,
+    cfgScale: 5.5,
+    isLumaRay2: true,
+    loop: true,
+    shotType: 'customize',
+    seed: 123,
+    cameraFixed: false,
+    safetyChecker: true,
+    voiceIds: ['voice_1'],
+    voiceControl: true,
+    multiPrompt: [{ prompt: 'Shot one', duration: 4 }],
+    extraInputValues: { style_strength: 0.6 },
+    initialImageUrl: 'https://cdn.maxvideoai.com/image.png',
+    resolvedFirstFrameUrl: 'https://cdn.maxvideoai.com/first.png',
+    resolvedAudioUrl: 'https://cdn.maxvideoai.com/audio.mp3',
+    normalizedReferenceImages: ['https://cdn.maxvideoai.com/ref.png'],
+    videoUrls: ['https://cdn.maxvideoai.com/source.mp4'],
+    lastFrameUrl: 'https://cdn.maxvideoai.com/last.png',
+    endImageUrl: 'https://cdn.maxvideoai.com/end.png',
+    elements: [{ frontalImageUrl: 'https://cdn.maxvideoai.com/face.png' }],
+    falInputs: [
+      {
+        name: 'image',
+        type: 'image/png',
+        size: 10,
+        kind: 'image',
+        slotId: 'image_url',
+        url: 'https://cdn.maxvideoai.com/image.png',
+      },
+    ],
+  });
+
+  assert.deepEqual(snapshot, {
+    schemaVersion: 1,
+    surface: 'video',
+    engineId: 'seedance-2-0',
+    engineLabel: 'Seedance 2.0',
+    inputMode: 'i2v',
+    prompt: 'Create a shot',
+    negativePrompt: 'blur',
+    core: {
+      durationSec: 8,
+      durationOption: '8',
+      numFrames: null,
+      aspectRatio: '16:9',
+      resolution: '1080p',
+      fps: 25,
+      iterationCount: 2,
+      audio: true,
+    },
+    advanced: {
+      cfgScale: 5.5,
+      loop: true,
+      shotType: 'customize',
+      seed: 123,
+      cameraFixed: false,
+      safetyChecker: true,
+      voiceIds: ['voice_1'],
+      voiceControl: true,
+      multiPrompt: [{ prompt: 'Shot one', duration: 4 }],
+      extraInputValues: { style_strength: 0.6 },
+    },
+    refs: {
+      imageUrl: 'https://cdn.maxvideoai.com/image.png',
+      audioUrl: 'https://cdn.maxvideoai.com/audio.mp3',
+      referenceImages: ['https://cdn.maxvideoai.com/ref.png'],
+      videoUrls: ['https://cdn.maxvideoai.com/source.mp4'],
+      firstFrameUrl: 'https://cdn.maxvideoai.com/first.png',
+      lastFrameUrl: 'https://cdn.maxvideoai.com/last.png',
+      endImageUrl: 'https://cdn.maxvideoai.com/end.png',
+      elements: [{ frontalImageUrl: 'https://cdn.maxvideoai.com/face.png' }],
+      inputs: [
+        {
+          name: 'image',
+          type: 'image/png',
+          size: 10,
+          kind: 'image',
+          slotId: 'image_url',
+          url: 'https://cdn.maxvideoai.com/image.png',
+        },
+      ],
+    },
+    meta: {
+      memberTier: 'pro',
+    },
+  });
+});
+
+test('settings snapshot helper normalizes empty optional values', () => {
+  const snapshot = buildGenerationSettingsSnapshot({
+    engineId: 'generic',
+    engineLabel: 'Generic',
+    mode: 't2v',
+    prompt: 'Prompt',
+    negativePrompt: '',
+    membershipTier: '',
+    durationSec: 4,
+    durationOption: null,
+    numFrames: null,
+    aspectRatio: null,
+    resolution: '720p',
+    clampedFps: undefined,
+    rawFps: 24,
+    iterationCount: null,
+    audioEnabled: undefined,
+    cfgScale: 'invalid',
+    isLumaRay2: false,
+    loop: true,
+    shotType: null,
+    seed: null,
+    cameraFixed: null,
+    safetyChecker: null,
+    voiceIds: [],
+    voiceControl: false,
+    multiPrompt: null,
+    extraInputValues: {},
+    initialImageUrl: undefined,
+    resolvedFirstFrameUrl: undefined,
+    resolvedAudioUrl: undefined,
+    normalizedReferenceImages: [],
+    videoUrls: [],
+    lastFrameUrl: undefined,
+    endImageUrl: null,
+    elements: null,
+    falInputs: undefined,
+  });
+
+  assert.equal((snapshot as { negativePrompt: unknown }).negativePrompt, null);
+  assert.deepEqual((snapshot as { core: { fps: number } }).core.fps, 24);
+  assert.deepEqual((snapshot as { advanced: { loop: unknown; extraInputValues: unknown } }).advanced.loop, null);
+  assert.deepEqual((snapshot as { advanced: { loop: unknown; extraInputValues: unknown } }).advanced.extraInputValues, null);
+  assert.deepEqual((snapshot as { refs: { videoUrls: unknown; inputs: unknown } }).refs.videoUrls, null);
+  assert.deepEqual((snapshot as { refs: { videoUrls: unknown; inputs: unknown } }).refs.inputs, null);
+  assert.deepEqual((snapshot as { meta: { memberTier: unknown } }).meta.memberTier, null);
+});


### PR DESCRIPTION
## Summary
- Move /api/generate settings snapshot construction into a focused route helper
- Keep provider video copy state able to enrich the same snapshot before persistence
- Add architecture and behavior coverage for core, advanced, refs, meta, trimming, and empty optional values

## Local verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-settings-snapshot.test.ts tests/generate-fal-request.test.ts tests/generate-metric-logger.test.ts tests/generate-receipt-snapshot.test.ts tests/generate-attachment-references.test.ts tests/generate-attachments.test.ts tests/generate-extra-input-values.test.ts tests/generate-payment-rollback-architecture.test.ts tests/generate-initial-video-job-architecture.test.ts tests/generate-fal-error-handling.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build