### PR TITLE
Split generate provider job tracker

### DIFF
--- a/frontend/app/api/generate/_lib/provider-job-tracker.ts
+++ b/frontend/app/api/generate/_lib/provider-job-tracker.ts
@@ -1,0 +1,73 @@
+import { query } from '@/lib/db';
+import type { FalInputSummary } from './fal-request';
+
+type QueryFn = (sql: string, params?: unknown[]) => Promise<unknown>;
+
+export type ProviderJobTracker = {
+  getLastProviderJobId: () => string | null;
+  setLastProviderJobId: (requestId: string | null | undefined) => void;
+  persistProviderJobId: (requestId: string) => Promise<void>;
+};
+
+export function createProviderJobTracker(params: {
+  jobId: string;
+  providerKey: string;
+  engineId: string;
+  prompt: string;
+  inputSummary: FalInputSummary;
+  now?: () => Date;
+  queryFn?: QueryFn;
+}): ProviderJobTracker {
+  let lastProviderJobId: string | null = null;
+  const queryFn = params.queryFn ?? query;
+  const now = params.now ?? (() => new Date());
+
+  const setLastProviderJobId = (requestId: string | null | undefined) => {
+    if (requestId) {
+      lastProviderJobId = requestId;
+    }
+  };
+
+  const persistProviderJobId = async (requestId: string) => {
+    if (!requestId || lastProviderJobId === requestId) return;
+    lastProviderJobId = requestId;
+    try {
+      await queryFn(
+        `UPDATE app_jobs
+         SET provider_job_id = $2, updated_at = NOW()
+         WHERE job_id = $1
+           AND (provider_job_id IS NULL OR provider_job_id <> $2)`,
+        [params.jobId, requestId]
+      );
+    } catch (error) {
+      console.warn('[api/generate] failed to persist provider_job_id', { jobId: params.jobId, requestId }, error);
+    }
+    try {
+      await queryFn(
+        `INSERT INTO fal_queue_log (job_id, provider, provider_job_id, engine_id, status, payload)
+         VALUES ($1,$2,$3,$4,$5,$6::jsonb)`,
+        [
+          params.jobId,
+          params.providerKey,
+          requestId,
+          params.engineId,
+          'enqueue',
+          JSON.stringify({
+            at: now().toISOString(),
+            engineId: params.engineId,
+            promptLength: params.prompt.length,
+            inputSummary: params.inputSummary,
+          }),
+        ]
+      );
+    } catch (error) {
+      console.warn('[queue-log] failed to record enqueue event', { jobId: params.jobId, requestId }, error);
+    }
+  };
+
+  return {
+    getLastProviderJobId: () => lastProviderJobId,
+    setLastProviderJobId,
+    persistProviderJobId,
+  };
+}

--- a/frontend/app/api/generate/route.ts
+++ b/frontend/app/api/generate/route.ts
@@ -26,6 +26,7 @@ import { buildReceiptSnapshot } from './_lib/receipt-snapshot';
 import { createGenerateMetricLogger } from './_lib/metric-logger';
 import { buildFalRequestParts } from './_lib/fal-request';
 import { buildGenerationSettingsSnapshot } from './_lib/settings-snapshot';
+import { createProviderJobTracker } from './_lib/provider-job-tracker';
 import {
   buildResponseFromExistingVideoJob,
   createAtomicInitialVideoJob,
@@ -1127,43 +1128,14 @@ export async function POST(req: NextRequest) {
   });
   let settingsSnapshotJson = JSON.stringify(settingsSnapshot);
 
-  let lastProviderJobId: string | null = null;
-  const persistProviderJobId = async (requestId: string) => {
-    if (!requestId || lastProviderJobId === requestId) return;
-    lastProviderJobId = requestId;
-    try {
-      await query(
-        `UPDATE app_jobs
-         SET provider_job_id = $2, updated_at = NOW()
-         WHERE job_id = $1
-           AND (provider_job_id IS NULL OR provider_job_id <> $2)`,
-        [jobId, requestId]
-      );
-    } catch (error) {
-      console.warn('[api/generate] failed to persist provider_job_id', { jobId, requestId }, error);
-    }
-    try {
-      await query(
-        `INSERT INTO fal_queue_log (job_id, provider, provider_job_id, engine_id, status, payload)
-         VALUES ($1,$2,$3,$4,$5,$6::jsonb)`,
-	      [
-	        jobId,
-	        providerKey,
-	        requestId,
-          engine.id,
-          'enqueue',
-          JSON.stringify({
-            at: new Date().toISOString(),
-            engineId: engine.id,
-            promptLength: prompt.length,
-            inputSummary: falInputSummary,
-          }),
-        ]
-      );
-    } catch (error) {
-      console.warn('[queue-log] failed to record enqueue event', { jobId, requestId }, error);
-    }
-  };
+  const providerJobTracker = createProviderJobTracker({
+    jobId,
+    providerKey,
+    engineId: engine.id,
+    prompt,
+    inputSummary: falInputSummary,
+  });
+  const { getLastProviderJobId, persistProviderJobId, setLastProviderJobId } = providerJobTracker;
 
   try {
     const initialJobState = await createAtomicInitialVideoJob({
@@ -1415,10 +1387,8 @@ export async function POST(req: NextRequest) {
         onQueueUpdate: (status) => {
           if (!status) return;
           const requestId =
-            (status as { request_id?: string }).request_id ?? lastProviderJobId ?? null;
-          if (requestId) {
-            lastProviderJobId = requestId;
-          }
+            (status as { request_id?: string }).request_id ?? getLastProviderJobId() ?? null;
+          setLastProviderJobId(requestId);
         },
       }
     );
@@ -1473,7 +1443,7 @@ export async function POST(req: NextRequest) {
         ? error.providerJobId
         : typeof (error as { providerJobId?: string } | undefined)?.providerJobId === 'string'
           ? (error as { providerJobId?: string }).providerJobId!
-          : lastProviderJobId ?? batchId ?? null;
+          : getLastProviderJobId() ?? batchId ?? null;
   const paymentStatusOverride =
       pendingReceipt && paymentMode === 'wallet'
         ? 'refunded_wallet'

--- a/tests/generate-provider-job-tracker.test.ts
+++ b/tests/generate-provider-job-tracker.test.ts
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { createProviderJobTracker } from '../frontend/app/api/generate/_lib/provider-job-tracker';
+
+const root = process.cwd();
+const routePath = join(root, 'frontend/app/api/generate/route.ts');
+const helperPath = join(root, 'frontend/app/api/generate/_lib/provider-job-tracker.ts');
+
+const routeSource = readFileSync(routePath, 'utf8');
+const helperSource = readFileSync(helperPath, 'utf8');
+
+test('generate route delegates provider job id tracking', () => {
+  assert.ok(existsSync(helperPath), 'provider job id tracking should live in the generate route _lib folder');
+  assert.match(routeSource, /from '\.\/_lib\/provider-job-tracker'/);
+  assert.doesNotMatch(routeSource, /let lastProviderJobId/, 'provider job id state belongs in provider-job-tracker.ts');
+  assert.doesNotMatch(routeSource, /INSERT INTO fal_queue_log \(job_id, provider, provider_job_id, engine_id, status, payload\)\n\s+VALUES \(\$1,\$2,\$3,\$4,\$5,\$6::jsonb\)[\s\S]*'enqueue'/, 'enqueue queue log SQL belongs in provider-job-tracker.ts');
+
+  const lineCount = routeSource.split('\n').length;
+  assert.ok(lineCount <= 2020, `/api/generate route should stay below 2020 lines after provider tracker extraction, got ${lineCount}`);
+});
+
+test('provider job tracker helper exposes the route contract', () => {
+  assert.match(helperSource, /export type ProviderJobTracker/, 'ProviderJobTracker type should be exported');
+  assert.match(helperSource, /export function createProviderJobTracker/, 'createProviderJobTracker should be exported');
+  assert.match(helperSource, /getLastProviderJobId/, 'last provider job getter should stay in the helper');
+  assert.match(helperSource, /persistProviderJobId/, 'provider job persistence should stay in the helper');
+});
+
+test('provider job tracker persists new provider ids and queue log payloads', async () => {
+  const queries: Array<{ sql: string; params?: unknown[] }> = [];
+  const tracker = createProviderJobTracker({
+    jobId: 'job_123',
+    providerKey: 'fal',
+    engineId: 'seedance-2-0',
+    prompt: 'Create a shot',
+    inputSummary: {
+      primaryImageUrl: 'https://cdn.maxvideoai.com/image.png',
+      primaryAudioUrl: null,
+      referenceImageCount: 1,
+      referenceVideoCount: 0,
+      referenceAudioCount: 0,
+      hasFirstFrame: false,
+      hasLastFrame: false,
+      inputSlots: [{ slotId: 'image_url', kind: 'image', hasUrl: true }],
+    },
+    now: () => new Date('2026-05-07T20:00:00.000Z'),
+    queryFn: async (sql, params) => {
+      queries.push({ sql, params });
+    },
+  });
+
+  await tracker.persistProviderJobId('fal_request_123');
+
+  assert.equal(tracker.getLastProviderJobId(), 'fal_request_123');
+  assert.equal(queries.length, 2);
+  assert.match(queries[0]?.sql ?? '', /UPDATE app_jobs/);
+  assert.deepEqual(queries[0]?.params, ['job_123', 'fal_request_123']);
+  assert.match(queries[1]?.sql ?? '', /INSERT INTO fal_queue_log/);
+  assert.deepEqual(queries[1]?.params?.slice(0, 5), ['job_123', 'fal', 'fal_request_123', 'seedance-2-0', 'enqueue']);
+  const payload = JSON.parse(String(queries[1]?.params?.[5]));
+  assert.deepEqual(payload, {
+    at: '2026-05-07T20:00:00.000Z',
+    engineId: 'seedance-2-0',
+    promptLength: 13,
+    inputSummary: {
+      primaryImageUrl: 'https://cdn.maxvideoai.com/image.png',
+      primaryAudioUrl: null,
+      referenceImageCount: 1,
+      referenceVideoCount: 0,
+      referenceAudioCount: 0,
+      hasFirstFrame: false,
+      hasLastFrame: false,
+      inputSlots: [{ slotId: 'image_url', kind: 'image', hasUrl: true }],
+    },
+  });
+});
+
+test('provider job tracker deduplicates repeated provider ids and accepts queue status ids', async () => {
+  const queries: Array<{ sql: string; params?: unknown[] }> = [];
+  const tracker = createProviderJobTracker({
+    jobId: 'job_123',
+    providerKey: 'fal',
+    engineId: 'veo-3-1',
+    prompt: 'Prompt',
+    inputSummary: {
+      primaryImageUrl: null,
+      primaryAudioUrl: null,
+      referenceImageCount: 0,
+      referenceVideoCount: 0,
+      referenceAudioCount: 0,
+      hasFirstFrame: false,
+      hasLastFrame: false,
+      inputSlots: [],
+    },
+    queryFn: async (sql, params) => {
+      queries.push({ sql, params });
+    },
+  });
+
+  tracker.setLastProviderJobId('from_queue');
+  assert.equal(tracker.getLastProviderJobId(), 'from_queue');
+
+  await tracker.persistProviderJobId('from_queue');
+  await tracker.persistProviderJobId('from_queue');
+
+  assert.equal(queries.length, 0);
+});


### PR DESCRIPTION
## Summary
- Move provider_job_id tracking, persistence, and enqueue queue logging out of /api/generate
- Keep the route using a small tracker interface for request id callbacks and provider error fallback
- Add architecture and behavior coverage for persistence, queue log payloads, duplicate ids, and queue status ids

## Local verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-provider-job-tracker.test.ts tests/generate-settings-snapshot.test.ts tests/generate-fal-request.test.ts tests/generate-metric-logger.test.ts tests/generate-receipt-snapshot.test.ts tests/generate-attachment-references.test.ts tests/generate-attachments.test.ts tests/generate-extra-input-values.test.ts tests/generate-payment-rollback-architecture.test.ts tests/generate-initial-video-job-architecture.test.ts tests/generate-fal-error-handling.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build