### PR TITLE
Split generate validation payload

### DIFF
--- a/frontend/app/api/generate/_lib/validation-payload.ts
+++ b/frontend/app/api/generate/_lib/validation-payload.ts
@@ -1,0 +1,279 @@
+import type { Mode } from '@/types/engines';
+import { validateRequest } from './validate';
+
+type GenerateValidationMetric = {
+  errorCode: string;
+  meta?: Record<string, unknown>;
+};
+
+type GenerateValidationDeps = {
+  validateRequestFn?: typeof validateRequest;
+};
+
+export type GenerateValidationPayloadResult =
+  | {
+      ok: true;
+      payload: Record<string, unknown>;
+      needsImage: boolean;
+      needsReferenceImages: boolean;
+      needsFirstLastFrames: boolean;
+      needsAudio: boolean;
+      needsSourceVideoEdit: boolean;
+    }
+  | {
+      ok: false;
+      status: number;
+      body: Record<string, unknown>;
+      metric: GenerateValidationMetric;
+    };
+
+export function buildGenerateValidationPayload(params: {
+  engineId: string;
+  mode: Mode;
+  prompt: string;
+  multiPrompt: Array<{ prompt: string; duration: number }> | null;
+  supportsResolution: boolean;
+  effectiveResolution: string;
+  supportsAspectRatio: boolean;
+  aspectRatio: string | null;
+  audioEnabled: boolean | undefined;
+  isBytePlusV1a: boolean;
+  supportsDuration: boolean;
+  numFrames: number | null;
+  validationDuration: number | string | null;
+  maxUploadedBytes: number;
+  resolvedFirstFrameUrl: string | null | undefined;
+  lastFrameUrl: string | null | undefined;
+  normalizedReferenceImages: string[];
+  videoUrls: string[];
+  audioUrls: string[];
+  resolvedAudioUrl: string | null | undefined;
+  sourceInputVideoUrl: string | null | undefined;
+  elements: Array<{ frontalImageUrl?: string; referenceImageUrls?: string[]; videoUrl?: string }> | null;
+  isLumaRay2: boolean;
+  initialImageUrl: string | null | undefined;
+  deps?: GenerateValidationDeps;
+}): GenerateValidationPayloadResult {
+  const validateRequestFn = params.deps?.validateRequestFn ?? validateRequest;
+  const payload: Record<string, unknown> = {};
+
+  if (params.prompt.length > 0) {
+    payload.prompt = params.prompt;
+  }
+  if (params.multiPrompt?.length) {
+    payload.multi_prompt = params.multiPrompt;
+  }
+  if (params.supportsResolution) {
+    payload.resolution = params.effectiveResolution;
+  }
+  if (params.supportsAspectRatio && params.aspectRatio) {
+    payload.aspect_ratio = params.aspectRatio;
+  }
+  if (typeof params.audioEnabled === 'boolean' && !params.isBytePlusV1a) {
+    payload.generate_audio = params.audioEnabled;
+  }
+
+  if (params.supportsDuration) {
+    if (params.numFrames != null) {
+      payload.num_frames = params.numFrames;
+    } else if (params.validationDuration != null) {
+      payload.duration = params.validationDuration;
+    }
+  }
+
+  if (params.maxUploadedBytes > 0) {
+    payload._uploadedFileMB = params.maxUploadedBytes / (1024 * 1024);
+  }
+
+  if (params.resolvedFirstFrameUrl) {
+    payload.first_frame_url = params.resolvedFirstFrameUrl;
+  }
+  if (params.lastFrameUrl) {
+    payload.last_frame_url = params.lastFrameUrl;
+  }
+  if (params.mode === 'ref2v' && params.normalizedReferenceImages.length) {
+    payload.image_urls = params.normalizedReferenceImages;
+  }
+  if (params.mode === 'ref2v' && params.videoUrls.length) {
+    payload.video_urls = params.videoUrls;
+  }
+  if (params.mode === 'ref2v') {
+    const refAudioUrls = Array.from(new Set([...(params.resolvedAudioUrl ? [params.resolvedAudioUrl] : []), ...params.audioUrls]));
+    if (refAudioUrls.length) {
+      payload.audio_urls = refAudioUrls;
+    }
+  }
+  if (params.mode === 'v2v' && params.normalizedReferenceImages.length) {
+    payload.reference_image_urls = params.normalizedReferenceImages;
+  }
+  if (params.mode === 'r2v' && params.videoUrls.length) {
+    payload.video_urls = params.videoUrls;
+  }
+  if (isSourceVideoEditMode(params.mode) && params.sourceInputVideoUrl) {
+    payload.video_url = params.sourceInputVideoUrl;
+  }
+  if (params.resolvedAudioUrl) {
+    payload.audio_url = params.resolvedAudioUrl;
+  }
+  if (params.elements?.length) {
+    payload.elements = params.elements;
+  }
+
+  const needsImage = params.mode === 'i2v' || params.mode === 'i2i';
+  const needsReferenceImages = params.mode === 'ref2v';
+  const needsFirstLastFrames = params.mode === 'fl2v';
+  const needsAudio = params.mode === 'a2v';
+  const needsSourceVideoEdit = isSourceVideoEditMode(params.mode);
+
+  const requiredInputError = validateRequiredInputs({
+    engineId: params.engineId,
+    mode: params.mode,
+    isLumaRay2: params.isLumaRay2,
+    isBytePlusV1a: params.isBytePlusV1a,
+    needsImage,
+    needsReferenceImages,
+    needsFirstLastFrames,
+    needsAudio,
+    needsSourceVideoEdit,
+    initialImageUrl: params.initialImageUrl,
+    resolvedFirstFrameUrl: params.resolvedFirstFrameUrl,
+    lastFrameUrl: params.lastFrameUrl,
+    normalizedReferenceImages: params.normalizedReferenceImages,
+    videoUrls: params.videoUrls,
+    sourceInputVideoUrl: params.sourceInputVideoUrl,
+    resolvedAudioUrl: params.resolvedAudioUrl,
+  });
+  if (requiredInputError) {
+    return requiredInputError;
+  }
+
+  if (params.isLumaRay2 && params.mode === 'i2v') {
+    payload.image_url = params.initialImageUrl;
+  } else if (needsImage) {
+    payload.image_url = params.initialImageUrl;
+  } else if ((params.mode === 'v2v' || params.mode === 'reframe') && params.initialImageUrl) {
+    payload.image_url = params.initialImageUrl;
+  }
+
+  const validationResult = validateRequestFn(params.engineId, params.mode, payload);
+  if (!validationResult.ok) {
+    return {
+      ok: false,
+      status: 400,
+      metric: {
+        errorCode: validationResult.error.code ?? 'ENGINE_CONSTRAINT',
+        meta: {
+          field: validationResult.error.field,
+          allowed: validationResult.error.allowed,
+          value: validationResult.error.value,
+        },
+      },
+      body: {
+        ok: false,
+        error: validationResult.error.code ?? 'ENGINE_CONSTRAINT',
+        message: validationResult.error.message,
+        field: validationResult.error.field,
+        allowed: validationResult.error.allowed,
+        value: validationResult.error.value,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    payload,
+    needsImage,
+    needsReferenceImages,
+    needsFirstLastFrames,
+    needsAudio,
+    needsSourceVideoEdit,
+  };
+}
+
+function isSourceVideoEditMode(mode: Mode): boolean {
+  return mode === 'v2v' || mode === 'reframe' || mode === 'extend' || mode === 'retake';
+}
+
+function validateRequiredInputs(params: {
+  engineId: string;
+  mode: Mode;
+  isLumaRay2: boolean;
+  isBytePlusV1a: boolean;
+  needsImage: boolean;
+  needsReferenceImages: boolean;
+  needsFirstLastFrames: boolean;
+  needsAudio: boolean;
+  needsSourceVideoEdit: boolean;
+  initialImageUrl: string | null | undefined;
+  resolvedFirstFrameUrl: string | null | undefined;
+  lastFrameUrl: string | null | undefined;
+  normalizedReferenceImages: string[];
+  videoUrls: string[];
+  sourceInputVideoUrl: string | null | undefined;
+  resolvedAudioUrl: string | null | undefined;
+}): Extract<GenerateValidationPayloadResult, { ok: false }> | null {
+  if (params.isLumaRay2 && params.mode === 'i2v') {
+    if (!params.initialImageUrl) {
+      return missingInput('IMAGE_URL_REQUIRED', params, 'Image URL is required for Luma Ray 2 image-to-video');
+    }
+    return null;
+  }
+  if (params.needsImage) {
+    if (!params.initialImageUrl) {
+      return missingInput('IMAGE_URL_REQUIRED', params, 'Image URL is required for this engine mode');
+    }
+    return null;
+  }
+  if (params.needsReferenceImages) {
+    const bytePlusHasAnyReference =
+      params.isBytePlusV1a && (params.normalizedReferenceImages.length > 0 || params.videoUrls.length > 0);
+    if (!params.normalizedReferenceImages.length && !bytePlusHasAnyReference) {
+      return missingInput(
+        'IMAGE_URL_REQUIRED',
+        params,
+        params.isBytePlusV1a
+          ? 'At least one reference image or video is required for this engine mode'
+          : 'Reference images are required for this engine mode'
+      );
+    }
+    return null;
+  }
+  if (params.needsFirstLastFrames) {
+    if (!params.resolvedFirstFrameUrl || !params.lastFrameUrl) {
+      return missingInput('IMAGE_URL_REQUIRED', params, 'Both first and last frames are required for this engine mode');
+    }
+    return null;
+  }
+  if (params.mode === 'r2v') {
+    if (!params.videoUrls.length) {
+      return missingInput('VIDEO_URL_REQUIRED', params, 'Video URLs are required for this engine mode');
+    }
+    return null;
+  }
+  if (params.needsSourceVideoEdit) {
+    if (!params.sourceInputVideoUrl) {
+      return missingInput('VIDEO_URL_REQUIRED', params, 'Source video is required for this engine mode');
+    }
+    return null;
+  }
+  if (params.needsAudio && !params.resolvedAudioUrl) {
+    return missingInput('AUDIO_URL_REQUIRED', params, 'Audio URL is required for this engine mode');
+  }
+  return null;
+}
+
+function missingInput(
+  errorCode: string,
+  params: { engineId: string; mode: Mode },
+  message: string
+): Extract<GenerateValidationPayloadResult, { ok: false }> {
+  return {
+    ok: false,
+    status: 400,
+    metric: {
+      errorCode,
+      meta: { engineId: params.engineId, mode: params.mode },
+    },
+    body: { ok: false, error: message },
+  };
+}

--- a/frontend/app/api/generate/route.ts
+++ b/frontend/app/api/generate/route.ts
@@ -7,7 +7,6 @@ import { generateVideo, FalGenerationError } from '@/lib/fal';
 import { getConfiguredEngine, getConfiguredEngineIncludingHidden } from '@/server/engines';
 import { ensureBillingSchema } from '@/lib/schema';
 import type { Mode } from '@/types/engines';
-import { validateRequest } from './_lib/validate';
 import {
   condenseFalErrorMessage,
   extractFalProviderMessage,
@@ -27,6 +26,7 @@ import { persistFinalChargeReceipt, persistWalletFailureRefundReceipt } from './
 import { buildInitialProviderMediaState, resolveProviderMediaState } from './_lib/provider-media';
 import { buildFinalGenerateResponse } from './_lib/final-response';
 import { resolveGenerateBillingPreflight } from './_lib/billing-preflight';
+import { buildGenerateValidationPayload } from './_lib/validation-payload';
 import {
   buildResponseFromExistingVideoJob,
   createAtomicInitialVideoJob,
@@ -668,172 +668,37 @@ export async function POST(req: NextRequest) {
     reference_images: body.reference_images,
     rawAudioUrl,
   });
-  const validationPayload: Record<string, unknown> = {};
-  if (prompt.length > 0) {
-    validationPayload.prompt = prompt;
+  const validationPayloadResult = buildGenerateValidationPayload({
+    engineId: engine.id,
+    mode,
+    prompt,
+    multiPrompt,
+    supportsResolution,
+    effectiveResolution,
+    supportsAspectRatio,
+    aspectRatio,
+    audioEnabled,
+    isBytePlusV1a,
+    supportsDuration,
+    numFrames,
+    validationDuration: lumaDurationInfo?.label ?? (Number.isFinite(durationSec) ? durationSec : null),
+    maxUploadedBytes,
+    resolvedFirstFrameUrl,
+    lastFrameUrl,
+    normalizedReferenceImages,
+    videoUrls,
+    audioUrls,
+    resolvedAudioUrl,
+    sourceInputVideoUrl,
+    elements,
+    isLumaRay2,
+    initialImageUrl,
+  });
+  if (!validationPayloadResult.ok) {
+    logMetric('rejected', validationPayloadResult.metric);
+    return NextResponse.json(validationPayloadResult.body, { status: validationPayloadResult.status });
   }
-  if (multiPrompt?.length) {
-    validationPayload.multi_prompt = multiPrompt;
-  }
-  if (supportsResolution) {
-    validationPayload.resolution = effectiveResolution;
-  }
-  if (supportsAspectRatio && aspectRatio) {
-    validationPayload.aspect_ratio = aspectRatio;
-  }
-  if (typeof audioEnabled === 'boolean' && !isBytePlusV1a) {
-    validationPayload.generate_audio = audioEnabled;
-  }
-
-  if (supportsDuration) {
-    if (numFrames != null) {
-      validationPayload.num_frames = numFrames;
-    } else if (lumaDurationInfo) {
-      validationPayload.duration = lumaDurationInfo.label;
-    } else if (Number.isFinite(durationSec)) {
-      validationPayload.duration = durationSec;
-    }
-  }
-
-  if (maxUploadedBytes > 0) {
-    validationPayload._uploadedFileMB = maxUploadedBytes / (1024 * 1024);
-  }
-
-  if (resolvedFirstFrameUrl) {
-    validationPayload.first_frame_url = resolvedFirstFrameUrl;
-  }
-  if (lastFrameUrl) {
-    validationPayload.last_frame_url = lastFrameUrl;
-  }
-  if (mode === 'ref2v' && normalizedReferenceImages.length) {
-    validationPayload.image_urls = normalizedReferenceImages;
-  }
-  if (mode === 'ref2v' && videoUrls.length) {
-    validationPayload.video_urls = videoUrls;
-  }
-  if (mode === 'ref2v') {
-    const refAudioUrls = Array.from(new Set([...(resolvedAudioUrl ? [resolvedAudioUrl] : []), ...audioUrls]));
-    if (refAudioUrls.length) {
-      validationPayload.audio_urls = refAudioUrls;
-    }
-  }
-  if (mode === 'v2v' && normalizedReferenceImages.length) {
-    validationPayload.reference_image_urls = normalizedReferenceImages;
-  }
-  if (mode === 'r2v' && videoUrls.length) {
-    validationPayload.video_urls = videoUrls;
-  }
-  if ((mode === 'v2v' || mode === 'reframe' || mode === 'extend' || mode === 'retake') && sourceInputVideoUrl) {
-    validationPayload.video_url = sourceInputVideoUrl;
-  }
-  if (resolvedAudioUrl) {
-    validationPayload.audio_url = resolvedAudioUrl;
-  }
-  if (elements?.length) {
-    validationPayload.elements = elements;
-  }
-
-  const needsImage = mode === 'i2v' || mode === 'i2i';
-  const needsReferenceImages = mode === 'ref2v';
-  const needsFirstLastFrames = mode === 'fl2v';
-  const needsAudio = mode === 'a2v';
-  const needsSourceVideoEdit = mode === 'v2v' || mode === 'reframe' || mode === 'extend' || mode === 'retake';
-  if (isLumaRay2 && mode === 'i2v') {
-    if (!initialImageUrl) {
-      logMetric('rejected', {
-        errorCode: 'IMAGE_URL_REQUIRED',
-        meta: { engineId: engine.id, mode },
-      });
-      return NextResponse.json({ ok: false, error: 'Image URL is required for Luma Ray 2 image-to-video' }, { status: 400 });
-    }
-    validationPayload.image_url = initialImageUrl;
-  } else if (needsImage) {
-    if (!initialImageUrl) {
-      logMetric('rejected', {
-        errorCode: 'IMAGE_URL_REQUIRED',
-        meta: { engineId: engine.id, mode },
-      });
-      return NextResponse.json({ ok: false, error: 'Image URL is required for this engine mode' }, { status: 400 });
-    }
-    if (initialImageUrl) {
-      validationPayload.image_url = initialImageUrl;
-    }
-  } else if (mode === 'v2v' || mode === 'reframe') {
-    if (initialImageUrl) {
-      validationPayload.image_url = initialImageUrl;
-    }
-  } else if (needsReferenceImages) {
-    const bytePlusHasAnyReference =
-      isBytePlusV1a && (normalizedReferenceImages.length > 0 || videoUrls.length > 0);
-    if (!normalizedReferenceImages.length && !bytePlusHasAnyReference) {
-      logMetric('rejected', {
-        errorCode: 'IMAGE_URL_REQUIRED',
-        meta: { engineId: engine.id, mode },
-      });
-      return NextResponse.json(
-        { ok: false, error: isBytePlusV1a ? 'At least one reference image or video is required for this engine mode' : 'Reference images are required for this engine mode' },
-        { status: 400 }
-      );
-    }
-  } else if (needsFirstLastFrames) {
-    if (!resolvedFirstFrameUrl || !lastFrameUrl) {
-      logMetric('rejected', {
-        errorCode: 'IMAGE_URL_REQUIRED',
-        meta: { engineId: engine.id, mode },
-      });
-      return NextResponse.json(
-        { ok: false, error: 'Both first and last frames are required for this engine mode' },
-        { status: 400 }
-      );
-    }
-  } else if (mode === 'r2v') {
-    if (!videoUrls.length) {
-      logMetric('rejected', {
-        errorCode: 'VIDEO_URL_REQUIRED',
-        meta: { engineId: engine.id, mode },
-      });
-      return NextResponse.json({ ok: false, error: 'Video URLs are required for this engine mode' }, { status: 400 });
-    }
-  } else if (needsSourceVideoEdit) {
-    if (!sourceInputVideoUrl) {
-      logMetric('rejected', {
-        errorCode: 'VIDEO_URL_REQUIRED',
-        meta: { engineId: engine.id, mode },
-      });
-      return NextResponse.json({ ok: false, error: 'Source video is required for this engine mode' }, { status: 400 });
-    }
-  } else if (needsAudio) {
-    if (!resolvedAudioUrl) {
-      logMetric('rejected', {
-        errorCode: 'AUDIO_URL_REQUIRED',
-        meta: { engineId: engine.id, mode },
-      });
-      return NextResponse.json({ ok: false, error: 'Audio URL is required for this engine mode' }, { status: 400 });
-    }
-  }
-
-  const validationResult = validateRequest(engine.id, mode, validationPayload);
-  if (!validationResult.ok) {
-    logMetric('rejected', {
-      errorCode: validationResult.error.code ?? 'ENGINE_CONSTRAINT',
-      meta: {
-        field: validationResult.error.field,
-        allowed: validationResult.error.allowed,
-        value: validationResult.error.value,
-      },
-    });
-    return NextResponse.json(
-      {
-        ok: false,
-        error: validationResult.error.code ?? 'ENGINE_CONSTRAINT',
-        message: validationResult.error.message,
-        field: validationResult.error.field,
-        allowed: validationResult.error.allowed,
-        value: validationResult.error.value,
-      },
-      { status: 400 }
-    );
-  }
+  const { needsImage, needsFirstLastFrames } = validationPayloadResult;
 
   const billingPreflight = await resolveGenerateBillingPreflight({
     req,

--- a/tests/generate-validation-payload.test.ts
+++ b/tests/generate-validation-payload.test.ts
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { buildGenerateValidationPayload } from '../frontend/app/api/generate/_lib/validation-payload';
+
+const root = process.cwd();
+const routePath = join(root, 'frontend/app/api/generate/route.ts');
+const helperPath = join(root, 'frontend/app/api/generate/_lib/validation-payload.ts');
+
+const routeSource = readFileSync(routePath, 'utf8');
+const helperSource = existsSync(helperPath) ? readFileSync(helperPath, 'utf8') : '';
+
+const baseParams = {
+  engineId: 'seedance-2-0',
+  mode: 't2v' as const,
+  prompt: 'A cinematic mountain shot',
+  multiPrompt: null,
+  supportsResolution: true,
+  effectiveResolution: '1080p',
+  supportsAspectRatio: true,
+  aspectRatio: '16:9',
+  audioEnabled: true,
+  isBytePlusV1a: false,
+  supportsDuration: true,
+  numFrames: null,
+  validationDuration: 8,
+  maxUploadedBytes: 0,
+  resolvedFirstFrameUrl: null,
+  lastFrameUrl: null,
+  normalizedReferenceImages: [],
+  videoUrls: [],
+  audioUrls: [],
+  resolvedAudioUrl: null,
+  sourceInputVideoUrl: null,
+  elements: null,
+  isLumaRay2: false,
+  initialImageUrl: null,
+};
+
+test('generate route delegates validation payload and required input checks', () => {
+  assert.ok(existsSync(helperPath), 'validation payload building should live in the generate route _lib folder');
+  assert.match(routeSource, /from '\.\/_lib\/validation-payload'/);
+  assert.doesNotMatch(routeSource, /const validationPayload: Record<string, unknown> = \{\}/);
+  assert.doesNotMatch(routeSource, /needsSourceVideoEdit/, 'required input branching belongs in validation-payload.ts');
+  assert.doesNotMatch(routeSource, /validateRequest\(engine\.id, mode, validationPayload\)/);
+
+  const lineCount = routeSource.split('\n').length;
+  assert.ok(lineCount <= 1585, `/api/generate route should stay below 1585 lines after validation payload extraction, got ${lineCount}`);
+});
+
+test('validation payload helper exposes the route contract', () => {
+  assert.match(helperSource, /export type GenerateValidationPayloadResult/, 'GenerateValidationPayloadResult should be exported');
+  assert.match(helperSource, /export function buildGenerateValidationPayload/, 'validation payload builder should be exported');
+});
+
+test('validation payload helper builds base payload and mode flags', () => {
+  const result = buildGenerateValidationPayload({
+    ...baseParams,
+    deps: {
+      validateRequestFn: () => ({ ok: true }),
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.payload, {
+    prompt: 'A cinematic mountain shot',
+    resolution: '1080p',
+    aspect_ratio: '16:9',
+    generate_audio: true,
+    duration: 8,
+  });
+  assert.equal(result.needsImage, false);
+  assert.equal(result.needsFirstLastFrames, false);
+  assert.equal(result.needsSourceVideoEdit, false);
+});
+
+test('validation payload helper accepts BytePlus ref2v with video-only references', () => {
+  const result = buildGenerateValidationPayload({
+    ...baseParams,
+    mode: 'ref2v',
+    isBytePlusV1a: true,
+    normalizedReferenceImages: [],
+    videoUrls: ['https://cdn.maxvideoai.com/ref.mp4'],
+    resolvedAudioUrl: 'https://cdn.maxvideoai.com/ref.wav',
+    audioUrls: ['https://cdn.maxvideoai.com/ref.wav', 'https://cdn.maxvideoai.com/alt.wav'],
+    deps: {
+      validateRequestFn: () => ({ ok: true }),
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.payload.video_urls, ['https://cdn.maxvideoai.com/ref.mp4']);
+  assert.deepEqual(result.payload.audio_urls, [
+    'https://cdn.maxvideoai.com/ref.wav',
+    'https://cdn.maxvideoai.com/alt.wav',
+  ]);
+  assert.equal(result.needsReferenceImages, true);
+});
+
+test('validation payload helper rejects missing Luma image-to-video image', () => {
+  const result = buildGenerateValidationPayload({
+    ...baseParams,
+    engineId: 'luma-ray-2',
+    mode: 'i2v',
+    isLumaRay2: true,
+    deps: {
+      validateRequestFn: () => ({ ok: true }),
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.metric, {
+    errorCode: 'IMAGE_URL_REQUIRED',
+    meta: { engineId: 'luma-ray-2', mode: 'i2v' },
+  });
+  assert.equal(result.status, 400);
+  assert.deepEqual(result.body, { ok: false, error: 'Image URL is required for Luma Ray 2 image-to-video' });
+});
+
+test('validation payload helper rejects missing first and last frames', () => {
+  const result = buildGenerateValidationPayload({
+    ...baseParams,
+    mode: 'fl2v',
+    resolvedFirstFrameUrl: 'https://cdn.maxvideoai.com/first.jpg',
+    lastFrameUrl: null,
+    deps: {
+      validateRequestFn: () => ({ ok: true }),
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.metric?.errorCode, 'IMAGE_URL_REQUIRED');
+  assert.deepEqual(result.body, { ok: false, error: 'Both first and last frames are required for this engine mode' });
+});
+
+test('validation payload helper converts engine constraint errors to route responses', () => {
+  const result = buildGenerateValidationPayload({
+    ...baseParams,
+    deps: {
+      validateRequestFn: () => ({
+        ok: false,
+        error: {
+          code: 'ENGINE_CONSTRAINT',
+          message: 'Unsupported duration',
+          field: 'duration',
+          allowed: [5, 10],
+          value: 8,
+        },
+      }),
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.metric, {
+    errorCode: 'ENGINE_CONSTRAINT',
+    meta: {
+      field: 'duration',
+      allowed: [5, 10],
+      value: 8,
+    },
+  });
+  assert.deepEqual(result.body, {
+    ok: false,
+    error: 'ENGINE_CONSTRAINT',
+    message: 'Unsupported duration',
+    field: 'duration',
+    allowed: [5, 10],
+    value: 8,
+  });
+});


### PR DESCRIPTION
## Summary
- Move /api/generate validation payload construction and required input checks into validation-payload.ts
- Keep route orchestration focused on handling validation result responses and passing mode flags to the Fal payload builder
- Add behavior coverage for base payloads, BytePlus ref2v video references, Luma i2v missing image, missing first/last frames, and engine constraint responses

## Local verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-validation-payload.test.ts tests/generate-billing-preflight.test.ts tests/generate-final-response.test.ts tests/generate-provider-media.test.ts tests/generate-final-receipts.test.ts tests/generate-final-job-persistence.test.ts tests/generate-provider-job-tracker.test.ts tests/generate-settings-snapshot.test.ts tests/generate-fal-request.test.ts tests/generate-metric-logger.test.ts tests/generate-receipt-snapshot.test.ts tests/generate-attachment-references.test.ts tests/generate-attachments.test.ts tests/generate-extra-input-values.test.ts tests/generate-payment-rollback-architecture.test.ts tests/generate-initial-video-job-architecture.test.ts tests/generate-fal-error-handling.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build