### PR TITLE
Split generate Fal submission

### DIFF
--- a/frontend/app/api/generate/_lib/fal-submission.ts
+++ b/frontend/app/api/generate/_lib/fal-submission.ts
@@ -1,0 +1,459 @@
+import { query } from '@/lib/db';
+import { translateError, type ErrorTranslationInput } from '@/lib/error-messages';
+import { FalGenerationError, generateVideo, type GeneratePayload, type GenerateResult } from '@/lib/fal';
+import { LUMA_RAY2_ERROR_UNSUPPORTED } from '@/lib/luma-ray2';
+import { rollbackPendingPayment } from './payment-rollback';
+import type { PaymentMode, PendingReceipt } from './initial-video-job';
+import {
+  condenseFalErrorMessage,
+  extractFalProviderMessage,
+  FalTimeoutError,
+  shouldDeferFalError,
+  withFalTimeout,
+} from './fal-error-handling';
+
+const LUMA_RAY2_TIMEOUT_MS = 180_000;
+const FAL_RETRY_DELAYS_MS = [5_000, 15_000, 30_000];
+const FAL_HARD_TIMEOUT_MS = 400_000;
+const FAL_PROGRESS_FLOOR = 10;
+
+type QueryFn = <T = unknown>(sql: string, params?: unknown[]) => Promise<T[]>;
+
+type LogMetricFn = (
+  kind: 'failed' | 'rejected' | 'accepted' | 'completed',
+  event?: {
+    jobId?: string;
+    errorCode?: string;
+    meta?: Record<string, unknown>;
+    durationMs?: number;
+  }
+) => void;
+
+type SubmitFalGenerateTaskDeps = {
+  generateVideoFn?: typeof generateVideo;
+  withFalTimeoutFn?: <T>(promise: Promise<T>, timeoutMs: number) => Promise<T>;
+  queryFn?: QueryFn;
+  rollbackPendingPaymentFn?: typeof rollbackPendingPayment;
+  markJobAwaitingFalFn?: typeof markJobAwaitingFal;
+};
+
+export type FalGenerateSubmissionResult =
+  | {
+      ok: true;
+      generationResult: GenerateResult;
+    }
+  | {
+      ok: false;
+      status: number;
+      body: Record<string, unknown>;
+    };
+
+export async function markJobAwaitingFal(params: {
+  jobId: string;
+  engineId: string;
+  providerJobId: string | null;
+  message: string | null;
+  statusLabel: string;
+  attempt: number;
+  context?: Record<string, unknown>;
+  progressFloor?: number;
+  deps?: {
+    queryFn?: QueryFn;
+  };
+}): Promise<void> {
+  const queryFn = params.deps?.queryFn ?? query;
+  const progressFloor = params.progressFloor ?? FAL_PROGRESS_FLOOR;
+  const message = params.message ? condenseFalErrorMessage(params.message) : null;
+  try {
+    await queryFn(
+      `UPDATE app_jobs
+       SET status = 'running',
+           progress = GREATEST(progress, $2),
+           message = CASE WHEN $3 IS NOT NULL THEN $3::text ELSE message END,
+           provider_job_id = COALESCE($4, provider_job_id),
+           provisional = FALSE,
+           updated_at = NOW()
+       WHERE job_id = $1`,
+      [params.jobId, progressFloor, message, params.providerJobId]
+    );
+  } catch (error) {
+    console.warn('[api/generate] failed to mark job awaiting Fal', { jobId: params.jobId }, error);
+  }
+
+  if (!params.providerJobId) {
+    return;
+  }
+
+  try {
+    await queryFn(
+      `INSERT INTO fal_queue_log (job_id, provider, provider_job_id, engine_id, status, payload)
+       VALUES ($1,$2,$3,$4,$5,$6::jsonb)`,
+      [
+        params.jobId,
+        'fal',
+        params.providerJobId,
+        params.engineId,
+        params.statusLabel,
+        JSON.stringify({
+          attempt: params.attempt,
+          at: new Date().toISOString(),
+          message,
+          context: params.context ?? null,
+        }),
+      ]
+    );
+  } catch (error) {
+    console.warn('[queue-log] failed to record transient Fal event', error);
+  }
+}
+
+export async function submitFalGenerateTask(params: {
+  falPayload: GeneratePayload;
+  jobId: string;
+  engineId: string;
+  engineLabel: string;
+  isLumaRay2: boolean;
+  batchId: string | null;
+  durationSec: number;
+  pendingReceipt: PendingReceipt | null;
+  paymentMode: PaymentMode;
+  walletChargeReserved: boolean;
+  getLastProviderJobId: () => string | null | undefined;
+  setLastProviderJobId: (providerJobId: string | null) => void;
+  persistProviderJobId: (providerJobId: string) => void | Promise<void>;
+  logMetricFn: LogMetricFn;
+  deps?: SubmitFalGenerateTaskDeps;
+}): Promise<FalGenerateSubmissionResult> {
+  const generateVideoFn = params.deps?.generateVideoFn ?? generateVideo;
+  const withFalTimeoutFn = params.deps?.withFalTimeoutFn ?? withFalTimeout;
+  const queryFn = params.deps?.queryFn ?? query;
+  const rollbackPendingPaymentFn = params.deps?.rollbackPendingPaymentFn ?? rollbackPendingPayment;
+  const markJobAwaitingFalFn = params.deps?.markJobAwaitingFalFn ?? markJobAwaitingFal;
+
+  try {
+    const promise = generateVideoFn(
+      { ...params.falPayload },
+      {
+        onRequestId: (requestId) => {
+          console.info('[fal] request id received', {
+            jobId: params.jobId,
+            engineId: params.engineId,
+            requestId,
+          });
+          params.persistProviderJobId(requestId);
+        },
+        onQueueUpdate: (status) => {
+          if (!status) return;
+          const requestId =
+            (status as { request_id?: string }).request_id ?? params.getLastProviderJobId() ?? null;
+          params.setLastProviderJobId(requestId);
+        },
+      }
+    );
+    const generationResult = await withFalTimeoutFn(
+      promise,
+      params.isLumaRay2 ? LUMA_RAY2_TIMEOUT_MS : FAL_HARD_TIMEOUT_MS
+    );
+    return { ok: true, generationResult };
+  } catch (error) {
+    const rawStatus =
+      error && typeof error === 'object' && 'status' in error ? (error as { status?: number }).status : undefined;
+    const metadataStatus =
+      error && typeof error === 'object' && '$metadata' in error
+        ? (error as { $metadata?: { httpStatusCode?: number } }).$metadata?.httpStatusCode
+        : undefined;
+    const status = rawStatus ?? metadataStatus;
+    const detail =
+      error && typeof error === 'object' && 'body' in error ? (error as { body?: unknown }).body ?? null : null;
+    const providerMessageRaw =
+      extractFalProviderMessage(detail) ??
+      (error instanceof FalGenerationError && error.body ? extractFalProviderMessage(error.body) : null) ??
+      (error && typeof error === 'object' && 'response' in error
+        ? extractFalProviderMessage((error as { response?: unknown }).response)
+        : null) ??
+      extractFalProviderMessage(error) ??
+      (error instanceof Error ? error.message : null);
+    const providerMessage = condenseFalErrorMessage(providerMessageRaw);
+    const effectiveProviderMessage =
+      providerMessage && providerMessage.toLowerCase() === 'fal request failed' ? null : providerMessage;
+    const isTimeoutError = error instanceof FalTimeoutError;
+    const isQuotaError =
+      status === 429 || (typeof providerMessage === 'string' && providerMessage.toLowerCase().includes('quota'));
+    const fallbackMessage = isTimeoutError
+      ? 'Generation timed out'
+      : isQuotaError
+        ? 'Provider is rate limiting'
+        : 'Fal request failed';
+    const rawErrorCode =
+      typeof (error as { code?: string } | undefined)?.code === 'string'
+        ? (error as { code?: string }).code
+        : null;
+    const translation = translateError({
+      code: isTimeoutError ? 'PROVIDER_BUSY' : isQuotaError ? 'RATE_LIMITED' : rawErrorCode,
+      status,
+      message: effectiveProviderMessage ?? providerMessage ?? fallbackMessage,
+      providerMessage: effectiveProviderMessage ?? providerMessage ?? null,
+    });
+    const failureMessage = translation.message;
+    const errorCode = translation.code;
+    const providerJobId: string | null =
+      error instanceof FalGenerationError && error.providerJobId
+        ? error.providerJobId
+        : typeof (error as { providerJobId?: string } | undefined)?.providerJobId === 'string'
+          ? (error as { providerJobId?: string }).providerJobId!
+          : params.getLastProviderJobId() ?? params.batchId ?? null;
+    const paymentStatusOverride =
+      params.pendingReceipt && params.paymentMode === 'wallet'
+        ? 'refunded_wallet'
+        : params.pendingReceipt && params.paymentMode !== 'wallet'
+          ? 'refunded'
+          : null;
+    const baseRefundDescription = `Refund ${params.engineLabel} - ${params.durationSec}s`;
+    const refundNote = failureMessage ?? null;
+    const refundDescription = refundNote ? `${baseRefundDescription} - ${refundNote}` : baseRefundDescription;
+
+    if (error instanceof FalGenerationError) {
+      (error as { code?: string }).code = errorCode;
+      (error as { userMessage?: string }).userMessage = failureMessage;
+    }
+
+    console.error(
+      '[api/generate] Fal generation failed',
+      {
+        jobId: params.jobId,
+        engineId: params.engineId,
+        status,
+        providerJobId,
+        providerMessage: effectiveProviderMessage ?? providerMessage ?? null,
+        detail: detail ?? null,
+      },
+      error
+    );
+
+    const deferable =
+      !isQuotaError &&
+      shouldDeferFalError({
+        error,
+        status,
+        detail,
+        providerMessage: effectiveProviderMessage ?? providerMessage ?? fallbackMessage,
+        providerJobId,
+      });
+
+    if (isTimeoutError) {
+      const progressFloor = Math.min(95, FAL_PROGRESS_FLOOR + FAL_RETRY_DELAYS_MS.length * 5);
+      const waitingMessage =
+        effectiveProviderMessage && effectiveProviderMessage !== fallbackMessage
+          ? `Still processing: ${effectiveProviderMessage}. Your request is in progress; we will update you shortly.`
+          : 'Rendering in progress; awaiting provider after timeout. We will refresh as soon as the next status arrives.';
+
+      if (providerJobId) {
+        await markJobAwaitingFalFn({
+          jobId: params.jobId,
+          engineId: params.engineId,
+          providerJobId,
+          message: waitingMessage,
+          statusLabel: 'deferred',
+          attempt: FAL_RETRY_DELAYS_MS.length + 1,
+          context: {
+            status,
+            deferred: true,
+            timeout: true,
+          },
+          progressFloor,
+          deps: { queryFn },
+        });
+      } else {
+        await queryFn(
+          `UPDATE app_jobs
+             SET status = 'running',
+                 progress = $2,
+                 message = $3,
+                 provisional = FALSE,
+                 updated_at = NOW()
+           WHERE job_id = $1`,
+          [params.jobId, progressFloor, waitingMessage]
+        ).catch((updateError) => {
+          console.error('[api/generate] failed to mark timeout job awaiting provider', updateError);
+        });
+      }
+
+      return buildDeferredFalResponse(params.jobId, providerJobId, progressFloor, waitingMessage);
+    }
+
+    if (deferable && providerJobId) {
+      const progressFloor = Math.min(95, FAL_PROGRESS_FLOOR + FAL_RETRY_DELAYS_MS.length * 5);
+      const waitingMessage =
+        effectiveProviderMessage && effectiveProviderMessage !== fallbackMessage
+          ? `Still processing: ${effectiveProviderMessage}. Your request is in progress; we will update you shortly.`
+          : 'Rendering in progress; next update imminent. No action needed while we wait for the next status update.';
+
+      await markJobAwaitingFalFn({
+        jobId: params.jobId,
+        engineId: params.engineId,
+        providerJobId,
+        message: waitingMessage,
+        statusLabel: 'deferred',
+        attempt: FAL_RETRY_DELAYS_MS.length + 1,
+        context: {
+          status,
+          deferred: true,
+        },
+        progressFloor,
+        deps: { queryFn },
+      });
+
+      return buildDeferredFalResponse(params.jobId, providerJobId, progressFloor, waitingMessage);
+    }
+
+    try {
+      await queryFn(
+        `UPDATE app_jobs
+         SET status = 'failed',
+             progress = 0,
+             message = $2,
+             provisional = FALSE,
+             provider_job_id = COALESCE($3, provider_job_id),
+             payment_status = CASE WHEN $4::text IS NOT NULL THEN $4 ELSE payment_status END,
+             updated_at = NOW()
+         WHERE job_id = $1`,
+        [params.jobId, failureMessage, providerJobId, paymentStatusOverride]
+      );
+    } catch (updateError) {
+      console.error('[api/generate] failed to update provisional job after Fal error', updateError);
+    }
+
+    if (params.pendingReceipt && !isTimeoutError) {
+      await rollbackPendingPaymentFn({
+        pendingReceipt: params.pendingReceipt,
+        walletChargeReserved: params.walletChargeReserved,
+        refundDescription,
+      });
+    }
+
+    if (status === 422) {
+      console.error('[generate] fal returned 422', providerMessage ?? '<no-provider-message>');
+      const translated = translateFalUnprocessableEntity({
+        status,
+        detail,
+        effectiveProviderMessage,
+        providerMessage,
+        isLumaRay2: params.isLumaRay2,
+      });
+
+      params.logMetricFn('failed', {
+        errorCode: translated.errorCode,
+        meta: { stage: 'provider_422', providerJobId },
+      });
+      return {
+        ok: false,
+        status: 422,
+        body: {
+          ok: false,
+          error: translated.errorCode,
+          message: translated.userMessage,
+          providerMessage: translated.providerMessage,
+          detail: detail ?? providerMessage,
+        },
+      };
+    }
+
+    params.logMetricFn('failed', {
+      errorCode,
+      meta: {
+        stage: 'provider_error',
+        providerJobId,
+        providerStatus: status ?? metadataStatus ?? null,
+      },
+    });
+    return {
+      ok: false,
+      status: isTimeoutError ? 504 : isQuotaError ? 429 : status ?? 500,
+      body: {
+        ok: false,
+        error: errorCode,
+        message: failureMessage,
+        providerMessage: effectiveProviderMessage ?? providerMessage ?? null,
+        detail,
+      },
+    };
+  }
+}
+
+function buildDeferredFalResponse(
+  jobId: string,
+  providerJobId: string | null,
+  progress: number,
+  message: string
+): FalGenerateSubmissionResult {
+  return {
+    ok: false,
+    status: 202,
+    body: {
+      ok: true,
+      jobId,
+      status: 'running',
+      progress,
+      providerJobId,
+      deferred: true,
+      message,
+    },
+  };
+}
+
+function translateFalUnprocessableEntity(params: {
+  status: number;
+  detail: unknown;
+  effectiveProviderMessage: string | null;
+  providerMessage: string | null;
+  isLumaRay2: boolean;
+}) {
+  let translatedErrorCode: string | null = null;
+  let translatedMessage: string | null = null;
+  let translatedProviderMessage: string | null = null;
+
+  const resolveTranslation = (input: ErrorTranslationInput) => {
+    const translation = translateError(input);
+    translatedErrorCode = translation.code;
+    translatedMessage = translation.message;
+    translatedProviderMessage = translation.providerMessage ?? translation.originalMessage ?? null;
+  };
+
+  if (params.detail && Array.isArray(params.detail) && params.detail.length) {
+    const firstDetail = params.detail[0] as Record<string, unknown>;
+    const detailCode = typeof firstDetail.type === 'string' ? firstDetail.type : undefined;
+    const detailMessage = typeof firstDetail.msg === 'string' ? firstDetail.msg : undefined;
+    resolveTranslation({
+      code: detailCode ?? 'FAL_UNPROCESSABLE_ENTITY',
+      status: params.status,
+      message: detailMessage ?? params.effectiveProviderMessage ?? params.providerMessage ?? null,
+      providerMessage: detailMessage ?? params.effectiveProviderMessage ?? params.providerMessage ?? null,
+    });
+  } else if (params.detail && typeof params.detail === 'object') {
+    const detailRecord = params.detail as Record<string, unknown>;
+    const detailCode = typeof detailRecord.code === 'string' ? detailRecord.code : undefined;
+    const detailMessage = typeof detailRecord.message === 'string' ? detailRecord.message : undefined;
+    resolveTranslation({
+      code: detailCode ?? 'FAL_UNPROCESSABLE_ENTITY',
+      status: params.status,
+      message: detailMessage ?? params.effectiveProviderMessage ?? params.providerMessage ?? null,
+      providerMessage: detailMessage ?? params.effectiveProviderMessage ?? params.providerMessage ?? null,
+    });
+  } else {
+    resolveTranslation({
+      code: 'FAL_UNPROCESSABLE_ENTITY',
+      status: params.status,
+      message: params.effectiveProviderMessage ?? params.providerMessage ?? null,
+      providerMessage: params.effectiveProviderMessage ?? params.providerMessage ?? null,
+    });
+  }
+
+  const errorCode = translatedErrorCode ?? 'FAL_UNPROCESSABLE_ENTITY';
+  return {
+    errorCode,
+    userMessage: params.isLumaRay2
+      ? LUMA_RAY2_ERROR_UNSUPPORTED
+      : translatedMessage ?? 'This request cannot be processed for this engine. Please adjust your inputs and try again.',
+    providerMessage: translatedProviderMessage ?? params.effectiveProviderMessage ?? params.providerMessage ?? null,
+  };
+}

--- a/frontend/app/api/generate/_lib/request-options.ts
+++ b/frontend/app/api/generate/_lib/request-options.ts
@@ -441,11 +441,11 @@ function normalizeGenerationElements(value: unknown): GenerationElement[] | null
       const videoUrl =
         typeof record.videoUrl === 'string' && record.videoUrl.trim().length ? record.videoUrl.trim() : null;
       if (!frontalImageUrl && referenceImageUrls.length === 0 && !videoUrl) return null;
-      return {
-        frontalImageUrl: frontalImageUrl ?? undefined,
-        referenceImageUrls: referenceImageUrls.length ? referenceImageUrls : undefined,
-        videoUrl: videoUrl ?? undefined,
-      };
+      const element: GenerationElement = {};
+      if (frontalImageUrl) element.frontalImageUrl = frontalImageUrl;
+      if (referenceImageUrls.length) element.referenceImageUrls = referenceImageUrls;
+      if (videoUrl) element.videoUrl = videoUrl;
+      return element;
     })
     .filter((entry: GenerationElement | null): entry is GenerationElement => Boolean(entry));
 

--- a/frontend/app/api/generate/route.ts
+++ b/frontend/app/api/generate/route.ts
@@ -3,17 +3,9 @@ export const runtime = 'nodejs';
 import { NextRequest, NextResponse } from 'next/server';
 import { isDatabaseConfigured, query } from '@/lib/db';
 import { randomUUID } from 'crypto';
-import { generateVideo, FalGenerationError } from '@/lib/fal';
 import { getConfiguredEngine, getConfiguredEngineIncludingHidden } from '@/server/engines';
 import { ensureBillingSchema } from '@/lib/schema';
 import type { Mode } from '@/types/engines';
-import {
-  condenseFalErrorMessage,
-  extractFalProviderMessage,
-  FalTimeoutError,
-  shouldDeferFalError,
-  withFalTimeout,
-} from './_lib/fal-error-handling';
 import { validateExtraInputValues } from './_lib/extra-input-values';
 import { processGenerationAttachments } from './_lib/attachments';
 import { deriveGenerationAttachmentReferences } from './_lib/attachment-references';
@@ -30,6 +22,7 @@ import { buildGenerateValidationPayload } from './_lib/validation-payload';
 import { submitBytePlusGenerateTask } from './_lib/byteplus-submission';
 import { buildGenerateRequestOptions, isVideoMode } from './_lib/request-options';
 import { resolveGenerateUserGate } from './_lib/auth-idempotency';
+import { submitFalGenerateTask } from './_lib/fal-submission';
 import {
   buildResponseFromExistingVideoJob,
   createAtomicInitialVideoJob,
@@ -38,8 +31,6 @@ import {
 } from './_lib/initial-video-job';
 import { rollbackPendingPayment } from './_lib/payment-rollback';
 import { generateAndPersistJobKeyframes } from '@/server/video-keyframes';
-import { translateError, type ErrorTranslationInput } from '@/lib/error-messages';
-import { LUMA_RAY2_ERROR_UNSUPPORTED } from '@/lib/luma-ray2';
 import { ensureUserPreferredCurrency } from '@/lib/currency';
 import { AdminAuthError, requireAdmin } from '@/server/admin';
 import {
@@ -53,66 +44,6 @@ import {
   shouldRoutePublicSeedanceToBytePlus,
   shouldRoutePublicSeedanceFastToBytePlus,
 } from '@/server/video-providers/byteplus-modelark';
-
-const LUMA_RAY2_TIMEOUT_MS = 180_000;
-const FAL_RETRY_DELAYS_MS = [5_000, 15_000, 30_000];
-const FAL_HARD_TIMEOUT_MS = 400_000;
-const FAL_PROGRESS_FLOOR = 10;
-
-async function markJobAwaitingFal(params: {
-  jobId: string;
-  engineId: string;
-  providerJobId: string | null;
-  message: string | null;
-  statusLabel: string;
-  attempt: number;
-  context?: Record<string, unknown>;
-  progressFloor?: number;
-}): Promise<void> {
-  const progressFloor = params.progressFloor ?? FAL_PROGRESS_FLOOR;
-  const message = params.message ? condenseFalErrorMessage(params.message) : null;
-  try {
-    await query(
-      `UPDATE app_jobs
-       SET status = 'running',
-           progress = GREATEST(progress, $2),
-           message = CASE WHEN $3 IS NOT NULL THEN $3::text ELSE message END,
-           provider_job_id = COALESCE($4, provider_job_id),
-           provisional = FALSE,
-           updated_at = NOW()
-       WHERE job_id = $1`,
-      [params.jobId, progressFloor, message, params.providerJobId]
-    );
-  } catch (error) {
-    console.warn('[api/generate] failed to mark job awaiting Fal', { jobId: params.jobId }, error);
-  }
-
-  if (!params.providerJobId) {
-    return;
-  }
-
-  try {
-    await query(
-      `INSERT INTO fal_queue_log (job_id, provider, provider_job_id, engine_id, status, payload)
-       VALUES ($1,$2,$3,$4,$5,$6::jsonb)`,
-      [
-        params.jobId,
-        'fal',
-        params.providerJobId,
-        params.engineId,
-        params.statusLabel,
-        JSON.stringify({
-          attempt: params.attempt,
-          at: new Date().toISOString(),
-          message,
-          context: params.context ?? null,
-        }),
-      ]
-    );
-  } catch (error) {
-    console.warn('[queue-log] failed to record transient Fal event', error);
-  }
-}
 
 export async function POST(req: NextRequest) {
   const requestStartedAt = Date.now();
@@ -271,7 +202,6 @@ export async function POST(req: NextRequest) {
   }
   const validatedExtraInputValues = extraInputValidation.values;
 
-  let generationResult: Awaited<ReturnType<typeof generateVideo>> | null = null;
   const attachmentProcessing = await processGenerationAttachments({ rawInputs: body.inputs, userId });
   if (!attachmentProcessing.ok) {
     return NextResponse.json(attachmentProcessing.body, { status: attachmentProcessing.status });
@@ -616,305 +546,26 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  try {
-    const promise = generateVideo(
-      { ...falPayload },
-      {
-        onRequestId: (requestId) => {
-          console.info('[fal] request id received', { jobId, engineId: engine.id, requestId });
-          persistProviderJobId(requestId);
-        },
-        onQueueUpdate: (status) => {
-          if (!status) return;
-          const requestId =
-            (status as { request_id?: string }).request_id ?? getLastProviderJobId() ?? null;
-          setLastProviderJobId(requestId);
-        },
-      }
-    );
-    generationResult = await withFalTimeout(
-      promise,
-      isLumaRay2 ? LUMA_RAY2_TIMEOUT_MS : FAL_HARD_TIMEOUT_MS
-    );
-  } catch (error) {
-    const rawStatus =
-      error && typeof error === 'object' && 'status' in error ? (error as { status?: number }).status : undefined;
-    const metadataStatus =
-      error && typeof error === 'object' && '$metadata' in error
-        ? ((error as { $metadata?: { httpStatusCode?: number } }).$metadata?.httpStatusCode)
-        : undefined;
-    const status = rawStatus ?? metadataStatus;
-    const detail =
-      error && typeof error === 'object' && 'body' in error ? (error as { body?: unknown }).body ?? null : null;
-    const providerMessageRaw =
-      extractFalProviderMessage(detail) ??
-      (error instanceof FalGenerationError && error.body ? extractFalProviderMessage(error.body) : null) ??
-      (error && typeof error === 'object' && 'response' in error
-        ? extractFalProviderMessage((error as { response?: unknown }).response)
-        : null) ??
-      extractFalProviderMessage(error) ??
-      (error instanceof Error ? error.message : null);
-    const providerMessage = condenseFalErrorMessage(providerMessageRaw);
-    const effectiveProviderMessage =
-      providerMessage && providerMessage.toLowerCase() === 'fal request failed' ? null : providerMessage;
-    const isTimeoutError = error instanceof FalTimeoutError;
-    const isQuotaError =
-      status === 429 ||
-      (typeof providerMessage === 'string' && providerMessage.toLowerCase().includes('quota'));
-    const fallbackMessage = isTimeoutError
-      ? 'Generation timed out'
-      : isQuotaError
-        ? 'Provider is rate limiting'
-        : 'Fal request failed';
-    const rawErrorCode =
-      typeof (error as { code?: string } | undefined)?.code === 'string'
-        ? (error as { code?: string }).code
-        : null;
-    const translation = translateError({
-      code: isTimeoutError ? 'PROVIDER_BUSY' : isQuotaError ? 'RATE_LIMITED' : rawErrorCode,
-      status,
-      message: effectiveProviderMessage ?? providerMessage ?? fallbackMessage,
-      providerMessage: effectiveProviderMessage ?? providerMessage ?? null,
-    });
-    const failureMessage = translation.message;
-    const errorCode = translation.code;
-    const providerJobId: string | null =
-      error instanceof FalGenerationError && error.providerJobId
-        ? error.providerJobId
-        : typeof (error as { providerJobId?: string } | undefined)?.providerJobId === 'string'
-          ? (error as { providerJobId?: string }).providerJobId!
-          : getLastProviderJobId() ?? batchId ?? null;
-  const paymentStatusOverride =
-      pendingReceipt && paymentMode === 'wallet'
-        ? 'refunded_wallet'
-        : pendingReceipt && paymentMode !== 'wallet'
-          ? 'refunded'
-          : null;
-    const baseRefundDescription = `Refund ${engine.label} - ${durationSec}s`;
-    const refundNote = failureMessage ?? null;
-    const refundDescription = refundNote ? `${baseRefundDescription} - ${refundNote}` : baseRefundDescription;
-
-    if (error instanceof FalGenerationError) {
-      (error as { code?: string }).code = errorCode;
-      (error as { userMessage?: string }).userMessage = failureMessage;
-    }
-
-    console.error(
-      '[api/generate] Fal generation failed',
-      {
-        jobId,
-        engineId: engine.id,
-        status,
-        providerJobId,
-        providerMessage: effectiveProviderMessage ?? providerMessage ?? null,
-        detail: detail ?? null,
-      },
-      error
-    );
-
-    const deferable =
-      !isQuotaError &&
-      shouldDeferFalError({
-        error,
-        status,
-        detail,
-        providerMessage: effectiveProviderMessage ?? providerMessage ?? fallbackMessage,
-        providerJobId,
-      });
-
-    if (isTimeoutError) {
-      const progressFloor = Math.min(95, FAL_PROGRESS_FLOOR + FAL_RETRY_DELAYS_MS.length * 5);
-      const waitingMessage =
-        effectiveProviderMessage && effectiveProviderMessage !== fallbackMessage
-          ? `Still processing: ${effectiveProviderMessage}. Your request is in progress; we will update you shortly.`
-          : 'Rendering in progress; awaiting provider after timeout. We will refresh as soon as the next status arrives.';
-
-      if (providerJobId) {
-        await markJobAwaitingFal({
-          jobId,
-          engineId: engine.id,
-          providerJobId,
-          message: waitingMessage,
-          statusLabel: 'deferred',
-          attempt: FAL_RETRY_DELAYS_MS.length + 1,
-          context: {
-            status,
-            deferred: true,
-            timeout: true,
-          },
-          progressFloor,
-        });
-      } else {
-        await query(
-          `UPDATE app_jobs
-             SET status = 'running',
-                 progress = $2,
-                 message = $3,
-                 provisional = FALSE,
-                 updated_at = NOW()
-           WHERE job_id = $1`,
-          [jobId, progressFloor, waitingMessage]
-        ).catch((updateError) => {
-          console.error('[api/generate] failed to mark timeout job awaiting provider', updateError);
-        });
-      }
-
-      return NextResponse.json(
-        {
-          ok: true,
-          jobId,
-          status: 'running',
-          progress: progressFloor,
-          providerJobId,
-          deferred: true,
-          message: waitingMessage,
-        },
-        { status: 202 }
-      );
-    }
-
-    if (deferable && providerJobId) {
-      const progressFloor = Math.min(95, FAL_PROGRESS_FLOOR + FAL_RETRY_DELAYS_MS.length * 5);
-      const waitingMessage =
-        effectiveProviderMessage && effectiveProviderMessage !== fallbackMessage
-          ? `Still processing: ${effectiveProviderMessage}. Your request is in progress; we will update you shortly.`
-          : 'Rendering in progress; next update imminent. No action needed while we wait for the next status update.';
-
-      await markJobAwaitingFal({
-        jobId,
-        engineId: engine.id,
-        providerJobId,
-        message: waitingMessage,
-        statusLabel: 'deferred',
-        attempt: FAL_RETRY_DELAYS_MS.length + 1,
-        context: {
-          status,
-          deferred: true,
-        },
-        progressFloor,
-      });
-
-      return NextResponse.json(
-        {
-          ok: true,
-          jobId,
-          status: 'running',
-          progress: progressFloor,
-          providerJobId,
-          deferred: true,
-          message: waitingMessage,
-        },
-        { status: 202 }
-      );
-    }
-
-    try {
-      await query(
-        `UPDATE app_jobs
-         SET status = 'failed',
-             progress = 0,
-             message = $2,
-             provisional = FALSE,
-             provider_job_id = COALESCE($3, provider_job_id),
-             payment_status = CASE WHEN $4::text IS NOT NULL THEN $4 ELSE payment_status END,
-             updated_at = NOW()
-         WHERE job_id = $1`,
-        [jobId, failureMessage, providerJobId, paymentStatusOverride]
-      );
-    } catch (updateError) {
-      console.error('[api/generate] failed to update provisional job after Fal error', updateError);
-    }
-
-    if (pendingReceipt && !isTimeoutError) {
-      await rollbackPendingPayment({
-        pendingReceipt,
-        walletChargeReserved,
-        refundDescription,
-      });
-    }
-
-    if (status === 422) {
-      console.error('[generate] fal returned 422', providerMessage ?? '<no-provider-message>');
-
-      let translatedErrorCode: string | null = null;
-      let translatedMessage: string | null = null;
-      let translatedProviderMessage: string | null = null;
-
-      const resolveTranslation = (input: ErrorTranslationInput) => {
-        const translation = translateError(input);
-        translatedErrorCode = translation.code;
-        translatedMessage = translation.message;
-        translatedProviderMessage = translation.providerMessage ?? translation.originalMessage ?? null;
-      };
-
-      if (detail && Array.isArray(detail) && detail.length) {
-        const firstDetail = detail[0] as Record<string, unknown>;
-        const detailCode = typeof firstDetail.type === 'string' ? firstDetail.type : undefined;
-        const detailMessage = typeof firstDetail.msg === 'string' ? firstDetail.msg : undefined;
-        resolveTranslation({
-          code: detailCode ?? 'FAL_UNPROCESSABLE_ENTITY',
-          status,
-          message: detailMessage ?? effectiveProviderMessage ?? providerMessage ?? null,
-          providerMessage: detailMessage ?? effectiveProviderMessage ?? providerMessage ?? null,
-        });
-      } else if (detail && typeof detail === 'object' && detail !== null) {
-        const detailRecord = detail as Record<string, unknown>;
-        const detailCode = typeof detailRecord.code === 'string' ? detailRecord.code : undefined;
-        const detailMessage = typeof detailRecord.message === 'string' ? detailRecord.message : undefined;
-        resolveTranslation({
-          code: detailCode ?? 'FAL_UNPROCESSABLE_ENTITY',
-          status,
-          message: detailMessage ?? effectiveProviderMessage ?? providerMessage ?? null,
-          providerMessage: detailMessage ?? effectiveProviderMessage ?? providerMessage ?? null,
-        });
-      } else {
-        resolveTranslation({
-          code: 'FAL_UNPROCESSABLE_ENTITY',
-          status,
-          message: effectiveProviderMessage ?? providerMessage ?? null,
-          providerMessage: effectiveProviderMessage ?? providerMessage ?? null,
-        });
-      }
-
-      const userMessage = isLumaRay2
-        ? LUMA_RAY2_ERROR_UNSUPPORTED
-        : translatedMessage ?? 'This request cannot be processed for this engine. Please adjust your inputs and try again.';
-
-      logMetric('failed', {
-        errorCode: translatedErrorCode ?? 'FAL_UNPROCESSABLE_ENTITY',
-        meta: { stage: 'provider_422', providerJobId },
-      });
-      return NextResponse.json(
-        {
-          ok: false,
-          error: translatedErrorCode ?? 'FAL_UNPROCESSABLE_ENTITY',
-          message: userMessage,
-          providerMessage: translatedProviderMessage ?? effectiveProviderMessage ?? providerMessage ?? null,
-          detail: detail ?? providerMessage,
-        },
-        { status: 422 }
-      );
-    }
-
-    logMetric('failed', {
-      errorCode,
-      meta: {
-        stage: 'provider_error',
-        providerJobId,
-        providerStatus: status ?? metadataStatus ?? null,
-      },
-    });
-    return NextResponse.json(
-      {
-        ok: false,
-        error: errorCode,
-        message: failureMessage,
-        providerMessage: effectiveProviderMessage ?? providerMessage ?? null,
-        detail,
-      },
-      { status: isTimeoutError ? 504 : isQuotaError ? 429 : status ?? 500 }
-    );
+  const falSubmission = await submitFalGenerateTask({
+    falPayload,
+    jobId,
+    engineId: engine.id,
+    engineLabel: engine.label,
+    isLumaRay2,
+    batchId,
+    durationSec,
+    pendingReceipt,
+    paymentMode,
+    walletChargeReserved,
+    getLastProviderJobId,
+    setLastProviderJobId,
+    persistProviderJobId,
+    logMetricFn: logMetric,
+  });
+  if (!falSubmission.ok) {
+    return NextResponse.json(falSubmission.body, { status: falSubmission.status });
   }
+  const { generationResult } = falSubmission;
 
   if (!generationResult) {
     throw new Error('Fal generation did not return a result.');

--- a/tests/generate-fal-error-handling.test.ts
+++ b/tests/generate-fal-error-handling.test.ts
@@ -15,13 +15,15 @@ import {
 const root = process.cwd();
 const routePath = join(root, 'frontend/app/api/generate/route.ts');
 const helperPath = join(root, 'frontend/app/api/generate/_lib/fal-error-handling.ts');
+const submissionPath = join(root, 'frontend/app/api/generate/_lib/fal-submission.ts');
 
 const routeSource = readFileSync(routePath, 'utf8');
 const helperSource = readFileSync(helperPath, 'utf8');
+const submissionSource = existsSync(submissionPath) ? readFileSync(submissionPath, 'utf8') : '';
 
 test('generate route delegates Fal error handling helpers', () => {
   assert.ok(existsSync(helperPath), 'Fal error helpers should live in the generate route _lib folder');
-  assert.match(routeSource, /from '\.\/_lib\/fal-error-handling'/);
+  assert.match(submissionSource || routeSource, /from '\.\/fal-error-handling'/);
 
   for (const implementationName of [
     'normalizeFalErrorValue',

--- a/tests/generate-fal-submission.test.ts
+++ b/tests/generate-fal-submission.test.ts
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  markJobAwaitingFal,
+  submitFalGenerateTask,
+} from '../frontend/app/api/generate/_lib/fal-submission';
+import { FalTimeoutError } from '../frontend/app/api/generate/_lib/fal-error-handling';
+import type { GeneratePayload, GenerateResult } from '../frontend/src/lib/fal';
+
+const root = process.cwd();
+const routePath = join(root, 'frontend/app/api/generate/route.ts');
+const helperPath = join(root, 'frontend/app/api/generate/_lib/fal-submission.ts');
+const routeSource = readFileSync(routePath, 'utf8');
+
+test('generate route delegates Fal submission and transient error handling', () => {
+  assert.ok(existsSync(helperPath), 'Fal submission should live in the generate route _lib folder');
+  assert.match(routeSource, /from '\.\/_lib\/fal-submission'/);
+  assert.match(routeSource, /const falSubmission = await submitFalGenerateTask/);
+  assert.doesNotMatch(routeSource, /generateVideo\(/);
+  assert.doesNotMatch(routeSource, /shouldDeferFalError/);
+  assert.doesNotMatch(routeSource, /FAL_RETRY_DELAYS_MS/);
+  assert.doesNotMatch(routeSource, /function markJobAwaitingFal/);
+
+  const lineCount = routeSource.split('\n').length;
+  assert.ok(lineCount <= 845, `/api/generate route should stay below 845 lines after Fal submission extraction, got ${lineCount}`);
+});
+
+test('Fal submission helper exposes the route contract', () => {
+  const helperSource = readFileSync(helperPath, 'utf8');
+
+  assert.match(helperSource, /export async function markJobAwaitingFal/);
+  assert.match(helperSource, /export async function submitFalGenerateTask/);
+  assert.match(helperSource, /FAL_RETRY_DELAYS_MS/);
+  assert.match(helperSource, /translateError/);
+  assert.match(helperSource, /rollbackPendingPayment/);
+});
+
+test('markJobAwaitingFal updates the running job and records provider queue context', async () => {
+  const queries: Array<{ sql: string; params?: unknown[] }> = [];
+
+  await markJobAwaitingFal({
+    jobId: 'job_123',
+    engineId: 'seedance-2-0',
+    providerJobId: 'fal_123',
+    message: ' still\nprocessing ',
+    statusLabel: 'deferred',
+    attempt: 4,
+    context: { deferred: true },
+    deps: {
+      queryFn: async (sql, params) => {
+        queries.push({ sql, params });
+        return [];
+      },
+    },
+  });
+
+  assert.equal(queries.length, 2);
+  assert.match(queries[0].sql, /UPDATE app_jobs/);
+  assert.equal(queries[0].params?.[2], 'still processing');
+  assert.match(queries[1].sql, /INSERT INTO fal_queue_log/);
+  assert.deepEqual(queries[1].params?.slice(0, 5), ['job_123', 'fal', 'fal_123', 'seedance-2-0', 'deferred']);
+});
+
+test('submitFalGenerateTask returns generation results and persists request ids', async () => {
+  const payload: GeneratePayload = { engineId: 'seedance-2-0', prompt: 'test', mode: 't2v' };
+  const persisted: string[] = [];
+  const result = await withMutedFalLogs(() => submitFalGenerateTask({
+    falPayload: payload,
+    jobId: 'job_123',
+    engineId: 'seedance-2-0',
+    engineLabel: 'Seedance 2.0',
+    isLumaRay2: false,
+    batchId: null,
+    durationSec: 5,
+    pendingReceipt: null,
+    paymentMode: 'platform',
+    walletChargeReserved: false,
+    getLastProviderJobId: () => null,
+    setLastProviderJobId: () => undefined,
+    persistProviderJobId: async (providerJobId) => {
+      persisted.push(providerJobId);
+    },
+    logMetricFn: () => undefined,
+    deps: {
+      generateVideoFn: async (_payload, hooks) => {
+        await hooks?.onRequestId?.('fal_request_123');
+        return {
+          provider: 'fal',
+          thumbUrl: '/thumb.svg',
+          providerJobId: 'fal_request_123',
+          status: 'running',
+          progress: 10,
+        } as GenerateResult;
+      },
+      withFalTimeoutFn: async (promise) => promise,
+    },
+  }));
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.generationResult.providerJobId, 'fal_request_123');
+  assert.deepEqual(persisted, ['fal_request_123']);
+});
+
+test('submitFalGenerateTask defers timeout responses without refunding pending payments', async () => {
+  const updates: Array<{ sql: string; params?: unknown[] }> = [];
+  let rolledBack = false;
+  const result = await withMutedFalLogs(() => submitFalGenerateTask({
+    falPayload: { engineId: 'seedance-2-0', prompt: 'test', mode: 't2v' },
+    jobId: 'job_123',
+    engineId: 'seedance-2-0',
+    engineLabel: 'Seedance 2.0',
+    isLumaRay2: false,
+    batchId: null,
+    durationSec: 5,
+    pendingReceipt: { jobId: 'job_123' } as never,
+    paymentMode: 'direct',
+    walletChargeReserved: false,
+    getLastProviderJobId: () => null,
+    setLastProviderJobId: () => undefined,
+    persistProviderJobId: async () => undefined,
+    logMetricFn: () => undefined,
+    deps: {
+      generateVideoFn: async () => {
+        throw new FalTimeoutError('timeout');
+      },
+      withFalTimeoutFn: async (promise) => promise,
+      queryFn: async (sql, params) => {
+        updates.push({ sql, params });
+        return [];
+      },
+      rollbackPendingPaymentFn: async () => {
+        rolledBack = true;
+      },
+    },
+  }));
+
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.status, 202);
+  assert.equal(result.body.deferred, true);
+  assert.equal(result.body.status, 'running');
+  assert.equal(rolledBack, false);
+  assert.match(updates[0].sql, /UPDATE app_jobs/);
+});
+
+async function withMutedFalLogs<T>(fn: () => Promise<T>): Promise<T> {
+  const originalInfo = console.info;
+  const originalError = console.error;
+  console.info = () => undefined;
+  console.error = () => undefined;
+  try {
+    return await fn();
+  } finally {
+    console.info = originalInfo;
+    console.error = originalError;
+  }
+}


### PR DESCRIPTION
## Summary
- Extract Fal submit, timeout/defer handling, provider error translation, queue logging, and rollback behavior into a route-local helper
- Keep /api/generate focused on orchestration and JSON response wiring
- Fix the TypeScript exact optional property issue in request option element normalization
- Add contract tests for the Fal submission helper and update the Fal error helper contract

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-fal-submission.test.ts
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/generate-*.test.ts tests/provider-message-copy.test.ts
- pnpm run test:validate
- pnpm --dir frontend exec tsc --noEmit
- npm --prefix frontend run lint
- npm run lint:exposure