### PR TITLE
Split generate billing preflight

### DIFF
--- a/frontend/app/api/generate/_lib/billing-preflight.ts
+++ b/frontend/app/api/generate/_lib/billing-preflight.ts
@@ -1,0 +1,357 @@
+import type { NextRequest } from 'next/server';
+import Stripe from 'stripe';
+
+import { ENV, receiptsPriceOnlyEnabled } from '@/lib/env';
+import { computePricingSnapshot, getPlatformFeeCents } from '@/lib/pricing';
+import { convertCents } from '@/lib/exchange';
+import { buildEngineAddonInput, applyEngineVariantPricing } from '@/lib/pricing-addons';
+import {
+  ensureUserPreferredCurrency,
+  getUserPreferredCurrency,
+  resolveCurrency,
+  type Currency,
+} from '@/lib/currency';
+import type { EngineCaps, Mode, PricingSnapshot } from '@/types/engines';
+import { buildReceiptSnapshot } from './receipt-snapshot';
+import type { PaymentMode, PendingReceipt } from './initial-video-job';
+
+const DISPLAY_CURRENCY = 'USD';
+const DISPLAY_CURRENCY_LOWER = 'usd';
+
+type PaymentIntentLike = {
+  id: string;
+  status: string;
+  amount?: number | null;
+  amount_received?: number | null;
+  currency?: string | null;
+  latest_charge?: string | { id?: string | null } | null;
+  metadata?: Record<string, string | undefined>;
+};
+
+type BillingPreflightDeps = {
+  getUserPreferredCurrencyFn?: typeof getUserPreferredCurrency;
+  resolveCurrencyFn?: typeof resolveCurrency;
+  applyEngineVariantPricingFn?: typeof applyEngineVariantPricing;
+  buildEngineAddonInputFn?: typeof buildEngineAddonInput;
+  computePricingSnapshotFn?: typeof computePricingSnapshot;
+  convertCentsFn?: typeof convertCents;
+  receiptsPriceOnlyEnabledFn?: typeof receiptsPriceOnlyEnabled;
+  buildReceiptSnapshotFn?: typeof buildReceiptSnapshot;
+  getPlatformFeeCentsFn?: typeof getPlatformFeeCents;
+  retrievePaymentIntentFn?: (paymentIntentId: string) => Promise<PaymentIntentLike>;
+  ensureUserPreferredCurrencyFn?: typeof ensureUserPreferredCurrency;
+};
+
+export type GenerateBillingPreflight = {
+  preferredCurrency: Currency | null;
+  resolvedCurrencyLower: Currency;
+  resolvedCurrencyUpper: string;
+  pricing: PricingSnapshot;
+  priceOnlyReceipts: boolean;
+  costBreakdownUsd: Record<string, unknown> | null;
+  receiptSnapshot: Record<string, unknown> | PricingSnapshot;
+  pricingSnapshotJson: string;
+  costBreakdownJson: string | null;
+  vendorAccountId: string | null;
+  applicationFeeCents: number;
+  visibility: 'public' | 'private';
+  indexable: boolean;
+  paymentMode: PaymentMode;
+  pendingReceipt: PendingReceipt | null;
+  paymentStatus: string;
+  stripePaymentIntentId: string | null;
+  stripeChargeId: string | null;
+};
+
+export type GenerateBillingPreflightResult =
+  | {
+      ok: true;
+      preflight: GenerateBillingPreflight;
+    }
+  | {
+      ok: false;
+      status: number;
+      body: Record<string, unknown>;
+      metric?: {
+        errorCode: string;
+        meta?: Record<string, unknown>;
+      };
+    };
+
+export async function resolveGenerateBillingPreflight(params: {
+  req: NextRequest;
+  engine: EngineCaps;
+  mode: Mode;
+  userId: string;
+  payment: { mode?: PaymentMode; paymentIntentId?: string | null };
+  jobId: string;
+  durationSec: number;
+  durationLabel: string | undefined;
+  pricingResolution: string;
+  effectiveResolution: string;
+  aspectRatio: string | null;
+  membershipTier: string | null | undefined;
+  soraVariant?: string;
+  isLumaRay2: boolean;
+  loop: boolean;
+  rawDurationOption: number | string | null;
+  lumaDurationLabel: string | null;
+  audioEnabled: boolean | undefined;
+  voiceControl: boolean;
+  deps?: BillingPreflightDeps;
+}): Promise<GenerateBillingPreflightResult> {
+  const deps = params.deps ?? {};
+  const getUserPreferredCurrencyFn = deps.getUserPreferredCurrencyFn ?? getUserPreferredCurrency;
+  const resolveCurrencyFn = deps.resolveCurrencyFn ?? resolveCurrency;
+  const applyEngineVariantPricingFn = deps.applyEngineVariantPricingFn ?? applyEngineVariantPricing;
+  const buildEngineAddonInputFn = deps.buildEngineAddonInputFn ?? buildEngineAddonInput;
+  const computePricingSnapshotFn = deps.computePricingSnapshotFn ?? computePricingSnapshot;
+  const convertCentsFn = deps.convertCentsFn ?? convertCents;
+  const receiptsPriceOnlyEnabledFn = deps.receiptsPriceOnlyEnabledFn ?? receiptsPriceOnlyEnabled;
+  const buildReceiptSnapshotFn = deps.buildReceiptSnapshotFn ?? buildReceiptSnapshot;
+  const getPlatformFeeCentsFn = deps.getPlatformFeeCentsFn ?? getPlatformFeeCents;
+  const ensureUserPreferredCurrencyFn = deps.ensureUserPreferredCurrencyFn ?? ensureUserPreferredCurrency;
+
+  let preferredCurrency = await getUserPreferredCurrencyFn(String(params.userId));
+  const currencyResolution = resolveCurrencyFn(
+    params.req,
+    preferredCurrency ? { preferred_currency: preferredCurrency } : undefined
+  );
+  const resolvedCurrencyLower = currencyResolution.currency;
+  const resolvedCurrencyUpper = resolvedCurrencyLower.toUpperCase();
+
+  const pricingEngine = applyEngineVariantPricingFn(params.engine, params.mode);
+  const pricingAddons = buildEngineAddonInputFn(pricingEngine, {
+    audioEnabled: params.audioEnabled,
+    voiceControl: params.voiceControl,
+  });
+  const pricing = await computePricingSnapshotFn({
+    engine: pricingEngine,
+    durationSec: params.durationSec,
+    resolution: params.pricingResolution,
+    mode: params.mode,
+    membershipTier: params.membershipTier,
+    loop: params.isLumaRay2 ? params.loop : undefined,
+    durationOption: params.lumaDurationLabel ?? params.rawDurationOption ?? null,
+    currency: DISPLAY_CURRENCY,
+    addons: pricingAddons,
+  });
+  const { cents: settlementAmountCents, rate: settlementFxRate, source: settlementFxSource } = await convertCentsFn(
+    pricing.totalCents,
+    DISPLAY_CURRENCY_LOWER,
+    resolvedCurrencyLower
+  );
+
+  const requestMeta: Record<string, unknown> = {
+    engineId: params.engine.id,
+    engineLabel: params.engine.label,
+    mode: params.mode,
+    durationSec: params.durationSec,
+    variant: params.soraVariant,
+    aspectRatio: params.aspectRatio ?? 'source',
+    resolution: params.effectiveResolution,
+    effectiveResolution: params.pricingResolution,
+  };
+  if (params.durationLabel) {
+    requestMeta.durationLabel = params.durationLabel;
+  }
+  if (params.isLumaRay2) {
+    requestMeta.loop = params.loop;
+  }
+
+  pricing.meta = {
+    ...(pricing.meta ?? {}),
+    request: requestMeta,
+    currency_source: currencyResolution.source,
+    currency_country: currencyResolution.country ?? null,
+    display_currency: DISPLAY_CURRENCY,
+    settlement_currency: resolvedCurrencyUpper,
+    settlement_amount_cents: settlementAmountCents,
+    settlement_fx_rate: settlementFxRate,
+    settlement_fx_source: settlementFxSource,
+  };
+
+  const priceOnlyReceipts = receiptsPriceOnlyEnabledFn();
+  const costBreakdownUsd = (pricing.meta?.cost_breakdown_usd as Record<string, unknown> | undefined) ?? null;
+  const receiptSnapshot = priceOnlyReceipts ? buildReceiptSnapshotFn(pricing) : pricing;
+  const pricingSnapshotJson = JSON.stringify(receiptSnapshot);
+  const costBreakdownJson = !priceOnlyReceipts && costBreakdownUsd ? JSON.stringify(costBreakdownUsd) : null;
+
+  const vendorAccountId: string | null = null;
+  const applicationFeeCents = getPlatformFeeCentsFn(pricing);
+  const visibility: 'public' | 'private' = 'private';
+  const indexable = false;
+
+  const paymentMode: PaymentMode = params.payment.mode ?? (params.userId ? 'wallet' : 'platform');
+  let pendingReceipt: PendingReceipt | null = null;
+  let paymentStatus = 'platform';
+  let stripePaymentIntentId: string | null = null;
+  let stripeChargeId: string | null = null;
+
+  if (paymentMode === 'wallet') {
+    const walletUserId = params.userId ? String(params.userId) : null;
+    if (!walletUserId) {
+      return {
+        ok: false,
+        status: 401,
+        body: { ok: false, error: 'Wallet payment requires authentication' },
+        metric: { errorCode: 'WALLET_AUTH_REQUIRED', meta: { paymentMode } },
+      };
+    }
+
+    pendingReceipt = {
+      userId: walletUserId,
+      amountCents: pricing.totalCents,
+      currency: DISPLAY_CURRENCY,
+      description: `Run ${params.engine.label} - ${params.durationSec}s`,
+      jobId: params.jobId,
+      snapshot: receiptSnapshot,
+      applicationFeeCents: priceOnlyReceipts ? null : applicationFeeCents,
+      vendorAccountId,
+    };
+    paymentStatus = 'paid_wallet';
+  } else if (paymentMode === 'direct') {
+    if (!ENV.STRIPE_SECRET_KEY && !deps.retrievePaymentIntentFn) {
+      return {
+        ok: false,
+        status: 501,
+        body: { ok: false, error: 'Stripe not configured' },
+        metric: { errorCode: 'STRIPE_NOT_CONFIGURED', meta: { paymentMode } },
+      };
+    }
+    if (!params.userId) {
+      return {
+        ok: false,
+        status: 401,
+        body: { ok: false, error: 'Direct payment requires authentication' },
+        metric: { errorCode: 'DIRECT_AUTH_REQUIRED', meta: { paymentMode } },
+      };
+    }
+    if (!params.payment.paymentIntentId) {
+      return {
+        ok: false,
+        status: 400,
+        body: { ok: false, error: 'PaymentIntent required for direct mode' },
+        metric: { errorCode: 'PAYMENT_INTENT_MISSING', meta: { paymentMode } },
+      };
+    }
+
+    const intent = await retrievePaymentIntent(params.payment.paymentIntentId, deps.retrievePaymentIntentFn);
+    const receivedSettlementCents = intent.amount_received ?? intent.amount ?? 0;
+    const metadataSettlementCents = intent.metadata?.settlement_amount_cents
+      ? Number(intent.metadata.settlement_amount_cents)
+      : null;
+    const expectedSettlementCents =
+      metadataSettlementCents && metadataSettlementCents > 0
+        ? metadataSettlementCents
+        : (await convertCentsFn(pricing.totalCents, DISPLAY_CURRENCY_LOWER, resolvedCurrencyLower)).cents;
+    if (intent.status !== 'succeeded' || receivedSettlementCents < expectedSettlementCents) {
+      return {
+        ok: false,
+        status: 402,
+        body: { ok: false, error: 'Payment not captured yet' },
+        metric: { errorCode: 'PAYMENT_NOT_CAPTURED', meta: { paymentIntentId: intent.id } },
+      };
+    }
+
+    const intentCurrency = intent.currency?.toUpperCase() ?? resolvedCurrencyUpper;
+    if (intentCurrency !== resolvedCurrencyUpper) {
+      console.warn('[payments] payment intent currency mismatch', {
+        expected: resolvedCurrencyUpper,
+        received: intentCurrency,
+        userId: params.userId,
+        paymentIntentId: intent.id,
+      });
+      return {
+        ok: false,
+        status: 409,
+        body: {
+          ok: false,
+          error: `Wallet currency locked to ${resolvedCurrencyUpper}. Contact support to request a change.`,
+        },
+        metric: { errorCode: 'PAYMENT_CURRENCY_MISMATCH', meta: { expected: resolvedCurrencyUpper, received: intentCurrency } },
+      };
+    }
+    if (!preferredCurrency) {
+      await ensureUserPreferredCurrencyFn(String(params.userId), resolvedCurrencyLower);
+      preferredCurrency = resolvedCurrencyLower;
+    }
+
+    stripePaymentIntentId = intent.id;
+    stripeChargeId =
+      typeof intent.latest_charge === 'string'
+        ? intent.latest_charge
+        : intent.latest_charge && typeof intent.latest_charge === 'object'
+          ? intent.latest_charge.id ?? null
+          : null;
+    const intentJobId = typeof intent.metadata?.job_id === 'string' ? intent.metadata.job_id : null;
+    if (intentJobId && intentJobId !== params.jobId) {
+      return {
+        ok: false,
+        status: 409,
+        body: { ok: false, error: 'Payment job mismatch' },
+      };
+    }
+
+    const metadataWalletAmountCents = intent.metadata?.wallet_amount_cents
+      ? Number(intent.metadata.wallet_amount_cents)
+      : pricing.totalCents;
+
+    pendingReceipt = {
+      userId: String(params.userId),
+      amountCents: metadataWalletAmountCents,
+      currency: DISPLAY_CURRENCY,
+      description: `Run ${params.engine.label} - ${params.durationSec}s`,
+      jobId: params.jobId,
+      snapshot: receiptSnapshot,
+      applicationFeeCents: null,
+      vendorAccountId,
+      stripePaymentIntentId,
+      stripeChargeId,
+    };
+    paymentStatus = 'paid_direct';
+  } else if (paymentMode === 'platform') {
+    paymentStatus = 'platform';
+  } else {
+    return {
+      ok: false,
+      status: 400,
+      body: { ok: false, error: 'Unsupported payment mode' },
+    };
+  }
+
+  return {
+    ok: true,
+    preflight: {
+      preferredCurrency,
+      resolvedCurrencyLower,
+      resolvedCurrencyUpper,
+      pricing,
+      priceOnlyReceipts,
+      costBreakdownUsd,
+      receiptSnapshot,
+      pricingSnapshotJson,
+      costBreakdownJson,
+      vendorAccountId,
+      applicationFeeCents,
+      visibility,
+      indexable,
+      paymentMode,
+      pendingReceipt,
+      paymentStatus,
+      stripePaymentIntentId,
+      stripeChargeId,
+    },
+  };
+}
+
+async function retrievePaymentIntent(
+  paymentIntentId: string,
+  retrievePaymentIntentFn: BillingPreflightDeps['retrievePaymentIntentFn']
+): Promise<PaymentIntentLike> {
+  if (retrievePaymentIntentFn) {
+    return retrievePaymentIntentFn(paymentIntentId);
+  }
+  const stripe = new Stripe(ENV.STRIPE_SECRET_KEY!, { apiVersion: '2023-10-16' });
+  return stripe.paymentIntents.retrieve(paymentIntentId, { expand: ['latest_charge'] }) as Promise<PaymentIntentLike>;
+}

--- a/frontend/app/api/generate/route.ts
+++ b/frontend/app/api/generate/route.ts
@@ -4,10 +4,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { isDatabaseConfigured, query } from '@/lib/db';
 import { randomUUID } from 'crypto';
 import { generateVideo, FalGenerationError } from '@/lib/fal';
-import { computePricingSnapshot, getPlatformFeeCents } from '@/lib/pricing';
 import { getConfiguredEngine, getConfiguredEngineIncludingHidden } from '@/server/engines';
-import Stripe from 'stripe';
-import { ENV, receiptsPriceOnlyEnabled } from '@/lib/env';
 import { ensureBillingSchema } from '@/lib/schema';
 import type { Mode } from '@/types/engines';
 import { validateRequest } from './_lib/validate';
@@ -21,7 +18,6 @@ import {
 import { validateExtraInputValues } from './_lib/extra-input-values';
 import { processGenerationAttachments } from './_lib/attachments';
 import { deriveGenerationAttachmentReferences } from './_lib/attachment-references';
-import { buildReceiptSnapshot } from './_lib/receipt-snapshot';
 import { createGenerateMetricLogger } from './_lib/metric-logger';
 import { buildFalRequestParts } from './_lib/fal-request';
 import { buildGenerationSettingsSnapshot } from './_lib/settings-snapshot';
@@ -30,13 +26,13 @@ import { persistFinalVideoJobUpdate, recordFinalGenerateQueueLog } from './_lib/
 import { persistFinalChargeReceipt, persistWalletFailureRefundReceipt } from './_lib/final-receipts';
 import { buildInitialProviderMediaState, resolveProviderMediaState } from './_lib/provider-media';
 import { buildFinalGenerateResponse } from './_lib/final-response';
+import { resolveGenerateBillingPreflight } from './_lib/billing-preflight';
 import {
   buildResponseFromExistingVideoJob,
   createAtomicInitialVideoJob,
   VideoInitialJobError,
   type ExistingVideoJobRow,
   type PaymentMode,
-  type PendingReceipt,
 } from './_lib/initial-video-job';
 import { rollbackPendingPayment } from './_lib/payment-rollback';
 import { generateAndPersistJobKeyframes } from '@/server/video-keyframes';
@@ -53,10 +49,7 @@ import {
   LUMA_RAY2_ERROR_UNSUPPORTED,
   type LumaRay2DurationLabel,
 } from '@/lib/luma-ray2';
-import { ensureUserPreferredCurrency, getUserPreferredCurrency, resolveCurrency } from '@/lib/currency';
-import type { Currency } from '@/lib/currency';
-import { convertCents } from '@/lib/exchange';
-import { applyEngineVariantPricing, buildEngineAddonInput } from '@/lib/pricing-addons';
+import { ensureUserPreferredCurrency } from '@/lib/currency';
 import { createSupabaseRouteClient } from '@/lib/supabase-ssr';
 import { AdminAuthError, requireAdmin, resolveLocalAdminBypassUserId } from '@/server/admin';
 import { buildRestrictedAccountPayload, getActiveAccountRestriction } from '@/server/fraud-cleanup';
@@ -79,9 +72,6 @@ import {
   shouldRoutePublicSeedanceFastToBytePlus,
   scrubBytePlusError,
 } from '@/server/video-providers/byteplus-modelark';
-
-const DISPLAY_CURRENCY = 'USD';
-const DISPLAY_CURRENCY_LOWER = 'usd';
 
 type VideoMode = Extract<Mode, 't2v' | 'i2v' | 'ref2v' | 'fl2v' | 'i2i' | 'v2v' | 'r2v' | 'a2v' | 'extend' | 'retake' | 'reframe'>;
 
@@ -636,86 +626,12 @@ export async function POST(req: NextRequest) {
       return NextResponse.json(buildResponseFromExistingVideoJob(existing, localKey));
     }
   }
-  const paymentMode: PaymentMode = payment.mode ?? (userId ? 'wallet' : 'platform');
-
-  let preferredCurrency: Currency | null = null;
-  if (userId) {
-    preferredCurrency = await getUserPreferredCurrency(String(userId));
-  }
-  const currencyResolution = resolveCurrency(req, preferredCurrency ? { preferred_currency: preferredCurrency } : undefined);
-  const resolvedCurrencyLower = currencyResolution.currency;
-  const resolvedCurrencyUpper = resolvedCurrencyLower.toUpperCase();
-
-  const pricingEngine = applyEngineVariantPricing(engine, mode);
-  const pricingAddons = buildEngineAddonInput(pricingEngine, {
-    audioEnabled,
-    voiceControl,
-  });
-  const pricing = await computePricingSnapshot({
-    engine: pricingEngine,
-    durationSec,
-    resolution: pricingResolution,
-    mode,
-    membershipTier: body.membershipTier,
-    loop: isLumaRay2 ? loop : undefined,
-    durationOption: lumaDurationInfo?.label ?? rawDurationOption ?? null,
-    currency: 'USD',
-    addons: pricingAddons,
-  });
-  const { cents: settlementAmountCents, rate: settlementFxRate, source: settlementFxSource } = await convertCents(
-    pricing.totalCents,
-    DISPLAY_CURRENCY_LOWER,
-    resolvedCurrencyLower
-  );
   const rawDurationLabel: LumaRay2DurationLabel | undefined =
     typeof rawDurationOption === 'string' && ['5s', '9s'].includes(rawDurationOption)
       ? (rawDurationOption as LumaRay2DurationLabel)
       : undefined;
   const durationLabel =
     lumaDurationInfo?.label ?? toLumaRay2DurationLabel(durationSec, rawDurationLabel) ?? undefined;
-  const requestMeta: Record<string, unknown> = {
-    engineId: engine.id,
-    engineLabel: engine.label,
-    mode,
-    durationSec,
-    variant: soraRequest?.variant,
-    aspectRatio: aspectRatio ?? 'source',
-    resolution: effectiveResolution,
-    effectiveResolution: pricingResolution,
-  };
-  if (durationLabel) {
-    requestMeta.durationLabel = durationLabel;
-  }
-  if (isLumaRay2) {
-    requestMeta.loop = loop;
-  }
-
-  pricing.meta = {
-    ...(pricing.meta ?? {}),
-    request: requestMeta,
-    currency_source: currencyResolution.source,
-    currency_country: currencyResolution.country ?? null,
-    display_currency: DISPLAY_CURRENCY,
-    settlement_currency: resolvedCurrencyUpper,
-    settlement_amount_cents: settlementAmountCents,
-    settlement_fx_rate: settlementFxRate,
-    settlement_fx_source: settlementFxSource,
-  };
-  const priceOnlyReceipts = receiptsPriceOnlyEnabled();
-  const costBreakdownUsd = (pricing.meta?.cost_breakdown_usd as Record<string, unknown> | undefined) ?? null;
-  const receiptSnapshot = priceOnlyReceipts ? buildReceiptSnapshot(pricing) : pricing;
-  const pricingSnapshotJson = JSON.stringify(receiptSnapshot);
-  const costBreakdownJson = !priceOnlyReceipts && costBreakdownUsd ? JSON.stringify(costBreakdownUsd) : null;
-
-  const vendorAccountId: string | null = null;
-  const applicationFeeCents = getPlatformFeeCents(pricing);
-  const visibility: 'public' | 'private' = 'private';
-  const indexable = false;
-
-  let pendingReceipt: PendingReceipt | null = null;
-  let paymentStatus: string = 'platform';
-  let stripePaymentIntentId: string | null = null;
-  let stripeChargeId: string | null = null;
   let walletChargeReserved = false;
 
   const extraInputValidation = validateExtraInputValues({ engine, mode, rawExtraInputValues });
@@ -919,112 +835,52 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  if (paymentMode === 'wallet') {
-    const walletUserId = userId ? String(userId) : null;
-    if (!walletUserId) {
-      logMetric('rejected', {
-        errorCode: 'WALLET_AUTH_REQUIRED',
-        meta: { paymentMode },
-      });
-      return NextResponse.json({ ok: false, error: 'Wallet payment requires authentication' }, { status: 401 });
+  const billingPreflight = await resolveGenerateBillingPreflight({
+    req,
+    engine,
+    mode,
+    userId,
+    payment,
+    jobId,
+    durationSec,
+    durationLabel,
+    pricingResolution,
+    effectiveResolution,
+    aspectRatio,
+    membershipTier: body.membershipTier,
+    soraVariant: soraRequest?.variant,
+    isLumaRay2,
+    loop,
+    rawDurationOption,
+    lumaDurationLabel: lumaDurationInfo?.label ?? null,
+    audioEnabled,
+    voiceControl,
+  });
+  if (!billingPreflight.ok) {
+    if (billingPreflight.metric) {
+      logMetric('rejected', billingPreflight.metric);
     }
-
-    pendingReceipt = {
-      userId: walletUserId,
-      amountCents: pricing.totalCents,
-      currency: DISPLAY_CURRENCY,
-      description: `Run ${engine.label} - ${durationSec}s`,
-      jobId,
-      snapshot: receiptSnapshot,
-      applicationFeeCents: priceOnlyReceipts ? null : applicationFeeCents,
-      vendorAccountId,
-    };
-    paymentStatus = 'paid_wallet';
-  } else if (paymentMode === 'direct') {
-    if (!ENV.STRIPE_SECRET_KEY) {
-      logMetric('rejected', { errorCode: 'STRIPE_NOT_CONFIGURED', meta: { paymentMode } });
-      return NextResponse.json({ ok: false, error: 'Stripe not configured' }, { status: 501 });
-    }
-    if (!userId) {
-      logMetric('rejected', { errorCode: 'DIRECT_AUTH_REQUIRED', meta: { paymentMode } });
-      return NextResponse.json({ ok: false, error: 'Direct payment requires authentication' }, { status: 401 });
-    }
-    if (!payment.paymentIntentId) {
-      logMetric('rejected', { errorCode: 'PAYMENT_INTENT_MISSING', meta: { paymentMode } });
-      return NextResponse.json({ ok: false, error: 'PaymentIntent required for direct mode' }, { status: 400 });
-    }
-    const stripe = new Stripe(ENV.STRIPE_SECRET_KEY, { apiVersion: '2023-10-16' });
-    const intent = await stripe.paymentIntents.retrieve(payment.paymentIntentId, { expand: ['latest_charge'] });
-
-    const receivedSettlementCents = intent.amount_received ?? intent.amount ?? 0;
-    const metadataSettlementCents = intent.metadata?.settlement_amount_cents
-      ? Number(intent.metadata.settlement_amount_cents)
-      : null;
-    const expectedSettlementCents = metadataSettlementCents && metadataSettlementCents > 0
-      ? metadataSettlementCents
-      : (await convertCents(pricing.totalCents, DISPLAY_CURRENCY_LOWER, resolvedCurrencyLower)).cents;
-    if (intent.status !== 'succeeded' || receivedSettlementCents < expectedSettlementCents) {
-      logMetric('rejected', {
-        errorCode: 'PAYMENT_NOT_CAPTURED',
-        meta: { paymentIntentId: intent.id },
-      });
-      return NextResponse.json({ ok: false, error: 'Payment not captured yet' }, { status: 402 });
-    }
-    const intentCurrency = intent.currency?.toUpperCase() ?? resolvedCurrencyUpper;
-    if (intentCurrency !== resolvedCurrencyUpper) {
-      console.warn('[payments] payment intent currency mismatch', {
-        expected: resolvedCurrencyUpper,
-        received: intentCurrency,
-        userId,
-        paymentIntentId: intent.id,
-      });
-      logMetric('rejected', {
-        errorCode: 'PAYMENT_CURRENCY_MISMATCH',
-        meta: { expected: resolvedCurrencyUpper, received: intentCurrency },
-      });
-      return NextResponse.json(
-        {
-          ok: false,
-          error: `Wallet currency locked to ${resolvedCurrencyUpper}. Contact support to request a change.`,
-        },
-        { status: 409 }
-      );
-    }
-    if (!preferredCurrency) {
-      await ensureUserPreferredCurrency(String(userId), resolvedCurrencyLower);
-      preferredCurrency = resolvedCurrencyLower;
-    }
-
-    stripePaymentIntentId = intent.id;
-    const latestCharge = typeof intent.latest_charge === 'string' ? intent.latest_charge : intent.latest_charge?.id ?? null;
-    stripeChargeId = latestCharge;
-    const intentJobId = typeof intent.metadata?.job_id === 'string' ? intent.metadata.job_id : null;
-    if (intentJobId && intentJobId !== jobId) {
-      return NextResponse.json({ ok: false, error: 'Payment job mismatch' }, { status: 409 });
-    }
-
-    const metadataWalletAmountCents = intent.metadata?.wallet_amount_cents
-      ? Number(intent.metadata.wallet_amount_cents)
-      : pricing.totalCents;
-
-    pendingReceipt = {
-      userId: String(userId),
-      amountCents: metadataWalletAmountCents,
-      currency: DISPLAY_CURRENCY,
-      description: `Run ${engine.label} - ${durationSec}s`,
-      jobId,
-      snapshot: receiptSnapshot,
-      applicationFeeCents: null,
-      vendorAccountId,
-      stripePaymentIntentId,
-      stripeChargeId,
-    };
-    paymentStatus = 'paid_direct';
-  } else if (paymentMode === 'platform') {
-    paymentStatus = 'platform';
-  } else {
-    return NextResponse.json({ ok: false, error: 'Unsupported payment mode' }, { status: 400 });
+    return NextResponse.json(billingPreflight.body, { status: billingPreflight.status });
   }
+
+  const billing = billingPreflight.preflight;
+  let { preferredCurrency } = billing;
+  const {
+    resolvedCurrencyLower,
+    pricing,
+    priceOnlyReceipts,
+    costBreakdownUsd,
+    pricingSnapshotJson,
+    costBreakdownJson,
+    vendorAccountId,
+    visibility,
+    indexable,
+    paymentMode,
+    pendingReceipt,
+    paymentStatus,
+    stripePaymentIntentId,
+    stripeChargeId,
+  } = billing;
 
   const placeholderThumb =
     aspectRatio === '9:16'

--- a/tests/generate-billing-preflight.test.ts
+++ b/tests/generate-billing-preflight.test.ts
@@ -1,0 +1,225 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { resolveGenerateBillingPreflight } from '../frontend/app/api/generate/_lib/billing-preflight';
+import type { PricingSnapshot } from '../frontend/types/engines';
+
+const root = process.cwd();
+const routePath = join(root, 'frontend/app/api/generate/route.ts');
+const helperPath = join(root, 'frontend/app/api/generate/_lib/billing-preflight.ts');
+
+const routeSource = readFileSync(routePath, 'utf8');
+const helperSource = existsSync(helperPath) ? readFileSync(helperPath, 'utf8') : '';
+
+const engine = {
+  id: 'seedance-2-0',
+  label: 'Seedance 2.0',
+  pricingDetails: undefined,
+} as never;
+
+const pricing = {
+  totalCents: 1200,
+  currency: 'USD',
+  meta: { cost_breakdown_usd: { provider: 400 } },
+} as PricingSnapshot;
+
+function createReq(country = 'US') {
+  return {
+    headers: {
+      get(name: string) {
+        return name === 'x-vercel-ip-country' ? country : null;
+      },
+    },
+  } as never;
+}
+
+test('generate route delegates billing and payment preflight', () => {
+  assert.ok(existsSync(helperPath), 'billing preflight should live in the generate route _lib folder');
+  assert.match(routeSource, /from '\.\/_lib\/billing-preflight'/);
+  assert.doesNotMatch(routeSource, /computePricingSnapshot/, 'pricing computation belongs in billing-preflight.ts');
+  assert.doesNotMatch(routeSource, /new Stripe/, 'direct payment preflight belongs in billing-preflight.ts');
+  assert.doesNotMatch(routeSource, /getUserPreferredCurrency/, 'currency preference lookup belongs in billing-preflight.ts');
+  assert.doesNotMatch(routeSource, /buildReceiptSnapshot/, 'receipt snapshot selection belongs in billing-preflight.ts');
+
+  const lineCount = routeSource.split('\n').length;
+  assert.ok(lineCount <= 1745, `/api/generate route should stay below 1745 lines after billing preflight extraction, got ${lineCount}`);
+});
+
+test('billing preflight helper exposes the route contract', () => {
+  assert.match(helperSource, /export type GenerateBillingPreflight/, 'GenerateBillingPreflight should be exported');
+  assert.match(helperSource, /export async function resolveGenerateBillingPreflight/, 'billing preflight resolver should be exported');
+});
+
+test('billing preflight builds wallet receipts and pricing metadata', async () => {
+  const result = await resolveGenerateBillingPreflight({
+    req: createReq('FR'),
+    engine,
+    mode: 't2v',
+    userId: 'user_123',
+    payment: { mode: 'wallet', paymentIntentId: null },
+    jobId: 'job_123',
+    durationSec: 8,
+    durationLabel: '8s',
+    pricingResolution: '1080p',
+    effectiveResolution: '1080p',
+    aspectRatio: '16:9',
+    membershipTier: 'pro',
+    isLumaRay2: false,
+    loop: false,
+    rawDurationOption: null,
+    lumaDurationLabel: null,
+    audioEnabled: true,
+    voiceControl: false,
+    deps: {
+      getUserPreferredCurrencyFn: async () => 'eur',
+      resolveCurrencyFn: () => ({ currency: 'eur', source: 'user_pref' }),
+      computePricingSnapshotFn: async () => ({ ...pricing, meta: { ...pricing.meta } }),
+      convertCentsFn: async () => ({ cents: 1104, rate: 0.92, source: 'test' }),
+      getPlatformFeeCentsFn: () => 300,
+      receiptsPriceOnlyEnabledFn: () => true,
+      buildReceiptSnapshotFn: () => ({ totalCents: 1200, currency: 'USD' }),
+      applyEngineVariantPricingFn: (value) => value,
+      buildEngineAddonInputFn: () => ({ audio: true }),
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.preflight.paymentMode, 'wallet');
+  assert.equal(result.preflight.paymentStatus, 'paid_wallet');
+  assert.equal(result.preflight.preferredCurrency, 'eur');
+  assert.equal(result.preflight.resolvedCurrencyUpper, 'EUR');
+  assert.deepEqual(result.preflight.pricing.meta?.request, {
+    engineId: 'seedance-2-0',
+    engineLabel: 'Seedance 2.0',
+    mode: 't2v',
+    durationSec: 8,
+    variant: undefined,
+    aspectRatio: '16:9',
+    resolution: '1080p',
+    effectiveResolution: '1080p',
+    durationLabel: '8s',
+  });
+  assert.equal(result.preflight.pricing.meta?.settlement_amount_cents, 1104);
+  assert.equal(result.preflight.pricingSnapshotJson, '{"totalCents":1200,"currency":"USD"}');
+  assert.equal(result.preflight.costBreakdownJson, null);
+  assert.deepEqual(result.preflight.pendingReceipt, {
+    userId: 'user_123',
+    amountCents: 1200,
+    currency: 'USD',
+    description: 'Run Seedance 2.0 - 8s',
+    jobId: 'job_123',
+    snapshot: { totalCents: 1200, currency: 'USD' },
+    applicationFeeCents: null,
+    vendorAccountId: null,
+  });
+});
+
+test('billing preflight accepts captured direct payment intents', async () => {
+  const ensuredCurrencies: string[] = [];
+  const result = await resolveGenerateBillingPreflight({
+    req: createReq(),
+    engine,
+    mode: 't2v',
+    userId: 'user_123',
+    payment: { mode: 'direct', paymentIntentId: 'pi_123' },
+    jobId: 'job_123',
+    durationSec: 8,
+    durationLabel: undefined,
+    pricingResolution: '720p',
+    effectiveResolution: '720p',
+    aspectRatio: null,
+    membershipTier: undefined,
+    isLumaRay2: false,
+    loop: false,
+    rawDurationOption: null,
+    lumaDurationLabel: null,
+    audioEnabled: false,
+    voiceControl: false,
+    deps: {
+      getUserPreferredCurrencyFn: async () => null,
+      resolveCurrencyFn: () => ({ currency: 'usd', source: 'default' }),
+      computePricingSnapshotFn: async () => ({ ...pricing, meta: { ...pricing.meta } }),
+      convertCentsFn: async () => ({ cents: 1200, rate: 1, source: 'test' }),
+      getPlatformFeeCentsFn: () => 300,
+      receiptsPriceOnlyEnabledFn: () => false,
+      buildReceiptSnapshotFn: (value) => ({ totalCents: value.totalCents, currency: value.currency }),
+      applyEngineVariantPricingFn: (value) => value,
+      buildEngineAddonInputFn: () => ({}),
+      retrievePaymentIntentFn: async () => ({
+        id: 'pi_123',
+        status: 'succeeded',
+        amount: 1200,
+        amount_received: 1200,
+        currency: 'usd',
+        latest_charge: { id: 'ch_123' },
+        metadata: {
+          job_id: 'job_123',
+          wallet_amount_cents: '1000',
+          settlement_amount_cents: '1200',
+        },
+      }),
+      ensureUserPreferredCurrencyFn: async (_userId, currency) => {
+        ensuredCurrencies.push(currency);
+      },
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.preflight.paymentStatus, 'paid_direct');
+  assert.equal(result.preflight.stripePaymentIntentId, 'pi_123');
+  assert.equal(result.preflight.stripeChargeId, 'ch_123');
+  assert.deepEqual(ensuredCurrencies, ['usd']);
+  assert.equal(result.preflight.pendingReceipt?.amountCents, 1000);
+  assert.equal(result.preflight.pendingReceipt?.stripePaymentIntentId, 'pi_123');
+  assert.equal(result.preflight.pendingReceipt?.stripeChargeId, 'ch_123');
+});
+
+test('billing preflight rejects underpaid direct payment intents', async () => {
+  const result = await resolveGenerateBillingPreflight({
+    req: createReq(),
+    engine,
+    mode: 't2v',
+    userId: 'user_123',
+    payment: { mode: 'direct', paymentIntentId: 'pi_123' },
+    jobId: 'job_123',
+    durationSec: 8,
+    durationLabel: undefined,
+    pricingResolution: '720p',
+    effectiveResolution: '720p',
+    aspectRatio: null,
+    membershipTier: undefined,
+    isLumaRay2: false,
+    loop: false,
+    rawDurationOption: null,
+    lumaDurationLabel: null,
+    audioEnabled: false,
+    voiceControl: false,
+    deps: {
+      getUserPreferredCurrencyFn: async () => 'usd',
+      resolveCurrencyFn: () => ({ currency: 'usd', source: 'user_pref' }),
+      computePricingSnapshotFn: async () => ({ ...pricing, meta: { ...pricing.meta } }),
+      convertCentsFn: async () => ({ cents: 1200, rate: 1, source: 'test' }),
+      getPlatformFeeCentsFn: () => 300,
+      receiptsPriceOnlyEnabledFn: () => false,
+      buildReceiptSnapshotFn: (value) => ({ totalCents: value.totalCents, currency: value.currency }),
+      applyEngineVariantPricingFn: (value) => value,
+      buildEngineAddonInputFn: () => ({}),
+      retrievePaymentIntentFn: async () => ({
+        id: 'pi_123',
+        status: 'succeeded',
+        amount: 800,
+        amount_received: 800,
+        currency: 'usd',
+        latest_charge: 'ch_123',
+        metadata: {},
+      }),
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.metric, { errorCode: 'PAYMENT_NOT_CAPTURED', meta: { paymentIntentId: 'pi_123' } });
+  assert.equal(result.status, 402);
+  assert.deepEqual(result.body, { ok: false, error: 'Payment not captured yet' });
+});

--- a/tests/generate-receipt-snapshot.test.ts
+++ b/tests/generate-receipt-snapshot.test.ts
@@ -8,13 +8,19 @@ import { buildReceiptSnapshot } from '../frontend/app/api/generate/_lib/receipt-
 const root = process.cwd();
 const routePath = join(root, 'frontend/app/api/generate/route.ts');
 const helperPath = join(root, 'frontend/app/api/generate/_lib/receipt-snapshot.ts');
+const billingHelperPath = join(root, 'frontend/app/api/generate/_lib/billing-preflight.ts');
 
 const routeSource = readFileSync(routePath, 'utf8');
 const helperSource = readFileSync(helperPath, 'utf8');
+const billingHelperSource = existsSync(billingHelperPath) ? readFileSync(billingHelperPath, 'utf8') : '';
 
 test('generate route delegates receipt snapshot building', () => {
   assert.ok(existsSync(helperPath), 'receipt snapshot building should live in the generate route _lib folder');
-  assert.match(routeSource, /from '\.\/_lib\/receipt-snapshot'/);
+  assert.match(
+    `${routeSource}\n${billingHelperSource}`,
+    /from '\.\/receipt-snapshot'|from '\.\/_lib\/receipt-snapshot'/,
+    'receipt snapshot helper should be imported by the route or its billing preflight helper'
+  );
   assert.doesNotMatch(routeSource, /function buildReceiptSnapshot/, 'receipt snapshot construction belongs in receipt-snapshot.ts');
   assert.doesNotMatch(routeSource, /discountCandidate/, 'discount pruning belongs in receipt-snapshot.ts');
   assert.doesNotMatch(routeSource, /taxesCandidate/, 'tax pruning belongs in receipt-snapshot.ts');


### PR DESCRIPTION
## Summary
- Move pricing, currency resolution, receipt snapshot selection, and wallet/direct payment preflight out of /api/generate
- Keep the route responsible for request orchestration while billing-preflight owns Stripe checks and pending receipt creation
- Add behavior coverage for wallet receipt metadata, captured direct payments, underpaid direct payments, and updated receipt-snapshot delegation

## Local verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-billing-preflight.test.ts tests/generate-final-response.test.ts tests/generate-provider-media.test.ts tests/generate-final-receipts.test.ts tests/generate-final-job-persistence.test.ts tests/generate-provider-job-tracker.test.ts tests/generate-settings-snapshot.test.ts tests/generate-fal-request.test.ts tests/generate-metric-logger.test.ts tests/generate-receipt-snapshot.test.ts tests/generate-attachment-references.test.ts tests/generate-attachments.test.ts tests/generate-extra-input-values.test.ts tests/generate-payment-rollback-architecture.test.ts tests/generate-initial-video-job-architecture.test.ts tests/generate-fal-error-handling.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build