### PR TITLE
Split generate provider media helpers

### DIFF
--- a/frontend/app/api/generate/_lib/provider-media.ts
+++ b/frontend/app/api/generate/_lib/provider-media.ts
@@ -1,0 +1,191 @@
+import { normalizeMediaUrl } from '@/lib/media';
+import type { GenerateResult } from '@/lib/fal';
+import type { VideoAsset } from '@/types/render';
+import {
+  buildNextProviderVideoCopyState,
+  buildSafeProviderMediaLog,
+  PROVIDER_VIDEO_COPY_FAILURE_MESSAGE,
+  PROVIDER_VIDEO_COPY_RETRY_MESSAGE,
+  shouldFailVideoJobOnProviderCopyMiss,
+  shouldRetryProviderVideoCopy,
+} from '@/server/provider-output-policy';
+import { ensureFastStartVideo } from '@/server/video-faststart';
+import { ensureJobThumbnail, isPlaceholderThumbnail } from '@/server/thumbnails';
+
+type ProviderMediaState = {
+  thumb: string;
+  previewFrame: string;
+  video: string | null;
+  videoAsset: VideoAsset | null;
+  providerMode: GenerateResult['provider'];
+  status: string;
+  progress: number;
+  providerJobId: string | null;
+};
+
+type ProviderMediaDeps = {
+  ensureFastStartVideoFn?: typeof ensureFastStartVideo;
+  ensureJobThumbnailFn?: typeof ensureJobThumbnail;
+  isPlaceholderThumbnailFn?: typeof isPlaceholderThumbnail;
+  shouldFailVideoJobOnProviderCopyMissFn?: typeof shouldFailVideoJobOnProviderCopyMiss;
+  buildNextProviderVideoCopyStateFn?: typeof buildNextProviderVideoCopyState;
+  shouldRetryProviderVideoCopyFn?: typeof shouldRetryProviderVideoCopy;
+  buildSafeProviderMediaLogFn?: typeof buildSafeProviderMediaLog;
+  now?: () => Date;
+};
+
+export type ProviderMediaResolution = ProviderMediaState & {
+  settingsSnapshotJson: string;
+  message: string | null;
+  sourceVideoUrl: string | null;
+};
+
+export function buildInitialProviderMediaState(params: {
+  generationResult: GenerateResult;
+  batchId: string | null;
+  placeholderThumb: string;
+}): ProviderMediaState {
+  const thumb =
+    normalizeMediaUrl(params.generationResult.thumbUrl) ??
+    (typeof params.generationResult.thumbUrl === 'string' && params.generationResult.thumbUrl.trim().length
+      ? params.generationResult.thumbUrl
+      : null) ??
+    params.placeholderThumb;
+  const video = normalizeMediaUrl(params.generationResult.videoUrl) ?? params.generationResult.videoUrl ?? null;
+
+  return {
+    thumb,
+    previewFrame: thumb,
+    video,
+    videoAsset: params.generationResult.video ?? null,
+    providerMode: params.generationResult.provider,
+    status: params.generationResult.status ?? (video ? 'completed' : 'queued'),
+    progress: typeof params.generationResult.progress === 'number' ? params.generationResult.progress : video ? 100 : 0,
+    providerJobId: params.generationResult.providerJobId ?? params.batchId ?? null,
+  };
+}
+
+export async function resolveProviderMediaState(params: {
+  state: ProviderMediaState;
+  generationResult: GenerateResult;
+  jobId: string;
+  userId: string;
+  isLumaRay2: boolean;
+  aspectRatio: string | null;
+  settingsSnapshot: Record<string, unknown>;
+  settingsSnapshotJson: string;
+  message: string | null;
+  deps?: ProviderMediaDeps;
+}): Promise<ProviderMediaResolution> {
+  const deps = params.deps ?? {};
+  const ensureFastStartVideoFn = deps.ensureFastStartVideoFn ?? ensureFastStartVideo;
+  const ensureJobThumbnailFn = deps.ensureJobThumbnailFn ?? ensureJobThumbnail;
+  const isPlaceholderThumbnailFn = deps.isPlaceholderThumbnailFn ?? isPlaceholderThumbnail;
+  const shouldFailVideoJobOnProviderCopyMissFn =
+    deps.shouldFailVideoJobOnProviderCopyMissFn ?? shouldFailVideoJobOnProviderCopyMiss;
+  const buildNextProviderVideoCopyStateFn = deps.buildNextProviderVideoCopyStateFn ?? buildNextProviderVideoCopyState;
+  const shouldRetryProviderVideoCopyFn = deps.shouldRetryProviderVideoCopyFn ?? shouldRetryProviderVideoCopy;
+  const buildSafeProviderMediaLogFn = deps.buildSafeProviderMediaLogFn ?? buildSafeProviderMediaLog;
+  const now = deps.now ?? (() => new Date());
+
+  let { thumb, previewFrame, video, videoAsset, status, progress } = params.state;
+  const { providerMode, providerJobId } = params.state;
+  let settingsSnapshotJson = params.settingsSnapshotJson;
+  let message = params.message;
+
+  if (params.isLumaRay2) {
+    console.info('[fal] luma ray generation', {
+      jobId: params.jobId,
+      providerJobId,
+      status,
+      video: buildSafeProviderMediaLogFn(video),
+    });
+  }
+
+  const sourceVideoUrl =
+    (typeof params.generationResult.video?.url === 'string' && params.generationResult.video.url.length
+      ? params.generationResult.video.url
+      : typeof params.generationResult.videoUrl === 'string' && params.generationResult.videoUrl.length
+        ? params.generationResult.videoUrl
+        : null) ?? null;
+  const isSourceAbsolute = Boolean(sourceVideoUrl && /^https?:\/\//i.test(sourceVideoUrl));
+  if (sourceVideoUrl && isSourceAbsolute) {
+    const fastStartVideo = await ensureFastStartVideoFn({
+      jobId: params.jobId,
+      userId: params.userId,
+      videoUrl: sourceVideoUrl,
+    });
+    if (fastStartVideo) {
+      video = fastStartVideo;
+      if (videoAsset) {
+        videoAsset.url = fastStartVideo;
+      }
+    } else if (
+      shouldFailVideoJobOnProviderCopyMissFn({
+        provider: providerMode,
+        sourceUrl: sourceVideoUrl,
+        copiedUrl: null,
+      })
+    ) {
+      const nextCopyState = buildNextProviderVideoCopyStateFn(params.settingsSnapshot, {
+        providerStatus: status,
+        reason: 'provider_video_copy_failed',
+      });
+      const canRetryCopy =
+        Boolean(providerJobId) &&
+        shouldRetryProviderVideoCopyFn({ state: nextCopyState, createdAt: now().toISOString() });
+      console.warn('[api/generate] provider video copy failed', {
+        jobId: params.jobId,
+        providerJobId,
+        provider: providerMode,
+        video: buildSafeProviderMediaLogFn(sourceVideoUrl),
+        retryDeferred: canRetryCopy,
+      });
+      video = null;
+      videoAsset = null;
+      params.settingsSnapshot.providerVideoCopy = nextCopyState;
+      settingsSnapshotJson = JSON.stringify(params.settingsSnapshot);
+      if (canRetryCopy) {
+        status = 'processing';
+        progress = 90;
+        message = PROVIDER_VIDEO_COPY_RETRY_MESSAGE;
+      } else {
+        status = 'failed';
+        progress = 0;
+        message = PROVIDER_VIDEO_COPY_FAILURE_MESSAGE;
+      }
+    }
+  }
+
+  const thumbnailSourceVideoUrl = video ?? sourceVideoUrl;
+  if (thumbnailSourceVideoUrl && /^https?:\/\//i.test(thumbnailSourceVideoUrl) && isPlaceholderThumbnailFn(thumb)) {
+    const generatedThumb = await ensureJobThumbnailFn({
+      jobId: params.jobId,
+      userId: params.userId,
+      videoUrl: thumbnailSourceVideoUrl,
+      aspectRatio: params.aspectRatio ?? undefined,
+      existingThumbUrl: thumb,
+    });
+    if (generatedThumb) {
+      thumb = generatedThumb;
+      previewFrame = generatedThumb;
+      if (videoAsset) {
+        videoAsset.thumbnailUrl = generatedThumb;
+      }
+    }
+  }
+
+  return {
+    thumb,
+    previewFrame,
+    video,
+    videoAsset,
+    providerMode,
+    status,
+    progress,
+    providerJobId,
+    settingsSnapshotJson,
+    message,
+    sourceVideoUrl,
+  };
+}

--- a/frontend/app/api/generate/route.ts
+++ b/frontend/app/api/generate/route.ts
@@ -9,7 +9,6 @@ import { getConfiguredEngine, getConfiguredEngineIncludingHidden } from '@/serve
 import Stripe from 'stripe';
 import { ENV, receiptsPriceOnlyEnabled } from '@/lib/env';
 import { ensureBillingSchema } from '@/lib/schema';
-import { normalizeMediaUrl } from '@/lib/media';
 import type { Mode } from '@/types/engines';
 import { validateRequest } from './_lib/validate';
 import {
@@ -29,6 +28,7 @@ import { buildGenerationSettingsSnapshot } from './_lib/settings-snapshot';
 import { createProviderJobTracker } from './_lib/provider-job-tracker';
 import { persistFinalVideoJobUpdate, recordFinalGenerateQueueLog } from './_lib/final-job-persistence';
 import { persistFinalChargeReceipt, persistWalletFailureRefundReceipt } from './_lib/final-receipts';
+import { buildInitialProviderMediaState, resolveProviderMediaState } from './_lib/provider-media';
 import {
   buildResponseFromExistingVideoJob,
   createAtomicInitialVideoJob,
@@ -38,16 +38,6 @@ import {
   type PendingReceipt,
 } from './_lib/initial-video-job';
 import { rollbackPendingPayment } from './_lib/payment-rollback';
-import {
-  buildNextProviderVideoCopyState,
-  buildSafeProviderMediaLog,
-  PROVIDER_VIDEO_COPY_FAILURE_MESSAGE,
-  PROVIDER_VIDEO_COPY_RETRY_MESSAGE,
-  shouldFailVideoJobOnProviderCopyMiss,
-  shouldRetryProviderVideoCopy,
-} from '@/server/provider-output-policy';
-import { ensureJobThumbnail, isPlaceholderThumbnail } from '@/server/thumbnails';
-import { ensureFastStartVideo } from '@/server/video-faststart';
 import { generateAndPersistJobKeyframes } from '@/server/video-keyframes';
 import { getEngineCaps } from '@/fixtures/engineCaps';
 import { getSoraVariantForEngine, isSoraEngineId, parseSoraRequest, type SoraRequest } from '@/lib/sora';
@@ -1682,19 +1672,21 @@ export async function POST(req: NextRequest) {
     throw new Error('Fal generation did not return a result.');
   }
 
-  let thumb =
-    normalizeMediaUrl(generationResult.thumbUrl) ??
-      (typeof generationResult.thumbUrl === 'string' && generationResult.thumbUrl.trim().length
-        ? generationResult.thumbUrl
-        : null) ??
-    placeholderThumb;
-  let previewFrame = thumb;
-  let video = normalizeMediaUrl(generationResult.videoUrl) ?? generationResult.videoUrl ?? null;
-  let videoAsset = generationResult.video ?? null;
-  const providerMode = generationResult.provider;
-  let status: string = generationResult.status ?? (video ? 'completed' : 'queued');
-  let progress = typeof generationResult.progress === 'number' ? generationResult.progress : video ? 100 : 0;
-  const providerJobId = generationResult.providerJobId ?? batchId ?? null;
+  const initialMediaState = buildInitialProviderMediaState({
+    generationResult,
+    batchId,
+    placeholderThumb,
+  });
+  let {
+    thumb,
+    previewFrame,
+    video,
+    videoAsset,
+    providerMode,
+    status,
+    progress,
+    providerJobId,
+  } = initialMediaState;
 
   // Safety net: if Fal didn’t return a provider job id and we have no video result, treat as failed and refund.
   if (!providerJobId && !video) {
@@ -1738,87 +1730,29 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  if (isLumaRay2) {
-    console.info('[fal] luma ray generation', {
-      jobId,
-      providerJobId,
-      status,
-      video: buildSafeProviderMediaLog(video),
-    });
-  }
-
-  const sourceVideoUrl =
-    (typeof generationResult.video?.url === 'string' && generationResult.video.url.length
-      ? generationResult.video.url
-      : typeof generationResult.videoUrl === 'string' && generationResult.videoUrl.length
-        ? generationResult.videoUrl
-        : null) ?? null;
-  const isSourceAbsolute = Boolean(sourceVideoUrl && /^https?:\/\//i.test(sourceVideoUrl));
-  if (sourceVideoUrl && isSourceAbsolute) {
-    const fastStartVideo = await ensureFastStartVideo({
-      jobId,
-      userId,
-      videoUrl: sourceVideoUrl,
-    });
-    if (fastStartVideo) {
-      video = fastStartVideo;
-      if (videoAsset) {
-        videoAsset.url = fastStartVideo;
-      }
-    } else if (
-      shouldFailVideoJobOnProviderCopyMiss({
-        provider: providerMode,
-        sourceUrl: sourceVideoUrl,
-        copiedUrl: null,
-      })
-    ) {
-      const nextCopyState = buildNextProviderVideoCopyState(settingsSnapshot, {
-        providerStatus: status,
-        reason: 'provider_video_copy_failed',
-      });
-      const canRetryCopy =
-        Boolean(providerJobId) &&
-        shouldRetryProviderVideoCopy({ state: nextCopyState, createdAt: new Date().toISOString() });
-      console.warn('[api/generate] provider video copy failed', {
-        jobId,
-        providerJobId,
-        provider: providerMode,
-        video: buildSafeProviderMediaLog(sourceVideoUrl),
-        retryDeferred: canRetryCopy,
-      });
-      video = null;
-      videoAsset = null;
-      (settingsSnapshot as Record<string, unknown>).providerVideoCopy = nextCopyState;
-      settingsSnapshotJson = JSON.stringify(settingsSnapshot);
-      if (canRetryCopy) {
-        status = 'processing';
-        progress = 90;
-        message = PROVIDER_VIDEO_COPY_RETRY_MESSAGE;
-      } else {
-        status = 'failed';
-        progress = 0;
-        message = PROVIDER_VIDEO_COPY_FAILURE_MESSAGE;
-      }
-    }
-  }
-
-  const thumbnailSourceVideoUrl = video ?? sourceVideoUrl;
-  if (thumbnailSourceVideoUrl && /^https?:\/\//i.test(thumbnailSourceVideoUrl) && isPlaceholderThumbnail(thumb)) {
-    const generatedThumb = await ensureJobThumbnail({
-      jobId,
-      userId,
-      videoUrl: thumbnailSourceVideoUrl,
-      aspectRatio: aspectRatio ?? undefined,
-      existingThumbUrl: thumb,
-    });
-    if (generatedThumb) {
-      thumb = generatedThumb;
-      previewFrame = generatedThumb;
-      if (videoAsset) {
-        videoAsset.thumbnailUrl = generatedThumb;
-      }
-    }
-  }
+  const mediaState = await resolveProviderMediaState({
+    state: initialMediaState,
+    generationResult,
+    jobId,
+    userId,
+    isLumaRay2,
+    aspectRatio,
+    settingsSnapshot,
+    settingsSnapshotJson,
+    message,
+  });
+  ({
+    thumb,
+    previewFrame,
+    video,
+    videoAsset,
+    providerMode,
+    status,
+    progress,
+    providerJobId,
+    settingsSnapshotJson,
+    message,
+  } = mediaState);
 
   try {
     await persistFinalVideoJobUpdate({

--- a/tests/generate-provider-media.test.ts
+++ b/tests/generate-provider-media.test.ts
@@ -1,0 +1,209 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  buildInitialProviderMediaState,
+  resolveProviderMediaState,
+} from '../frontend/app/api/generate/_lib/provider-media';
+import type { GenerateResult } from '../frontend/src/lib/fal';
+
+const root = process.cwd();
+const routePath = join(root, 'frontend/app/api/generate/route.ts');
+const helperPath = join(root, 'frontend/app/api/generate/_lib/provider-media.ts');
+
+const routeSource = readFileSync(routePath, 'utf8');
+const helperSource = readFileSync(helperPath, 'utf8');
+
+const baseResult = (overrides: Partial<GenerateResult> = {}): GenerateResult => ({
+  provider: 'fal',
+  thumbUrl: '',
+  videoUrl: undefined,
+  ...overrides,
+});
+
+test('generate route delegates provider media handling', () => {
+  assert.ok(existsSync(helperPath), 'provider media handling should live in the generate route _lib folder');
+  assert.match(routeSource, /from '\.\/_lib\/provider-media'/);
+  assert.doesNotMatch(routeSource, /normalizeMediaUrl/, 'media URL normalization belongs in provider-media.ts');
+  assert.doesNotMatch(routeSource, /ensureFastStartVideo/, 'fast-start copy belongs in provider-media.ts');
+  assert.doesNotMatch(routeSource, /provider_video_copy_failed/, 'provider copy fallback belongs in provider-media.ts');
+  assert.doesNotMatch(routeSource, /ensureJobThumbnail/, 'thumbnail generation belongs in provider-media.ts');
+
+  const lineCount = routeSource.split('\n').length;
+  assert.ok(lineCount <= 1870, `/api/generate route should stay below 1870 lines after provider media extraction, got ${lineCount}`);
+});
+
+test('provider media helper exposes the route contract', () => {
+  assert.match(helperSource, /export type ProviderMediaResolution/, 'ProviderMediaResolution should be exported');
+  assert.match(helperSource, /export function buildInitialProviderMediaState/, 'buildInitialProviderMediaState should be exported');
+  assert.match(helperSource, /export async function resolveProviderMediaState/, 'resolveProviderMediaState should be exported');
+});
+
+test('provider media helper builds initial state from provider result fallbacks', () => {
+  assert.deepEqual(
+    buildInitialProviderMediaState({
+      generationResult: baseResult({
+        thumbUrl: '',
+        videoUrl: 'https://cdn.maxvideoai.com/video.mp4',
+        providerJobId: undefined,
+      }),
+      batchId: 'batch_123',
+      placeholderThumb: '/assets/frames/thumb-16x9.svg',
+    }),
+    {
+      thumb: '/assets/frames/thumb-16x9.svg',
+      previewFrame: '/assets/frames/thumb-16x9.svg',
+      video: 'https://cdn.maxvideoai.com/video.mp4',
+      videoAsset: null,
+      providerMode: 'fal',
+      status: 'completed',
+      progress: 100,
+      providerJobId: 'batch_123',
+    }
+  );
+});
+
+test('provider media helper applies fast-start copy and generated thumbnail', async () => {
+  const videoAsset = {
+    url: 'https://provider.example.com/video.mp4',
+    mime: 'video/mp4',
+    width: 1280,
+    height: 720,
+    durationSec: 8,
+    tags: [],
+  };
+  const generationResult = baseResult({
+    thumbUrl: '/assets/frames/thumb-16x9.svg',
+    videoUrl: 'https://provider.example.com/video.mp4',
+    video: videoAsset,
+    providerJobId: 'provider_123',
+  });
+  const state = buildInitialProviderMediaState({
+    generationResult,
+    batchId: null,
+    placeholderThumb: '/assets/frames/thumb-16x9.svg',
+  });
+
+  const resolved = await resolveProviderMediaState({
+    state,
+    generationResult,
+    jobId: 'job_123',
+    userId: 'user_123',
+    isLumaRay2: false,
+    aspectRatio: '16:9',
+    settingsSnapshot: { schemaVersion: 1 },
+    settingsSnapshotJson: '{"schemaVersion":1}',
+    message: null,
+    deps: {
+      ensureFastStartVideoFn: async () => 'https://cdn.maxvideoai.com/copied.mp4',
+      ensureJobThumbnailFn: async () => 'https://cdn.maxvideoai.com/thumb.jpg',
+      isPlaceholderThumbnailFn: () => true,
+    },
+  });
+
+  assert.equal(resolved.video, 'https://cdn.maxvideoai.com/copied.mp4');
+  assert.equal(resolved.videoAsset?.url, 'https://cdn.maxvideoai.com/copied.mp4');
+  assert.equal(resolved.thumb, 'https://cdn.maxvideoai.com/thumb.jpg');
+  assert.equal(resolved.previewFrame, 'https://cdn.maxvideoai.com/thumb.jpg');
+  assert.equal(resolved.videoAsset?.thumbnailUrl, 'https://cdn.maxvideoai.com/thumb.jpg');
+});
+
+test('provider media helper defers provider copy miss when retry is allowed', async () => {
+  const originalWarn = console.warn;
+  console.warn = () => undefined;
+  try {
+    const settingsSnapshot = { schemaVersion: 1 };
+    const generationResult = baseResult({
+      thumbUrl: '/assets/frames/thumb-16x9.svg',
+      videoUrl: 'https://provider.example.com/video.mp4',
+      providerJobId: 'provider_123',
+    });
+    const state = buildInitialProviderMediaState({
+      generationResult,
+      batchId: null,
+      placeholderThumb: '/assets/frames/thumb-16x9.svg',
+    });
+
+    const resolved = await resolveProviderMediaState({
+      state,
+      generationResult,
+      jobId: 'job_123',
+      userId: 'user_123',
+      isLumaRay2: false,
+      aspectRatio: '16:9',
+      settingsSnapshot,
+      settingsSnapshotJson: '{"schemaVersion":1}',
+      message: null,
+      deps: {
+        ensureFastStartVideoFn: async () => null,
+        shouldFailVideoJobOnProviderCopyMissFn: () => true,
+        buildNextProviderVideoCopyStateFn: () => ({ retryCount: 1 }) as never,
+        shouldRetryProviderVideoCopyFn: () => true,
+        isPlaceholderThumbnailFn: () => false,
+        buildSafeProviderMediaLogFn: (value) => ({ value }) as never,
+        now: () => new Date('2026-05-07T20:00:00.000Z'),
+      },
+    });
+
+    assert.equal(resolved.video, null);
+    assert.equal(resolved.videoAsset, null);
+    assert.equal(resolved.status, 'processing');
+    assert.equal(resolved.progress, 90);
+    assert.equal(resolved.message, 'Generated video is ready. Copying it to MaxVideoAI storage.');
+    assert.deepEqual(settingsSnapshot, {
+      schemaVersion: 1,
+      providerVideoCopy: { retryCount: 1 },
+    });
+    assert.equal(resolved.settingsSnapshotJson, '{"schemaVersion":1,"providerVideoCopy":{"retryCount":1}}');
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+test('provider media helper fails provider copy miss when retry is not allowed', async () => {
+  const originalWarn = console.warn;
+  console.warn = () => undefined;
+  try {
+    const generationResult = baseResult({
+      thumbUrl: '/assets/frames/thumb-16x9.svg',
+      videoUrl: 'https://provider.example.com/video.mp4',
+      providerJobId: 'provider_123',
+    });
+    const state = buildInitialProviderMediaState({
+      generationResult,
+      batchId: null,
+      placeholderThumb: '/assets/frames/thumb-16x9.svg',
+    });
+
+    const resolved = await resolveProviderMediaState({
+      state,
+      generationResult,
+      jobId: 'job_123',
+      userId: 'user_123',
+      isLumaRay2: false,
+      aspectRatio: '16:9',
+      settingsSnapshot: { schemaVersion: 1 },
+      settingsSnapshotJson: '{"schemaVersion":1}',
+      message: null,
+      deps: {
+        ensureFastStartVideoFn: async () => null,
+        shouldFailVideoJobOnProviderCopyMissFn: () => true,
+        buildNextProviderVideoCopyStateFn: () => ({ retryCount: 5 }) as never,
+        shouldRetryProviderVideoCopyFn: () => false,
+        isPlaceholderThumbnailFn: () => false,
+        buildSafeProviderMediaLogFn: (value) => ({ value }) as never,
+      },
+    });
+
+    assert.equal(resolved.status, 'failed');
+    assert.equal(resolved.progress, 0);
+    assert.equal(
+      resolved.message,
+      'The provider finished this render, but the video could not be copied to MaxVideoAI storage. Please retry.'
+    );
+  } finally {
+    console.warn = originalWarn;
+  }
+});


### PR DESCRIPTION
## Summary
- Move provider media normalization, fast-start copy, provider-copy fallback, and thumbnail generation out of /api/generate
- Keep missing provider id rollback/HTTP response in the route while the helper handles media state mutations and settings snapshot updates
- Add architecture and behavior coverage for initial media state, fast-start copy, generated thumbnails, retryable copy miss, and failed copy miss

## Local verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-provider-media.test.ts tests/generate-final-receipts.test.ts tests/generate-final-job-persistence.test.ts tests/generate-provider-job-tracker.test.ts tests/generate-settings-snapshot.test.ts tests/generate-fal-request.test.ts tests/generate-metric-logger.test.ts tests/generate-receipt-snapshot.test.ts tests/generate-attachment-references.test.ts tests/generate-attachments.test.ts tests/generate-extra-input-values.test.ts tests/generate-payment-rollback-architecture.test.ts tests/generate-initial-video-job-architecture.test.ts tests/generate-fal-error-handling.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build