### PR TITLE
Split generate final response builder

### DIFF
--- a/frontend/app/api/generate/_lib/final-response.ts
+++ b/frontend/app/api/generate/_lib/final-response.ts
@@ -1,0 +1,105 @@
+import type { GenerateResult } from '@/lib/fal';
+import type { PricingSnapshot } from '@/types/engines';
+import type { VideoAsset } from '@/types/render';
+import type { PaymentMode, PendingReceipt } from './initial-video-job';
+
+export type FinalGenerateResponse = {
+  ok: true;
+  jobId: string;
+  videoUrl: string | null;
+  video: VideoAsset | null;
+  thumbUrl: string;
+  status: string;
+  progress: number;
+  pricing: PricingSnapshot;
+  paymentStatus: string;
+  provider: GenerateResult['provider'];
+  providerJobId: string | null;
+  batchId: string | null;
+  groupId: string | null;
+  iterationIndex: number | null;
+  iterationCount: number | null;
+  renderIds: Array<string | null> | null;
+  heroRenderId: string | null;
+  localKey: string | null;
+  message: string | null;
+  etaSeconds: number | null;
+  etaLabel: string | null;
+};
+
+export function resolveGenerateResponsePaymentStatus(params: {
+  status: string;
+  pendingReceipt: PendingReceipt | null;
+  paymentMode: PaymentMode;
+  paymentStatus: string;
+}): string {
+  return params.status === 'failed' && params.pendingReceipt && params.paymentMode === 'wallet'
+    ? 'refunded_wallet'
+    : params.paymentStatus;
+}
+
+export function buildFinalGenerateResponse(params: {
+  jobId: string;
+  media: {
+    video: string | null;
+    videoAsset: VideoAsset | null;
+    thumb: string;
+  };
+  completion: {
+    status: string;
+    progress: number;
+    message: string | null;
+    etaSeconds: number | null;
+    etaLabel: string | null;
+  };
+  pricing: PricingSnapshot;
+  payment: {
+    pendingReceipt: PendingReceipt | null;
+    paymentMode: PaymentMode;
+    paymentStatus: string;
+  };
+  provider: {
+    providerMode: GenerateResult['provider'];
+    providerJobId: string | null;
+  };
+  batch: {
+    batchId: string | null;
+    groupId: string | null;
+    iterationIndex: number | null;
+    iterationCount: number | null;
+    renderIds: Array<string | null> | null;
+    heroRenderId: string | null;
+    localKey: string | null;
+  };
+}): FinalGenerateResponse {
+  const paymentStatus = resolveGenerateResponsePaymentStatus({
+    status: params.completion.status,
+    pendingReceipt: params.payment.pendingReceipt,
+    paymentMode: params.payment.paymentMode,
+    paymentStatus: params.payment.paymentStatus,
+  });
+
+  return {
+    ok: true,
+    jobId: params.jobId,
+    videoUrl: params.media.video,
+    video: params.media.videoAsset,
+    thumbUrl: params.media.thumb,
+    status: params.completion.status,
+    progress: params.completion.progress,
+    pricing: params.pricing,
+    paymentStatus,
+    provider: params.provider.providerMode,
+    providerJobId: params.provider.providerJobId,
+    batchId: params.batch.batchId,
+    groupId: params.batch.groupId,
+    iterationIndex: params.batch.iterationIndex,
+    iterationCount: params.batch.iterationCount,
+    renderIds: params.batch.renderIds,
+    heroRenderId: params.batch.heroRenderId,
+    localKey: params.batch.localKey,
+    message: params.completion.message,
+    etaSeconds: params.completion.etaSeconds,
+    etaLabel: params.completion.etaLabel,
+  };
+}

--- a/frontend/app/api/generate/route.ts
+++ b/frontend/app/api/generate/route.ts
@@ -29,6 +29,7 @@ import { createProviderJobTracker } from './_lib/provider-job-tracker';
 import { persistFinalVideoJobUpdate, recordFinalGenerateQueueLog } from './_lib/final-job-persistence';
 import { persistFinalChargeReceipt, persistWalletFailureRefundReceipt } from './_lib/final-receipts';
 import { buildInitialProviderMediaState, resolveProviderMediaState } from './_lib/provider-media';
+import { buildFinalGenerateResponse } from './_lib/final-response';
 import {
   buildResponseFromExistingVideoJob,
   createAtomicInitialVideoJob,
@@ -1828,40 +1829,33 @@ export async function POST(req: NextRequest) {
     priceOnlyReceipts,
   });
 
-  const responsePaymentStatus =
-    status === 'failed' && pendingReceipt && paymentMode === 'wallet' ? 'refunded_wallet' : paymentStatus;
+  const finalResponse = buildFinalGenerateResponse({
+    jobId,
+    media: { video, videoAsset, thumb },
+    completion: { status, progress, message, etaSeconds, etaLabel },
+    pricing,
+    payment: { pendingReceipt, paymentMode, paymentStatus },
+    provider: { providerMode, providerJobId },
+    batch: {
+      batchId,
+      groupId,
+      iterationIndex,
+      iterationCount,
+      renderIds,
+      heroRenderId,
+      localKey,
+    },
+  });
 
   logMetric(status === 'failed' ? 'failed' : 'completed', {
     jobId,
     meta: {
       providerJobId,
       provider: providerMode,
-      paymentStatus: responsePaymentStatus,
+      paymentStatus: finalResponse.paymentStatus,
       inputSummary: falInputSummary,
     },
   });
 
-  return NextResponse.json({
-    ok: true,
-    jobId,
-    videoUrl: video,
-    video: videoAsset,
-    thumbUrl: thumb,
-    status,
-    progress,
-    pricing,
-    paymentStatus: responsePaymentStatus,
-    provider: providerMode,
-    providerJobId,
-    batchId,
-    groupId,
-    iterationIndex,
-    iterationCount,
-    renderIds,
-    heroRenderId,
-    localKey,
-    message,
-    etaSeconds,
-    etaLabel,
-  });
+  return NextResponse.json(finalResponse);
 }

--- a/tests/generate-final-response.test.ts
+++ b/tests/generate-final-response.test.ts
@@ -1,0 +1,197 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  buildFinalGenerateResponse,
+  resolveGenerateResponsePaymentStatus,
+} from '../frontend/app/api/generate/_lib/final-response';
+import type { PendingReceipt } from '../frontend/app/api/generate/_lib/initial-video-job';
+import type { PricingSnapshot } from '../frontend/types/engines';
+import type { VideoAsset } from '../frontend/types/render';
+
+const root = process.cwd();
+const routePath = join(root, 'frontend/app/api/generate/route.ts');
+const helperPath = join(root, 'frontend/app/api/generate/_lib/final-response.ts');
+
+const routeSource = readFileSync(routePath, 'utf8');
+const helperSource = readFileSync(helperPath, 'utf8');
+
+const pricing = {
+  totalCents: 1200,
+  currency: 'USD',
+} as PricingSnapshot;
+
+const pendingReceipt: PendingReceipt = {
+  userId: 'user_123',
+  amountCents: 1200,
+  currency: 'USD',
+  description: 'Run Seedance - 8s',
+  jobId: 'job_123',
+  snapshot: { totalCents: 1200 },
+  applicationFeeCents: 300,
+  vendorAccountId: 'acct_123',
+  stripePaymentIntentId: 'pi_123',
+  stripeChargeId: 'ch_123',
+};
+
+test('generate route delegates final response building', () => {
+  assert.ok(existsSync(helperPath), 'final response building should live in the generate route _lib folder');
+  assert.match(routeSource, /from '\.\/_lib\/final-response'/);
+  assert.match(routeSource, /const finalResponse = buildFinalGenerateResponse/);
+  assert.match(routeSource, /return NextResponse\.json\(finalResponse\)/);
+  assert.doesNotMatch(
+    routeSource,
+    /return NextResponse\.json\(\{\n\s+ok: true,\n\s+jobId,\n\s+videoUrl: video,/,
+    'final success response shape belongs in final-response.ts'
+  );
+
+  const lineCount = routeSource.split('\n').length;
+  assert.ok(lineCount <= 1865, `/api/generate route should stay below 1865 lines after final response extraction, got ${lineCount}`);
+});
+
+test('final response helper exposes the route contract', () => {
+  assert.match(helperSource, /export type FinalGenerateResponse/, 'FinalGenerateResponse should be exported');
+  assert.match(helperSource, /export function resolveGenerateResponsePaymentStatus/, 'payment status resolver should be exported');
+  assert.match(helperSource, /export function buildFinalGenerateResponse/, 'final response builder should be exported');
+});
+
+test('final response helper builds the completed generation payload', () => {
+  const videoAsset = {
+    url: 'https://cdn.maxvideoai.com/video.mp4',
+    mime: 'video/mp4',
+  } as VideoAsset;
+
+  assert.deepEqual(
+    buildFinalGenerateResponse({
+      jobId: 'job_123',
+      media: {
+        video: 'https://cdn.maxvideoai.com/video.mp4',
+        videoAsset,
+        thumb: 'https://cdn.maxvideoai.com/thumb.jpg',
+      },
+      completion: {
+        status: 'completed',
+        progress: 100,
+        message: 'Render complete',
+        etaSeconds: null,
+        etaLabel: null,
+      },
+      pricing,
+      payment: {
+        pendingReceipt: null,
+        paymentMode: 'wallet',
+        paymentStatus: 'paid_wallet',
+      },
+      provider: {
+        providerMode: 'fal',
+        providerJobId: 'provider_123',
+      },
+      batch: {
+        batchId: 'batch_123',
+        groupId: 'group_123',
+        iterationIndex: 0,
+        iterationCount: 2,
+        renderIds: ['job_123', 'job_456'],
+        heroRenderId: 'job_123',
+        localKey: 'local_123',
+      },
+    }),
+    {
+      ok: true,
+      jobId: 'job_123',
+      videoUrl: 'https://cdn.maxvideoai.com/video.mp4',
+      video: videoAsset,
+      thumbUrl: 'https://cdn.maxvideoai.com/thumb.jpg',
+      status: 'completed',
+      progress: 100,
+      pricing,
+      paymentStatus: 'paid_wallet',
+      provider: 'fal',
+      providerJobId: 'provider_123',
+      batchId: 'batch_123',
+      groupId: 'group_123',
+      iterationIndex: 0,
+      iterationCount: 2,
+      renderIds: ['job_123', 'job_456'],
+      heroRenderId: 'job_123',
+      localKey: 'local_123',
+      message: 'Render complete',
+      etaSeconds: null,
+      etaLabel: null,
+    }
+  );
+});
+
+test('final response helper reports refunded wallet status for failed wallet generations', () => {
+  assert.equal(
+    resolveGenerateResponsePaymentStatus({
+      status: 'failed',
+      pendingReceipt,
+      paymentMode: 'wallet',
+      paymentStatus: 'paid_wallet',
+    }),
+    'refunded_wallet'
+  );
+
+  const response = buildFinalGenerateResponse({
+    jobId: 'job_123',
+    media: {
+      video: null,
+      videoAsset: null,
+      thumb: '/assets/frames/thumb-16x9.svg',
+    },
+    completion: {
+      status: 'failed',
+      progress: 0,
+      message: 'Provider copy failed',
+      etaSeconds: 30,
+      etaLabel: '30s',
+    },
+    pricing,
+    payment: {
+      pendingReceipt,
+      paymentMode: 'wallet',
+      paymentStatus: 'paid_wallet',
+    },
+    provider: {
+      providerMode: 'fal',
+      providerJobId: 'provider_123',
+    },
+    batch: {
+      batchId: null,
+      groupId: null,
+      iterationIndex: null,
+      iterationCount: null,
+      renderIds: null,
+      heroRenderId: null,
+      localKey: null,
+    },
+  });
+
+  assert.equal(response.paymentStatus, 'refunded_wallet');
+  assert.equal(response.videoUrl, null);
+  assert.equal(response.message, 'Provider copy failed');
+});
+
+test('payment status resolver preserves non-wallet statuses', () => {
+  assert.equal(
+    resolveGenerateResponsePaymentStatus({
+      status: 'failed',
+      pendingReceipt,
+      paymentMode: 'direct',
+      paymentStatus: 'paid_direct',
+    }),
+    'paid_direct'
+  );
+  assert.equal(
+    resolveGenerateResponsePaymentStatus({
+      status: 'completed',
+      pendingReceipt,
+      paymentMode: 'wallet',
+      paymentStatus: 'paid_wallet',
+    }),
+    'paid_wallet'
+  );
+});


### PR DESCRIPTION
## Summary
- Move final /api/generate success response construction into a pure final-response helper
- Keep wallet failed-response payment status normalization with the response contract
- Add architecture and behavior coverage for completed responses, refunded wallet failures, and non-wallet payment status preservation

## Local verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-final-response.test.ts tests/generate-provider-media.test.ts tests/generate-final-receipts.test.ts tests/generate-final-job-persistence.test.ts tests/generate-provider-job-tracker.test.ts tests/generate-settings-snapshot.test.ts tests/generate-fal-request.test.ts tests/generate-metric-logger.test.ts tests/generate-receipt-snapshot.test.ts tests/generate-attachment-references.test.ts tests/generate-attachments.test.ts tests/generate-extra-input-values.test.ts tests/generate-payment-rollback-architecture.test.ts tests/generate-initial-video-job-architecture.test.ts tests/generate-fal-error-handling.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build