### PR TITLE
Split generate final job persistence

### DIFF
--- a/frontend/app/api/generate/_lib/final-job-persistence.ts
+++ b/frontend/app/api/generate/_lib/final-job-persistence.ts
@@ -1,0 +1,133 @@
+import { query } from '@/lib/db';
+import type { FalInputSummary } from './fal-request';
+
+type QueryFn = (sql: string, params?: unknown[]) => Promise<unknown>;
+
+export async function persistFinalVideoJobUpdate(params: {
+  jobId: string;
+  thumb: string | null;
+  aspectRatio: string | null;
+  previewFrame: string | null;
+  etaSeconds: number | null;
+  etaLabel: string | null;
+  video: string | null;
+  status: string;
+  progress: number;
+  providerJobId: string | null;
+  finalPriceCents: number;
+  pricingSnapshotJson: string;
+  costBreakdownJson: string | null;
+  currency: string;
+  vendorAccountId: string | null;
+  paymentStatus: string;
+  stripePaymentIntentId: string | null;
+  stripeChargeId: string | null;
+  visibility: 'public' | 'private';
+  indexable: boolean;
+  message: string | null;
+  settingsSnapshotJson: string;
+  queryFn?: QueryFn;
+}): Promise<void> {
+  const queryFn = params.queryFn ?? query;
+  await queryFn(
+    `UPDATE app_jobs
+     SET thumb_url = $2,
+         aspect_ratio = $3,
+         preview_frame = $4,
+         eta_seconds = $5,
+         eta_label = $6,
+         video_url = $7,
+         status = $8,
+         progress = $9,
+         provider_job_id = COALESCE($10, provider_job_id),
+         final_price_cents = $11,
+         pricing_snapshot = $12::jsonb,
+         cost_breakdown_usd = $13::jsonb,
+         currency = $14,
+         vendor_account_id = $15,
+         payment_status = $16,
+         stripe_payment_intent_id = $17,
+         stripe_charge_id = $18,
+         visibility = $19,
+         indexable = $20,
+         message = $21,
+         settings_snapshot = $22::jsonb,
+         provisional = FALSE,
+         updated_at = NOW()
+     WHERE job_id = $1`,
+    [
+      params.jobId,
+      params.thumb,
+      params.aspectRatio,
+      params.previewFrame,
+      params.etaSeconds,
+      params.etaLabel,
+      params.video,
+      params.status,
+      params.progress,
+      params.providerJobId,
+      params.finalPriceCents,
+      params.pricingSnapshotJson,
+      params.costBreakdownJson,
+      params.currency,
+      params.vendorAccountId,
+      params.paymentStatus,
+      params.stripePaymentIntentId,
+      params.stripeChargeId,
+      params.visibility,
+      params.indexable,
+      params.message,
+      params.settingsSnapshotJson,
+    ]
+  );
+}
+
+export async function recordFinalGenerateQueueLog(params: {
+  jobId: string;
+  provider: string;
+  providerJobId: string | null;
+  engineId: string;
+  status: string;
+  durationSec: number;
+  durationLabel: string | undefined;
+  aspectRatio: string | null;
+  resolution: string;
+  loop: boolean | undefined;
+  inputSummary: FalInputSummary;
+  totalCents: number;
+  currency: string;
+  costBreakdownUsd: Record<string, unknown> | null;
+  queryFn?: QueryFn;
+}): Promise<void> {
+  const queryFn = params.queryFn ?? query;
+  try {
+    await queryFn(
+      `INSERT INTO fal_queue_log (job_id, provider, provider_job_id, engine_id, status, payload)
+       VALUES ($1,$2,$3,$4,$5,$6::jsonb)`,
+      [
+        params.jobId,
+        params.provider,
+        params.providerJobId,
+        params.engineId,
+        params.status,
+        JSON.stringify({
+          request: {
+            durationSec: params.durationSec,
+            durationLabel: params.durationLabel,
+            aspectRatio: params.aspectRatio,
+            resolution: params.resolution,
+            loop: params.loop,
+          },
+          inputSummary: params.inputSummary,
+          pricing: {
+            totalCents: params.totalCents,
+            currency: params.currency,
+            cost_breakdown_usd: params.costBreakdownUsd,
+          },
+        }),
+      ]
+    );
+  } catch (error) {
+    console.warn('[queue-log] failed to insert entry', error);
+  }
+}

--- a/frontend/app/api/generate/route.ts
+++ b/frontend/app/api/generate/route.ts
@@ -27,6 +27,7 @@ import { createGenerateMetricLogger } from './_lib/metric-logger';
 import { buildFalRequestParts } from './_lib/fal-request';
 import { buildGenerationSettingsSnapshot } from './_lib/settings-snapshot';
 import { createProviderJobTracker } from './_lib/provider-job-tracker';
+import { persistFinalVideoJobUpdate, recordFinalGenerateQueueLog } from './_lib/final-job-persistence';
 import {
   buildResponseFromExistingVideoJob,
   createAtomicInitialVideoJob,
@@ -1819,57 +1820,30 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    await query(
-      `UPDATE app_jobs
-       SET thumb_url = $2,
-           aspect_ratio = $3,
-           preview_frame = $4,
-           eta_seconds = $5,
-           eta_label = $6,
-           video_url = $7,
-           status = $8,
-           progress = $9,
-           provider_job_id = COALESCE($10, provider_job_id),
-           final_price_cents = $11,
-           pricing_snapshot = $12::jsonb,
-           cost_breakdown_usd = $13::jsonb,
-           currency = $14,
-           vendor_account_id = $15,
-           payment_status = $16,
-           stripe_payment_intent_id = $17,
-           stripe_charge_id = $18,
-           visibility = $19,
-           indexable = $20,
-           message = $21,
-           settings_snapshot = $22::jsonb,
-           provisional = FALSE,
-           updated_at = NOW()
-       WHERE job_id = $1`,
-      [
-        jobId,
-        thumb,
-        aspectRatio,
-        previewFrame,
-        etaSeconds,
-        etaLabel,
-        video,
-        status,
-        progress,
-        providerJobId,
-        pricing.totalCents,
-        pricingSnapshotJson,
-        costBreakdownJson,
-        pricing.currency,
-        vendorAccountId,
-        paymentStatus,
-        stripePaymentIntentId,
-        stripeChargeId,
-        visibility,
-        indexable,
-        message,
-        settingsSnapshotJson,
-      ]
-    );
+    await persistFinalVideoJobUpdate({
+      jobId,
+      thumb,
+      aspectRatio,
+      previewFrame,
+      etaSeconds,
+      etaLabel,
+      video,
+      status,
+      progress,
+      providerJobId,
+      finalPriceCents: pricing.totalCents,
+      pricingSnapshotJson,
+      costBreakdownJson,
+      currency: pricing.currency,
+      vendorAccountId,
+      paymentStatus,
+      stripePaymentIntentId,
+      stripeChargeId,
+      visibility,
+      indexable,
+      message,
+      settingsSnapshotJson,
+    });
   } catch (error) {
     console.error('[api/generate] failed to update job record', error);
     if (pendingReceipt) {
@@ -1909,36 +1883,22 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  try {
-    await query(
-      `INSERT INTO fal_queue_log (job_id, provider, provider_job_id, engine_id, status, payload)
-       VALUES ($1,$2,$3,$4,$5,$6::jsonb)`,
-      [
-        jobId,
-        providerMode,
-        providerJobId,
-        engine.id,
-        status,
-        JSON.stringify({
-          request: {
-            durationSec,
-            durationLabel,
-            aspectRatio,
-            resolution: effectiveResolution,
-            loop: isLumaRay2 ? loop : undefined,
-          },
-          inputSummary: falInputSummary,
-          pricing: {
-            totalCents: pricing.totalCents,
-            currency: pricing.currency,
-            cost_breakdown_usd: costBreakdownUsd,
-          },
-        }),
-      ]
-    );
-  } catch (error) {
-    console.warn('[queue-log] failed to insert entry', error);
-  }
+  await recordFinalGenerateQueueLog({
+    jobId,
+    provider: providerMode,
+    providerJobId,
+    engineId: engine.id,
+    status,
+    durationSec,
+    durationLabel,
+    aspectRatio,
+    resolution: effectiveResolution,
+    loop: isLumaRay2 ? loop : undefined,
+    inputSummary: falInputSummary,
+    totalCents: pricing.totalCents,
+    currency: pricing.currency,
+    costBreakdownUsd,
+  });
 
   if (status === 'completed' && video) {
     await generateAndPersistJobKeyframes({

--- a/tests/generate-final-job-persistence.test.ts
+++ b/tests/generate-final-job-persistence.test.ts
@@ -1,0 +1,188 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  persistFinalVideoJobUpdate,
+  recordFinalGenerateQueueLog,
+} from '../frontend/app/api/generate/_lib/final-job-persistence';
+
+const root = process.cwd();
+const routePath = join(root, 'frontend/app/api/generate/route.ts');
+const helperPath = join(root, 'frontend/app/api/generate/_lib/final-job-persistence.ts');
+
+const routeSource = readFileSync(routePath, 'utf8');
+const helperSource = readFileSync(helperPath, 'utf8');
+
+test('generate route delegates final job persistence and final queue logging', () => {
+  assert.ok(existsSync(helperPath), 'final job persistence should live in the generate route _lib folder');
+  assert.match(routeSource, /from '\.\/_lib\/final-job-persistence'/);
+  assert.doesNotMatch(routeSource, /SET thumb_url = \$2/, 'final app_jobs update SQL belongs in final-job-persistence.ts');
+  assert.doesNotMatch(routeSource, /cost_breakdown_usd: costBreakdownUsd/, 'final queue log payload belongs in final-job-persistence.ts');
+
+  const lineCount = routeSource.split('\n').length;
+  assert.ok(lineCount <= 1980, `/api/generate route should stay below 1980 lines after final persistence extraction, got ${lineCount}`);
+});
+
+test('final job persistence helper exposes the route contract', () => {
+  assert.match(helperSource, /export async function persistFinalVideoJobUpdate/, 'persistFinalVideoJobUpdate should be exported');
+  assert.match(helperSource, /export async function recordFinalGenerateQueueLog/, 'recordFinalGenerateQueueLog should be exported');
+  assert.match(helperSource, /UPDATE app_jobs/, 'final app_jobs update SQL should stay with the helper');
+});
+
+test('final job persistence helper writes the expected app_jobs update params', async () => {
+  const queries: Array<{ sql: string; params?: unknown[] }> = [];
+
+  await persistFinalVideoJobUpdate({
+    jobId: 'job_123',
+    thumb: '/thumb.svg',
+    aspectRatio: '16:9',
+    previewFrame: '/thumb.svg',
+    etaSeconds: 30,
+    etaLabel: '30s',
+    video: 'https://cdn.maxvideoai.com/video.mp4',
+    status: 'completed',
+    progress: 100,
+    providerJobId: 'provider_123',
+    finalPriceCents: 1200,
+    pricingSnapshotJson: '{"totalCents":1200}',
+    costBreakdownJson: '{"provider":100}',
+    currency: 'USD',
+    vendorAccountId: null,
+    paymentStatus: 'paid_wallet',
+    stripePaymentIntentId: null,
+    stripeChargeId: null,
+    visibility: 'private',
+    indexable: false,
+    message: 'Render complete',
+    settingsSnapshotJson: '{"schemaVersion":1}',
+    queryFn: async (sql, params) => {
+      queries.push({ sql, params });
+    },
+  });
+
+  assert.equal(queries.length, 1);
+  assert.match(queries[0]?.sql ?? '', /UPDATE app_jobs/);
+  assert.deepEqual(queries[0]?.params, [
+    'job_123',
+    '/thumb.svg',
+    '16:9',
+    '/thumb.svg',
+    30,
+    '30s',
+    'https://cdn.maxvideoai.com/video.mp4',
+    'completed',
+    100,
+    'provider_123',
+    1200,
+    '{"totalCents":1200}',
+    '{"provider":100}',
+    'USD',
+    null,
+    'paid_wallet',
+    null,
+    null,
+    'private',
+    false,
+    'Render complete',
+    '{"schemaVersion":1}',
+  ]);
+});
+
+test('final queue log helper records request, input summary, and pricing payload', async () => {
+  const queries: Array<{ sql: string; params?: unknown[] }> = [];
+
+  await recordFinalGenerateQueueLog({
+    jobId: 'job_123',
+    provider: 'fal',
+    providerJobId: 'provider_123',
+    engineId: 'seedance-2-0',
+    status: 'completed',
+    durationSec: 8,
+    durationLabel: '8s',
+    aspectRatio: '16:9',
+    resolution: '1080p',
+    loop: undefined,
+    inputSummary: {
+      primaryImageUrl: null,
+      primaryAudioUrl: null,
+      referenceImageCount: 0,
+      referenceVideoCount: 0,
+      referenceAudioCount: 0,
+      hasFirstFrame: false,
+      hasLastFrame: false,
+      inputSlots: [],
+    },
+    totalCents: 1200,
+    currency: 'USD',
+    costBreakdownUsd: { provider: 100 },
+    queryFn: async (sql, params) => {
+      queries.push({ sql, params });
+    },
+  });
+
+  assert.equal(queries.length, 1);
+  assert.match(queries[0]?.sql ?? '', /INSERT INTO fal_queue_log/);
+  assert.deepEqual(queries[0]?.params?.slice(0, 5), ['job_123', 'fal', 'provider_123', 'seedance-2-0', 'completed']);
+  assert.deepEqual(JSON.parse(String(queries[0]?.params?.[5])), {
+    request: {
+      durationSec: 8,
+      durationLabel: '8s',
+      aspectRatio: '16:9',
+      resolution: '1080p',
+    },
+    inputSummary: {
+      primaryImageUrl: null,
+      primaryAudioUrl: null,
+      referenceImageCount: 0,
+      referenceVideoCount: 0,
+      referenceAudioCount: 0,
+      hasFirstFrame: false,
+      hasLastFrame: false,
+      inputSlots: [],
+    },
+    pricing: {
+      totalCents: 1200,
+      currency: 'USD',
+      cost_breakdown_usd: { provider: 100 },
+    },
+  });
+});
+
+test('final queue log helper swallows logging failures', async () => {
+  const originalWarn = console.warn;
+  console.warn = () => undefined;
+  try {
+    await recordFinalGenerateQueueLog({
+      jobId: 'job_123',
+      provider: 'fal',
+      providerJobId: null,
+      engineId: 'veo-3-1',
+      status: 'queued',
+      durationSec: 4,
+      durationLabel: undefined,
+      aspectRatio: null,
+      resolution: '720p',
+      loop: false,
+      inputSummary: {
+        primaryImageUrl: null,
+        primaryAudioUrl: null,
+        referenceImageCount: 0,
+        referenceVideoCount: 0,
+        referenceAudioCount: 0,
+        hasFirstFrame: false,
+        hasLastFrame: false,
+        inputSlots: [],
+      },
+      totalCents: 100,
+      currency: 'USD',
+      costBreakdownUsd: null,
+      queryFn: async () => {
+        throw new Error('db down');
+      },
+    });
+  } finally {
+    console.warn = originalWarn;
+  }
+});


### PR DESCRIPTION
## Summary
- Move final app_jobs update persistence out of /api/generate
- Move final fal_queue_log request/input/pricing payload logging out of the route
- Add architecture and behavior coverage for update params, queue log payload, and swallowed queue log failures

## Local verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-final-job-persistence.test.ts tests/generate-provider-job-tracker.test.ts tests/generate-settings-snapshot.test.ts tests/generate-fal-request.test.ts tests/generate-metric-logger.test.ts tests/generate-receipt-snapshot.test.ts tests/generate-attachment-references.test.ts tests/generate-attachments.test.ts tests/generate-extra-input-values.test.ts tests/generate-payment-rollback-architecture.test.ts tests/generate-initial-video-job-architecture.test.ts tests/generate-fal-error-handling.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build