### PR TITLE
Split generate request options

### DIFF
--- a/frontend/app/api/generate/_lib/request-options.ts
+++ b/frontend/app/api/generate/_lib/request-options.ts
@@ -1,0 +1,604 @@
+import { getEngineCaps } from '@/fixtures/engineCaps';
+import {
+  getLumaRay2DurationInfo,
+  getLumaRay2ResolutionInfo,
+  isLumaRay2AspectRatio,
+  isLumaRay2EngineId,
+  normaliseLumaRay2Loop,
+  toLumaRay2DurationLabel,
+  LUMA_RAY2_ERROR_UNSUPPORTED,
+  type LumaRay2DurationLabel,
+} from '@/lib/luma-ray2';
+import { getSoraVariantForEngine, isSoraEngineId, parseSoraRequest, type SoraRequest } from '@/lib/sora';
+import {
+  BYTEPLUS_SEEDANCE_ASPECT_RATIOS,
+  getBytePlusSeedanceAllowedResolutions,
+} from '@/server/video-providers/byteplus-modelark';
+import type { EngineCaps, Mode } from '@/types/engines';
+
+export type VideoMode = Extract<
+  Mode,
+  't2v' | 'i2v' | 'ref2v' | 'fl2v' | 'i2i' | 'v2v' | 'r2v' | 'a2v' | 'extend' | 'retake' | 'reframe'
+>;
+
+export type MultiPromptEntry = {
+  prompt: string;
+  duration: number;
+};
+
+export type GenerationElement = {
+  frontalImageUrl?: string;
+  referenceImageUrls?: string[];
+  videoUrl?: string;
+};
+
+export type GenerateRequestOptionsMetric = {
+  errorCode: string;
+  meta?: Record<string, unknown>;
+};
+
+export type GenerateRequestOptions = {
+  prompt: string;
+  multiPrompt: MultiPromptEntry[] | null;
+  audioEnabled: boolean | undefined;
+  isLumaRay2: boolean;
+  supportsDuration: boolean;
+  supportsResolution: boolean;
+  supportsFps: boolean;
+  supportsAspectRatio: boolean;
+  rawDurationOption: number | string | null;
+  rawDurationLabel: LumaRay2DurationLabel | undefined;
+  durationLabel: string | undefined;
+  durationSec: number;
+  lumaDurationInfo: ReturnType<typeof getLumaRay2DurationInfo>;
+  shotType: 'customize' | 'intelligent' | null;
+  seed: number | null;
+  cameraFixed: boolean | null;
+  safetyChecker: boolean | null;
+  voiceIds: string[];
+  voiceControl: boolean;
+  elements: GenerationElement[] | null;
+  endImageUrl: string | null;
+  rawAudioUrl: string | null;
+  aspectRatio: string | null;
+  batchId: string | null;
+  groupId: string | null;
+  iterationIndex: number | null;
+  iterationCount: number | null;
+  renderIds: string[] | null;
+  heroRenderId: string | null;
+  message: string | null;
+  etaSeconds: number | null;
+  etaLabel: string | null;
+  rawExtraInputValues: Record<string, unknown> | null;
+  requestedResolution: string;
+  pricingResolution: string;
+  effectiveResolution: string;
+  numFrames: number | null;
+  loop: boolean;
+  soraRequest: SoraRequest | null;
+};
+
+export type GenerateRequestOptionsResult =
+  | {
+      ok: true;
+      options: GenerateRequestOptions;
+    }
+  | {
+      ok: false;
+      status: number;
+      body: Record<string, unknown>;
+      metric?: GenerateRequestOptionsMetric;
+    };
+
+export function isVideoMode(value: unknown): value is VideoMode {
+  return (
+    value === 't2v' ||
+    value === 'i2v' ||
+    value === 'ref2v' ||
+    value === 'fl2v' ||
+    value === 'i2i' ||
+    value === 'v2v' ||
+    value === 'r2v' ||
+    value === 'a2v' ||
+    value === 'extend' ||
+    value === 'retake' ||
+    value === 'reframe'
+  );
+}
+
+export function buildGenerateRequestOptions(params: {
+  body: Record<string, unknown>;
+  engine: EngineCaps;
+  mode: Mode;
+  isBytePlusV1a: boolean;
+}): GenerateRequestOptionsResult {
+  const { body, engine, mode, isBytePlusV1a } = params;
+  const prompt = String(body.prompt || '');
+  const multiPrompt = normalizeMultiPrompt(body.multiPrompt);
+  const multiPromptTotalSec = multiPrompt
+    ? multiPrompt.reduce((sum: number, entry: MultiPromptEntry) => sum + (entry.duration || 0), 0)
+    : 0;
+  let audioEnabled =
+    typeof body.audio === 'boolean'
+      ? body.audio
+      : typeof body.generate_audio === 'boolean'
+        ? body.generate_audio
+        : undefined;
+  const isLumaRay2 = isLumaRay2EngineId(engine.id);
+  const capability = getEngineCaps(engine.id, mode);
+  const supportsDuration = capability ? Boolean(capability.duration || capability.frames) : true;
+  const supportsResolution = capability ? Boolean(capability.resolution && capability.resolution.length) : true;
+  const supportsFps = capability
+    ? Array.isArray(capability.fps)
+      ? capability.fps.length > 0
+      : typeof capability.fps === 'number'
+    : true;
+  const supportsAspectRatio = capability ? Boolean(capability.aspectRatio && capability.aspectRatio.length) : true;
+  const rawDurationOption =
+    typeof body.durationOption === 'number' || typeof body.durationOption === 'string' ? body.durationOption : null;
+  let durationSec = Number(body.durationSec || body.duration || 4);
+  if (multiPromptTotalSec > 0) {
+    durationSec = multiPromptTotalSec;
+  }
+  const lumaDurationInfo =
+    isLumaRay2 && supportsDuration ? getLumaRay2DurationInfo(rawDurationOption ?? durationSec) : null;
+  if (isLumaRay2 && supportsDuration && !lumaDurationInfo) {
+    return {
+      ok: false,
+      status: 400,
+      metric: {
+        errorCode: 'LUMA_DURATION_UNSUPPORTED',
+        meta: { durationOption: rawDurationOption, durationSec: body.durationSec },
+      },
+      body: { ok: false, error: LUMA_RAY2_ERROR_UNSUPPORTED },
+    };
+  }
+  if (lumaDurationInfo) {
+    durationSec = lumaDurationInfo.seconds;
+  }
+
+  const shotTypeRaw = typeof body.shotType === 'string' ? body.shotType.trim().toLowerCase() : '';
+  const shotType = shotTypeRaw === 'intelligent' ? 'intelligent' : shotTypeRaw === 'customize' ? 'customize' : null;
+  const seed = normalizeSeed(body.seed);
+  const cameraFixed = typeof body.cameraFixed === 'boolean' ? body.cameraFixed : null;
+  const safetyChecker = typeof body.safetyChecker === 'boolean' ? body.safetyChecker : null;
+  const voiceIds = normalizeStringArray(body.voiceIds);
+  const voiceControl = Boolean(body.voiceControl) || voiceIds.length > 0;
+  if (voiceControl) {
+    audioEnabled = true;
+  }
+  const elements = normalizeGenerationElements(body.elements);
+  const endImageUrl =
+    typeof body.endImageUrl === 'string' && body.endImageUrl.trim().length ? body.endImageUrl.trim() : null;
+  const rawAudioUrl =
+    typeof body.audioUrl === 'string' && body.audioUrl.trim().length
+      ? body.audioUrl.trim()
+      : typeof body.audio_url === 'string' && body.audio_url.trim().length
+        ? body.audio_url.trim()
+        : null;
+  const rawAspectRatio =
+    supportsAspectRatio && typeof body.aspectRatio === 'string' && body.aspectRatio.trim().length
+      ? body.aspectRatio.trim()
+      : null;
+  const fallbackAspectRatio = supportsAspectRatio
+    ? capability?.aspectRatio?.find((value) => value !== 'auto') ??
+      engine.aspectRatios?.find((value) => value !== 'auto') ??
+      engine.aspectRatios?.[0] ??
+      '16:9'
+    : null;
+  let aspectRatio =
+    rawAspectRatio && fallbackAspectRatio
+      ? rawAspectRatio === 'auto'
+        ? fallbackAspectRatio
+        : rawAspectRatio
+      : rawAspectRatio ?? fallbackAspectRatio ?? null;
+  if (isLumaRay2 && supportsAspectRatio) {
+    if (aspectRatio && !isLumaRay2AspectRatio(aspectRatio, { includeSquare: mode === 'reframe' })) {
+      return {
+        ok: false,
+        status: 400,
+        metric: {
+          errorCode: 'LUMA_ASPECT_UNSUPPORTED',
+          meta: { aspectRatio },
+        },
+        body: { ok: false, error: LUMA_RAY2_ERROR_UNSUPPORTED },
+      };
+    }
+    if (!aspectRatio) {
+      aspectRatio = fallbackAspectRatio ?? '16:9';
+    }
+  }
+
+  const batchId = trimString(body.batchId);
+  const groupId = trimString(body.groupId);
+  const iterationIndex =
+    typeof body.iterationIndex === 'number' && Number.isFinite(body.iterationIndex)
+      ? Math.max(0, Math.trunc(body.iterationIndex))
+      : null;
+  const iterationCount =
+    typeof body.iterationCount === 'number' && Number.isFinite(body.iterationCount)
+      ? Math.max(1, Math.trunc(body.iterationCount))
+      : null;
+  const renderIds =
+    Array.isArray(body.renderIds) && body.renderIds.length
+      ? body.renderIds.map((value: unknown) => (typeof value === 'string' ? value : null)).filter(isPresentString)
+      : null;
+  const heroRenderId = trimString(body.heroRenderId);
+  const message = trimString(body.message);
+  const etaSeconds =
+    typeof body.etaSeconds === 'number' && Number.isFinite(body.etaSeconds)
+      ? Math.max(0, Math.trunc(body.etaSeconds))
+      : null;
+  const etaLabel = trimString(body.etaLabel);
+  const rawExtraInputValues =
+    body.extraInputValues && typeof body.extraInputValues === 'object' && !Array.isArray(body.extraInputValues)
+      ? (body.extraInputValues as Record<string, unknown>)
+      : null;
+
+  let requestedResolution =
+    typeof body.resolution === 'string' && body.resolution.trim().length
+      ? body.resolution.trim()
+      : engine.resolutions?.[0] ?? '1080p';
+  let pricingResolution =
+    requestedResolution === 'auto'
+      ? engine.resolutions.find((value) => value !== 'auto') ?? engine.resolutions[0] ?? '1080p'
+      : requestedResolution;
+  let effectiveResolution = requestedResolution === 'auto' ? pricingResolution : requestedResolution;
+  let lumaResolutionInfo = isLumaRay2 && supportsResolution ? getLumaRay2ResolutionInfo(requestedResolution) : null;
+  if (isLumaRay2 && supportsResolution) {
+    if (requestedResolution === 'auto') {
+      requestedResolution = '540p';
+      lumaResolutionInfo = getLumaRay2ResolutionInfo(requestedResolution);
+    }
+    if (!lumaResolutionInfo) {
+      return {
+        ok: false,
+        status: 400,
+        body: { ok: false, error: LUMA_RAY2_ERROR_UNSUPPORTED },
+      };
+    }
+    pricingResolution = lumaResolutionInfo.value;
+    effectiveResolution = lumaResolutionInfo.value;
+    requestedResolution = lumaResolutionInfo.value;
+  } else if (!supportsResolution) {
+    const fallbackResolution =
+      engine.resolutions.find((value) => value !== 'auto') ?? engine.resolutions[0] ?? '540p';
+    pricingResolution = fallbackResolution;
+    effectiveResolution = fallbackResolution;
+    requestedResolution = fallbackResolution;
+  }
+  if ((engine.id === 'ltx-2-fast' || engine.id === 'ltx-2-3-fast') && durationSec > 10) {
+    requestedResolution = '1080p';
+    pricingResolution = '1080p';
+    effectiveResolution = '1080p';
+  }
+  if (isBytePlusV1a) {
+    const bytePlusResult = normalizeBytePlusOptions({
+      engineId: engine.id,
+      durationSec,
+      requestedResolution,
+      aspectRatio,
+    });
+    if (!bytePlusResult.ok) {
+      return bytePlusResult;
+    }
+    durationSec = bytePlusResult.durationSec;
+    requestedResolution = bytePlusResult.resolution;
+    pricingResolution = bytePlusResult.resolution;
+    effectiveResolution = bytePlusResult.resolution;
+    aspectRatio = bytePlusResult.aspectRatio;
+    audioEnabled = audioEnabled ?? true;
+  }
+
+  const rawNumFrames =
+    typeof body.numFrames === 'number'
+      ? body.numFrames
+      : typeof body.num_frames === 'number'
+        ? body.num_frames
+        : null;
+  const numFrames =
+    rawNumFrames != null && Number.isFinite(rawNumFrames) && rawNumFrames > 0 ? Math.round(rawNumFrames) : null;
+  const loopValue = isLumaRay2 ? normaliseLumaRay2Loop(body.loop) : undefined;
+  const loop = isLumaRay2 ? loopValue === true : false;
+
+  let soraRequest: SoraRequest | null = null;
+  if (isSoraEngineId(engine.id)) {
+    const soraResult = buildSoraRequestOptions({
+      body,
+      engine,
+      mode,
+      prompt,
+      requestedResolution,
+      rawAspectRatio,
+      durationSec,
+    });
+    if (!soraResult.ok) {
+      return soraResult;
+    }
+    soraRequest = soraResult.soraRequest;
+    durationSec = soraRequest.duration;
+    requestedResolution = soraRequest.resolution;
+    const fallbackResolution =
+      engine.resolutions.find((value) => value !== 'auto') ?? engine.resolutions[0] ?? '720p';
+    pricingResolution = soraRequest.resolution === 'auto' ? fallbackResolution : soraRequest.resolution;
+    effectiveResolution = soraRequest.resolution === 'auto' ? fallbackResolution : soraRequest.resolution;
+    const fallbackAspectNormalized =
+      engine.aspectRatios?.find((value) => value !== 'auto') ?? engine.aspectRatios?.[0] ?? '16:9';
+    aspectRatio =
+      soraRequest.mode === 'i2v' && soraRequest.aspect_ratio === 'auto'
+        ? fallbackAspectNormalized
+        : soraRequest.aspect_ratio === 'auto'
+          ? fallbackAspectNormalized
+          : soraRequest.aspect_ratio;
+  }
+
+  const rawDurationLabel: LumaRay2DurationLabel | undefined =
+    typeof rawDurationOption === 'string' && ['5s', '9s'].includes(rawDurationOption)
+      ? (rawDurationOption as LumaRay2DurationLabel)
+      : undefined;
+  const durationLabel = lumaDurationInfo?.label ?? toLumaRay2DurationLabel(durationSec, rawDurationLabel) ?? undefined;
+
+  return {
+    ok: true,
+    options: {
+      prompt,
+      multiPrompt,
+      audioEnabled,
+      isLumaRay2,
+      supportsDuration,
+      supportsResolution,
+      supportsFps,
+      supportsAspectRatio,
+      rawDurationOption,
+      rawDurationLabel,
+      durationLabel,
+      durationSec,
+      lumaDurationInfo,
+      shotType,
+      seed,
+      cameraFixed,
+      safetyChecker,
+      voiceIds,
+      voiceControl,
+      elements,
+      endImageUrl,
+      rawAudioUrl,
+      aspectRatio,
+      batchId,
+      groupId,
+      iterationIndex,
+      iterationCount,
+      renderIds,
+      heroRenderId,
+      message,
+      etaSeconds,
+      etaLabel,
+      rawExtraInputValues,
+      requestedResolution,
+      pricingResolution,
+      effectiveResolution,
+      numFrames,
+      loop,
+      soraRequest,
+    },
+  };
+}
+
+function normalizeMultiPrompt(value: unknown): MultiPromptEntry[] | null {
+  if (!Array.isArray(value)) return null;
+  const entries = value
+    .map((entry: unknown) => {
+      if (!entry || typeof entry !== 'object') return null;
+      const record = entry as Record<string, unknown>;
+      const promptValue = typeof record.prompt === 'string' ? record.prompt.trim() : '';
+      const durationValue =
+        typeof record.duration === 'number'
+          ? Math.round(record.duration)
+          : typeof record.duration === 'string'
+            ? Math.round(Number(record.duration.replace(/[^\d.]/g, '')))
+            : 0;
+      if (!promptValue) return null;
+      return { prompt: promptValue, duration: durationValue };
+    })
+    .filter((entry: MultiPromptEntry | null): entry is MultiPromptEntry => Boolean(entry));
+
+  return entries.length ? entries : null;
+}
+
+function normalizeSeed(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+  if (typeof value === 'string' && value.trim().length && Number.isFinite(Number(value))) {
+    return Math.trunc(Number(value));
+  }
+  return null;
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  const values = Array.isArray(value) ? value : typeof value === 'string' ? value.split(',') : null;
+  return values
+    ? values.map((entry: unknown) => (typeof entry === 'string' ? entry.trim() : '')).filter(isPresentString)
+    : [];
+}
+
+function normalizeGenerationElements(value: unknown): GenerationElement[] | null {
+  if (!Array.isArray(value)) return null;
+  const elements = value
+    .map((entry: unknown) => {
+      if (!entry || typeof entry !== 'object') return null;
+      const record = entry as Record<string, unknown>;
+      const frontalImageUrl =
+        typeof record.frontalImageUrl === 'string' && record.frontalImageUrl.trim().length
+          ? record.frontalImageUrl.trim()
+          : null;
+      const referenceImageUrls = Array.isArray(record.referenceImageUrls)
+        ? record.referenceImageUrls
+            .map((item: unknown) => (typeof item === 'string' ? item.trim() : ''))
+            .filter(isPresentString)
+        : [];
+      const videoUrl =
+        typeof record.videoUrl === 'string' && record.videoUrl.trim().length ? record.videoUrl.trim() : null;
+      if (!frontalImageUrl && referenceImageUrls.length === 0 && !videoUrl) return null;
+      return {
+        frontalImageUrl: frontalImageUrl ?? undefined,
+        referenceImageUrls: referenceImageUrls.length ? referenceImageUrls : undefined,
+        videoUrl: videoUrl ?? undefined,
+      };
+    })
+    .filter((entry: GenerationElement | null): entry is GenerationElement => Boolean(entry));
+
+  return elements.length ? elements : null;
+}
+
+function normalizeBytePlusOptions(params: {
+  engineId: string;
+  durationSec: number;
+  requestedResolution: string;
+  aspectRatio: string | null;
+}):
+  | {
+      ok: true;
+      durationSec: number;
+      resolution: string;
+      aspectRatio: string;
+    }
+  | Extract<GenerateRequestOptionsResult, { ok: false }> {
+  const normalizedDuration = Math.trunc(params.durationSec);
+  if (
+    !Number.isFinite(params.durationSec) ||
+    normalizedDuration !== params.durationSec ||
+    normalizedDuration < 5 ||
+    normalizedDuration > 15
+  ) {
+    return {
+      ok: false,
+      status: 400,
+      metric: {
+        errorCode: 'BYTEPLUS_DURATION_UNSUPPORTED',
+        meta: { durationSec: params.durationSec },
+      },
+      body: {
+        ok: false,
+        error: 'BYTEPLUS_DURATION_UNSUPPORTED',
+        message: 'This Seedance route requires an integer duration from 5 to 15 seconds.',
+      },
+    };
+  }
+  const allowedResolutions = getBytePlusSeedanceAllowedResolutions(params.engineId);
+  const bytePlusResolution = params.requestedResolution === 'auto' ? '720p' : params.requestedResolution;
+  if (!allowedResolutions.includes(bytePlusResolution as (typeof allowedResolutions)[number])) {
+    return {
+      ok: false,
+      status: 400,
+      metric: {
+        errorCode: 'BYTEPLUS_RESOLUTION_UNSUPPORTED',
+        meta: { resolution: params.requestedResolution, engineId: params.engineId },
+      },
+      body: {
+        ok: false,
+        error: 'BYTEPLUS_RESOLUTION_UNSUPPORTED',
+        message: 'This Seedance route does not support this resolution for the selected model.',
+      },
+    };
+  }
+  const bytePlusAspectRatio = !params.aspectRatio || params.aspectRatio === 'auto' ? '16:9' : params.aspectRatio;
+  if (!BYTEPLUS_SEEDANCE_ASPECT_RATIOS.includes(bytePlusAspectRatio as (typeof BYTEPLUS_SEEDANCE_ASPECT_RATIOS)[number])) {
+    return {
+      ok: false,
+      status: 400,
+      metric: {
+        errorCode: 'BYTEPLUS_RATIO_UNSUPPORTED',
+        meta: { aspectRatio: params.aspectRatio, engineId: params.engineId },
+      },
+      body: {
+        ok: false,
+        error: 'BYTEPLUS_RATIO_UNSUPPORTED',
+        message: 'This Seedance route does not support this aspect ratio.',
+      },
+    };
+  }
+  return {
+    ok: true,
+    durationSec: normalizedDuration,
+    resolution: bytePlusResolution,
+    aspectRatio: bytePlusAspectRatio,
+  };
+}
+
+function buildSoraRequestOptions(params: {
+  body: Record<string, unknown>;
+  engine: EngineCaps;
+  mode: Mode;
+  prompt: string;
+  requestedResolution: string;
+  rawAspectRatio: string | null;
+  durationSec: number;
+}):
+  | {
+      ok: true;
+      soraRequest: SoraRequest;
+    }
+  | Extract<GenerateRequestOptionsResult, { ok: false }> {
+  const variant = getSoraVariantForEngine(params.engine.id);
+  const fallbackAspect = params.mode === 'i2v' ? 'auto' : '16:9';
+  const soraDefaultResolution =
+    params.engine.resolutions.find((value) => value !== 'auto') ?? params.engine.resolutions[0] ?? '720p';
+  const candidate: Record<string, unknown> = {
+    variant,
+    mode: params.mode,
+    prompt: params.prompt,
+    resolution:
+      params.requestedResolution === 'auto' && params.mode === 't2v'
+        ? soraDefaultResolution
+        : params.requestedResolution,
+    aspect_ratio: params.rawAspectRatio ?? fallbackAspect,
+    duration: params.durationSec,
+    api_key:
+      typeof params.body.apiKey === 'string' && params.body.apiKey.trim().length ? params.body.apiKey.trim() : undefined,
+  };
+
+  if (params.mode === 'i2v') {
+    const imageUrl =
+      typeof params.body.imageUrl === 'string' && params.body.imageUrl.trim().length
+        ? params.body.imageUrl.trim()
+        : typeof params.body.image_url === 'string' && params.body.image_url.trim().length
+          ? params.body.image_url.trim()
+          : undefined;
+    if (!imageUrl) {
+      return {
+        ok: false,
+        status: 400,
+        metric: {
+          errorCode: 'IMAGE_URL_REQUIRED',
+          meta: { engineId: params.engine.id, mode: params.mode },
+        },
+        body: { ok: false, error: 'Image URL is required for Sora image-to-video' },
+      };
+    }
+    candidate.image_url = imageUrl;
+  }
+
+  try {
+    return { ok: true, soraRequest: parseSoraRequest(candidate) };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 400,
+      body: {
+        ok: false,
+        error: 'Invalid Sora payload',
+        details: error instanceof Error ? error.message : undefined,
+      },
+    };
+  }
+}
+
+function trimString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length ? value.trim() : null;
+}
+
+function isPresentString(value: string | null): value is string {
+  return typeof value === 'string' && value.length > 0;
+}

--- a/frontend/app/api/generate/route.ts
+++ b/frontend/app/api/generate/route.ts
@@ -28,6 +28,7 @@ import { buildFinalGenerateResponse } from './_lib/final-response';
 import { resolveGenerateBillingPreflight } from './_lib/billing-preflight';
 import { buildGenerateValidationPayload } from './_lib/validation-payload';
 import { submitBytePlusGenerateTask } from './_lib/byteplus-submission';
+import { buildGenerateRequestOptions, isVideoMode } from './_lib/request-options';
 import {
   buildResponseFromExistingVideoJob,
   createAtomicInitialVideoJob,
@@ -37,27 +38,14 @@ import {
 } from './_lib/initial-video-job';
 import { rollbackPendingPayment } from './_lib/payment-rollback';
 import { generateAndPersistJobKeyframes } from '@/server/video-keyframes';
-import { getEngineCaps } from '@/fixtures/engineCaps';
-import { getSoraVariantForEngine, isSoraEngineId, parseSoraRequest, type SoraRequest } from '@/lib/sora';
 import { translateError, type ErrorTranslationInput } from '@/lib/error-messages';
-import {
-  getLumaRay2DurationInfo,
-  getLumaRay2ResolutionInfo,
-  isLumaRay2EngineId,
-  isLumaRay2AspectRatio,
-  normaliseLumaRay2Loop,
-  toLumaRay2DurationLabel,
-  LUMA_RAY2_ERROR_UNSUPPORTED,
-  type LumaRay2DurationLabel,
-} from '@/lib/luma-ray2';
+import { LUMA_RAY2_ERROR_UNSUPPORTED } from '@/lib/luma-ray2';
 import { ensureUserPreferredCurrency } from '@/lib/currency';
 import { createSupabaseRouteClient } from '@/lib/supabase-ssr';
 import { AdminAuthError, requireAdmin, resolveLocalAdminBypassUserId } from '@/server/admin';
 import { buildRestrictedAccountPayload, getActiveAccountRestriction } from '@/server/fraud-cleanup';
 import {
   BYTEPLUS_MODELARK_PROVIDER,
-  BYTEPLUS_SEEDANCE_ASPECT_RATIOS,
-  getBytePlusSeedanceAllowedResolutions,
   isSeedanceBytePlusModeAllowed,
   isSeedanceFastBytePlusModeAllowed,
   isBytePlusModelArkEnabled,
@@ -68,28 +56,10 @@ import {
   shouldRoutePublicSeedanceFastToBytePlus,
 } from '@/server/video-providers/byteplus-modelark';
 
-type VideoMode = Extract<Mode, 't2v' | 'i2v' | 'ref2v' | 'fl2v' | 'i2i' | 'v2v' | 'r2v' | 'a2v' | 'extend' | 'retake' | 'reframe'>;
-
 const LUMA_RAY2_TIMEOUT_MS = 180_000;
 const FAL_RETRY_DELAYS_MS = [5_000, 15_000, 30_000];
 const FAL_HARD_TIMEOUT_MS = 400_000;
 const FAL_PROGRESS_FLOOR = 10;
-
-function isVideoMode(value: unknown): value is VideoMode {
-  return (
-    value === 't2v' ||
-    value === 'i2v' ||
-    value === 'ref2v' ||
-    value === 'fl2v' ||
-    value === 'i2i' ||
-    value === 'v2v' ||
-    value === 'r2v' ||
-    value === 'a2v' ||
-    value === 'extend' ||
-    value === 'retake' ||
-    value === 'reframe'
-  );
-}
 
 async function resolveUserId(req?: NextRequest): Promise<string | null> {
   try {
@@ -245,342 +215,61 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ ok: false, error: 'This Seedance route only supports the configured modes.' }, { status: 400 });
   }
 
-  const prompt = String(body.prompt || '');
-  const multiPromptRaw = Array.isArray(body.multiPrompt) ? body.multiPrompt : null;
-  const multiPrompt = multiPromptRaw
-    ? multiPromptRaw
-        .map((entry: unknown) => {
-          if (!entry || typeof entry !== 'object') return null;
-          const record = entry as Record<string, unknown>;
-          const promptValue = typeof record.prompt === 'string' ? record.prompt.trim() : '';
-          const durationValue =
-            typeof record.duration === 'number'
-              ? Math.round(record.duration)
-              : typeof record.duration === 'string'
-                ? Math.round(Number(record.duration.replace(/[^\d.]/g, '')))
-                : 0;
-          if (!promptValue) return null;
-          return { prompt: promptValue, duration: durationValue };
-        })
-        .filter(
-          (entry: { prompt: string; duration: number } | null): entry is { prompt: string; duration: number } =>
-            Boolean(entry)
-        )
-    : null;
-  const multiPromptTotalSec = multiPrompt
-    ? multiPrompt.reduce(
-        (sum: number, entry: { prompt: string; duration: number }) => sum + (entry.duration || 0),
-        0
-      )
-    : 0;
-  let audioEnabled =
-    typeof body.audio === 'boolean'
-      ? body.audio
-      : typeof body.generate_audio === 'boolean'
-        ? body.generate_audio
-        : undefined;
-  const isLumaRay2 = isLumaRay2EngineId(engine.id);
-  const capability = getEngineCaps(engine.id, mode);
-  const supportsDuration = capability ? Boolean(capability.duration || capability.frames) : true;
-  const supportsResolution = capability ? Boolean(capability.resolution && capability.resolution.length) : true;
-  const supportsFps = capability
-    ? Array.isArray(capability.fps)
-      ? capability.fps.length > 0
-      : typeof capability.fps === 'number'
-    : true;
-  const supportsAspectRatio = capability ? Boolean(capability.aspectRatio && capability.aspectRatio.length) : true;
-  const rawDurationOption =
-    typeof body.durationOption === 'number' || typeof body.durationOption === 'string' ? body.durationOption : null;
-  let durationSec = Number(body.durationSec || body.duration || 4);
-  if (multiPromptTotalSec > 0) {
-    durationSec = multiPromptTotalSec;
-  }
-  const lumaDurationInfo =
-    isLumaRay2 && supportsDuration ? getLumaRay2DurationInfo(rawDurationOption ?? durationSec) : null;
-  if (isLumaRay2 && supportsDuration && !lumaDurationInfo) {
-    logMetric('rejected', {
-      errorCode: 'LUMA_DURATION_UNSUPPORTED',
-      meta: { durationOption: rawDurationOption, durationSec: body.durationSec },
-    });
-    return NextResponse.json({ ok: false, error: LUMA_RAY2_ERROR_UNSUPPORTED }, { status: 400 });
-  }
-  if (lumaDurationInfo) {
-    durationSec = lumaDurationInfo.seconds;
-  }
-  const shotTypeRaw = typeof body.shotType === 'string' ? body.shotType.trim().toLowerCase() : '';
-  const shotType = shotTypeRaw === 'intelligent' ? 'intelligent' : shotTypeRaw === 'customize' ? 'customize' : null;
-  const seedRaw = body.seed;
-  const seed =
-    typeof seedRaw === 'number' && Number.isFinite(seedRaw)
-      ? Math.trunc(seedRaw)
-      : typeof seedRaw === 'string' && seedRaw.trim().length
-        ? Number.isFinite(Number(seedRaw))
-          ? Math.trunc(Number(seedRaw))
-          : null
-        : null;
-  const cameraFixed = typeof body.cameraFixed === 'boolean' ? body.cameraFixed : null;
-  const safetyChecker = typeof body.safetyChecker === 'boolean' ? body.safetyChecker : null;
-  const voiceIdsRaw = Array.isArray(body.voiceIds)
-    ? body.voiceIds
-    : typeof body.voiceIds === 'string'
-      ? body.voiceIds.split(',')
-      : null;
-  const voiceIds = voiceIdsRaw
-    ? voiceIdsRaw
-        .map((value: unknown) => (typeof value === 'string' ? value.trim() : ''))
-        .filter((value: string): value is string => value.length > 0)
-    : [];
-  const voiceControl = Boolean(body.voiceControl) || voiceIds.length > 0;
-  if (voiceControl) {
-    audioEnabled = true;
-  }
-  const elementsRaw = Array.isArray(body.elements) ? body.elements : null;
-  const elements = elementsRaw
-    ? elementsRaw
-        .map((entry: unknown) => {
-          if (!entry || typeof entry !== 'object') return null;
-          const record = entry as Record<string, unknown>;
-          const frontalImageUrl =
-            typeof record.frontalImageUrl === 'string' && record.frontalImageUrl.trim().length
-              ? record.frontalImageUrl.trim()
-              : null;
-          const referenceImageUrls = Array.isArray(record.referenceImageUrls)
-            ? record.referenceImageUrls
-                .map((value: unknown) => (typeof value === 'string' ? value.trim() : ''))
-                .filter((value: string): value is string => value.length > 0)
-            : [];
-          const videoUrl =
-            typeof record.videoUrl === 'string' && record.videoUrl.trim().length ? record.videoUrl.trim() : null;
-          if (!frontalImageUrl && referenceImageUrls.length === 0 && !videoUrl) return null;
-          return {
-            frontalImageUrl: frontalImageUrl ?? undefined,
-            referenceImageUrls: referenceImageUrls.length ? referenceImageUrls : undefined,
-            videoUrl: videoUrl ?? undefined,
-          };
-        })
-        .filter(
-          (
-            entry: { frontalImageUrl?: string; referenceImageUrls?: string[]; videoUrl?: string } | null
-          ): entry is { frontalImageUrl?: string; referenceImageUrls?: string[]; videoUrl?: string } => Boolean(entry)
-        )
-    : null;
-  const endImageUrl =
-    typeof body.endImageUrl === 'string' && body.endImageUrl.trim().length ? body.endImageUrl.trim() : null;
-  const rawAudioUrl =
-    typeof body.audioUrl === 'string' && body.audioUrl.trim().length
-      ? body.audioUrl.trim()
-      : typeof body.audio_url === 'string' && body.audio_url.trim().length
-        ? body.audio_url.trim()
-        : null;
-  const rawAspectRatio =
-    supportsAspectRatio && typeof body.aspectRatio === 'string' && body.aspectRatio.trim().length
-      ? body.aspectRatio.trim()
-      : null;
-  const fallbackAspectRatio = supportsAspectRatio
-    ? capability?.aspectRatio?.find((value) => value !== 'auto') ??
-      engine.aspectRatios?.find((value) => value !== 'auto') ??
-      engine.aspectRatios?.[0] ??
-      '16:9'
-    : null;
-  let aspectRatio =
-    rawAspectRatio && fallbackAspectRatio
-      ? rawAspectRatio === 'auto'
-        ? fallbackAspectRatio
-        : rawAspectRatio
-      : rawAspectRatio ?? fallbackAspectRatio ?? null;
-  if (isLumaRay2 && supportsAspectRatio) {
-    if (aspectRatio && !isLumaRay2AspectRatio(aspectRatio, { includeSquare: mode === 'reframe' })) {
-      logMetric('rejected', {
-        errorCode: 'LUMA_ASPECT_UNSUPPORTED',
-        meta: { aspectRatio },
-      });
-      return NextResponse.json({ ok: false, error: LUMA_RAY2_ERROR_UNSUPPORTED }, { status: 400 });
+  const requestOptionsResult = buildGenerateRequestOptions({
+    body,
+    engine,
+    mode,
+    isBytePlusV1a,
+  });
+  if (!requestOptionsResult.ok) {
+    if (requestOptionsResult.metric) {
+      logMetric('rejected', requestOptionsResult.metric);
     }
-    if (!aspectRatio) {
-      aspectRatio = fallbackAspectRatio ?? '16:9';
-    }
+    return NextResponse.json(requestOptionsResult.body, { status: requestOptionsResult.status });
   }
-  const batchId = typeof body.batchId === 'string' && body.batchId.trim().length ? body.batchId.trim() : null;
-  const groupId = typeof body.groupId === 'string' && body.groupId.trim().length ? body.groupId.trim() : null;
-  const iterationIndex =
-    typeof body.iterationIndex === 'number' && Number.isFinite(body.iterationIndex)
-      ? Math.max(0, Math.trunc(body.iterationIndex))
-      : null;
-  const iterationCount =
-    typeof body.iterationCount === 'number' && Number.isFinite(body.iterationCount)
-      ? Math.max(1, Math.trunc(body.iterationCount))
-      : null;
-  const renderIds =
-    Array.isArray(body.renderIds) && body.renderIds.length
-      ? body.renderIds.map((value: unknown) => (typeof value === 'string' ? value : null)).filter(Boolean)
-      : null;
-  const heroRenderId =
-    typeof body.heroRenderId === 'string' && body.heroRenderId.trim().length ? body.heroRenderId.trim() : null;
-  let message = typeof body.message === 'string' && body.message.trim().length ? body.message.trim() : null;
-  const etaSeconds =
-    typeof body.etaSeconds === 'number' && Number.isFinite(body.etaSeconds)
-      ? Math.max(0, Math.trunc(body.etaSeconds))
-      : null;
-  const etaLabel = typeof body.etaLabel === 'string' && body.etaLabel.trim().length ? body.etaLabel.trim() : null;
-  const rawExtraInputValues =
-    body.extraInputValues && typeof body.extraInputValues === 'object' && !Array.isArray(body.extraInputValues)
-      ? (body.extraInputValues as Record<string, unknown>)
-      : null;
 
-  let requestedResolution =
-    typeof body.resolution === 'string' && body.resolution.trim().length
-      ? body.resolution.trim()
-      : engine.resolutions?.[0] ?? '1080p';
-  let pricingResolution =
-    requestedResolution === 'auto'
-      ? engine.resolutions.find((value) => value !== 'auto') ?? engine.resolutions[0] ?? '1080p'
-      : requestedResolution;
-  let effectiveResolution = requestedResolution === 'auto' ? pricingResolution : requestedResolution;
-  let lumaResolutionInfo = isLumaRay2 && supportsResolution ? getLumaRay2ResolutionInfo(requestedResolution) : null;
-  if (isLumaRay2 && supportsResolution) {
-    if (requestedResolution === 'auto') {
-      requestedResolution = '540p';
-      lumaResolutionInfo = getLumaRay2ResolutionInfo(requestedResolution);
-    }
-    if (!lumaResolutionInfo) {
-      return NextResponse.json({ ok: false, error: LUMA_RAY2_ERROR_UNSUPPORTED }, { status: 400 });
-    }
-    pricingResolution = lumaResolutionInfo.value;
-    effectiveResolution = lumaResolutionInfo.value;
-    requestedResolution = lumaResolutionInfo.value;
-  } else if (!supportsResolution) {
-    const fallbackResolution =
-      engine.resolutions.find((value) => value !== 'auto') ?? engine.resolutions[0] ?? '540p';
-    pricingResolution = fallbackResolution;
-    effectiveResolution = fallbackResolution;
-    requestedResolution = fallbackResolution;
-  }
-  if ((engine.id === 'ltx-2-fast' || engine.id === 'ltx-2-3-fast') && durationSec > 10) {
-    // Fal requirement: 12–20s clips must run at 1080p/25fps on LTX fast variants.
-    requestedResolution = '1080p';
-    pricingResolution = '1080p';
-    effectiveResolution = '1080p';
-  }
-  if (isBytePlusV1a) {
-    const normalizedDuration = Math.trunc(durationSec);
-    if (!Number.isFinite(durationSec) || normalizedDuration !== durationSec || normalizedDuration < 5 || normalizedDuration > 15) {
-      logMetric('rejected', {
-        errorCode: 'BYTEPLUS_DURATION_UNSUPPORTED',
-        meta: { durationSec },
-      });
-      return NextResponse.json(
-        { ok: false, error: 'BYTEPLUS_DURATION_UNSUPPORTED', message: 'This Seedance route requires an integer duration from 5 to 15 seconds.' },
-        { status: 400 }
-      );
-    }
-    durationSec = normalizedDuration;
-    const allowedResolutions = getBytePlusSeedanceAllowedResolutions(engine.id);
-    const bytePlusResolution = requestedResolution === 'auto' ? '720p' : requestedResolution;
-    if (!allowedResolutions.includes(bytePlusResolution as (typeof allowedResolutions)[number])) {
-      logMetric('rejected', {
-        errorCode: 'BYTEPLUS_RESOLUTION_UNSUPPORTED',
-        meta: { resolution: requestedResolution, engineId: engine.id },
-      });
-      return NextResponse.json(
-        { ok: false, error: 'BYTEPLUS_RESOLUTION_UNSUPPORTED', message: 'This Seedance route does not support this resolution for the selected model.' },
-        { status: 400 }
-      );
-    }
-    const bytePlusAspectRatio = !aspectRatio || aspectRatio === 'auto' ? '16:9' : aspectRatio;
-    if (!BYTEPLUS_SEEDANCE_ASPECT_RATIOS.includes(bytePlusAspectRatio as (typeof BYTEPLUS_SEEDANCE_ASPECT_RATIOS)[number])) {
-      logMetric('rejected', {
-        errorCode: 'BYTEPLUS_RATIO_UNSUPPORTED',
-        meta: { aspectRatio, engineId: engine.id },
-      });
-      return NextResponse.json(
-        { ok: false, error: 'BYTEPLUS_RATIO_UNSUPPORTED', message: 'This Seedance route does not support this aspect ratio.' },
-        { status: 400 }
-      );
-    }
-    requestedResolution = bytePlusResolution;
-    pricingResolution = bytePlusResolution;
-    effectiveResolution = bytePlusResolution;
-    aspectRatio = bytePlusAspectRatio;
-    audioEnabled = audioEnabled ?? true;
-  }
+  const {
+    prompt,
+    multiPrompt,
+    audioEnabled,
+    isLumaRay2,
+    supportsDuration,
+    supportsResolution,
+    supportsFps,
+    supportsAspectRatio,
+    rawDurationOption,
+    rawDurationLabel,
+    durationLabel,
+    durationSec,
+    lumaDurationInfo,
+    shotType,
+    seed,
+    cameraFixed,
+    safetyChecker,
+    voiceIds,
+    voiceControl,
+    elements,
+    endImageUrl,
+    rawAudioUrl,
+    aspectRatio,
+    batchId,
+    groupId,
+    iterationIndex,
+    iterationCount,
+    renderIds,
+    heroRenderId,
+    etaSeconds,
+    etaLabel,
+    rawExtraInputValues,
+    pricingResolution,
+    effectiveResolution,
+    numFrames,
+    loop,
+    soraRequest,
+  } = requestOptionsResult.options;
+  let { message } = requestOptionsResult.options;
   metricState.durationSec = durationSec;
   metricState.resolution = effectiveResolution;
-
-  const rawNumFrames =
-    typeof body.numFrames === 'number'
-      ? body.numFrames
-      : typeof body.num_frames === 'number'
-        ? body.num_frames
-        : null;
-  const numFrames =
-    rawNumFrames != null && Number.isFinite(rawNumFrames) && rawNumFrames > 0 ? Math.round(rawNumFrames) : null;
-
-  const loopValue = isLumaRay2 ? normaliseLumaRay2Loop(body.loop) : undefined;
-  const loop = isLumaRay2 ? loopValue === true : false;
-
-  let soraRequest: SoraRequest | null = null;
-  if (isSoraEngineId(engine.id)) {
-    const variant = getSoraVariantForEngine(engine.id);
-    const fallbackAspect = mode === 'i2v' ? 'auto' : '16:9';
-    const soraDefaultResolution =
-      engine.resolutions.find((value) => value !== 'auto') ?? engine.resolutions[0] ?? '720p';
-    const candidate: Record<string, unknown> = {
-      variant,
-      mode,
-      prompt,
-      resolution: requestedResolution === 'auto' && mode === 't2v' ? soraDefaultResolution : requestedResolution,
-      aspect_ratio: rawAspectRatio ?? fallbackAspect,
-      duration: durationSec,
-      api_key: typeof body.apiKey === 'string' && body.apiKey.trim().length ? body.apiKey.trim() : undefined,
-    };
-
-    if (mode === 'i2v') {
-      const imageUrl =
-        typeof body.imageUrl === 'string' && body.imageUrl.trim().length
-          ? body.imageUrl.trim()
-          : typeof body.image_url === 'string' && body.image_url.trim().length
-            ? body.image_url.trim()
-            : undefined;
-      if (!imageUrl) {
-        logMetric('rejected', {
-          errorCode: 'IMAGE_URL_REQUIRED',
-          meta: { engineId: engine.id, mode },
-        });
-        return NextResponse.json({ ok: false, error: 'Image URL is required for Sora image-to-video' }, { status: 400 });
-      }
-      candidate.image_url = imageUrl;
-    }
-
-    try {
-      soraRequest = parseSoraRequest(candidate);
-    } catch (error) {
-      return NextResponse.json(
-        {
-          ok: false,
-          error: 'Invalid Sora payload',
-          details: error instanceof Error ? error.message : undefined,
-        },
-        { status: 400 }
-      );
-    }
-
-    durationSec = soraRequest.duration;
-    requestedResolution = soraRequest.resolution;
-    const fallbackResolution =
-      engine.resolutions.find((value) => value !== 'auto') ?? engine.resolutions[0] ?? '720p';
-    pricingResolution = soraRequest.resolution === 'auto' ? fallbackResolution : soraRequest.resolution;
-    effectiveResolution = soraRequest.resolution === 'auto' ? fallbackResolution : soraRequest.resolution;
-    const fallbackAspectNormalized =
-      engine.aspectRatios?.find((value) => value !== 'auto') ?? engine.aspectRatios?.[0] ?? '16:9';
-    aspectRatio =
-      soraRequest.mode === 'i2v' && soraRequest.aspect_ratio === 'auto'
-        ? fallbackAspectNormalized
-        : soraRequest.aspect_ratio === 'auto'
-          ? fallbackAspectNormalized
-          : soraRequest.aspect_ratio;
-    metricState.durationSec = durationSec;
-    metricState.resolution = effectiveResolution;
-  }
 
   const payment: { mode?: PaymentMode; paymentIntentId?: string | null } =
     typeof body.payment === 'object' && body.payment
@@ -621,12 +310,6 @@ export async function POST(req: NextRequest) {
       return NextResponse.json(buildResponseFromExistingVideoJob(existing, localKey));
     }
   }
-  const rawDurationLabel: LumaRay2DurationLabel | undefined =
-    typeof rawDurationOption === 'string' && ['5s', '9s'].includes(rawDurationOption)
-      ? (rawDurationOption as LumaRay2DurationLabel)
-      : undefined;
-  const durationLabel =
-    lumaDurationInfo?.label ?? toLumaRay2DurationLabel(durationSec, rawDurationLabel) ?? undefined;
   let walletChargeReserved = false;
 
   const extraInputValidation = validateExtraInputValues({ engine, mode, rawExtraInputValues });

--- a/tests/generate-request-options.test.ts
+++ b/tests/generate-request-options.test.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  buildGenerateRequestOptions,
+  isVideoMode,
+} from '../frontend/app/api/generate/_lib/request-options';
+import type { EngineCaps } from '../frontend/types/engines';
+
+const root = process.cwd();
+const routePath = join(root, 'frontend/app/api/generate/route.ts');
+const helperPath = join(root, 'frontend/app/api/generate/_lib/request-options.ts');
+const routeSource = readFileSync(routePath, 'utf8');
+
+const baseEngine = {
+  id: 'test-video-engine',
+  label: 'Test Video Engine',
+  modes: ['t2v', 'i2v'],
+  resolutions: ['auto', '720p', '1080p'],
+  aspectRatios: ['auto', '16:9', '9:16'],
+} as EngineCaps;
+
+test('generate route delegates request option normalization', () => {
+  assert.ok(existsSync(helperPath), 'request option normalization should live in the generate route _lib folder');
+  assert.match(routeSource, /from '\.\/_lib\/request-options'/);
+  assert.doesNotMatch(routeSource, /const multiPromptRaw = Array\.isArray\(body\.multiPrompt\)/);
+  assert.doesNotMatch(routeSource, /parseSoraRequest\(candidate\)/);
+  assert.doesNotMatch(routeSource, /BYTEPLUS_DURATION_UNSUPPORTED/);
+
+  const lineCount = routeSource.split('\n').length;
+  assert.ok(lineCount <= 1240, `/api/generate route should stay below 1240 lines after request option extraction, got ${lineCount}`);
+});
+
+test('request option helper exposes the route contract', () => {
+  const helperSource = readFileSync(helperPath, 'utf8');
+
+  assert.match(helperSource, /export function isVideoMode/);
+  assert.match(helperSource, /export function buildGenerateRequestOptions/);
+  assert.match(helperSource, /parseSoraRequest/);
+  assert.match(helperSource, /BYTEPLUS_DURATION_UNSUPPORTED/);
+});
+
+test('request option helper normalizes multi-prompt duration and render metadata', () => {
+  const result = buildGenerateRequestOptions({
+    body: {
+      prompt: '  castle reveal  ',
+      multiPrompt: [
+        { prompt: 'shot one', duration: '3s' },
+        { prompt: 'shot two', duration: 4.4 },
+        { prompt: '   ', duration: 9 },
+      ],
+      durationSec: 2,
+      aspectRatio: 'auto',
+      resolution: 'auto',
+      renderIds: ['a', 12, 'b'],
+      iterationIndex: 2.8,
+      iterationCount: 0,
+    },
+    engine: baseEngine,
+    mode: 't2v',
+    isBytePlusV1a: false,
+  });
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+
+  assert.equal(result.options.prompt, '  castle reveal  ');
+  assert.deepEqual(result.options.multiPrompt, [
+    { prompt: 'shot one', duration: 3 },
+    { prompt: 'shot two', duration: 4 },
+  ]);
+  assert.equal(result.options.durationSec, 7);
+  assert.equal(result.options.aspectRatio, '16:9');
+  assert.equal(result.options.requestedResolution, 'auto');
+  assert.equal(result.options.pricingResolution, '720p');
+  assert.deepEqual(result.options.renderIds, ['a', 'b']);
+  assert.equal(result.options.iterationIndex, 2);
+  assert.equal(result.options.iterationCount, 1);
+});
+
+test('request option helper rejects unsupported BytePlus durations before provider submission', () => {
+  const result = buildGenerateRequestOptions({
+    body: {
+      prompt: 'seedance render',
+      durationSec: 4,
+      resolution: '720p',
+      aspectRatio: '16:9',
+    },
+    engine: {
+      ...baseEngine,
+      id: 'seedance-2-0',
+      label: 'Seedance 2.0',
+      resolutions: ['480p', '720p', '1080p'],
+      aspectRatios: ['16:9', '9:16'],
+    } as EngineCaps,
+    mode: 't2v',
+    isBytePlusV1a: true,
+  });
+
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+
+  assert.equal(result.status, 400);
+  assert.equal(result.body.error, 'BYTEPLUS_DURATION_UNSUPPORTED');
+  assert.equal(result.metric?.errorCode, 'BYTEPLUS_DURATION_UNSUPPORTED');
+});
+
+test('request option helper keeps video mode narrowing explicit', () => {
+  assert.equal(isVideoMode('t2v'), true);
+  assert.equal(isVideoMode('t2i'), false);
+  assert.equal(isVideoMode('unknown'), false);
+});


### PR DESCRIPTION
## Summary
- Extract generate request option parsing and provider-specific normalization into route-local helper
- Keep /api/generate as orchestration while preserving Luma, Sora, BytePlus, multi-prompt, and render metadata behavior
- Add contract tests for the new helper and route delegation

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-request-options.test.ts
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-*.test.ts tests/provider-message-copy.test.ts
- pnpm run test:validate
- npm --prefix frontend run lint
- npm run lint:exposure