### PR TITLE
Split generate final receipt helpers

### DIFF
--- a/frontend/app/api/generate/_lib/final-receipts.ts
+++ b/frontend/app/api/generate/_lib/final-receipts.ts
@@ -1,0 +1,84 @@
+import { query } from '@/lib/db';
+import type { PendingReceipt, PaymentMode } from './initial-video-job';
+
+type QueryFn = (sql: string, params?: unknown[]) => Promise<unknown>;
+
+export async function persistFinalChargeReceipt(params: {
+  pendingReceipt: PendingReceipt | null;
+  walletChargeReserved: boolean;
+  queryFn?: QueryFn;
+}): Promise<void> {
+  if (!params.pendingReceipt || params.walletChargeReserved) {
+    return;
+  }
+
+  const queryFn = params.queryFn ?? query;
+  const receipt = params.pendingReceipt;
+  try {
+    await queryFn(
+      `INSERT INTO app_receipts (user_id, type, amount_cents, currency, description, job_id, surface, billing_product_key, pricing_snapshot, application_fee_cents, vendor_account_id, stripe_payment_intent_id, stripe_charge_id, platform_revenue_cents, destination_acct)
+       VALUES ($1,'charge',$2,$3,$4,$5,$6,$7,$8::jsonb,$9,$10,$11,$12,$13,$14)`,
+      [
+        receipt.userId,
+        receipt.amountCents,
+        receipt.currency,
+        receipt.description,
+        receipt.jobId,
+        'video',
+        null,
+        JSON.stringify(receipt.snapshot),
+        receipt.applicationFeeCents ?? null,
+        receipt.vendorAccountId,
+        receipt.stripePaymentIntentId ?? null,
+        receipt.stripeChargeId ?? null,
+        receipt.applicationFeeCents ?? null,
+        receipt.vendorAccountId,
+      ]
+    );
+  } catch (error) {
+    console.error('[api/generate] failed to persist payment receipt', error);
+  }
+}
+
+export async function persistWalletFailureRefundReceipt(params: {
+  status: string;
+  pendingReceipt: PendingReceipt | null;
+  paymentMode: PaymentMode;
+  engineLabel: string;
+  durationSec: number;
+  priceOnlyReceipts: boolean;
+  queryFn?: QueryFn;
+}): Promise<void> {
+  if (params.status !== 'failed' || !params.pendingReceipt || params.paymentMode !== 'wallet') {
+    return;
+  }
+
+  const queryFn = params.queryFn ?? query;
+  const receipt = params.pendingReceipt;
+  try {
+    await queryFn(
+      `INSERT INTO app_receipts (user_id, type, amount_cents, currency, description, job_id, surface, billing_product_key, pricing_snapshot, application_fee_cents, vendor_account_id, stripe_payment_intent_id, stripe_charge_id, platform_revenue_cents, destination_acct)
+       VALUES ($1,'refund',$2,$3,$4,$5,$6,$7,$8::jsonb,$9,$10,$11,$12,$13,$14)
+       ON CONFLICT DO NOTHING`,
+      [
+        receipt.userId,
+        receipt.amountCents,
+        receipt.currency,
+        `Refund ${params.engineLabel} - ${params.durationSec}s`,
+        receipt.jobId,
+        'video',
+        null,
+        JSON.stringify(receipt.snapshot),
+        params.priceOnlyReceipts ? null : 0,
+        params.priceOnlyReceipts ? null : receipt.vendorAccountId,
+        receipt.stripePaymentIntentId ?? null,
+        receipt.stripeChargeId ?? null,
+        params.priceOnlyReceipts ? null : 0,
+        params.priceOnlyReceipts ? null : receipt.vendorAccountId,
+      ]
+    );
+    await queryFn(`UPDATE app_jobs SET payment_status = 'refunded_wallet' WHERE job_id = $1`, [receipt.jobId]);
+  } catch (error) {
+    console.warn('[wallet] failed to record refund', error);
+  }
+}

--- a/frontend/app/api/generate/route.ts
+++ b/frontend/app/api/generate/route.ts
@@ -28,6 +28,7 @@ import { buildFalRequestParts } from './_lib/fal-request';
 import { buildGenerationSettingsSnapshot } from './_lib/settings-snapshot';
 import { createProviderJobTracker } from './_lib/provider-job-tracker';
 import { persistFinalVideoJobUpdate, recordFinalGenerateQueueLog } from './_lib/final-job-persistence';
+import { persistFinalChargeReceipt, persistWalletFailureRefundReceipt } from './_lib/final-receipts';
 import {
   buildResponseFromExistingVideoJob,
   createAtomicInitialVideoJob,
@@ -1856,32 +1857,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ ok: false, error: 'Failed to update job record' }, { status: 500 });
   }
 
-  if (pendingReceipt && !walletChargeReserved) {
-    try {
-      await query(
-        `INSERT INTO app_receipts (user_id, type, amount_cents, currency, description, job_id, surface, billing_product_key, pricing_snapshot, application_fee_cents, vendor_account_id, stripe_payment_intent_id, stripe_charge_id, platform_revenue_cents, destination_acct)
-         VALUES ($1,'charge',$2,$3,$4,$5,$6,$7,$8::jsonb,$9,$10,$11,$12,$13,$14)`,
-        [
-          pendingReceipt.userId,
-          pendingReceipt.amountCents,
-          pendingReceipt.currency,
-          pendingReceipt.description,
-          pendingReceipt.jobId,
-          'video',
-          null,
-          JSON.stringify(pendingReceipt.snapshot),
-          pendingReceipt.applicationFeeCents ?? null,
-          pendingReceipt.vendorAccountId,
-          pendingReceipt.stripePaymentIntentId ?? null,
-          pendingReceipt.stripeChargeId ?? null,
-          pendingReceipt.applicationFeeCents ?? null,
-          pendingReceipt.vendorAccountId,
-        ]
-      );
-    } catch (error) {
-      console.error('[api/generate] failed to persist payment receipt', error);
-    }
-  }
+  await persistFinalChargeReceipt({ pendingReceipt, walletChargeReserved });
 
   await recordFinalGenerateQueueLog({
     jobId,
@@ -1909,34 +1885,14 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  if (status === 'failed' && pendingReceipt && paymentMode === 'wallet') {
-    try {
-      await query(
-        `INSERT INTO app_receipts (user_id, type, amount_cents, currency, description, job_id, surface, billing_product_key, pricing_snapshot, application_fee_cents, vendor_account_id, stripe_payment_intent_id, stripe_charge_id, platform_revenue_cents, destination_acct)
-         VALUES ($1,'refund',$2,$3,$4,$5,$6,$7,$8::jsonb,$9,$10,$11,$12,$13,$14)
-         ON CONFLICT DO NOTHING`,
-        [
-          pendingReceipt.userId,
-          pendingReceipt.amountCents,
-          pendingReceipt.currency,
-          `Refund ${engine.label} - ${durationSec}s`,
-          pendingReceipt.jobId,
-          'video',
-          null,
-          JSON.stringify(pendingReceipt.snapshot),
-          priceOnlyReceipts ? null : 0,
-          priceOnlyReceipts ? null : pendingReceipt.vendorAccountId,
-          pendingReceipt.stripePaymentIntentId ?? null,
-          pendingReceipt.stripeChargeId ?? null,
-          priceOnlyReceipts ? null : 0,
-          priceOnlyReceipts ? null : pendingReceipt.vendorAccountId,
-        ]
-      );
-      await query(`UPDATE app_jobs SET payment_status = 'refunded_wallet' WHERE job_id = $1`, [jobId]);
-    } catch (error) {
-      console.warn('[wallet] failed to record refund', error);
-    }
-  }
+  await persistWalletFailureRefundReceipt({
+    status,
+    pendingReceipt,
+    paymentMode,
+    engineLabel: engine.label,
+    durationSec,
+    priceOnlyReceipts,
+  });
 
   const responsePaymentStatus =
     status === 'failed' && pendingReceipt && paymentMode === 'wallet' ? 'refunded_wallet' : paymentStatus;

--- a/tests/generate-final-receipts.test.ts
+++ b/tests/generate-final-receipts.test.ts
@@ -1,0 +1,163 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  persistFinalChargeReceipt,
+  persistWalletFailureRefundReceipt,
+} from '../frontend/app/api/generate/_lib/final-receipts';
+import type { PendingReceipt } from '../frontend/app/api/generate/_lib/initial-video-job';
+
+const root = process.cwd();
+const routePath = join(root, 'frontend/app/api/generate/route.ts');
+const helperPath = join(root, 'frontend/app/api/generate/_lib/final-receipts.ts');
+
+const routeSource = readFileSync(routePath, 'utf8');
+const helperSource = readFileSync(helperPath, 'utf8');
+
+const pendingReceipt: PendingReceipt = {
+  userId: 'user_123',
+  amountCents: 1200,
+  currency: 'USD',
+  description: 'Run Seedance - 8s',
+  jobId: 'job_123',
+  snapshot: { totalCents: 1200 },
+  applicationFeeCents: 300,
+  vendorAccountId: 'acct_123',
+  stripePaymentIntentId: 'pi_123',
+  stripeChargeId: 'ch_123',
+};
+
+test('generate route delegates final receipt persistence', () => {
+  assert.ok(existsSync(helperPath), 'final receipt persistence should live in the generate route _lib folder');
+  assert.match(routeSource, /from '\.\/_lib\/final-receipts'/);
+  assert.doesNotMatch(routeSource, /INSERT INTO app_receipts \(user_id, type, amount_cents/, 'final receipt SQL belongs in final-receipts.ts');
+  assert.doesNotMatch(routeSource, /UPDATE app_jobs SET payment_status = 'refunded_wallet'/, 'wallet refund status update belongs in final-receipts.ts');
+
+  const lineCount = routeSource.split('\n').length;
+  assert.ok(lineCount <= 1940, `/api/generate route should stay below 1940 lines after final receipt extraction, got ${lineCount}`);
+});
+
+test('final receipts helper exposes the route contract', () => {
+  assert.match(helperSource, /export async function persistFinalChargeReceipt/, 'persistFinalChargeReceipt should be exported');
+  assert.match(helperSource, /export async function persistWalletFailureRefundReceipt/, 'persistWalletFailureRefundReceipt should be exported');
+  assert.match(helperSource, /ON CONFLICT DO NOTHING/, 'wallet refund insert should stay idempotent');
+});
+
+test('final charge receipt helper skips wallet-reserved receipts', async () => {
+  const queries: Array<{ sql: string; params?: unknown[] }> = [];
+
+  await persistFinalChargeReceipt({
+    pendingReceipt,
+    walletChargeReserved: true,
+    queryFn: async (sql, params) => {
+      queries.push({ sql, params });
+    },
+  });
+
+  assert.deepEqual(queries, []);
+});
+
+test('final charge receipt helper inserts non-wallet-reserved charges', async () => {
+  const queries: Array<{ sql: string; params?: unknown[] }> = [];
+
+  await persistFinalChargeReceipt({
+    pendingReceipt,
+    walletChargeReserved: false,
+    queryFn: async (sql, params) => {
+      queries.push({ sql, params });
+    },
+  });
+
+  assert.equal(queries.length, 1);
+  assert.match(queries[0]?.sql ?? '', /INSERT INTO app_receipts/);
+  assert.deepEqual(queries[0]?.params, [
+    'user_123',
+    1200,
+    'USD',
+    'Run Seedance - 8s',
+    'job_123',
+    'video',
+    null,
+    '{"totalCents":1200}',
+    300,
+    'acct_123',
+    'pi_123',
+    'ch_123',
+    300,
+    'acct_123',
+  ]);
+});
+
+test('wallet failure refund helper records refund and marks the job refunded', async () => {
+  const queries: Array<{ sql: string; params?: unknown[] }> = [];
+
+  await persistWalletFailureRefundReceipt({
+    status: 'failed',
+    pendingReceipt,
+    paymentMode: 'wallet',
+    engineLabel: 'Seedance',
+    durationSec: 8,
+    priceOnlyReceipts: false,
+    queryFn: async (sql, params) => {
+      queries.push({ sql, params });
+    },
+  });
+
+  assert.equal(queries.length, 2);
+  assert.match(queries[0]?.sql ?? '', /INSERT INTO app_receipts/);
+  assert.deepEqual(queries[0]?.params, [
+    'user_123',
+    1200,
+    'USD',
+    'Refund Seedance - 8s',
+    'job_123',
+    'video',
+    null,
+    '{"totalCents":1200}',
+    0,
+    'acct_123',
+    'pi_123',
+    'ch_123',
+    0,
+    'acct_123',
+  ]);
+  assert.match(queries[1]?.sql ?? '', /UPDATE app_jobs SET payment_status = 'refunded_wallet'/);
+  assert.deepEqual(queries[1]?.params, ['job_123']);
+});
+
+test('wallet failure refund helper honors price-only receipts and skips non-wallet states', async () => {
+  const queries: Array<{ sql: string; params?: unknown[] }> = [];
+
+  await persistWalletFailureRefundReceipt({
+    status: 'completed',
+    pendingReceipt,
+    paymentMode: 'wallet',
+    engineLabel: 'Seedance',
+    durationSec: 8,
+    priceOnlyReceipts: true,
+    queryFn: async (sql, params) => {
+      queries.push({ sql, params });
+    },
+  });
+  assert.deepEqual(queries, []);
+
+  await persistWalletFailureRefundReceipt({
+    status: 'failed',
+    pendingReceipt,
+    paymentMode: 'wallet',
+    engineLabel: 'Seedance',
+    durationSec: 8,
+    priceOnlyReceipts: true,
+    queryFn: async (sql, params) => {
+      queries.push({ sql, params });
+    },
+  });
+
+  assert.equal(queries.length, 2);
+  assert.equal(queries[0]?.params?.[8], null);
+  assert.equal(queries[0]?.params?.[9], null);
+  assert.equal(queries[0]?.params?.[12], null);
+  assert.equal(queries[0]?.params?.[13], null);
+});


### PR DESCRIPTION
## Summary
- Move final charge receipt persistence out of /api/generate
- Move failed wallet refund receipt persistence and refunded_wallet job update into a focused helper
- Add architecture and behavior coverage for skipped wallet-reserved charges, charge params, refund params, and price-only receipts

## Local verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-final-receipts.test.ts tests/generate-final-job-persistence.test.ts tests/generate-provider-job-tracker.test.ts tests/generate-settings-snapshot.test.ts tests/generate-fal-request.test.ts tests/generate-metric-logger.test.ts tests/generate-receipt-snapshot.test.ts tests/generate-attachment-references.test.ts tests/generate-attachments.test.ts tests/generate-extra-input-values.test.ts tests/generate-payment-rollback-architecture.test.ts tests/generate-initial-video-job-architecture.test.ts tests/generate-fal-error-handling.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build