### PR TITLE
Split generate auth idempotency

### DIFF
--- a/frontend/app/api/generate/_lib/auth-idempotency.ts
+++ b/frontend/app/api/generate/_lib/auth-idempotency.ts
@@ -1,0 +1,130 @@
+import type { NextRequest } from 'next/server';
+import { query } from '@/lib/db';
+import { createSupabaseRouteClient } from '@/lib/supabase-ssr';
+import { resolveLocalAdminBypassUserId } from '@/server/admin';
+import { buildRestrictedAccountPayload, getActiveAccountRestriction } from '@/server/fraud-cleanup';
+import { buildResponseFromExistingVideoJob, type ExistingVideoJobRow } from './initial-video-job';
+
+type GenerateAuthMetric = {
+  errorCode: string;
+};
+
+type QueryFn = <T = unknown>(sql: string, params?: unknown[]) => Promise<T[]>;
+
+export type GenerateUserGateResult =
+  | {
+      kind: 'ready';
+      userId: string;
+      localKey: string | null;
+    }
+  | {
+      kind: 'response';
+      status: number;
+      body: Record<string, unknown>;
+      metric?: GenerateAuthMetric;
+    };
+
+type ResolveGenerateUserIdDeps = {
+  createSupabaseRouteClientFn?: typeof createSupabaseRouteClient;
+  resolveLocalAdminBypassUserIdFn?: typeof resolveLocalAdminBypassUserId;
+};
+
+type ResolveGenerateUserGateDeps = ResolveGenerateUserIdDeps & {
+  resolveGenerateUserIdFn?: (req?: NextRequest) => Promise<string | null>;
+  getActiveAccountRestrictionFn?: typeof getActiveAccountRestriction;
+  buildRestrictedAccountPayloadFn?: typeof buildRestrictedAccountPayload;
+  buildResponseFromExistingVideoJobFn?: typeof buildResponseFromExistingVideoJob;
+  queryFn?: QueryFn;
+};
+
+export async function resolveGenerateUserId(
+  req?: NextRequest,
+  deps: ResolveGenerateUserIdDeps = {}
+): Promise<string | null> {
+  const createSupabaseRouteClientFn = deps.createSupabaseRouteClientFn ?? createSupabaseRouteClient;
+  const resolveLocalAdminBypassUserIdFn =
+    deps.resolveLocalAdminBypassUserIdFn ?? resolveLocalAdminBypassUserId;
+
+  try {
+    const supabase = await createSupabaseRouteClientFn();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (user?.id) {
+      return user.id;
+    }
+  } catch {
+    // Keep auth fallback tolerant so local admin bypass still works in dev.
+  }
+
+  const localAdminUserId = await resolveLocalAdminBypassUserIdFn(req);
+  return localAdminUserId || null;
+}
+
+export async function resolveGenerateUserGate(params: {
+  req: NextRequest;
+  body: Record<string, unknown>;
+  deps?: ResolveGenerateUserGateDeps;
+}): Promise<GenerateUserGateResult> {
+  const deps = params.deps ?? {};
+  const resolveGenerateUserIdFn = deps.resolveGenerateUserIdFn ?? ((req?: NextRequest) => resolveGenerateUserId(req, deps));
+  const userId = await resolveGenerateUserIdFn(params.req);
+
+  if (!userId) {
+    return {
+      kind: 'response',
+      status: 401,
+      metric: { errorCode: 'AUTH_REQUIRED' },
+      body: { ok: false, error: 'auth_required', message: 'Authentication required.' },
+    };
+  }
+
+  const getActiveAccountRestrictionFn = deps.getActiveAccountRestrictionFn ?? getActiveAccountRestriction;
+  const restriction = await getActiveAccountRestrictionFn(userId);
+  if (restriction) {
+    const buildRestrictedAccountPayloadFn = deps.buildRestrictedAccountPayloadFn ?? buildRestrictedAccountPayload;
+    return {
+      kind: 'response',
+      status: 403,
+      metric: { errorCode: 'ACCOUNT_RESTRICTED' },
+      body: buildRestrictedAccountPayloadFn(),
+    };
+  }
+
+  const localKey =
+    typeof params.body.localKey === 'string' && params.body.localKey.trim().length
+      ? params.body.localKey.trim()
+      : null;
+  if (localKey) {
+    const queryFn = deps.queryFn ?? query;
+    const existingJobs = await queryFn<ExistingVideoJobRow>(
+      `
+        SELECT job_id, user_id, status, video_url, thumb_url, provider_job_id, progress, message,
+               batch_id, group_id, iteration_index, iteration_count, render_ids, hero_render_id
+          FROM app_jobs
+         WHERE user_id = $1
+           AND local_key = $2
+           AND created_at > NOW() - INTERVAL '30 minutes'
+         ORDER BY created_at DESC
+         LIMIT 1
+      `,
+      [userId, localKey]
+    );
+    const existing = existingJobs[0];
+    if (existing) {
+      const buildResponseFromExistingVideoJobFn =
+        deps.buildResponseFromExistingVideoJobFn ?? buildResponseFromExistingVideoJob;
+      return {
+        kind: 'response',
+        status: 200,
+        body: buildResponseFromExistingVideoJobFn(existing, localKey),
+      };
+    }
+  }
+
+  return {
+    kind: 'ready',
+    userId,
+    localKey,
+  };
+}

--- a/frontend/app/api/generate/route.ts
+++ b/frontend/app/api/generate/route.ts
@@ -29,11 +29,11 @@ import { resolveGenerateBillingPreflight } from './_lib/billing-preflight';
 import { buildGenerateValidationPayload } from './_lib/validation-payload';
 import { submitBytePlusGenerateTask } from './_lib/byteplus-submission';
 import { buildGenerateRequestOptions, isVideoMode } from './_lib/request-options';
+import { resolveGenerateUserGate } from './_lib/auth-idempotency';
 import {
   buildResponseFromExistingVideoJob,
   createAtomicInitialVideoJob,
   VideoInitialJobError,
-  type ExistingVideoJobRow,
   type PaymentMode,
 } from './_lib/initial-video-job';
 import { rollbackPendingPayment } from './_lib/payment-rollback';
@@ -41,9 +41,7 @@ import { generateAndPersistJobKeyframes } from '@/server/video-keyframes';
 import { translateError, type ErrorTranslationInput } from '@/lib/error-messages';
 import { LUMA_RAY2_ERROR_UNSUPPORTED } from '@/lib/luma-ray2';
 import { ensureUserPreferredCurrency } from '@/lib/currency';
-import { createSupabaseRouteClient } from '@/lib/supabase-ssr';
-import { AdminAuthError, requireAdmin, resolveLocalAdminBypassUserId } from '@/server/admin';
-import { buildRestrictedAccountPayload, getActiveAccountRestriction } from '@/server/fraud-cleanup';
+import { AdminAuthError, requireAdmin } from '@/server/admin';
 import {
   BYTEPLUS_MODELARK_PROVIDER,
   isSeedanceBytePlusModeAllowed,
@@ -60,25 +58,6 @@ const LUMA_RAY2_TIMEOUT_MS = 180_000;
 const FAL_RETRY_DELAYS_MS = [5_000, 15_000, 30_000];
 const FAL_HARD_TIMEOUT_MS = 400_000;
 const FAL_PROGRESS_FLOOR = 10;
-
-async function resolveUserId(req?: NextRequest): Promise<string | null> {
-  try {
-    const supabase = await createSupabaseRouteClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (user?.id) {
-      return user.id;
-    }
-  } catch {
-    // swallow helper errors
-  }
-  const localAdminUserId = await resolveLocalAdminBypassUserId(req);
-  if (localAdminUserId) {
-    return localAdminUserId;
-  }
-  return null;
-}
 
 async function markJobAwaitingFal(params: {
   jobId: string;
@@ -275,41 +254,15 @@ export async function POST(req: NextRequest) {
     typeof body.payment === 'object' && body.payment
       ? { mode: body.payment.mode, paymentIntentId: body.payment.paymentIntentId }
       : {};
-  const authenticatedUserId = await resolveUserId(req);
-  if (!authenticatedUserId) {
-    logMetric('rejected', { errorCode: 'AUTH_REQUIRED' });
-    return NextResponse.json(
-      { ok: false, error: 'auth_required', message: 'Authentication required.' },
-      { status: 401 }
-    );
-  }
-  const userId = authenticatedUserId;
-  metricState.userId = userId;
-  const restriction = await getActiveAccountRestriction(userId);
-  if (restriction) {
-    logMetric('rejected', { errorCode: 'ACCOUNT_RESTRICTED' });
-    return NextResponse.json(buildRestrictedAccountPayload(), { status: 403 });
-  }
-  const localKey = typeof body.localKey === 'string' && body.localKey.trim().length ? body.localKey.trim() : null;
-  if (localKey && userId) {
-    const existingJobs = await query<ExistingVideoJobRow>(
-      `
-        SELECT job_id, user_id, status, video_url, thumb_url, provider_job_id, progress, message,
-               batch_id, group_id, iteration_index, iteration_count, render_ids, hero_render_id
-          FROM app_jobs
-         WHERE user_id = $1
-           AND local_key = $2
-           AND created_at > NOW() - INTERVAL '30 minutes'
-         ORDER BY created_at DESC
-         LIMIT 1
-      `,
-      [userId, localKey]
-    );
-    const existing = existingJobs[0];
-    if (existing) {
-      return NextResponse.json(buildResponseFromExistingVideoJob(existing, localKey));
+  const userGate = await resolveGenerateUserGate({ req, body });
+  if (userGate.kind === 'response') {
+    if (userGate.metric) {
+      logMetric('rejected', userGate.metric);
     }
+    return NextResponse.json(userGate.body, { status: userGate.status });
   }
+  const { userId, localKey } = userGate;
+  metricState.userId = userId;
   let walletChargeReserved = false;
 
   const extraInputValidation = validateExtraInputValues({ engine, mode, rawExtraInputValues });

--- a/tests/generate-auth-idempotency.test.ts
+++ b/tests/generate-auth-idempotency.test.ts
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  resolveGenerateUserGate,
+  resolveGenerateUserId,
+} from '../frontend/app/api/generate/_lib/auth-idempotency';
+
+const root = process.cwd();
+const routePath = join(root, 'frontend/app/api/generate/route.ts');
+const helperPath = join(root, 'frontend/app/api/generate/_lib/auth-idempotency.ts');
+const routeSource = readFileSync(routePath, 'utf8');
+
+test('generate route delegates auth and local-key idempotency', () => {
+  assert.ok(existsSync(helperPath), 'auth and idempotency should live in the generate route _lib folder');
+  assert.match(routeSource, /from '\.\/_lib\/auth-idempotency'/);
+  assert.doesNotMatch(routeSource, /createSupabaseRouteClient/);
+  assert.doesNotMatch(routeSource, /resolveLocalAdminBypassUserId/);
+  assert.doesNotMatch(routeSource, /getActiveAccountRestriction/);
+  assert.doesNotMatch(routeSource, /created_at > NOW\(\) - INTERVAL '30 minutes'/);
+
+  const lineCount = routeSource.split('\n').length;
+  assert.ok(lineCount <= 1110, `/api/generate route should stay below 1110 lines after auth extraction, got ${lineCount}`);
+});
+
+test('auth idempotency helper exposes the route contract', () => {
+  const helperSource = readFileSync(helperPath, 'utf8');
+
+  assert.match(helperSource, /export async function resolveGenerateUserId/);
+  assert.match(helperSource, /export async function resolveGenerateUserGate/);
+  assert.match(helperSource, /buildResponseFromExistingVideoJob/);
+  assert.match(helperSource, /created_at > NOW\(\) - INTERVAL '30 minutes'/);
+});
+
+test('resolveGenerateUserId falls back to the local admin bypass after Supabase misses', async () => {
+  const userId = await resolveGenerateUserId({} as never, {
+    createSupabaseRouteClientFn: async () => ({
+      auth: {
+        getUser: async () => ({ data: { user: null } }),
+      },
+    }),
+    resolveLocalAdminBypassUserIdFn: async () => 'admin_user_123',
+  });
+
+  assert.equal(userId, 'admin_user_123');
+});
+
+test('resolveGenerateUserGate returns an auth response before DB work when no user is available', async () => {
+  let queried = false;
+  const result = await resolveGenerateUserGate({
+    req: {} as never,
+    body: { localKey: 'abc' },
+    deps: {
+      resolveGenerateUserIdFn: async () => null,
+      queryFn: async () => {
+        queried = true;
+        return [];
+      },
+    },
+  });
+
+  assert.equal(result.kind, 'response');
+  assert.equal(result.status, 401);
+  assert.equal(result.metric?.errorCode, 'AUTH_REQUIRED');
+  assert.equal(queried, false);
+});
+
+test('resolveGenerateUserGate returns an existing local-key render response', async () => {
+  const result = await resolveGenerateUserGate({
+    req: {} as never,
+    body: { localKey: ' local_render ' },
+    deps: {
+      resolveGenerateUserIdFn: async () => 'user_123',
+      getActiveAccountRestrictionFn: async () => null,
+      queryFn: async () => [
+        {
+          job_id: 'job_123',
+          user_id: 'user_123',
+          status: 'running',
+          video_url: null,
+          thumb_url: '/thumb.svg',
+          provider_job_id: 'provider_123',
+          progress: 35,
+          message: 'Rendering',
+          batch_id: null,
+          group_id: null,
+          iteration_index: null,
+          iteration_count: null,
+          render_ids: null,
+          hero_render_id: null,
+        },
+      ],
+    },
+  });
+
+  assert.equal(result.kind, 'response');
+  assert.equal(result.status, 200);
+  assert.equal(result.body.jobId, 'job_123');
+  assert.equal(result.body.localKey, 'local_render');
+});


### PR DESCRIPTION
## Summary
- Extract generate user auth, local admin fallback, account restriction, and localKey idempotency lookup into a route-local helper
- Keep the route responsible for logging metrics and returning JSON responses
- Add contract tests for auth/idempotency helper behavior

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-auth-idempotency.test.ts
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-*.test.ts tests/provider-message-copy.test.ts
- pnpm run test:validate
- npm --prefix frontend run lint
- npm run lint:exposure