### PR TITLE
Split generate BytePlus submission

### DIFF
--- a/frontend/app/api/generate/_lib/byteplus-submission.ts
+++ b/frontend/app/api/generate/_lib/byteplus-submission.ts
@@ -1,0 +1,245 @@
+import type { Mode, PricingSnapshot } from '@/types/engines';
+import { query } from '@/lib/db';
+import {
+  BYTEPLUS_MODELARK_PROVIDER,
+  buildBytePlusSeedancePayload,
+  BytePlusModelArkError,
+  getBytePlusArkConfig,
+  getBytePlusModelArkClient,
+  getBytePlusSeedanceAllowedResolutions,
+  getBytePlusUserSafeErrorMessage,
+  scrubBytePlusError,
+} from '@/server/video-providers/byteplus-modelark';
+import { rollbackPendingPayment } from './payment-rollback';
+import type { PaymentMode, PendingReceipt } from './initial-video-job';
+
+type QueryFn = (sql: string, params?: unknown[]) => Promise<unknown>;
+type LogMetricFn = (
+  kind: 'accepted' | 'failed',
+  options: { jobId?: string; errorCode?: string; meta?: Record<string, unknown> }
+) => void;
+
+type BytePlusSubmissionDeps = {
+  getBytePlusArkConfigFn?: typeof getBytePlusArkConfig;
+  buildBytePlusSeedancePayloadFn?: typeof buildBytePlusSeedancePayload;
+  getBytePlusModelArkClientFn?: typeof getBytePlusModelArkClient;
+  getBytePlusSeedanceAllowedResolutionsFn?: typeof getBytePlusSeedanceAllowedResolutions;
+  getBytePlusUserSafeErrorMessageFn?: typeof getBytePlusUserSafeErrorMessage;
+  scrubBytePlusErrorFn?: typeof scrubBytePlusError;
+  queryFn?: QueryFn;
+  rollbackPendingPaymentFn?: typeof rollbackPendingPayment;
+  persistProviderJobIdFn?: (providerJobId: string) => Promise<void>;
+  logMetricFn?: LogMetricFn;
+};
+
+export type BytePlusSubmissionResult =
+  | {
+      ok: true;
+      body: Record<string, unknown>;
+    }
+  | {
+      ok: false;
+      body: Record<string, unknown>;
+      status: number;
+    };
+
+export async function submitBytePlusGenerateTask(params: {
+  jobId: string;
+  userId: string;
+  engineId: string;
+  engineLabel: string;
+  isPublicSeedanceBytePlus: boolean;
+  prompt: string;
+  durationSec: number;
+  mode: Mode;
+  initialImageUrl: string | null | undefined;
+  endImageUrl: string | null;
+  normalizedReferenceImages: string[];
+  videoUrls: string[];
+  resolvedAudioUrl: string | null | undefined;
+  audioUrls: string[];
+  effectiveResolution: string;
+  aspectRatio: string | null;
+  audioEnabled: boolean | undefined;
+  placeholderThumb: string;
+  pricing: PricingSnapshot;
+  paymentStatus: string;
+  pendingReceipt: PendingReceipt | null;
+  paymentMode: PaymentMode;
+  walletChargeReserved: boolean;
+  batchId: string | null;
+  groupId: string | null;
+  iterationIndex: number | null;
+  iterationCount: number | null;
+  renderIds: Array<string | null> | null;
+  heroRenderId: string | null;
+  localKey: string | null;
+  deps?: BytePlusSubmissionDeps;
+}): Promise<BytePlusSubmissionResult> {
+  const deps = params.deps ?? {};
+  const getBytePlusArkConfigFn = deps.getBytePlusArkConfigFn ?? getBytePlusArkConfig;
+  const buildBytePlusSeedancePayloadFn = deps.buildBytePlusSeedancePayloadFn ?? buildBytePlusSeedancePayload;
+  const getBytePlusModelArkClientFn = deps.getBytePlusModelArkClientFn ?? getBytePlusModelArkClient;
+  const getBytePlusSeedanceAllowedResolutionsFn =
+    deps.getBytePlusSeedanceAllowedResolutionsFn ?? getBytePlusSeedanceAllowedResolutions;
+  const getBytePlusUserSafeErrorMessageFn = deps.getBytePlusUserSafeErrorMessageFn ?? getBytePlusUserSafeErrorMessage;
+  const scrubBytePlusErrorFn = deps.scrubBytePlusErrorFn ?? scrubBytePlusError;
+  const queryFn = deps.queryFn ?? query;
+  const rollbackPendingPaymentFn = deps.rollbackPendingPaymentFn ?? rollbackPendingPayment;
+  const persistProviderJobIdFn = deps.persistProviderJobIdFn;
+  const logMetricFn = deps.logMetricFn;
+
+  try {
+    const config = getBytePlusArkConfigFn();
+    const payload = buildBytePlusSeedancePayloadFn({
+      modelId: params.isPublicSeedanceBytePlus ? config.seedanceModelId : config.seedanceFastModelId,
+      prompt: params.prompt,
+      durationSec: params.durationSec,
+      mode: toBytePlusMode(params.mode),
+      imageUrl: params.mode === 'i2v' ? params.initialImageUrl : null,
+      endImageUrl: params.mode === 'i2v' ? params.endImageUrl : null,
+      referenceImageUrls: params.mode === 'ref2v' || params.mode === 'v2v' ? params.normalizedReferenceImages : undefined,
+      referenceVideoUrls:
+        params.mode === 'ref2v' || params.mode === 'v2v' || params.mode === 'extend' ? params.videoUrls : undefined,
+      referenceAudioUrls:
+        params.mode === 'ref2v' || params.mode === 'v2v' || params.mode === 'extend'
+          ? Array.from(new Set([...(params.resolvedAudioUrl ? [params.resolvedAudioUrl] : []), ...params.audioUrls]))
+          : undefined,
+      resolution: params.effectiveResolution,
+      ratio: params.aspectRatio,
+      generateAudio: params.audioEnabled !== false,
+      allowedResolutions: getBytePlusSeedanceAllowedResolutionsFn(params.engineId),
+    });
+    const providerTask = await getBytePlusModelArkClientFn().createSeedanceFastTask(payload);
+    const providerJobId = providerTask.providerJobId;
+    await persistProviderJobIdFn?.(providerJobId);
+    const status = providerTask.status === 'running' ? 'running' : 'queued';
+    const progress = providerTask.status === 'running' ? 30 : 10;
+
+    await queryFn(
+      `UPDATE app_jobs
+       SET status = $2,
+           progress = $3,
+           message = $4,
+           provider = $5,
+           provider_job_id = $6,
+           provisional = FALSE,
+           updated_at = NOW()
+       WHERE job_id = $1`,
+      [params.jobId, status, progress, 'Render submitted.', BYTEPLUS_MODELARK_PROVIDER, providerJobId]
+    );
+    logMetricFn?.('accepted', {
+      jobId: params.jobId,
+      meta: {
+        providerJobId,
+        provider: BYTEPLUS_MODELARK_PROVIDER,
+        inputSummary: {
+          mode: params.mode,
+          promptLength: params.prompt.length,
+          durationSec: params.durationSec,
+          resolution: params.effectiveResolution,
+          aspectRatio: params.aspectRatio,
+          generateAudio: params.audioEnabled !== false,
+          hasImage: Boolean(params.mode === 'i2v' && params.initialImageUrl),
+          hasEndImage: Boolean(params.mode === 'i2v' && params.endImageUrl),
+          referenceImageCount: params.mode === 'ref2v' || params.mode === 'v2v' ? params.normalizedReferenceImages.length : 0,
+          referenceVideoCount:
+            params.mode === 'ref2v' || params.mode === 'v2v' || params.mode === 'extend' ? params.videoUrls.length : 0,
+          referenceAudioCount:
+            params.mode === 'ref2v' || params.mode === 'v2v' || params.mode === 'extend' ? params.audioUrls.length : 0,
+        },
+      },
+    });
+
+    return {
+      ok: true,
+      body: {
+        ok: true,
+        jobId: params.jobId,
+        videoUrl: null,
+        video: null,
+        thumbUrl: params.placeholderThumb,
+        status,
+        progress,
+        pricing: params.pricing,
+        paymentStatus: params.paymentStatus,
+        provider: BYTEPLUS_MODELARK_PROVIDER,
+        providerJobId,
+        batchId: params.batchId,
+        groupId: params.groupId,
+        iterationIndex: params.iterationIndex,
+        iterationCount: params.iterationCount,
+        renderIds: params.renderIds,
+        heroRenderId: params.heroRenderId,
+        localKey: params.localKey,
+      },
+    };
+  } catch (error) {
+    const providerMessage = scrubBytePlusErrorFn(error);
+    const providerStatus = error instanceof BytePlusModelArkError ? error.status : null;
+    const errorCode = error instanceof BytePlusModelArkError && error.code ? error.code : 'BYTEPLUS_PROVIDER_ERROR';
+    const failureMessage = getBytePlusUserSafeErrorMessageFn(providerMessage);
+    console.warn('[byteplus] task submission failed', {
+      jobId: params.jobId,
+      engineId: params.engineId,
+      status: providerStatus,
+      code: errorCode,
+      message: providerMessage,
+    });
+    try {
+      await queryFn(
+        `UPDATE app_jobs
+         SET status = 'failed',
+             progress = 0,
+             message = $2,
+             provider = $3,
+             provisional = FALSE,
+             payment_status = CASE WHEN $4::text IS NOT NULL THEN $4 ELSE payment_status END,
+             updated_at = NOW()
+         WHERE job_id = $1`,
+        [
+          params.jobId,
+          failureMessage,
+          BYTEPLUS_MODELARK_PROVIDER,
+          params.pendingReceipt ? (params.paymentMode === 'wallet' ? 'refunded_wallet' : 'refunded') : null,
+        ]
+      );
+    } catch (updateError) {
+      console.warn('[byteplus] failed to mark submission failure', { jobId: params.jobId }, updateError);
+    }
+    if (params.pendingReceipt) {
+      await rollbackPendingPaymentFn({
+        pendingReceipt: params.pendingReceipt,
+        walletChargeReserved: params.walletChargeReserved,
+        refundDescription: `Refund ${params.engineLabel} - ${params.durationSec}s - BytePlus start failed`,
+      });
+    }
+    logMetricFn?.('failed', {
+      jobId: params.jobId,
+      errorCode,
+      meta: { provider: BYTEPLUS_MODELARK_PROVIDER, providerStatus },
+    });
+
+    return {
+      ok: false,
+      status: providerStatus && providerStatus >= 400 && providerStatus < 500 ? 502 : 503,
+      body: {
+        ok: false,
+        error: errorCode,
+        message: failureMessage,
+      },
+    };
+  }
+}
+
+function toBytePlusMode(mode: Mode): 't2v' | 'i2v' | 'ref2v' | 'v2v' | 'extend' {
+  return mode === 'i2v'
+    ? 'i2v'
+    : mode === 'ref2v'
+      ? 'ref2v'
+      : mode === 'v2v'
+        ? 'v2v'
+        : mode === 'extend'
+          ? 'extend'
+          : 't2v';
+}

--- a/frontend/app/api/generate/route.ts
+++ b/frontend/app/api/generate/route.ts
@@ -27,6 +27,7 @@ import { buildInitialProviderMediaState, resolveProviderMediaState } from './_li
 import { buildFinalGenerateResponse } from './_lib/final-response';
 import { resolveGenerateBillingPreflight } from './_lib/billing-preflight';
 import { buildGenerateValidationPayload } from './_lib/validation-payload';
+import { submitBytePlusGenerateTask } from './_lib/byteplus-submission';
 import {
   buildResponseFromExistingVideoJob,
   createAtomicInitialVideoJob,
@@ -55,13 +56,8 @@ import { AdminAuthError, requireAdmin, resolveLocalAdminBypassUserId } from '@/s
 import { buildRestrictedAccountPayload, getActiveAccountRestriction } from '@/server/fraud-cleanup';
 import {
   BYTEPLUS_MODELARK_PROVIDER,
-  buildBytePlusSeedancePayload,
-  BytePlusModelArkError,
   BYTEPLUS_SEEDANCE_ASPECT_RATIOS,
-  getBytePlusArkConfig,
-  getBytePlusModelArkClient,
   getBytePlusSeedanceAllowedResolutions,
-  getBytePlusUserSafeErrorMessage,
   isSeedanceBytePlusModeAllowed,
   isSeedanceFastBytePlusModeAllowed,
   isBytePlusModelArkEnabled,
@@ -70,7 +66,6 @@ import {
   seedanceFastBytePlusAdminOnly,
   shouldRoutePublicSeedanceToBytePlus,
   shouldRoutePublicSeedanceFastToBytePlus,
-  scrubBytePlusError,
 } from '@/server/video-providers/byteplus-modelark';
 
 type VideoMode = Extract<Mode, 't2v' | 'i2v' | 'ref2v' | 'fl2v' | 'i2i' | 'v2v' | 'r2v' | 'a2v' | 'extend' | 'retake' | 'reframe'>;
@@ -943,151 +938,46 @@ export async function POST(req: NextRequest) {
   }
 
   if (isBytePlusV1a) {
-    try {
-      const config = getBytePlusArkConfig();
-      const payload = buildBytePlusSeedancePayload({
-        modelId: isPublicSeedanceBytePlus ? config.seedanceModelId : config.seedanceFastModelId,
-        prompt,
-        durationSec,
-        mode:
-          mode === 'i2v'
-            ? 'i2v'
-            : mode === 'ref2v'
-              ? 'ref2v'
-              : mode === 'v2v'
-                ? 'v2v'
-                : mode === 'extend'
-                  ? 'extend'
-                  : 't2v',
-        imageUrl: mode === 'i2v' ? initialImageUrl : null,
-        endImageUrl: mode === 'i2v' ? endImageUrl : null,
-        referenceImageUrls: mode === 'ref2v' || mode === 'v2v' ? normalizedReferenceImages : undefined,
-        referenceVideoUrls: mode === 'ref2v' || mode === 'v2v' || mode === 'extend' ? videoUrls : undefined,
-        referenceAudioUrls:
-          mode === 'ref2v' || mode === 'v2v' || mode === 'extend'
-            ? Array.from(new Set([...(resolvedAudioUrl ? [resolvedAudioUrl] : []), ...audioUrls]))
-            : undefined,
-        resolution: effectiveResolution,
-        ratio: aspectRatio,
-        generateAudio: audioEnabled !== false,
-        allowedResolutions: getBytePlusSeedanceAllowedResolutions(engine.id),
-      });
-      const providerTask = await getBytePlusModelArkClient().createSeedanceFastTask(payload);
-      const providerJobId = providerTask.providerJobId;
-      await persistProviderJobId(providerJobId);
-      await query(
-        `UPDATE app_jobs
-         SET status = $2,
-             progress = $3,
-             message = $4,
-             provider = $5,
-             provider_job_id = $6,
-             provisional = FALSE,
-             updated_at = NOW()
-         WHERE job_id = $1`,
-        [
-          jobId,
-          providerTask.status === 'running' ? 'running' : 'queued',
-          providerTask.status === 'running' ? 30 : 10,
-          'Render submitted.',
-          BYTEPLUS_MODELARK_PROVIDER,
-          providerJobId,
-        ]
-      );
-      logMetric('accepted', {
-        jobId,
-        meta: {
-          providerJobId,
-          provider: BYTEPLUS_MODELARK_PROVIDER,
-          inputSummary: {
-            mode,
-            promptLength: prompt.length,
-            durationSec,
-            resolution: effectiveResolution,
-            aspectRatio,
-            generateAudio: audioEnabled !== false,
-            hasImage: Boolean(mode === 'i2v' && initialImageUrl),
-            hasEndImage: Boolean(mode === 'i2v' && endImageUrl),
-            referenceImageCount: mode === 'ref2v' || mode === 'v2v' ? normalizedReferenceImages.length : 0,
-            referenceVideoCount: mode === 'ref2v' || mode === 'v2v' || mode === 'extend' ? videoUrls.length : 0,
-            referenceAudioCount: mode === 'ref2v' || mode === 'v2v' || mode === 'extend' ? audioUrls.length : 0,
-          },
-        },
-      });
-      return NextResponse.json({
-        ok: true,
-        jobId,
-        videoUrl: null,
-        video: null,
-        thumbUrl: placeholderThumb,
-        status: providerTask.status === 'running' ? 'running' : 'queued',
-        progress: providerTask.status === 'running' ? 30 : 10,
-        pricing,
-        paymentStatus,
-        provider: BYTEPLUS_MODELARK_PROVIDER,
-        providerJobId,
-        batchId,
-        groupId,
-        iterationIndex,
-        iterationCount,
-        renderIds,
-        heroRenderId,
-        localKey,
-      });
-    } catch (error) {
-      const providerMessage = scrubBytePlusError(error);
-      const providerStatus = error instanceof BytePlusModelArkError ? error.status : null;
-      const errorCode = error instanceof BytePlusModelArkError && error.code ? error.code : 'BYTEPLUS_PROVIDER_ERROR';
-      const failureMessage = getBytePlusUserSafeErrorMessage(providerMessage);
-      console.warn('[byteplus] task submission failed', {
-        jobId,
-        engineId: engine.id,
-        status: providerStatus,
-        code: errorCode,
-        message: providerMessage,
-      });
-      try {
-        await query(
-          `UPDATE app_jobs
-           SET status = 'failed',
-               progress = 0,
-               message = $2,
-               provider = $3,
-               provisional = FALSE,
-               payment_status = CASE WHEN $4::text IS NOT NULL THEN $4 ELSE payment_status END,
-               updated_at = NOW()
-           WHERE job_id = $1`,
-          [
-            jobId,
-            failureMessage,
-            BYTEPLUS_MODELARK_PROVIDER,
-            pendingReceipt ? (paymentMode === 'wallet' ? 'refunded_wallet' : 'refunded') : null,
-          ]
-        );
-      } catch (updateError) {
-        console.warn('[byteplus] failed to mark submission failure', { jobId }, updateError);
-      }
-      if (pendingReceipt) {
-        await rollbackPendingPayment({
-          pendingReceipt,
-          walletChargeReserved,
-          refundDescription: `Refund ${engine.label} - ${durationSec}s - BytePlus start failed`,
-        });
-      }
-      logMetric('failed', {
-        jobId,
-        errorCode,
-        meta: { provider: BYTEPLUS_MODELARK_PROVIDER, providerStatus },
-      });
-      return NextResponse.json(
-        {
-          ok: false,
-          error: errorCode,
-          message: failureMessage,
-        },
-        { status: providerStatus && providerStatus >= 400 && providerStatus < 500 ? 502 : 503 }
-      );
-    }
+    const bytePlusSubmission = await submitBytePlusGenerateTask({
+      jobId,
+      userId,
+      engineId: engine.id,
+      engineLabel: engine.label,
+      isPublicSeedanceBytePlus,
+      prompt,
+      durationSec,
+      mode,
+      initialImageUrl,
+      endImageUrl,
+      normalizedReferenceImages,
+      videoUrls,
+      resolvedAudioUrl,
+      audioUrls,
+      effectiveResolution,
+      aspectRatio,
+      audioEnabled,
+      placeholderThumb,
+      pricing,
+      paymentStatus,
+      pendingReceipt,
+      paymentMode,
+      walletChargeReserved,
+      batchId,
+      groupId,
+      iterationIndex,
+      iterationCount,
+      renderIds,
+      heroRenderId,
+      localKey,
+      deps: {
+        persistProviderJobIdFn: persistProviderJobId,
+        logMetricFn: logMetric,
+      },
+    });
+    return NextResponse.json(
+      bytePlusSubmission.body,
+      bytePlusSubmission.ok ? undefined : { status: bytePlusSubmission.status }
+    );
   }
 
   try {

--- a/tests/generate-byteplus-submission.test.ts
+++ b/tests/generate-byteplus-submission.test.ts
@@ -1,0 +1,208 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { submitBytePlusGenerateTask } from '../frontend/app/api/generate/_lib/byteplus-submission';
+import type { PendingReceipt } from '../frontend/app/api/generate/_lib/initial-video-job';
+
+const root = process.cwd();
+const routePath = join(root, 'frontend/app/api/generate/route.ts');
+const helperPath = join(root, 'frontend/app/api/generate/_lib/byteplus-submission.ts');
+
+const routeSource = readFileSync(routePath, 'utf8');
+const helperSource = existsSync(helperPath) ? readFileSync(helperPath, 'utf8') : '';
+
+const pendingReceipt: PendingReceipt = {
+  userId: 'user_123',
+  amountCents: 1200,
+  currency: 'USD',
+  description: 'Run Seedance - 8s',
+  jobId: 'job_123',
+  snapshot: { totalCents: 1200 },
+  applicationFeeCents: null,
+  vendorAccountId: null,
+};
+
+const baseParams = {
+  jobId: 'job_123',
+  userId: 'user_123',
+  engineId: 'seedance-2-0',
+  engineLabel: 'Seedance 2.0',
+  isPublicSeedanceBytePlus: true,
+  prompt: 'A cinematic mountain shot',
+  durationSec: 8,
+  mode: 'ref2v' as const,
+  initialImageUrl: null,
+  endImageUrl: null,
+  normalizedReferenceImages: ['https://cdn.maxvideoai.com/ref.jpg'],
+  videoUrls: ['https://cdn.maxvideoai.com/ref.mp4'],
+  resolvedAudioUrl: 'https://cdn.maxvideoai.com/ref.wav',
+  audioUrls: ['https://cdn.maxvideoai.com/ref.wav', 'https://cdn.maxvideoai.com/alt.wav'],
+  effectiveResolution: '720p',
+  aspectRatio: '16:9',
+  audioEnabled: true,
+  placeholderThumb: '/assets/frames/thumb-16x9.svg',
+  pricing: { totalCents: 1200, currency: 'USD' } as never,
+  paymentStatus: 'paid_wallet',
+  pendingReceipt: null,
+  paymentMode: 'wallet' as const,
+  walletChargeReserved: true,
+  batchId: 'batch_123',
+  groupId: 'group_123',
+  iterationIndex: 0,
+  iterationCount: 2,
+  renderIds: ['job_123', 'job_456'],
+  heroRenderId: 'job_123',
+  localKey: 'local_123',
+};
+
+test('generate route delegates BytePlus submission', () => {
+  assert.ok(existsSync(helperPath), 'BytePlus submission should live in the generate route _lib folder');
+  assert.match(routeSource, /from '\.\/_lib\/byteplus-submission'/);
+  assert.doesNotMatch(routeSource, /buildBytePlusSeedancePayload/, 'BytePlus payload construction belongs in byteplus-submission.ts');
+  assert.doesNotMatch(routeSource, /createSeedanceFastTask/, 'BytePlus task creation belongs in byteplus-submission.ts');
+  assert.doesNotMatch(routeSource, /\[byteplus\] task submission failed/, 'BytePlus failure handling belongs in byteplus-submission.ts');
+
+  const lineCount = routeSource.split('\n').length;
+  assert.ok(lineCount <= 1475, `/api/generate route should stay below 1475 lines after BytePlus extraction, got ${lineCount}`);
+});
+
+test('BytePlus submission helper exposes the route contract', () => {
+  assert.match(helperSource, /export type BytePlusSubmissionResult/, 'BytePlusSubmissionResult should be exported');
+  assert.match(helperSource, /export async function submitBytePlusGenerateTask/, 'submitBytePlusGenerateTask should be exported');
+});
+
+test('BytePlus submission helper creates task, updates job, logs, and returns queued response', async () => {
+  const queries: Array<{ sql: string; params?: unknown[] }> = [];
+  const persistedProviderIds: string[] = [];
+  const logs: Array<{ kind: string; options: Record<string, unknown> }> = [];
+  const builtPayloads: Record<string, unknown>[] = [];
+
+  const result = await submitBytePlusGenerateTask({
+    ...baseParams,
+    deps: {
+      getBytePlusArkConfigFn: () => ({ seedanceModelId: 'model-public', seedanceFastModelId: 'model-fast' }),
+      buildBytePlusSeedancePayloadFn: (payload) => {
+        builtPayloads.push(payload);
+        return { ...payload, normalized: true };
+      },
+      getBytePlusModelArkClientFn: () => ({
+        createSeedanceFastTask: async () => ({ providerJobId: 'provider_123', status: 'queued' }),
+      }),
+      getBytePlusSeedanceAllowedResolutionsFn: () => ['720p', '1080p'] as never,
+      queryFn: async (sql, params) => {
+        queries.push({ sql, params });
+      },
+      persistProviderJobIdFn: async (providerJobId) => {
+        persistedProviderIds.push(providerJobId);
+      },
+      logMetricFn: (kind, options) => {
+        logs.push({ kind, options });
+      },
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(builtPayloads[0], {
+    modelId: 'model-public',
+    prompt: 'A cinematic mountain shot',
+    durationSec: 8,
+    mode: 'ref2v',
+    imageUrl: null,
+    endImageUrl: null,
+    referenceImageUrls: ['https://cdn.maxvideoai.com/ref.jpg'],
+    referenceVideoUrls: ['https://cdn.maxvideoai.com/ref.mp4'],
+    referenceAudioUrls: ['https://cdn.maxvideoai.com/ref.wav', 'https://cdn.maxvideoai.com/alt.wav'],
+    resolution: '720p',
+    ratio: '16:9',
+    generateAudio: true,
+    allowedResolutions: ['720p', '1080p'],
+  });
+  assert.deepEqual(persistedProviderIds, ['provider_123']);
+  assert.match(queries[0]?.sql ?? '', /UPDATE app_jobs/);
+  assert.deepEqual(queries[0]?.params, [
+    'job_123',
+    'queued',
+    10,
+    'Render submitted.',
+    'byteplus_modelark',
+    'provider_123',
+  ]);
+  assert.equal(logs[0]?.kind, 'accepted');
+  assert.deepEqual(result.body, {
+    ok: true,
+    jobId: 'job_123',
+    videoUrl: null,
+    video: null,
+    thumbUrl: '/assets/frames/thumb-16x9.svg',
+    status: 'queued',
+    progress: 10,
+    pricing: { totalCents: 1200, currency: 'USD' },
+    paymentStatus: 'paid_wallet',
+    provider: 'byteplus_modelark',
+    providerJobId: 'provider_123',
+    batchId: 'batch_123',
+    groupId: 'group_123',
+    iterationIndex: 0,
+    iterationCount: 2,
+    renderIds: ['job_123', 'job_456'],
+    heroRenderId: 'job_123',
+    localKey: 'local_123',
+  });
+});
+
+test('BytePlus submission helper marks failed tasks, rolls back payments, and returns provider error', async () => {
+  const originalWarn = console.warn;
+  console.warn = () => undefined;
+  const queries: Array<{ sql: string; params?: unknown[] }> = [];
+  const rollbacks: Array<{ refundDescription: string }> = [];
+  const logs: Array<{ kind: string; options: Record<string, unknown> }> = [];
+
+  try {
+    const result = await submitBytePlusGenerateTask({
+      ...baseParams,
+      pendingReceipt,
+      deps: {
+        getBytePlusArkConfigFn: () => ({ seedanceModelId: 'model-public', seedanceFastModelId: 'model-fast' }),
+        buildBytePlusSeedancePayloadFn: (payload) => payload,
+        getBytePlusModelArkClientFn: () => ({
+          createSeedanceFastTask: async () => {
+            throw new Error('provider down');
+          },
+        }),
+        getBytePlusSeedanceAllowedResolutionsFn: () => ['720p'] as never,
+        getBytePlusUserSafeErrorMessageFn: () => 'Provider is temporarily unavailable',
+        scrubBytePlusErrorFn: () => 'raw provider error',
+        queryFn: async (sql, params) => {
+          queries.push({ sql, params });
+        },
+        rollbackPendingPaymentFn: async ({ refundDescription }) => {
+          rollbacks.push({ refundDescription });
+        },
+        logMetricFn: (kind, options) => {
+          logs.push({ kind, options });
+        },
+      },
+    });
+
+    assert.equal(result.ok, false);
+    assert.match(queries[0]?.sql ?? '', /UPDATE app_jobs/);
+    assert.deepEqual(queries[0]?.params, [
+      'job_123',
+      'Provider is temporarily unavailable',
+      'byteplus_modelark',
+      'refunded_wallet',
+    ]);
+    assert.deepEqual(rollbacks, [{ refundDescription: 'Refund Seedance 2.0 - 8s - BytePlus start failed' }]);
+    assert.equal(logs[0]?.kind, 'failed');
+    assert.deepEqual(result.body, {
+      ok: false,
+      error: 'BYTEPLUS_PROVIDER_ERROR',
+      message: 'Provider is temporarily unavailable',
+    });
+    assert.equal(result.status, 503);
+  } finally {
+    console.warn = originalWarn;
+  }
+});


### PR DESCRIPTION
## Summary
- Move BytePlus payload construction, task creation, DB updates, success response, provider error handling, and rollback handling out of /api/generate
- Keep the route as the provider branch orchestrator while byteplus-submission owns BytePlus lifecycle details
- Add behavior coverage for queued BytePlus submissions and failed provider submissions with rollback

## Local verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-byteplus-submission.test.ts tests/generate-validation-payload.test.ts tests/generate-billing-preflight.test.ts tests/generate-final-response.test.ts tests/generate-provider-media.test.ts tests/generate-final-receipts.test.ts tests/generate-final-job-persistence.test.ts tests/generate-provider-job-tracker.test.ts tests/generate-settings-snapshot.test.ts tests/generate-fal-request.test.ts tests/generate-metric-logger.test.ts tests/generate-receipt-snapshot.test.ts tests/generate-attachment-references.test.ts tests/generate-attachments.test.ts tests/generate-extra-input-values.test.ts tests/generate-payment-rollback-architecture.test.ts tests/generate-initial-video-job-architecture.test.ts tests/generate-fal-error-handling.test.ts
- pnpm --prefix frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check
- pnpm --prefix frontend run build