### PR TITLE
Split best-for detail helpers

### DIFF
--- a/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/best-for/[usecase]/_lib/best-for-detail-config.ts
+++ b/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/best-for/[usecase]/_lib/best-for-detail-config.ts
@@ -1,0 +1,388 @@
+import type { AppLocale } from '@/i18n/locales';
+import engineCatalog from '@/config/engine-catalog.json';
+import compareConfig from '@/config/compare-config.json';
+
+export interface Params {
+  locale?: AppLocale;
+  usecase: string;
+}
+
+export interface BestForEntry {
+  slug: string;
+  title: string;
+  description?: string;
+  tier: number;
+  topPicks?: string[];
+  relatedComparisons?: string[];
+}
+
+export type RelatedGuideEntry = BestForEntry & {
+  displayTitle: string;
+};
+
+export type EngineCatalogEntry = {
+  engineId?: string;
+  modelSlug: string;
+  marketingName: string;
+  provider?: string;
+  brandId?: string;
+  family?: string;
+  bestFor?: string;
+};
+
+export type EngineScore = {
+  engineId?: string;
+  modelSlug?: string;
+  fidelity?: number;
+  motion?: number;
+  anatomy?: number;
+  textRendering?: number;
+  consistency?: number;
+  lipsyncQuality?: number;
+  sequencingQuality?: number;
+};
+
+export type EngineScoresFile = {
+  version?: string;
+  last_updated?: string;
+  scores?: EngineScore[];
+};
+
+export type RankedPick = {
+  slug: string;
+  engine?: EngineCatalogEntry;
+  rank: number;
+  criterion: string;
+  score?: number;
+  accent: string;
+  reason: string;
+  bullets: string[];
+};
+
+export type ExamplePreviewPick = RankedPick & {
+  examplesSlug: string;
+  heroThumbUrl?: string | null;
+};
+
+export const BEST_FOR_PAGES = compareConfig.bestForPages as BestForEntry[];
+export const ENGINE_CATALOG = engineCatalog as EngineCatalogEntry[];
+export const ENGINE_BY_SLUG = new Map(ENGINE_CATALOG.map((entry) => [entry.modelSlug, entry]));
+
+export const DETAIL_COPY: Record<
+  AppLocale,
+  {
+    eyebrow: string;
+    shortlist: string;
+    shortlistDescription: string;
+    ranked: string;
+    rank: string;
+    topPick: string;
+    provider: string;
+    fit: string;
+    evidence: string;
+    topReason: string;
+    shortlistReason: string;
+    viewModel: string;
+    viewExamples: string;
+    compareWith: string;
+    compareShortlistCta: string;
+    examplesCta: string;
+    alsoAvailable: string;
+    chooseTitle: string;
+    examplesTitle: string;
+    examplesDescription: string;
+    whyTitle: string;
+    mistakesTitle: string;
+    fullAnalysis: string;
+    relatedGuides: string;
+    allGuides: string;
+    score: string;
+    overall: string;
+    criteriaNote: string;
+    compareShortlist: string;
+    compareDescription: string;
+    contentComing: string;
+    backToHub: string;
+    backToTop: string;
+    criteria: string;
+    quickLinks: string;
+    tier: string;
+    browseAllExamples: string;
+  }
+> = {
+  en: {
+    eyebrow: 'Best for',
+    shortlist: 'Recommended shortlist',
+    shortlistDescription: 'Model cards use the same visual language as the model pages, with the strongest engines shown first.',
+    ranked: 'Ranked picks',
+    rank: 'Rank',
+    topPick: 'Top pick',
+    provider: 'Provider',
+    fit: 'Best fit',
+    evidence: 'Why it fits',
+    topReason: 'Primary recommendation for this search intent, based on the criteria above.',
+    shortlistReason: 'Strong shortlist option when this criterion matters for the final video.',
+    viewModel: 'View model',
+    viewExamples: 'View examples',
+    compareWith: 'Compare vs',
+    compareShortlistCta: 'Compare the shortlist',
+    examplesCta: 'View cinematic examples',
+    alsoAvailable: 'Also available',
+    chooseTitle: 'When should you choose each engine?',
+    examplesTitle: 'Examples to review first',
+    examplesDescription: 'Preview real output direction before making a decision.',
+    whyTitle: 'Why these models rank here',
+    mistakesTitle: 'Avoid these mistakes',
+    fullAnalysis: 'Read the full analysis',
+    relatedGuides: 'Related best-for guides',
+    allGuides: 'View all guides',
+    score: 'Score',
+    overall: 'Best overall',
+    criteriaNote: 'Scores combine quality, control, consistency, and cost efficiency.',
+    compareShortlist: 'Compare the shortlist',
+    compareDescription: 'Useful side-by-side pages for validating tradeoffs before picking a model.',
+    contentComing: 'Content coming soon.',
+    backToHub: 'Back to Best-for hub',
+    backToTop: 'Back to top',
+    criteria: 'Decision criteria',
+    quickLinks: 'Quick links',
+    tier: 'Tier',
+    browseAllExamples: 'Browse all examples',
+  },
+  fr: {
+    eyebrow: 'Meilleur pour',
+    shortlist: 'Shortlist recommandée',
+    shortlistDescription: 'Les cards reprennent le style des pages modèles, avec les modèles les plus adaptés en premier.',
+    ranked: 'Sélection classée',
+    rank: 'Rang',
+    topPick: 'Premier choix',
+    provider: 'Fournisseur',
+    fit: 'Meilleur usage',
+    evidence: 'Pourquoi ça matche',
+    topReason: 'Recommandation principale pour cette intention de recherche, d’après les critères ci-dessus.',
+    shortlistReason: 'Option forte de la shortlist quand ce critère compte dans la vidéo finale.',
+    viewModel: 'Voir le modèle',
+    viewExamples: 'Voir les exemples',
+    compareWith: 'Comparer avec',
+    compareShortlistCta: 'Comparer la shortlist',
+    examplesCta: 'Voir les exemples cinéma',
+    alsoAvailable: 'Aussi disponible',
+    chooseTitle: 'Quand choisir chaque modèle ?',
+    examplesTitle: 'Exemples à vérifier d’abord',
+    examplesDescription: 'Prévisualisez le rendu avant de choisir un modèle.',
+    whyTitle: 'Pourquoi ces modèles sont classés ici',
+    mistakesTitle: 'Erreurs à éviter',
+    fullAnalysis: 'Lire l’analyse complète',
+    relatedGuides: 'Guides Best-for liés',
+    allGuides: 'Voir tous les guides',
+    score: 'Score',
+    overall: 'Meilleur choix',
+    criteriaNote: 'Les scores combinent qualité, contrôle, cohérence et efficacité coût.',
+    compareShortlist: 'Comparer la shortlist',
+    compareDescription: 'Des pages côte à côte utiles pour valider les compromis avant de choisir un modèle.',
+    contentComing: 'Contenu bientôt disponible.',
+    backToHub: 'Retour au hub Best-for',
+    backToTop: 'Retour en haut',
+    criteria: 'Critères de décision',
+    quickLinks: 'Liens rapides',
+    tier: 'Niveau',
+    browseAllExamples: 'Voir tous les exemples',
+  },
+  es: {
+    eyebrow: 'Mejor para',
+    shortlist: 'Shortlist recomendada',
+    shortlistDescription: 'Las cards reutilizan el lenguaje visual de las páginas de modelos, con los modelos ideales primero.',
+    ranked: 'Selección ordenada',
+    rank: 'Puesto',
+    topPick: 'Primera opción',
+    provider: 'Proveedor',
+    fit: 'Ideal para',
+    evidence: 'Por qué encaja',
+    topReason: 'Recomendación principal para esta intención de búsqueda, según los criterios anteriores.',
+    shortlistReason: 'Opción fuerte de la shortlist cuando este criterio pesa en el video final.',
+    viewModel: 'Ver modelo',
+    viewExamples: 'Ver ejemplos',
+    compareWith: 'Comparar con',
+    compareShortlistCta: 'Comparar la shortlist',
+    examplesCta: 'Ver ejemplos cinematográficos',
+    alsoAvailable: 'También disponible',
+    chooseTitle: '¿Cuándo elegir cada modelo?',
+    examplesTitle: 'Ejemplos para revisar primero',
+    examplesDescription: 'Previsualiza la dirección del resultado antes de elegir un modelo.',
+    whyTitle: 'Por qué estos modelos están aquí',
+    mistakesTitle: 'Evita estos errores',
+    fullAnalysis: 'Leer el análisis completo',
+    relatedGuides: 'Guías Mejor para relacionadas',
+    allGuides: 'Ver todas las guías',
+    score: 'Puntuación',
+    overall: 'Mejor opción',
+    criteriaNote: 'Las puntuaciones combinan calidad, control, consistencia y eficiencia de costo.',
+    compareShortlist: 'Comparar la shortlist',
+    compareDescription: 'Páginas lado a lado útiles para validar compromisos antes de elegir modelo.',
+    contentComing: 'Contenido próximamente.',
+    backToHub: 'Volver al espacio Mejor para',
+    backToTop: 'Volver arriba',
+    criteria: 'Criterios de decisión',
+    quickLinks: 'Enlaces rápidos',
+    tier: 'Nivel',
+    browseAllExamples: 'Ver todos los ejemplos',
+  },
+};
+
+export type BestForDetailCopy = (typeof DETAIL_COPY)[AppLocale];
+
+export const USECASE_CRITERIA: Record<string, Record<AppLocale, string[]>> = {
+  'image-to-video': {
+    en: ['Image fidelity after motion', 'Camera control from a still', 'Clean product and subject preservation'],
+    fr: ['Fidélité de l’image après mouvement', 'Contrôle caméra depuis une image fixe', 'Préservation propre du produit ou sujet'],
+    es: ['Fidelidad de imagen tras el movimiento', 'Control de cámara desde una imagen fija', 'Preservación limpia del producto o sujeto'],
+  },
+  'cinematic-realism': {
+    en: ['Camera language and lighting', 'Natural motion physics', 'High-end visual polish'],
+    fr: ['Langage caméra et lumière', 'Physique du mouvement naturelle', 'Rendu visuel premium'],
+    es: ['Lenguaje de cámara e iluminación', 'Física de movimiento natural', 'Pulido visual premium'],
+  },
+  'character-reference': {
+    en: ['Stable identity', 'Wardrobe and prop retention', 'Reference-aware shot control'],
+    fr: ['Identité stable', 'Tenue et accessoires conservés', 'Contrôle des plans par référence'],
+    es: ['Identidad estable', 'Vestuario y accesorios consistentes', 'Control de planos con referencia'],
+  },
+  'reference-to-video': {
+    en: ['Strong visual reference following', 'Flexible image or clip guidance', 'Good result with approved assets'],
+    fr: ['Respect fort des références visuelles', 'Guidage flexible par image ou clip', 'Bon rendu depuis assets validés'],
+    es: ['Seguimiento fuerte de referencias visuales', 'Guía flexible por imagen o clip', 'Buen resultado con assets aprobados'],
+  },
+  'multi-shot-video': {
+    en: ['Several shots from one prompt', 'Sequence continuity', 'Edited-feeling final output'],
+    fr: ['Plusieurs plans depuis un prompt', 'Continuité de séquence', 'Résultat final déjà monté'],
+    es: ['Varios planos desde un prompt', 'Continuidad de secuencia', 'Resultado final con sensación de montaje'],
+  },
+  '4k-video': {
+    en: ['Native or practical high resolution', 'Detail retention', 'Delivery-ready upscale path'],
+    fr: ['Haute résolution native ou exploitable', 'Conservation du détail', 'Chemin clair vers une livraison finale'],
+    es: ['Alta resolución nativa o práctica', 'Retención de detalle', 'Ruta clara hacia entrega final'],
+  },
+  ads: {
+    en: ['Product clarity', 'Campaign-grade polish', 'Variation-friendly output'],
+    fr: ['Clarté produit', 'Finition niveau campagne', 'Sorties faciles à décliner'],
+    es: ['Claridad de producto', 'Acabado de campaña', 'Salida fácil de versionar'],
+  },
+  'ugc-ads': {
+    en: ['Creator-style realism', 'Dialogue and social proof', 'Fast hook testing'],
+    fr: ['Réalisme style créateur', 'Dialogue et preuve sociale', 'Tests rapides de hooks'],
+    es: ['Realismo estilo creador', 'Diálogo y prueba social', 'Pruebas rápidas de hooks'],
+  },
+  'product-videos': {
+    en: ['Packshot stability', 'Material and texture quality', 'Clean ecommerce motion'],
+    fr: ['Stabilité packshot', 'Qualité matière et texture', 'Mouvement ecommerce propre'],
+    es: ['Estabilidad de packshot', 'Calidad de materiales y textura', 'Movimiento ecommerce limpio'],
+  },
+  'lipsync-dialogue': {
+    en: ['Mouth timing', 'Voice and native audio options', 'Face consistency'],
+    fr: ['Timing bouche', 'Options voix et audio natif', 'Cohérence du visage'],
+    es: ['Sincronía de boca', 'Opciones de voz y audio nativo', 'Consistencia facial'],
+  },
+  'fast-drafts': {
+    en: ['Iteration speed', 'Low-cost variants', 'Enough control for review'],
+    fr: ['Vitesse d’itération', 'Variantes à coût réduit', 'Contrôle suffisant pour valider'],
+    es: ['Velocidad de iteración', 'Variantes de bajo costo', 'Control suficiente para revisar'],
+  },
+  'stylized-anime': {
+    en: ['Stylized motion', 'Illustration coherence', 'Non-photoreal flexibility'],
+    fr: ['Mouvement stylisé', 'Cohérence d’illustration', 'Flexibilité non photoréaliste'],
+    es: ['Movimiento estilizado', 'Coherencia de ilustración', 'Flexibilidad no fotorrealista'],
+  },
+};
+
+export const USECASE_CHIPS: Record<string, Record<AppLocale, string[]>> = {
+  'image-to-video': {
+    en: ['Image fidelity', 'Motion control', 'Subject lock', 'Reference frames', 'Cost control'],
+    fr: ['Fidélité image', 'Contrôle du mouvement', 'Sujet verrouillé', 'Frames de référence', 'Contrôle du coût'],
+    es: ['Fidelidad de imagen', 'Control de movimiento', 'Sujeto estable', 'Frames de referencia', 'Control de costo'],
+  },
+  'cinematic-realism': {
+    en: ['Camera language', 'Lighting', 'Motion physics', 'Visual polish', 'Cost control'],
+    fr: ['Langage caméra', 'Lumière', 'Physique du mouvement', 'Rendu visuel', 'Contrôle du coût'],
+    es: ['Lenguaje de cámara', 'Iluminación', 'Física del movimiento', 'Pulido visual', 'Control de costo'],
+  },
+  'character-reference': {
+    en: ['Identity lock', 'Wardrobe', 'Props', 'Shot continuity', 'Input limits'],
+    fr: ['Identité verrouillée', 'Tenue', 'Accessoires', 'Continuité des plans', 'Limites d’entrée'],
+    es: ['Identidad estable', 'Vestuario', 'Props', 'Continuidad de planos', 'Límites de entrada'],
+  },
+  'reference-to-video': {
+    en: ['References', 'Style frames', 'Audio cues', 'Product consistency', 'Output control'],
+    fr: ['Références', 'Style frames', 'Repères audio', 'Cohérence produit', 'Contrôle du rendu'],
+    es: ['Referencias', 'Style frames', 'Señales de audio', 'Consistencia de producto', 'Control de salida'],
+  },
+  'multi-shot-video': {
+    en: ['Shot order', 'Continuity', 'Scene labels', 'Prompt structure', 'Final edit'],
+    fr: ['Ordre des plans', 'Continuité', 'Labels de scène', 'Structure du prompt', 'Montage final'],
+    es: ['Orden de planos', 'Continuidad', 'Etiquetas de escena', 'Estructura del prompt', 'Edición final'],
+  },
+  '4k-video': {
+    en: ['Native 4K', 'Detail retention', 'Upscale path', 'Final delivery', 'Cost control'],
+    fr: ['4K native', 'Détails conservés', 'Chemin upscale', 'Livraison finale', 'Contrôle du coût'],
+    es: ['4K nativo', 'Retención de detalle', 'Ruta de upscale', 'Entrega final', 'Control de costo'],
+  },
+  ads: {
+    en: ['Product clarity', 'Offer framing', 'Visual polish', 'Variant testing', 'Review speed'],
+    fr: ['Clarté produit', 'Angle offre', 'Rendu propre', 'Tests de variantes', 'Vitesse de review'],
+    es: ['Claridad de producto', 'Marco de oferta', 'Pulido visual', 'Pruebas de variantes', 'Velocidad de revisión'],
+  },
+  'ugc-ads': {
+    en: ['Creator realism', 'Dialogue', 'Face consistency', 'Hook testing', 'Social proof'],
+    fr: ['Réalisme créateur', 'Dialogue', 'Cohérence visage', 'Tests de hooks', 'Preuve sociale'],
+    es: ['Realismo de creador', 'Diálogo', 'Consistencia facial', 'Pruebas de hooks', 'Prueba social'],
+  },
+  'product-videos': {
+    en: ['Packshot stability', 'Textures', 'Clean reveals', 'Ecommerce motion', 'Brand fit'],
+    fr: ['Stabilité packshot', 'Textures', 'Reveals propres', 'Mouvement ecommerce', 'Fit marque'],
+    es: ['Estabilidad de packshot', 'Texturas', 'Reveals limpios', 'Movimiento ecommerce', 'Encaje de marca'],
+  },
+  'lipsync-dialogue': {
+    en: ['Mouth timing', 'Voice sync', 'Face consistency', 'Audio options', 'Short dialogue'],
+    fr: ['Timing bouche', 'Sync voix', 'Cohérence visage', 'Options audio', 'Dialogue court'],
+    es: ['Timing de boca', 'Sync de voz', 'Consistencia facial', 'Opciones de audio', 'Diálogo corto'],
+  },
+  'fast-drafts': {
+    en: ['Speed', 'Low cost', 'Rough timing', 'Variant testing', 'Review loop'],
+    fr: ['Vitesse', 'Coût bas', 'Timing brouillon', 'Tests de variantes', 'Boucle de review'],
+    es: ['Velocidad', 'Bajo costo', 'Timing preliminar', 'Pruebas de variantes', 'Ciclo de revisión'],
+  },
+  'stylized-anime': {
+    en: ['Line quality', 'Style consistency', 'Color blocks', 'Stylized motion', 'Creative tests'],
+    fr: ['Qualité du trait', 'Cohérence de style', 'Aplats de couleur', 'Mouvement stylisé', 'Tests créatifs'],
+    es: ['Calidad de línea', 'Consistencia de estilo', 'Bloques de color', 'Movimiento estilizado', 'Pruebas creativas'],
+  },
+};
+
+export const DECISION_CRITERIA_FILLERS: Record<AppLocale, string[]> = {
+  en: ['Cost efficiency and speed', 'Reliability and consistency'],
+  fr: ['Efficacité coût et vitesse', 'Fiabilité et cohérence'],
+  es: ['Eficiencia de costo y velocidad', 'Fiabilidad y consistencia'],
+};
+
+export const USECASE_MISTAKE_FALLBACKS: Record<AppLocale, string[]> = {
+  en: [
+    'Choosing a model without matching the use case.',
+    'Ignoring references, style frames, or input limits.',
+    'Overcomplicating the first-pass prompt.',
+    'Skipping draft passes and going straight to premium.',
+    'Not checking cost before generation.',
+  ],
+  fr: [
+    'Choisir un modèle sans matcher le cas d’usage.',
+    'Ignorer les références, style frames ou limites d’input.',
+    'Complexifier le prompt dès la première passe.',
+    'Sauter les tests et aller directement sur du premium.',
+    'Ne pas vérifier le coût avant génération.',
+  ],
+  es: [
+    'Elegir un modelo sin ajustar el objetivo creativo.',
+    'Ignorar referencias, style frames o límites de entrada.',
+    'Complicar demasiado el primer prompt.',
+    'Saltar los borradores e ir directo a premium.',
+    'No revisar el costo antes de generar.',
+  ],
+};

--- a/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/best-for/[usecase]/_lib/best-for-detail-helpers.ts
+++ b/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/best-for/[usecase]/_lib/best-for-detail-helpers.ts
@@ -1,0 +1,651 @@
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+import type { AppLocale } from '@/i18n/locales';
+import { defaultLocale, locales } from '@/i18n/locales';
+import { getLocalizedUrl } from '@/lib/metadataUrls';
+import { canonicalizePublishedCompareSlug, isPublishedComparisonSlug } from '@/lib/compare-hub/data';
+import { getContentEntries, getEntryBySlug } from '@/lib/content/markdown';
+import { EXAMPLES_HERO_SELECTION_LIMIT, pickFirstPlayableVideo } from '@/lib/examples/heroVideo';
+import { listExampleFamilyPage } from '@/server/videos';
+import {
+  BEST_FOR_PAGES,
+  DECISION_CRITERIA_FILLERS,
+  ENGINE_BY_SLUG,
+  ENGINE_CATALOG,
+  USECASE_CHIPS,
+  USECASE_CRITERIA,
+  USECASE_MISTAKE_FALLBACKS,
+  type BestForDetailCopy,
+  type BestForEntry,
+  type EngineCatalogEntry,
+  type EngineScore,
+  type EngineScoresFile,
+  type ExamplePreviewPick,
+  type RankedPick,
+  type RelatedGuideEntry,
+} from './best-for-detail-config';
+
+export function getEntry(slug: string): BestForEntry | undefined {
+  return BEST_FOR_PAGES.find((entry) => entry.slug === slug);
+}
+
+export function buildComparisonLabel(slug: string) {
+  const [leftSlug, rightSlug] = slug.split('-vs-');
+  const left = leftSlug ? ENGINE_BY_SLUG.get(leftSlug)?.marketingName ?? leftSlug : slug;
+  const right = rightSlug ? ENGINE_BY_SLUG.get(rightSlug)?.marketingName ?? rightSlug : '';
+  return right ? `${left} vs ${right}` : slug;
+}
+
+export async function getBestForEntry(locale: AppLocale, slug: string) {
+  const localizedRoot = locale === defaultLocale ? 'content/en/best-for' : `content/${locale}/best-for`;
+  const localized = await getEntryBySlug(localizedRoot, slug);
+  if (localized) return localized;
+  return getEntryBySlug('content/en/best-for', slug);
+}
+
+export async function getLocalizedBestForEntry(locale: AppLocale, slug: string) {
+  const localizedRoot = locale === defaultLocale ? 'content/en/best-for' : `content/${locale}/best-for`;
+  return getEntryBySlug(localizedRoot, slug);
+}
+
+export async function resolveAvailableLocales(slug: string): Promise<AppLocale[]> {
+  const available = await Promise.all(
+    locales.map(async (locale) => {
+      const localized = await getEntryBySlug(`content/${locale}/best-for`, slug);
+      if (localized) {
+        return locale;
+      }
+      if (locale === 'en') {
+        const fallback = await getEntryBySlug('content/en/best-for', slug);
+        if (fallback) {
+          return locale;
+        }
+      }
+      return null;
+    })
+  );
+  const filtered = available.filter((locale): locale is AppLocale => Boolean(locale));
+  return filtered.length ? filtered : (['en'] as AppLocale[]);
+}
+
+export async function loadEngineScores(): Promise<Map<string, EngineScore>> {
+  const candidates = [
+    path.join(process.cwd(), 'data', 'benchmarks', 'engine-scores.v1.json'),
+    path.join(process.cwd(), '..', 'data', 'benchmarks', 'engine-scores.v1.json'),
+  ];
+  for (const candidate of candidates) {
+    try {
+      const raw = await fs.readFile(candidate, 'utf8');
+      const data = JSON.parse(raw) as EngineScoresFile;
+      const map = new Map<string, EngineScore>();
+      (data.scores ?? []).forEach((entry) => {
+        const key = entry.modelSlug ?? entry.engineId;
+        if (key) {
+          map.set(key, entry);
+        }
+      });
+      return map;
+    } catch {
+      // keep trying
+    }
+  }
+  return new Map();
+}
+
+const USECASE_WEIGHTS: Record<string, Partial<Record<keyof EngineScore, number>>> = {
+  'ugc-ads': { motion: 0.3, fidelity: 0.25, consistency: 0.2, lipsyncQuality: 0.15, textRendering: 0.1 },
+  'product-videos': { fidelity: 0.35, consistency: 0.25, anatomy: 0.2, motion: 0.1, textRendering: 0.1 },
+  'lipsync-dialogue': { lipsyncQuality: 0.4, consistency: 0.2, fidelity: 0.2, motion: 0.1, anatomy: 0.1 },
+  'cinematic-realism': { fidelity: 0.35, motion: 0.25, consistency: 0.2, anatomy: 0.1, textRendering: 0.1 },
+  'fast-drafts': { motion: 0.3, consistency: 0.25, fidelity: 0.2, textRendering: 0.15, anatomy: 0.1 },
+  'vertical-shorts': { motion: 0.3, consistency: 0.25, fidelity: 0.2, textRendering: 0.15, anatomy: 0.1 },
+  'image-to-video': { consistency: 0.3, fidelity: 0.3, motion: 0.2, anatomy: 0.1, textRendering: 0.1 },
+  'stylized-anime': { consistency: 0.3, motion: 0.25, fidelity: 0.2, textRendering: 0.15, anatomy: 0.1 },
+  'character-reference': { consistency: 0.4, anatomy: 0.2, fidelity: 0.2, motion: 0.1, textRendering: 0.1 },
+  'reference-to-video': { consistency: 0.35, fidelity: 0.3, motion: 0.2, anatomy: 0.1, textRendering: 0.05 },
+  'multi-shot-video': { sequencingQuality: 0.35, consistency: 0.25, motion: 0.2, fidelity: 0.15, anatomy: 0.05 },
+  '4k-video': { fidelity: 0.45, consistency: 0.25, motion: 0.15, anatomy: 0.1, textRendering: 0.05 },
+  ads: { fidelity: 0.3, consistency: 0.25, textRendering: 0.2, motion: 0.15, anatomy: 0.1 },
+};
+
+function scoreEngineForUsecase(score: EngineScore, weights: Partial<Record<keyof EngineScore, number>>) {
+  let total = 0;
+  let weightSum = 0;
+  Object.entries(weights).forEach(([key, weight]) => {
+    const value = score[key as keyof EngineScore];
+    if (typeof value === 'number' && typeof weight === 'number') {
+      total += value * weight;
+      weightSum += weight;
+    }
+  });
+  if (weightSum === 0) return 0;
+  return total / weightSum;
+}
+
+export function resolveTopPicks(entry: BestForEntry, scores: Map<string, EngineScore>): string[] {
+  if (entry.topPicks?.length) return entry.topPicks;
+  const weights = USECASE_WEIGHTS[entry.slug] ?? {};
+  const ranked = ENGINE_CATALOG.map((engine) => {
+    const score = scores.get(engine.modelSlug) ?? (engine.engineId ? scores.get(engine.engineId) : null) ?? null;
+    const value = score ? scoreEngineForUsecase(score, weights) : 0;
+    return { slug: engine.modelSlug, value };
+  })
+    .sort((a, b) => b.value - a.value)
+    .slice(0, 3)
+    .map((entry) => entry.slug);
+  return ranked.length ? ranked : ENGINE_CATALOG.slice(0, 3).map((engine) => engine.modelSlug);
+}
+
+export function buildRankedPick({
+  usecaseSlug,
+  modelSlug,
+  rank,
+  scores,
+  criteria,
+  copy,
+  locale,
+}: {
+  usecaseSlug: string;
+  modelSlug: string;
+  rank: number;
+  scores: Map<string, EngineScore>;
+  criteria: string[];
+  copy: BestForDetailCopy;
+  locale: AppLocale;
+}): RankedPick {
+  const engine = ENGINE_BY_SLUG.get(modelSlug);
+  const score = getFitScore(usecaseSlug, scores.get(modelSlug) ?? (engine?.engineId ? scores.get(engine.engineId) : undefined));
+  const criterion = criteria[(rank - 1) % criteria.length] ?? criteria[0] ?? copy.fit;
+  const fallbackScore = Math.max(6.8, 8.6 - rank * 0.22);
+  return {
+    slug: modelSlug,
+    engine,
+    rank,
+    criterion,
+    score: score ?? fallbackScore,
+    accent: getEngineAccent(modelSlug),
+    reason: buildPickReason(locale, usecaseSlug, criterion, rank),
+    bullets: buildPickBullets(locale, criteria, rank),
+  };
+}
+
+export async function resolveExamplePreviewPicks(picks: RankedPick[]): Promise<ExamplePreviewPick[]> {
+  const examplesSlugs = Array.from(new Set(picks.map((pick) => getExamplesSlug(pick))));
+  const heroThumbEntries = await Promise.all(
+    examplesSlugs.map(async (examplesSlug) => {
+      try {
+        const result = await listExampleFamilyPage(examplesSlug, {
+          sort: 'playlist',
+          limit: EXAMPLES_HERO_SELECTION_LIMIT,
+          offset: 0,
+        });
+        const heroVideo = pickFirstPlayableVideo(result.items);
+        return [examplesSlug, heroVideo?.thumbUrl ?? null] as const;
+      } catch {
+        return [examplesSlug, null] as const;
+      }
+    })
+  );
+  const heroThumbBySlug = new Map(heroThumbEntries);
+
+  return picks.map((pick) => {
+    const examplesSlug = getExamplesSlug(pick);
+    return {
+      ...pick,
+      examplesSlug,
+      heroThumbUrl: heroThumbBySlug.get(examplesSlug) ?? null,
+    };
+  });
+}
+
+export function getBestForDisplayTitle(locale: AppLocale, entry?: BestForEntry, fallbackTitle?: string) {
+  if (!entry) return fallbackTitle ?? 'Best AI video engines by use case';
+  if (locale !== 'en') return fallbackTitle ?? entry.title;
+  const intentLabels: Record<string, string> = {
+    'image-to-video': 'image-to-video',
+    'cinematic-realism': 'cinematic realism',
+    'character-reference': 'character reference',
+    'reference-to-video': 'reference-to-video',
+    'multi-shot-video': 'multi-shot video',
+    '4k-video': '4K video',
+    ads: 'ads',
+    'ugc-ads': 'UGC videos',
+    'product-videos': 'product videos',
+    'lipsync-dialogue': 'lip sync and dialogue',
+    'fast-drafts': 'fast drafts',
+    'stylized-anime': 'anime and stylized video',
+  };
+  return `Best AI video engines for ${intentLabels[entry.slug] ?? entry.title.replace(/^Best\s+/i, '').toLowerCase()}`;
+}
+
+export function buildBestForHeroDescription(locale: AppLocale, entry: BestForEntry, fallbackDescription?: string) {
+  if (locale !== 'en') return fallbackDescription ?? entry.description ?? 'Editorial guidance for picking the best AI video engines by use case.';
+  const names = (entry.topPicks ?? []).slice(0, 3).map((slug) => ENGINE_BY_SLUG.get(slug)?.marketingName ?? slug);
+  if (!names.length) return fallbackDescription ?? entry.description ?? 'Compare AI video engines before spending credits.';
+  return `Compare ${formatList(names)} for ${entry.title.replace(/^Best\s+/i, '').replace(/\s+AI generator$/i, '').toLowerCase()} before spending credits.`;
+}
+
+export function buildBestForMetaDescription(locale: AppLocale, entry: BestForEntry, fallbackDescription?: string) {
+  if (locale !== 'en') return fallbackDescription ?? entry.description ?? 'Compare the best AI video engines by use case.';
+  const names = (entry.topPicks ?? []).slice(0, 3).map((slug) => ENGINE_BY_SLUG.get(slug)?.marketingName ?? slug);
+  const engineText = names.length ? ` Compare ${formatList(names)}` : ' Compare leading AI video engines';
+  return `${fallbackDescription ?? entry.description ?? entry.title}.${engineText} by quality, control, consistency, cost, and workflow fit.`;
+}
+
+export function buildBestForKeywords(locale: AppLocale, entry: BestForEntry, localizedTitle: string) {
+  const engines = (entry.topPicks ?? []).map((slug) => ENGINE_BY_SLUG.get(slug)?.marketingName ?? slug);
+  const genericKeyword =
+    locale === 'fr'
+      ? `${entry.slug.replace(/-/g, ' ')} générateur vidéo IA`
+      : locale === 'es'
+        ? `${entry.slug.replace(/-/g, ' ')} generador de video con IA`
+        : `${entry.slug.replace(/-/g, ' ')} AI video generator`;
+  return Array.from(
+    new Set([
+      localizedTitle,
+      genericKeyword,
+      ...engines,
+      ...getUsecaseChips(locale, entry.slug, []),
+    ])
+  );
+}
+
+function formatList(items: string[]) {
+  if (items.length <= 1) return items[0] ?? '';
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(', ')} and ${items[items.length - 1]}`;
+}
+
+export function formatScore(score?: number) {
+  return typeof score === 'number' && Number.isFinite(score) ? score.toFixed(1) : '-';
+}
+
+function buildPickReason(locale: AppLocale, usecaseSlug: string, criterion: string, rank: number) {
+  const prefixes: Record<AppLocale, string[]> = {
+    en: ['Best balance of', 'Strong option for', 'Useful when you need'],
+    fr: ['Meilleur équilibre pour', 'Option forte pour', 'Utile si vous cherchez'],
+    es: ['Mejor equilibrio para', 'Opción fuerte para', 'Útil si necesitas'],
+  };
+  const suffixes: Record<string, Record<AppLocale, string>> = {
+    'cinematic-realism': {
+      en: 'cinematic camera direction',
+      fr: 'une direction caméra cinématique',
+      es: 'dirección de cámara cinematográfica',
+    },
+    'character-reference': {
+      en: 'stable identity across shots',
+      fr: 'une identité stable entre les plans',
+      es: 'identidad estable entre planos',
+    },
+    'reference-to-video': {
+      en: 'controlled reference workflows',
+      fr: 'des workflows de référence contrôlés',
+      es: 'workflows de referencia controlados',
+    },
+    'multi-shot-video': {
+      en: 'planned sequences',
+      fr: 'des séquences planifiées',
+      es: 'secuencias planificadas',
+    },
+    '4k-video': {
+      en: 'final delivery detail',
+      fr: 'le niveau de détail final',
+      es: 'detalle para entrega final',
+    },
+    ads: {
+      en: 'campaign-ready output',
+      fr: 'un rendu prêt pour campagne',
+      es: 'salidas listas para campaña',
+    },
+    'ugc-ads': {
+      en: 'creator-style social clips',
+      fr: 'des clips sociaux style créateur',
+      es: 'clips sociales estilo creador',
+    },
+    'product-videos': {
+      en: 'clean product storytelling',
+      fr: 'un storytelling produit propre',
+      es: 'storytelling de producto limpio',
+    },
+    'lipsync-dialogue': {
+      en: 'speaking character control',
+      fr: 'le contrôle de personnages parlants',
+      es: 'control de personajes con diálogo',
+    },
+    'fast-drafts': {
+      en: 'fast iteration loops',
+      fr: 'des boucles d’itération rapides',
+      es: 'ciclos rápidos de iteración',
+    },
+    'stylized-anime': {
+      en: 'stylized motion',
+      fr: 'du mouvement stylisé',
+      es: 'movimiento estilizado',
+    },
+    'image-to-video': {
+      en: 'motion from approved images',
+      fr: 'l’animation depuis images validées',
+      es: 'movimiento desde imágenes aprobadas',
+    },
+  };
+  const prefix = prefixes[locale]?.[Math.min(rank - 1, 2)] ?? prefixes.en[Math.min(rank - 1, 2)];
+  const suffix = suffixes[usecaseSlug]?.[locale] ?? suffixes[usecaseSlug]?.en ?? (locale === 'fr' ? 'ce cas d’usage' : locale === 'es' ? 'este objetivo' : 'this use case');
+  const connector = locale === 'en' ? 'for' : locale === 'es' ? 'en' : 'sur';
+  return `${prefix} ${criterion.toLowerCase()} ${connector} ${suffix}.`;
+}
+
+function buildPickBullets(locale: AppLocale, criteria: string[], rank: number) {
+  const primary = criteria[(rank - 1) % criteria.length] ?? criteria[0] ?? 'Use-case fit';
+  const secondary = criteria[rank % criteria.length] ?? criteria[1] ?? 'Reliable output';
+  const tertiary = criteria[(rank + 1) % criteria.length] ?? criteria[2] ?? 'Efficient review loop';
+  const labels: Record<AppLocale, [string, string, string]> = {
+    en: ['Strong', 'Good', 'Practical'],
+    fr: ['Fort sur', 'Bon sur', 'Pratique pour'],
+    es: ['Fuerte en', 'Bueno en', 'Práctico para'],
+  };
+  const [first, second, third] = labels[locale] ?? labels.en;
+  return [`${first} ${primary.toLowerCase()}`, `${second} ${secondary.toLowerCase()}`, `${third} ${tertiary.toLowerCase()}`];
+}
+
+export function getPublishedRelatedComparisons(entry: BestForEntry) {
+  return Array.from(
+    new Set(
+      (entry.relatedComparisons ?? [])
+        .filter((slug) => isPublishedComparisonSlug(slug))
+        .map((slug) => canonicalizePublishedCompareSlug(slug))
+    )
+  );
+}
+
+export function pickComparisonSlug(picks: RankedPick[], relatedComparisons: string[]) {
+  const explicit = relatedComparisons.find((slug) => isPublishedComparisonSlug(slug));
+  if (explicit) return canonicalizePublishedCompareSlug(explicit);
+  for (let index = 0; index < picks.length; index += 1) {
+    for (let nextIndex = index + 1; nextIndex < picks.length; nextIndex += 1) {
+      const candidate = `${picks[index].slug}-vs-${picks[nextIndex].slug}`;
+      if (isPublishedComparisonSlug(candidate)) {
+        return canonicalizePublishedCompareSlug(candidate);
+      }
+    }
+  }
+  return null;
+}
+
+export function findComparisonForPick(slug: string, relatedComparisons: string[]) {
+  return relatedComparisons.find((comparison) => comparison.split('-vs-').includes(slug)) ?? null;
+}
+
+export function getExamplesSlug(pick: RankedPick) {
+  return pick.engine?.family ?? pick.slug;
+}
+
+export function getTopPicksTitle(locale: AppLocale, slug: string) {
+  const labels: Record<string, Record<AppLocale, string>> = {
+    'cinematic-realism': {
+      en: 'Top picks for cinematic shots',
+      fr: 'Meilleurs choix pour plans cinéma',
+      es: 'Mejores opciones para planos cinematográficos',
+    },
+    'character-reference': {
+      en: 'Top picks for character reference',
+      fr: 'Meilleurs choix pour character reference',
+      es: 'Mejores opciones para character reference',
+    },
+    'reference-to-video': {
+      en: 'Top picks for reference-to-video',
+      fr: 'Meilleurs choix pour reference-to-video',
+      es: 'Mejores opciones para reference-to-video',
+    },
+    'multi-shot-video': {
+      en: 'Top picks for multi-shot video',
+      fr: 'Meilleurs choix pour multi-shot',
+      es: 'Mejores opciones para multi-shot',
+    },
+    '4k-video': {
+      en: 'Top picks for 4K delivery',
+      fr: 'Meilleurs choix pour livraison 4K',
+      es: 'Mejores opciones para entrega 4K',
+    },
+    ads: {
+      en: 'Top picks for ads',
+      fr: 'Meilleurs choix pour publicités',
+      es: 'Mejores opciones para anuncios',
+    },
+    'ugc-ads': {
+      en: 'Top picks for UGC videos',
+      fr: 'Meilleurs choix pour vidéos UGC',
+      es: 'Mejores opciones para videos UGC',
+    },
+    'product-videos': {
+      en: 'Top picks for product videos',
+      fr: 'Meilleurs choix pour vidéos produit',
+      es: 'Mejores opciones para videos de producto',
+    },
+    'lipsync-dialogue': {
+      en: 'Top picks for dialogue',
+      fr: 'Meilleurs choix pour dialogue',
+      es: 'Mejores opciones para diálogo',
+    },
+    'fast-drafts': {
+      en: 'Top picks for fast drafts',
+      fr: 'Meilleurs choix pour tests rapides',
+      es: 'Mejores opciones para borradores rápidos',
+    },
+    'stylized-anime': {
+      en: 'Top picks for stylized video',
+      fr: 'Meilleurs choix pour vidéo stylisée',
+      es: 'Mejores opciones para video estilizado',
+    },
+    'image-to-video': {
+      en: 'Top picks for image-to-video',
+      fr: 'Meilleurs choix image vers vidéo',
+      es: 'Mejores opciones de imagen a video',
+    },
+  };
+  return labels[slug]?.[locale] ?? labels[slug]?.en ?? (locale === 'fr' ? 'Meilleurs choix' : locale === 'es' ? 'Mejores opciones' : 'Top picks');
+}
+
+function getRelatedBestForGuides(slug: string) {
+  const relatedBySlug: Record<string, string[]> = {
+    'cinematic-realism': ['fast-drafts', 'multi-shot-video', 'product-videos', 'character-reference', '4k-video'],
+    'image-to-video': ['reference-to-video', 'product-videos', 'character-reference', 'ads'],
+    'character-reference': ['reference-to-video', 'ugc-ads', 'multi-shot-video', 'product-videos'],
+    'reference-to-video': ['image-to-video', 'character-reference', 'product-videos', 'ads'],
+    'multi-shot-video': ['cinematic-realism', 'character-reference', 'ads', 'fast-drafts'],
+    '4k-video': ['cinematic-realism', 'product-videos', 'ads', 'fast-drafts'],
+    ads: ['ugc-ads', 'product-videos', 'cinematic-realism', 'reference-to-video'],
+    'ugc-ads': ['ads', 'lipsync-dialogue', 'character-reference', 'fast-drafts'],
+    'product-videos': ['ads', 'image-to-video', 'reference-to-video', '4k-video'],
+    'lipsync-dialogue': ['ugc-ads', 'character-reference', 'cinematic-realism', 'fast-drafts'],
+    'fast-drafts': ['cinematic-realism', 'ads', 'multi-shot-video', '4k-video'],
+    'stylized-anime': ['fast-drafts', 'image-to-video', 'multi-shot-video', 'character-reference'],
+  };
+  const targets = relatedBySlug[slug] ?? BEST_FOR_PAGES.filter((entry) => entry.slug !== slug).slice(0, 4).map((entry) => entry.slug);
+  return targets.map((target) => getEntry(target)).filter((entry): entry is BestForEntry => Boolean(entry)).slice(0, 5);
+}
+
+export async function resolveRelatedBestForGuides(locale: AppLocale, slug: string): Promise<RelatedGuideEntry[]> {
+  const guides = getRelatedBestForGuides(slug);
+  const localizedRoot = locale === defaultLocale ? 'content/en/best-for' : `content/${locale}/best-for`;
+  const [localizedEntries, englishEntries] = await Promise.all([
+    getContentEntries(localizedRoot),
+    locale === defaultLocale ? Promise.resolve([]) : getContentEntries('content/en/best-for'),
+  ]);
+  const localizedBySlug = new Map(localizedEntries.map((entry) => [entry.slug, entry]));
+  const englishBySlug = new Map(englishEntries.map((entry) => [entry.slug, entry]));
+
+  return guides.map((guide) => {
+    const content = localizedBySlug.get(guide.slug) ?? englishBySlug.get(guide.slug);
+    return {
+      ...guide,
+      displayTitle: content?.title ?? guide.title,
+    };
+  });
+}
+
+export function getAlsoAvailableModels(slug: string, topPicks: string[]) {
+  const preferred: Record<string, string[]> = {
+    'cinematic-realism': ['ltx-2-3-fast', 'wan-2-6', 'pika-text-to-video', 'happy-horse-1-0'],
+    'image-to-video': ['sora-2-pro', 'veo-3-1-fast', 'pika-text-to-video', 'happy-horse-1-0'],
+    'character-reference': ['seedance-2-0', 'sora-2-pro', 'veo-3-1', 'happy-horse-1-0'],
+    'reference-to-video': ['sora-2-pro', 'veo-3-1-fast', 'wan-2-6', 'happy-horse-1-0'],
+    'multi-shot-video': ['ltx-2-3-pro', 'wan-2-6', 'pika-text-to-video', 'happy-horse-1-0'],
+    '4k-video': ['kling-3-pro', 'veo-3-1', 'sora-2-pro'],
+    ads: ['veo-3-1-fast', 'sora-2-pro', 'pika-text-to-video', 'happy-horse-1-0'],
+    'ugc-ads': ['ltx-2-3-pro', 'veo-3-1-fast', 'pika-text-to-video', 'happy-horse-1-0'],
+    'product-videos': ['kling-3-4k', 'veo-3-1-fast', 'pika-text-to-video', 'happy-horse-1-0'],
+    'lipsync-dialogue': ['ltx-2-3-pro', 'sora-2', 'pika-text-to-video', 'happy-horse-1-0'],
+    'fast-drafts': ['pika-text-to-video', 'minimax-hailuo-02-text', 'wan-2-6'],
+    'stylized-anime': ['seedance-2-0', 'wan-2-6', 'ltx-2-3-fast'],
+  };
+  return (preferred[slug] ?? [])
+    .filter((modelSlug) => !topPicks.includes(modelSlug))
+    .map((modelSlug) => ENGINE_BY_SLUG.get(modelSlug))
+    .filter((engine): engine is EngineCatalogEntry => Boolean(engine))
+    .slice(0, 3);
+}
+
+export function buildReasonSentence(locale: AppLocale, usecaseSlug: string, pick: RankedPick) {
+  const usecaseLabel = getUsecaseLabel(locale, usecaseSlug);
+  if (locale === 'fr') {
+    return `est classé ici car il donne aux utilisateurs MaxVideoAI une route pratique vers ${pick.criterion.toLowerCase()}, tout en gardant le flux adapté à ${usecaseLabel}.`;
+  }
+  if (locale === 'es') {
+    return `está aquí porque da a los usuarios de MaxVideoAI una ruta práctica hacia ${pick.criterion.toLowerCase()}, manteniendo el flujo adecuado para ${usecaseLabel}.`;
+  }
+  return `ranks here because it gives MaxVideoAI users a practical route to ${pick.criterion.toLowerCase()} while keeping the workflow suitable for ${usecaseLabel}.`;
+}
+
+export function buildUsecaseMistakes(locale: AppLocale, usecaseSlug: string, criteria: string[]) {
+  const label = getUsecaseLabel(locale, usecaseSlug);
+  const primary = criteria[0] ?? USECASE_MISTAKE_FALLBACKS[locale]?.[0] ?? USECASE_MISTAKE_FALLBACKS.en[0];
+  const secondary = criteria[1] ?? USECASE_MISTAKE_FALLBACKS[locale]?.[1] ?? USECASE_MISTAKE_FALLBACKS.en[1];
+  const tertiary = criteria[2] ?? USECASE_MISTAKE_FALLBACKS[locale]?.[2] ?? USECASE_MISTAKE_FALLBACKS.en[2];
+
+  if (locale === 'fr') {
+    return [
+      `Choisir un modèle pour ${label} sans vérifier ${primary.toLowerCase()}.`,
+      `Multiplier les références alors que ${secondary.toLowerCase()} doit rester prioritaire.`,
+      `Passer directement au modèle premium avant d’avoir validé ${tertiary.toLowerCase()}.`,
+      'Oublier de contrôler le coût avant de générer.',
+      'Comparer seulement les fiches modèles sans ouvrir les exemples réels liés à ce cas d’usage.',
+    ];
+  }
+
+  if (locale === 'es') {
+    return [
+      `Elegir un motor para ${label} sin comprobar ${primary.toLowerCase()}.`,
+      `Añadir demasiadas referencias cuando ${secondary.toLowerCase()} debería ser la prioridad.`,
+      `Pasar directo al modelo premium antes de validar ${tertiary.toLowerCase()}.`,
+      'Olvidar revisar el coste antes de generar.',
+      'Comparar solo fichas de modelos sin abrir ejemplos reales para este objetivo.',
+    ];
+  }
+
+  return [
+    `Choosing an engine for ${label} without checking ${primary.toLowerCase()}.`,
+    `Adding too many references when ${secondary.toLowerCase()} should stay primary.`,
+    `Going straight to a premium model before validating ${tertiary.toLowerCase()}.`,
+    'Forgetting to check the cost before generation.',
+    'Comparing model pages only without opening real examples for this use case.',
+  ];
+}
+
+export function serializeJsonLd(data: unknown): string {
+  return JSON.stringify(data).replace(/</g, '\\u003c');
+}
+
+export function buildBreadcrumbJsonLd(locale: AppLocale, entry: BestForEntry, title: string, canonicalUrl: string) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Best for',
+        item: getLocalizedUrl(locale, '/ai-video-engines/best-for'),
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: title || entry.title,
+        item: canonicalUrl,
+      },
+    ],
+  };
+}
+
+export function buildBestForItemListJsonLd(locale: AppLocale, picks: RankedPick[], canonicalUrl: string) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: `Ranked AI video engines for ${canonicalUrl.split('/').pop()?.replace(/-/g, ' ') ?? 'this use case'}`,
+    itemListOrder: 'https://schema.org/ItemListOrderAscending',
+    itemListElement: picks.map((pick) => ({
+      '@type': 'ListItem',
+      position: pick.rank,
+      name: pick.engine?.marketingName ?? pick.slug,
+      url: getLocalizedUrl(locale, `/models/${pick.slug}`),
+    })),
+  };
+}
+
+export function buildBestForWebPageJsonLd(title: string, description: string, canonicalUrl: string) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: title,
+    url: canonicalUrl,
+    description,
+  };
+}
+
+function getFitScore(slug: string, score?: EngineScore) {
+  if (!score) return undefined;
+  const weights = USECASE_WEIGHTS[slug] ?? {};
+  const value = scoreEngineForUsecase(score, weights);
+  return value > 0 ? value : undefined;
+}
+
+export function getUsecaseCriteria(locale: AppLocale, slug: string) {
+  return USECASE_CRITERIA[slug]?.[locale] ?? USECASE_CRITERIA[slug]?.en ?? USECASE_CRITERIA['image-to-video'].en;
+}
+
+export function getUsecaseChips(locale: AppLocale, slug: string, fallback: string[]) {
+  return USECASE_CHIPS[slug]?.[locale] ?? USECASE_CHIPS[slug]?.en ?? fallback;
+}
+
+function getUsecaseLabel(locale: AppLocale, slug: string) {
+  const labels: Record<string, Record<AppLocale, string>> = {
+    'cinematic-realism': { en: 'cinematic realism', fr: 'un rendu cinématique', es: 'realismo cinematográfico' },
+    'character-reference': { en: 'character reference', fr: 'la référence personnage', es: 'referencia de personaje' },
+    'reference-to-video': { en: 'reference-to-video', fr: 'la vidéo guidée par référence', es: 'video guiado por referencia' },
+    'multi-shot-video': { en: 'multi-shot video', fr: 'la vidéo multi-plan', es: 'video multi-plano' },
+    '4k-video': { en: '4K video', fr: 'la vidéo 4K', es: 'video 4K' },
+    ads: { en: 'ads', fr: 'les publicités', es: 'anuncios' },
+    'ugc-ads': { en: 'UGC videos', fr: 'les vidéos UGC', es: 'videos UGC' },
+    'product-videos': { en: 'product videos', fr: 'les vidéos produit', es: 'videos de producto' },
+    'lipsync-dialogue': { en: 'lip sync and dialogue', fr: 'la synchronisation labiale et le dialogue', es: 'sincronización labial y diálogo' },
+    'fast-drafts': { en: 'fast drafts', fr: 'les tests rapides', es: 'borradores rápidos' },
+    'stylized-anime': { en: 'anime and stylized video', fr: 'la vidéo anime et stylisée', es: 'anime y video estilizado' },
+    'image-to-video': { en: 'image-to-video', fr: "l'image vers vidéo", es: 'imagen a video' },
+  };
+  return labels[slug]?.[locale] ?? labels[slug]?.en ?? slug.replace(/-/g, ' ');
+}
+
+export function getFilledCriteria(locale: AppLocale, criteria: string[]) {
+  return criteria.concat(DECISION_CRITERIA_FILLERS[locale] ?? DECISION_CRITERIA_FILLERS.en).slice(0, 5);
+}
+
+function getEngineAccent(slug: string) {
+  if (slug.includes('kling')) return '#7c3aed';
+  if (slug.includes('seedance')) return '#0ea5e9';
+  if (slug.includes('veo')) return '#22c55e';
+  if (slug.includes('sora')) return '#111827';
+  if (slug.includes('ltx')) return '#f59e0b';
+  if (slug.includes('pika')) return '#ec4899';
+  if (slug.includes('minimax')) return '#f97316';
+  if (slug.includes('wan')) return '#6366f1';
+  return '#6366f1';
+}

--- a/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/best-for/[usecase]/page.tsx
+++ b/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/best-for/[usecase]/page.tsx
@@ -1,389 +1,58 @@
 import type { Metadata } from 'next';
 import Image from 'next/image';
 import { notFound } from 'next/navigation';
-import path from 'node:path';
-import { promises as fs } from 'node:fs';
 import { ArrowUp, Check, ChevronRight, PlayCircle } from 'lucide-react';
 import { Link } from '@/i18n/navigation';
 import type { AppLocale } from '@/i18n/locales';
-import { defaultLocale, locales } from '@/i18n/locales';
+import { locales } from '@/i18n/locales';
 import { getLocalizedUrl } from '@/lib/metadataUrls';
 import { buildSeoMetadata } from '@/lib/seo/metadata';
 import { resolveLocalizedFallbackSeo } from '@/lib/seo/localizedFallback';
-import { canonicalizePublishedCompareSlug, isPublishedComparisonSlug } from '@/lib/compare-hub/data';
-import { getContentEntries, getEntryBySlug, type ContentEntry } from '@/lib/content/markdown';
+import type { ContentEntry } from '@/lib/content/markdown';
 import { EngineIcon } from '@/components/ui/EngineIcon';
-import { EXAMPLES_HERO_SELECTION_LIMIT, pickFirstPlayableVideo } from '@/lib/examples/heroVideo';
-import { listExampleFamilyPage } from '@/server/videos';
-import engineCatalog from '@/config/engine-catalog.json';
-import compareConfig from '@/config/compare-config.json';
-
-interface Params {
-  locale?: AppLocale;
-  usecase: string;
-}
-
-interface BestForEntry {
-  slug: string;
-  title: string;
-  description?: string;
-  tier: number;
-  topPicks?: string[];
-  relatedComparisons?: string[];
-}
-
-type RelatedGuideEntry = BestForEntry & {
-  displayTitle: string;
-};
-
-type EngineCatalogEntry = {
-  engineId?: string;
-  modelSlug: string;
-  marketingName: string;
-  provider?: string;
-  brandId?: string;
-  family?: string;
-  bestFor?: string;
-};
-
-type EngineScore = {
-  engineId?: string;
-  modelSlug?: string;
-  fidelity?: number;
-  motion?: number;
-  anatomy?: number;
-  textRendering?: number;
-  consistency?: number;
-  lipsyncQuality?: number;
-  sequencingQuality?: number;
-};
-
-type EngineScoresFile = {
-  version?: string;
-  last_updated?: string;
-  scores?: EngineScore[];
-};
-
-const BEST_FOR_PAGES = compareConfig.bestForPages as BestForEntry[];
-const ENGINE_CATALOG = engineCatalog as EngineCatalogEntry[];
-const ENGINE_BY_SLUG = new Map(ENGINE_CATALOG.map((entry) => [entry.modelSlug, entry]));
-
-const DETAIL_COPY: Record<
-  AppLocale,
-  {
-    eyebrow: string;
-    shortlist: string;
-    shortlistDescription: string;
-    ranked: string;
-    rank: string;
-    topPick: string;
-    provider: string;
-    fit: string;
-    evidence: string;
-    topReason: string;
-    shortlistReason: string;
-    viewModel: string;
-    viewExamples: string;
-    compareWith: string;
-    compareShortlistCta: string;
-    examplesCta: string;
-    alsoAvailable: string;
-    chooseTitle: string;
-    examplesTitle: string;
-    examplesDescription: string;
-    whyTitle: string;
-    mistakesTitle: string;
-    fullAnalysis: string;
-    relatedGuides: string;
-    allGuides: string;
-    score: string;
-    overall: string;
-    criteriaNote: string;
-    compareShortlist: string;
-    compareDescription: string;
-    contentComing: string;
-    backToHub: string;
-    backToTop: string;
-    criteria: string;
-    quickLinks: string;
-    tier: string;
-    browseAllExamples: string;
-  }
-> = {
-  en: {
-    eyebrow: 'Best for',
-    shortlist: 'Recommended shortlist',
-    shortlistDescription: 'Model cards use the same visual language as the model pages, with the strongest engines shown first.',
-    ranked: 'Ranked picks',
-    rank: 'Rank',
-    topPick: 'Top pick',
-    provider: 'Provider',
-    fit: 'Best fit',
-    evidence: 'Why it fits',
-    topReason: 'Primary recommendation for this search intent, based on the criteria above.',
-    shortlistReason: 'Strong shortlist option when this criterion matters for the final video.',
-    viewModel: 'View model',
-    viewExamples: 'View examples',
-    compareWith: 'Compare vs',
-    compareShortlistCta: 'Compare the shortlist',
-    examplesCta: 'View cinematic examples',
-    alsoAvailable: 'Also available',
-    chooseTitle: 'When should you choose each engine?',
-    examplesTitle: 'Examples to review first',
-    examplesDescription: 'Preview real output direction before making a decision.',
-    whyTitle: 'Why these models rank here',
-    mistakesTitle: 'Avoid these mistakes',
-    fullAnalysis: 'Read the full analysis',
-    relatedGuides: 'Related best-for guides',
-    allGuides: 'View all guides',
-    score: 'Score',
-    overall: 'Best overall',
-    criteriaNote: 'Scores combine quality, control, consistency, and cost efficiency.',
-    compareShortlist: 'Compare the shortlist',
-    compareDescription: 'Useful side-by-side pages for validating tradeoffs before picking a model.',
-    contentComing: 'Content coming soon.',
-    backToHub: 'Back to Best-for hub',
-    backToTop: 'Back to top',
-    criteria: 'Decision criteria',
-    quickLinks: 'Quick links',
-    tier: 'Tier',
-    browseAllExamples: 'Browse all examples',
-  },
-  fr: {
-    eyebrow: 'Meilleur pour',
-    shortlist: 'Shortlist recommandée',
-    shortlistDescription: 'Les cards reprennent le style des pages modèles, avec les modèles les plus adaptés en premier.',
-    ranked: 'Sélection classée',
-    rank: 'Rang',
-    topPick: 'Premier choix',
-    provider: 'Fournisseur',
-    fit: 'Meilleur usage',
-    evidence: 'Pourquoi ça matche',
-    topReason: 'Recommandation principale pour cette intention de recherche, d’après les critères ci-dessus.',
-    shortlistReason: 'Option forte de la shortlist quand ce critère compte dans la vidéo finale.',
-    viewModel: 'Voir le modèle',
-    viewExamples: 'Voir les exemples',
-    compareWith: 'Comparer avec',
-    compareShortlistCta: 'Comparer la shortlist',
-    examplesCta: 'Voir les exemples cinéma',
-    alsoAvailable: 'Aussi disponible',
-    chooseTitle: 'Quand choisir chaque modèle ?',
-    examplesTitle: 'Exemples à vérifier d’abord',
-    examplesDescription: 'Prévisualisez le rendu avant de choisir un modèle.',
-    whyTitle: 'Pourquoi ces modèles sont classés ici',
-    mistakesTitle: 'Erreurs à éviter',
-    fullAnalysis: 'Lire l’analyse complète',
-    relatedGuides: 'Guides Best-for liés',
-    allGuides: 'Voir tous les guides',
-    score: 'Score',
-    overall: 'Meilleur choix',
-    criteriaNote: 'Les scores combinent qualité, contrôle, cohérence et efficacité coût.',
-    compareShortlist: 'Comparer la shortlist',
-    compareDescription: 'Des pages côte à côte utiles pour valider les compromis avant de choisir un modèle.',
-    contentComing: 'Contenu bientôt disponible.',
-    backToHub: 'Retour au hub Best-for',
-    backToTop: 'Retour en haut',
-    criteria: 'Critères de décision',
-    quickLinks: 'Liens rapides',
-    tier: 'Niveau',
-    browseAllExamples: 'Voir tous les exemples',
-  },
-  es: {
-    eyebrow: 'Mejor para',
-    shortlist: 'Shortlist recomendada',
-    shortlistDescription: 'Las cards reutilizan el lenguaje visual de las páginas de modelos, con los modelos ideales primero.',
-    ranked: 'Selección ordenada',
-    rank: 'Puesto',
-    topPick: 'Primera opción',
-    provider: 'Proveedor',
-    fit: 'Ideal para',
-    evidence: 'Por qué encaja',
-    topReason: 'Recomendación principal para esta intención de búsqueda, según los criterios anteriores.',
-    shortlistReason: 'Opción fuerte de la shortlist cuando este criterio pesa en el video final.',
-    viewModel: 'Ver modelo',
-    viewExamples: 'Ver ejemplos',
-    compareWith: 'Comparar con',
-    compareShortlistCta: 'Comparar la shortlist',
-    examplesCta: 'Ver ejemplos cinematográficos',
-    alsoAvailable: 'También disponible',
-    chooseTitle: '¿Cuándo elegir cada modelo?',
-    examplesTitle: 'Ejemplos para revisar primero',
-    examplesDescription: 'Previsualiza la dirección del resultado antes de elegir un modelo.',
-    whyTitle: 'Por qué estos modelos están aquí',
-    mistakesTitle: 'Evita estos errores',
-    fullAnalysis: 'Leer el análisis completo',
-    relatedGuides: 'Guías Mejor para relacionadas',
-    allGuides: 'Ver todas las guías',
-    score: 'Puntuación',
-    overall: 'Mejor opción',
-    criteriaNote: 'Las puntuaciones combinan calidad, control, consistencia y eficiencia de costo.',
-    compareShortlist: 'Comparar la shortlist',
-    compareDescription: 'Páginas lado a lado útiles para validar compromisos antes de elegir modelo.',
-    contentComing: 'Contenido próximamente.',
-    backToHub: 'Volver al espacio Mejor para',
-    backToTop: 'Volver arriba',
-    criteria: 'Criterios de decisión',
-    quickLinks: 'Enlaces rápidos',
-    tier: 'Nivel',
-    browseAllExamples: 'Ver todos los ejemplos',
-  },
-};
-
-const USECASE_CRITERIA: Record<string, Record<AppLocale, string[]>> = {
-  'image-to-video': {
-    en: ['Image fidelity after motion', 'Camera control from a still', 'Clean product and subject preservation'],
-    fr: ['Fidélité de l’image après mouvement', 'Contrôle caméra depuis une image fixe', 'Préservation propre du produit ou sujet'],
-    es: ['Fidelidad de imagen tras el movimiento', 'Control de cámara desde una imagen fija', 'Preservación limpia del producto o sujeto'],
-  },
-  'cinematic-realism': {
-    en: ['Camera language and lighting', 'Natural motion physics', 'High-end visual polish'],
-    fr: ['Langage caméra et lumière', 'Physique du mouvement naturelle', 'Rendu visuel premium'],
-    es: ['Lenguaje de cámara e iluminación', 'Física de movimiento natural', 'Pulido visual premium'],
-  },
-  'character-reference': {
-    en: ['Stable identity', 'Wardrobe and prop retention', 'Reference-aware shot control'],
-    fr: ['Identité stable', 'Tenue et accessoires conservés', 'Contrôle des plans par référence'],
-    es: ['Identidad estable', 'Vestuario y accesorios consistentes', 'Control de planos con referencia'],
-  },
-  'reference-to-video': {
-    en: ['Strong visual reference following', 'Flexible image or clip guidance', 'Good result with approved assets'],
-    fr: ['Respect fort des références visuelles', 'Guidage flexible par image ou clip', 'Bon rendu depuis assets validés'],
-    es: ['Seguimiento fuerte de referencias visuales', 'Guía flexible por imagen o clip', 'Buen resultado con assets aprobados'],
-  },
-  'multi-shot-video': {
-    en: ['Several shots from one prompt', 'Sequence continuity', 'Edited-feeling final output'],
-    fr: ['Plusieurs plans depuis un prompt', 'Continuité de séquence', 'Résultat final déjà monté'],
-    es: ['Varios planos desde un prompt', 'Continuidad de secuencia', 'Resultado final con sensación de montaje'],
-  },
-  '4k-video': {
-    en: ['Native or practical high resolution', 'Detail retention', 'Delivery-ready upscale path'],
-    fr: ['Haute résolution native ou exploitable', 'Conservation du détail', 'Chemin clair vers une livraison finale'],
-    es: ['Alta resolución nativa o práctica', 'Retención de detalle', 'Ruta clara hacia entrega final'],
-  },
-  ads: {
-    en: ['Product clarity', 'Campaign-grade polish', 'Variation-friendly output'],
-    fr: ['Clarté produit', 'Finition niveau campagne', 'Sorties faciles à décliner'],
-    es: ['Claridad de producto', 'Acabado de campaña', 'Salida fácil de versionar'],
-  },
-  'ugc-ads': {
-    en: ['Creator-style realism', 'Dialogue and social proof', 'Fast hook testing'],
-    fr: ['Réalisme style créateur', 'Dialogue et preuve sociale', 'Tests rapides de hooks'],
-    es: ['Realismo estilo creador', 'Diálogo y prueba social', 'Pruebas rápidas de hooks'],
-  },
-  'product-videos': {
-    en: ['Packshot stability', 'Material and texture quality', 'Clean ecommerce motion'],
-    fr: ['Stabilité packshot', 'Qualité matière et texture', 'Mouvement ecommerce propre'],
-    es: ['Estabilidad de packshot', 'Calidad de materiales y textura', 'Movimiento ecommerce limpio'],
-  },
-  'lipsync-dialogue': {
-    en: ['Mouth timing', 'Voice and native audio options', 'Face consistency'],
-    fr: ['Timing bouche', 'Options voix et audio natif', 'Cohérence du visage'],
-    es: ['Sincronía de boca', 'Opciones de voz y audio nativo', 'Consistencia facial'],
-  },
-  'fast-drafts': {
-    en: ['Iteration speed', 'Low-cost variants', 'Enough control for review'],
-    fr: ['Vitesse d’itération', 'Variantes à coût réduit', 'Contrôle suffisant pour valider'],
-    es: ['Velocidad de iteración', 'Variantes de bajo costo', 'Control suficiente para revisar'],
-  },
-  'stylized-anime': {
-    en: ['Stylized motion', 'Illustration coherence', 'Non-photoreal flexibility'],
-    fr: ['Mouvement stylisé', 'Cohérence d’illustration', 'Flexibilité non photoréaliste'],
-    es: ['Movimiento estilizado', 'Coherencia de ilustración', 'Flexibilidad no fotorrealista'],
-  },
-};
-
-const USECASE_CHIPS: Record<string, Record<AppLocale, string[]>> = {
-  'image-to-video': {
-    en: ['Image fidelity', 'Motion control', 'Subject lock', 'Reference frames', 'Cost control'],
-    fr: ['Fidélité image', 'Contrôle du mouvement', 'Sujet verrouillé', 'Frames de référence', 'Contrôle du coût'],
-    es: ['Fidelidad de imagen', 'Control de movimiento', 'Sujeto estable', 'Frames de referencia', 'Control de costo'],
-  },
-  'cinematic-realism': {
-    en: ['Camera language', 'Lighting', 'Motion physics', 'Visual polish', 'Cost control'],
-    fr: ['Langage caméra', 'Lumière', 'Physique du mouvement', 'Rendu visuel', 'Contrôle du coût'],
-    es: ['Lenguaje de cámara', 'Iluminación', 'Física del movimiento', 'Pulido visual', 'Control de costo'],
-  },
-  'character-reference': {
-    en: ['Identity lock', 'Wardrobe', 'Props', 'Shot continuity', 'Input limits'],
-    fr: ['Identité verrouillée', 'Tenue', 'Accessoires', 'Continuité des plans', 'Limites d’entrée'],
-    es: ['Identidad estable', 'Vestuario', 'Props', 'Continuidad de planos', 'Límites de entrada'],
-  },
-  'reference-to-video': {
-    en: ['References', 'Style frames', 'Audio cues', 'Product consistency', 'Output control'],
-    fr: ['Références', 'Style frames', 'Repères audio', 'Cohérence produit', 'Contrôle du rendu'],
-    es: ['Referencias', 'Style frames', 'Señales de audio', 'Consistencia de producto', 'Control de salida'],
-  },
-  'multi-shot-video': {
-    en: ['Shot order', 'Continuity', 'Scene labels', 'Prompt structure', 'Final edit'],
-    fr: ['Ordre des plans', 'Continuité', 'Labels de scène', 'Structure du prompt', 'Montage final'],
-    es: ['Orden de planos', 'Continuidad', 'Etiquetas de escena', 'Estructura del prompt', 'Edición final'],
-  },
-  '4k-video': {
-    en: ['Native 4K', 'Detail retention', 'Upscale path', 'Final delivery', 'Cost control'],
-    fr: ['4K native', 'Détails conservés', 'Chemin upscale', 'Livraison finale', 'Contrôle du coût'],
-    es: ['4K nativo', 'Retención de detalle', 'Ruta de upscale', 'Entrega final', 'Control de costo'],
-  },
-  ads: {
-    en: ['Product clarity', 'Offer framing', 'Visual polish', 'Variant testing', 'Review speed'],
-    fr: ['Clarté produit', 'Angle offre', 'Rendu propre', 'Tests de variantes', 'Vitesse de review'],
-    es: ['Claridad de producto', 'Marco de oferta', 'Pulido visual', 'Pruebas de variantes', 'Velocidad de revisión'],
-  },
-  'ugc-ads': {
-    en: ['Creator realism', 'Dialogue', 'Face consistency', 'Hook testing', 'Social proof'],
-    fr: ['Réalisme créateur', 'Dialogue', 'Cohérence visage', 'Tests de hooks', 'Preuve sociale'],
-    es: ['Realismo de creador', 'Diálogo', 'Consistencia facial', 'Pruebas de hooks', 'Prueba social'],
-  },
-  'product-videos': {
-    en: ['Packshot stability', 'Textures', 'Clean reveals', 'Ecommerce motion', 'Brand fit'],
-    fr: ['Stabilité packshot', 'Textures', 'Reveals propres', 'Mouvement ecommerce', 'Fit marque'],
-    es: ['Estabilidad de packshot', 'Texturas', 'Reveals limpios', 'Movimiento ecommerce', 'Encaje de marca'],
-  },
-  'lipsync-dialogue': {
-    en: ['Mouth timing', 'Voice sync', 'Face consistency', 'Audio options', 'Short dialogue'],
-    fr: ['Timing bouche', 'Sync voix', 'Cohérence visage', 'Options audio', 'Dialogue court'],
-    es: ['Timing de boca', 'Sync de voz', 'Consistencia facial', 'Opciones de audio', 'Diálogo corto'],
-  },
-  'fast-drafts': {
-    en: ['Speed', 'Low cost', 'Rough timing', 'Variant testing', 'Review loop'],
-    fr: ['Vitesse', 'Coût bas', 'Timing brouillon', 'Tests de variantes', 'Boucle de review'],
-    es: ['Velocidad', 'Bajo costo', 'Timing preliminar', 'Pruebas de variantes', 'Ciclo de revisión'],
-  },
-  'stylized-anime': {
-    en: ['Line quality', 'Style consistency', 'Color blocks', 'Stylized motion', 'Creative tests'],
-    fr: ['Qualité du trait', 'Cohérence de style', 'Aplats de couleur', 'Mouvement stylisé', 'Tests créatifs'],
-    es: ['Calidad de línea', 'Consistencia de estilo', 'Bloques de color', 'Movimiento estilizado', 'Pruebas creativas'],
-  },
-};
-
-const DECISION_CRITERIA_FILLERS: Record<AppLocale, string[]> = {
-  en: ['Cost efficiency and speed', 'Reliability and consistency'],
-  fr: ['Efficacité coût et vitesse', 'Fiabilité et cohérence'],
-  es: ['Eficiencia de costo y velocidad', 'Fiabilidad y consistencia'],
-};
-
-const USECASE_MISTAKE_FALLBACKS: Record<AppLocale, string[]> = {
-  en: [
-    'Choosing a model without matching the use case.',
-    'Ignoring references, style frames, or input limits.',
-    'Overcomplicating the first-pass prompt.',
-    'Skipping draft passes and going straight to premium.',
-    'Not checking cost before generation.',
-  ],
-  fr: [
-    'Choisir un modèle sans matcher le cas d’usage.',
-    'Ignorer les références, style frames ou limites d’input.',
-    'Complexifier le prompt dès la première passe.',
-    'Sauter les tests et aller directement sur du premium.',
-    'Ne pas vérifier le coût avant génération.',
-  ],
-  es: [
-    'Elegir un modelo sin ajustar el objetivo creativo.',
-    'Ignorar referencias, style frames o límites de entrada.',
-    'Complicar demasiado el primer prompt.',
-    'Saltar los borradores e ir directo a premium.',
-    'No revisar el costo antes de generar.',
-  ],
-};
+import {
+  BEST_FOR_PAGES,
+  DETAIL_COPY,
+  type BestForDetailCopy,
+  type BestForEntry,
+  type EngineCatalogEntry,
+  type ExamplePreviewPick,
+  type Params,
+  type RankedPick,
+  type RelatedGuideEntry,
+} from './_lib/best-for-detail-config';
+import {
+  buildBestForHeroDescription,
+  buildBestForItemListJsonLd,
+  buildBestForKeywords,
+  buildBestForMetaDescription,
+  buildBestForWebPageJsonLd,
+  buildBreadcrumbJsonLd,
+  buildComparisonLabel,
+  buildRankedPick,
+  buildReasonSentence,
+  buildUsecaseMistakes,
+  findComparisonForPick,
+  formatScore,
+  getAlsoAvailableModels,
+  getBestForDisplayTitle,
+  getBestForEntry,
+  getEntry,
+  getExamplesSlug,
+  getFilledCriteria,
+  getLocalizedBestForEntry,
+  getPublishedRelatedComparisons,
+  getTopPicksTitle,
+  getUsecaseChips,
+  getUsecaseCriteria,
+  loadEngineScores,
+  pickComparisonSlug,
+  resolveAvailableLocales,
+  resolveExamplePreviewPicks,
+  resolveRelatedBestForGuides,
+  resolveTopPicks,
+  serializeJsonLd,
+} from './_lib/best-for-detail-helpers';
 
 export const dynamicParams = false;
 
@@ -397,49 +66,6 @@ export async function generateStaticParams(): Promise<Params[]> {
   return params;
 }
 
-function getEntry(slug: string): BestForEntry | undefined {
-  return BEST_FOR_PAGES.find((entry) => entry.slug === slug);
-}
-
-function buildComparisonLabel(slug: string) {
-  const [leftSlug, rightSlug] = slug.split('-vs-');
-  const left = leftSlug ? ENGINE_BY_SLUG.get(leftSlug)?.marketingName ?? leftSlug : slug;
-  const right = rightSlug ? ENGINE_BY_SLUG.get(rightSlug)?.marketingName ?? rightSlug : '';
-  return right ? `${left} vs ${right}` : slug;
-}
-
-async function getBestForEntry(locale: AppLocale, slug: string) {
-  const localizedRoot = locale === defaultLocale ? 'content/en/best-for' : `content/${locale}/best-for`;
-  const localized = await getEntryBySlug(localizedRoot, slug);
-  if (localized) return localized;
-  return getEntryBySlug('content/en/best-for', slug);
-}
-
-async function getLocalizedBestForEntry(locale: AppLocale, slug: string) {
-  const localizedRoot = locale === defaultLocale ? 'content/en/best-for' : `content/${locale}/best-for`;
-  return getEntryBySlug(localizedRoot, slug);
-}
-
-async function resolveAvailableLocales(slug: string): Promise<AppLocale[]> {
-  const available = await Promise.all(
-    locales.map(async (locale) => {
-      const localized = await getEntryBySlug(`content/${locale}/best-for`, slug);
-      if (localized) {
-        return locale;
-      }
-      if (locale === 'en') {
-        const fallback = await getEntryBySlug('content/en/best-for', slug);
-        if (fallback) {
-          return locale;
-        }
-      }
-      return null;
-    })
-  );
-  const filtered = available.filter((locale): locale is AppLocale => Boolean(locale));
-  return filtered.length ? filtered : (['en'] as AppLocale[]);
-}
-
 export async function generateMetadata(props: { params: Promise<Params> }): Promise<Metadata> {
   const params = await props.params;
   if (!BEST_FOR_PAGES.length) {
@@ -448,14 +74,14 @@ export async function generateMetadata(props: { params: Promise<Params> }): Prom
   const locale = params.locale ?? 'en';
   const entry = getEntry(params.usecase);
   const localizedContent = await getLocalizedBestForEntry(locale, params.usecase);
-  const content = localizedContent ?? (await getEntryBySlug('content/en/best-for', params.usecase));
+  const content = localizedContent ?? (await getBestForEntry('en', params.usecase));
   const title = getBestForDisplayTitle(locale, entry, content?.title);
   const description = entry
     ? buildBestForMetaDescription(locale, entry, content?.description)
     : 'Editorial guide to pick the best AI video engines by use case.';
   const seo = resolveLocalizedFallbackSeo({
     locale,
-    hasLocalizedVersion: locale === defaultLocale || Boolean(localizedContent),
+    hasLocalizedVersion: locale === 'en' || Boolean(localizedContent),
     englishPath: `/ai-video-engines/best-for/${params.usecase}`,
     availableLocales: await resolveAvailableLocales(params.usecase),
   });
@@ -619,22 +245,6 @@ export default async function BestForDetailPage(props: { params: Promise<Params>
   );
 }
 
-type RankedPick = {
-  slug: string;
-  engine?: EngineCatalogEntry;
-  rank: number;
-  criterion: string;
-  score?: number;
-  accent: string;
-  reason: string;
-  bullets: string[];
-};
-
-type ExamplePreviewPick = RankedPick & {
-  examplesSlug: string;
-  heroThumbUrl?: string | null;
-};
-
 function TopPicksPanel({
   entry,
   picks,
@@ -646,7 +256,7 @@ function TopPicksPanel({
   picks: RankedPick[];
   relatedComparisons: string[];
   locale: AppLocale;
-  copy: (typeof DETAIL_COPY)[AppLocale];
+  copy: BestForDetailCopy;
 }) {
   const comparisonSlug = pickComparisonSlug(picks, relatedComparisons);
 
@@ -701,7 +311,7 @@ function RankedShortlistCard({
 }: {
   pick: RankedPick;
   relatedComparisons: string[];
-  copy: (typeof DETAIL_COPY)[AppLocale];
+  copy: BestForDetailCopy;
 }) {
   const compareSlug = findComparisonForPick(pick.slug, relatedComparisons);
   return (
@@ -764,7 +374,7 @@ function RankedShortlistCard({
   );
 }
 
-function AlsoAvailableRow({ models, copy }: { models: EngineCatalogEntry[]; copy: (typeof DETAIL_COPY)[AppLocale] }) {
+function AlsoAvailableRow({ models, copy }: { models: EngineCatalogEntry[]; copy: BestForDetailCopy }) {
   return (
     <div className="flex flex-wrap items-center gap-2 rounded-[12px] border border-hairline bg-surface-2 px-4 py-3">
       <p className="mr-1 text-xs font-semibold text-text-primary">{copy.alsoAvailable}:</p>
@@ -782,7 +392,7 @@ function AlsoAvailableRow({ models, copy }: { models: EngineCatalogEntry[]; copy
   );
 }
 
-function ChooseEngineStrip({ picks, copy }: { picks: RankedPick[]; copy: (typeof DETAIL_COPY)[AppLocale] }) {
+function ChooseEngineStrip({ picks, copy }: { picks: RankedPick[]; copy: BestForDetailCopy }) {
   return (
     <section className="space-y-3">
       <h2 className="text-2xl font-semibold text-text-primary">{copy.chooseTitle}</h2>
@@ -808,7 +418,7 @@ function ChooseEngineStrip({ picks, copy }: { picks: RankedPick[]; copy: (typeof
   );
 }
 
-function ExamplesPreview({ picks, copy }: { picks: ExamplePreviewPick[]; copy: (typeof DETAIL_COPY)[AppLocale] }) {
+function ExamplesPreview({ picks, copy }: { picks: ExamplePreviewPick[]; copy: BestForDetailCopy }) {
   return (
     <section id="examples" className="space-y-4">
       <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-end">
@@ -865,7 +475,7 @@ function EditorialReasonCard({
   entry: BestForEntry;
   picks: RankedPick[];
   locale: AppLocale;
-  copy: (typeof DETAIL_COPY)[AppLocale];
+  copy: BestForDetailCopy;
 }) {
   return (
     <section className="rounded-[14px] border border-hairline bg-surface p-5 shadow-sm">
@@ -895,7 +505,7 @@ function MistakesCard({
   locale: AppLocale;
   usecaseSlug: string;
   criteria: string[];
-  copy: (typeof DETAIL_COPY)[AppLocale];
+  copy: BestForDetailCopy;
 }) {
   const mistakes = buildUsecaseMistakes(locale, usecaseSlug, criteria);
   return (
@@ -915,41 +525,6 @@ function MistakesCard({
   );
 }
 
-function buildUsecaseMistakes(locale: AppLocale, usecaseSlug: string, criteria: string[]) {
-  const label = getUsecaseLabel(locale, usecaseSlug);
-  const primary = criteria[0] ?? USECASE_MISTAKE_FALLBACKS[locale]?.[0] ?? USECASE_MISTAKE_FALLBACKS.en[0];
-  const secondary = criteria[1] ?? USECASE_MISTAKE_FALLBACKS[locale]?.[1] ?? USECASE_MISTAKE_FALLBACKS.en[1];
-  const tertiary = criteria[2] ?? USECASE_MISTAKE_FALLBACKS[locale]?.[2] ?? USECASE_MISTAKE_FALLBACKS.en[2];
-
-  if (locale === 'fr') {
-    return [
-      `Choisir un modèle pour ${label} sans vérifier ${primary.toLowerCase()}.`,
-      `Multiplier les références alors que ${secondary.toLowerCase()} doit rester prioritaire.`,
-      `Passer directement au modèle premium avant d’avoir validé ${tertiary.toLowerCase()}.`,
-      'Oublier de contrôler le coût avant de générer.',
-      'Comparer seulement les fiches modèles sans ouvrir les exemples réels liés à ce cas d’usage.',
-    ];
-  }
-
-  if (locale === 'es') {
-    return [
-      `Elegir un motor para ${label} sin comprobar ${primary.toLowerCase()}.`,
-      `Añadir demasiadas referencias cuando ${secondary.toLowerCase()} debería ser la prioridad.`,
-      `Pasar directo al modelo premium antes de validar ${tertiary.toLowerCase()}.`,
-      'Olvidar revisar el coste antes de generar.',
-      'Comparar solo fichas de modelos sin abrir ejemplos reales para este objetivo.',
-    ];
-  }
-
-  return [
-    `Choosing an engine for ${label} without checking ${primary.toLowerCase()}.`,
-    `Adding too many references when ${secondary.toLowerCase()} should stay primary.`,
-    `Going straight to a premium model before validating ${tertiary.toLowerCase()}.`,
-    'Forgetting to check the cost before generation.',
-    'Comparing model pages only without opening real examples for this use case.',
-  ];
-}
-
 function CriteriaCard({
   criteria,
   locale,
@@ -957,9 +532,9 @@ function CriteriaCard({
 }: {
   criteria: string[];
   locale: AppLocale;
-  copy: (typeof DETAIL_COPY)[AppLocale];
+  copy: BestForDetailCopy;
 }) {
-  const filledCriteria = criteria.concat(DECISION_CRITERIA_FILLERS[locale] ?? DECISION_CRITERIA_FILLERS.en).slice(0, 5);
+  const filledCriteria = getFilledCriteria(locale, criteria);
   return (
     <section className="rounded-[16px] border border-hairline bg-surface p-5 shadow-card">
       <p className="text-sm font-semibold text-text-primary">{copy.criteria}</p>
@@ -977,7 +552,7 @@ function CriteriaCard({
   );
 }
 
-function CompareCard({ comparisons, copy }: { comparisons: string[]; copy: (typeof DETAIL_COPY)[AppLocale] }) {
+function CompareCard({ comparisons, copy }: { comparisons: string[]; copy: BestForDetailCopy }) {
   if (!comparisons.length) return null;
   return (
     <section className="rounded-[16px] border border-hairline bg-surface p-5 shadow-card">
@@ -999,7 +574,7 @@ function CompareCard({ comparisons, copy }: { comparisons: string[]; copy: (type
   );
 }
 
-function RelatedGuidesCard({ guides, copy }: { guides: RelatedGuideEntry[]; copy: (typeof DETAIL_COPY)[AppLocale] }) {
+function RelatedGuidesCard({ guides, copy }: { guides: RelatedGuideEntry[]; copy: BestForDetailCopy }) {
   return (
     <section className="rounded-[16px] border border-hairline bg-surface p-5 shadow-card">
       <p className="text-sm font-semibold text-text-primary">{copy.relatedGuides}</p>
@@ -1025,7 +600,7 @@ function RelatedGuidesCard({ guides, copy }: { guides: RelatedGuideEntry[]; copy
   );
 }
 
-function QuickLinksCard({ copy }: { copy: (typeof DETAIL_COPY)[AppLocale] }) {
+function QuickLinksCard({ copy }: { copy: BestForDetailCopy }) {
   return (
     <section className="rounded-[16px] border border-hairline bg-surface p-5 shadow-card">
       <p className="text-sm font-semibold text-text-primary">{copy.quickLinks}</p>
@@ -1062,547 +637,4 @@ function BestForContent({ content, contentComing }: { content: ContentEntry | nu
       <div className="prose prose-slate max-w-none" dangerouslySetInnerHTML={{ __html: content.content }} />
     </article>
   );
-}
-
-async function loadEngineScores(): Promise<Map<string, EngineScore>> {
-  const candidates = [
-    path.join(process.cwd(), 'data', 'benchmarks', 'engine-scores.v1.json'),
-    path.join(process.cwd(), '..', 'data', 'benchmarks', 'engine-scores.v1.json'),
-  ];
-  for (const candidate of candidates) {
-    try {
-      const raw = await fs.readFile(candidate, 'utf8');
-      const data = JSON.parse(raw) as EngineScoresFile;
-      const map = new Map<string, EngineScore>();
-      (data.scores ?? []).forEach((entry) => {
-        const key = entry.modelSlug ?? entry.engineId;
-        if (key) {
-          map.set(key, entry);
-        }
-      });
-      return map;
-    } catch {
-      // keep trying
-    }
-  }
-  return new Map();
-}
-
-const USECASE_WEIGHTS: Record<string, Partial<Record<keyof EngineScore, number>>> = {
-  'ugc-ads': { motion: 0.3, fidelity: 0.25, consistency: 0.2, lipsyncQuality: 0.15, textRendering: 0.1 },
-  'product-videos': { fidelity: 0.35, consistency: 0.25, anatomy: 0.2, motion: 0.1, textRendering: 0.1 },
-  'lipsync-dialogue': { lipsyncQuality: 0.4, consistency: 0.2, fidelity: 0.2, motion: 0.1, anatomy: 0.1 },
-  'cinematic-realism': { fidelity: 0.35, motion: 0.25, consistency: 0.2, anatomy: 0.1, textRendering: 0.1 },
-  'fast-drafts': { motion: 0.3, consistency: 0.25, fidelity: 0.2, textRendering: 0.15, anatomy: 0.1 },
-  'vertical-shorts': { motion: 0.3, consistency: 0.25, fidelity: 0.2, textRendering: 0.15, anatomy: 0.1 },
-  'image-to-video': { consistency: 0.3, fidelity: 0.3, motion: 0.2, anatomy: 0.1, textRendering: 0.1 },
-  'stylized-anime': { consistency: 0.3, motion: 0.25, fidelity: 0.2, textRendering: 0.15, anatomy: 0.1 },
-  'character-reference': { consistency: 0.4, anatomy: 0.2, fidelity: 0.2, motion: 0.1, textRendering: 0.1 },
-  'reference-to-video': { consistency: 0.35, fidelity: 0.3, motion: 0.2, anatomy: 0.1, textRendering: 0.05 },
-  'multi-shot-video': { sequencingQuality: 0.35, consistency: 0.25, motion: 0.2, fidelity: 0.15, anatomy: 0.05 },
-  '4k-video': { fidelity: 0.45, consistency: 0.25, motion: 0.15, anatomy: 0.1, textRendering: 0.05 },
-  ads: { fidelity: 0.3, consistency: 0.25, textRendering: 0.2, motion: 0.15, anatomy: 0.1 },
-};
-
-function scoreEngineForUsecase(score: EngineScore, weights: Partial<Record<keyof EngineScore, number>>) {
-  let total = 0;
-  let weightSum = 0;
-  Object.entries(weights).forEach(([key, weight]) => {
-    const value = score[key as keyof EngineScore];
-    if (typeof value === 'number' && typeof weight === 'number') {
-      total += value * weight;
-      weightSum += weight;
-    }
-  });
-  if (weightSum === 0) return 0;
-  return total / weightSum;
-}
-
-function resolveTopPicks(entry: BestForEntry, scores: Map<string, EngineScore>): string[] {
-  if (entry.topPicks?.length) return entry.topPicks;
-  const weights = USECASE_WEIGHTS[entry.slug] ?? {};
-  const ranked = ENGINE_CATALOG.map((engine) => {
-    const score = scores.get(engine.modelSlug) ?? (engine.engineId ? scores.get(engine.engineId) : null) ?? null;
-    const value = score ? scoreEngineForUsecase(score, weights) : 0;
-    return { slug: engine.modelSlug, value };
-  })
-    .sort((a, b) => b.value - a.value)
-    .slice(0, 3)
-    .map((entry) => entry.slug);
-  return ranked.length ? ranked : ENGINE_CATALOG.slice(0, 3).map((engine) => engine.modelSlug);
-}
-
-function buildRankedPick({
-  usecaseSlug,
-  modelSlug,
-  rank,
-  scores,
-  criteria,
-  copy,
-  locale,
-}: {
-  usecaseSlug: string;
-  modelSlug: string;
-  rank: number;
-  scores: Map<string, EngineScore>;
-  criteria: string[];
-  copy: (typeof DETAIL_COPY)[AppLocale];
-  locale: AppLocale;
-}): RankedPick {
-  const engine = ENGINE_BY_SLUG.get(modelSlug);
-  const score = getFitScore(usecaseSlug, scores.get(modelSlug) ?? (engine?.engineId ? scores.get(engine.engineId) : undefined));
-  const criterion = criteria[(rank - 1) % criteria.length] ?? criteria[0] ?? copy.fit;
-  const fallbackScore = Math.max(6.8, 8.6 - rank * 0.22);
-  return {
-    slug: modelSlug,
-    engine,
-    rank,
-    criterion,
-    score: score ?? fallbackScore,
-    accent: getEngineAccent(modelSlug),
-    reason: buildPickReason(locale, usecaseSlug, criterion, rank),
-    bullets: buildPickBullets(locale, criteria, rank),
-  };
-}
-
-async function resolveExamplePreviewPicks(picks: RankedPick[]): Promise<ExamplePreviewPick[]> {
-  const examplesSlugs = Array.from(new Set(picks.map((pick) => getExamplesSlug(pick))));
-  const heroThumbEntries = await Promise.all(
-    examplesSlugs.map(async (examplesSlug) => {
-      try {
-        const result = await listExampleFamilyPage(examplesSlug, {
-          sort: 'playlist',
-          limit: EXAMPLES_HERO_SELECTION_LIMIT,
-          offset: 0,
-        });
-        const heroVideo = pickFirstPlayableVideo(result.items);
-        return [examplesSlug, heroVideo?.thumbUrl ?? null] as const;
-      } catch {
-        return [examplesSlug, null] as const;
-      }
-    })
-  );
-  const heroThumbBySlug = new Map(heroThumbEntries);
-
-  return picks.map((pick) => {
-    const examplesSlug = getExamplesSlug(pick);
-    return {
-      ...pick,
-      examplesSlug,
-      heroThumbUrl: heroThumbBySlug.get(examplesSlug) ?? null,
-    };
-  });
-}
-
-function getBestForDisplayTitle(locale: AppLocale, entry?: BestForEntry, fallbackTitle?: string) {
-  if (!entry) return fallbackTitle ?? 'Best AI video engines by use case';
-  if (locale !== 'en') return fallbackTitle ?? entry.title;
-  const intentLabels: Record<string, string> = {
-    'image-to-video': 'image-to-video',
-    'cinematic-realism': 'cinematic realism',
-    'character-reference': 'character reference',
-    'reference-to-video': 'reference-to-video',
-    'multi-shot-video': 'multi-shot video',
-    '4k-video': '4K video',
-    ads: 'ads',
-    'ugc-ads': 'UGC videos',
-    'product-videos': 'product videos',
-    'lipsync-dialogue': 'lip sync and dialogue',
-    'fast-drafts': 'fast drafts',
-    'stylized-anime': 'anime and stylized video',
-  };
-  return `Best AI video engines for ${intentLabels[entry.slug] ?? entry.title.replace(/^Best\s+/i, '').toLowerCase()}`;
-}
-
-function buildBestForHeroDescription(locale: AppLocale, entry: BestForEntry, fallbackDescription?: string) {
-  if (locale !== 'en') return fallbackDescription ?? entry.description ?? 'Editorial guidance for picking the best AI video engines by use case.';
-  const names = (entry.topPicks ?? []).slice(0, 3).map((slug) => ENGINE_BY_SLUG.get(slug)?.marketingName ?? slug);
-  if (!names.length) return fallbackDescription ?? entry.description ?? 'Compare AI video engines before spending credits.';
-  return `Compare ${formatList(names)} for ${entry.title.replace(/^Best\s+/i, '').replace(/\s+AI generator$/i, '').toLowerCase()} before spending credits.`;
-}
-
-function buildBestForMetaDescription(locale: AppLocale, entry: BestForEntry, fallbackDescription?: string) {
-  if (locale !== 'en') return fallbackDescription ?? entry.description ?? 'Compare the best AI video engines by use case.';
-  const names = (entry.topPicks ?? []).slice(0, 3).map((slug) => ENGINE_BY_SLUG.get(slug)?.marketingName ?? slug);
-  const engineText = names.length ? ` Compare ${formatList(names)}` : ' Compare leading AI video engines';
-  return `${fallbackDescription ?? entry.description ?? entry.title}.${engineText} by quality, control, consistency, cost, and workflow fit.`;
-}
-
-function buildBestForKeywords(locale: AppLocale, entry: BestForEntry, localizedTitle: string) {
-  const engines = (entry.topPicks ?? []).map((slug) => ENGINE_BY_SLUG.get(slug)?.marketingName ?? slug);
-  const genericKeyword =
-    locale === 'fr'
-      ? `${entry.slug.replace(/-/g, ' ')} générateur vidéo IA`
-      : locale === 'es'
-        ? `${entry.slug.replace(/-/g, ' ')} generador de video con IA`
-        : `${entry.slug.replace(/-/g, ' ')} AI video generator`;
-  return Array.from(
-    new Set([
-      localizedTitle,
-      genericKeyword,
-      ...engines,
-      ...getUsecaseChips(locale, entry.slug, []),
-    ])
-  );
-}
-
-function formatList(items: string[]) {
-  if (items.length <= 1) return items[0] ?? '';
-  if (items.length === 2) return `${items[0]} and ${items[1]}`;
-  return `${items.slice(0, -1).join(', ')} and ${items[items.length - 1]}`;
-}
-
-function formatScore(score?: number) {
-  return typeof score === 'number' && Number.isFinite(score) ? score.toFixed(1) : '-';
-}
-
-function buildPickReason(locale: AppLocale, usecaseSlug: string, criterion: string, rank: number) {
-  const prefixes: Record<AppLocale, string[]> = {
-    en: ['Best balance of', 'Strong option for', 'Useful when you need'],
-    fr: ['Meilleur équilibre pour', 'Option forte pour', 'Utile si vous cherchez'],
-    es: ['Mejor equilibrio para', 'Opción fuerte para', 'Útil si necesitas'],
-  };
-  const suffixes: Record<string, Record<AppLocale, string>> = {
-    'cinematic-realism': {
-      en: 'cinematic camera direction',
-      fr: 'une direction caméra cinématique',
-      es: 'dirección de cámara cinematográfica',
-    },
-    'character-reference': {
-      en: 'stable identity across shots',
-      fr: 'une identité stable entre les plans',
-      es: 'identidad estable entre planos',
-    },
-    'reference-to-video': {
-      en: 'controlled reference workflows',
-      fr: 'des workflows de référence contrôlés',
-      es: 'workflows de referencia controlados',
-    },
-    'multi-shot-video': {
-      en: 'planned sequences',
-      fr: 'des séquences planifiées',
-      es: 'secuencias planificadas',
-    },
-    '4k-video': {
-      en: 'final delivery detail',
-      fr: 'le niveau de détail final',
-      es: 'detalle para entrega final',
-    },
-    ads: {
-      en: 'campaign-ready output',
-      fr: 'un rendu prêt pour campagne',
-      es: 'salidas listas para campaña',
-    },
-    'ugc-ads': {
-      en: 'creator-style social clips',
-      fr: 'des clips sociaux style créateur',
-      es: 'clips sociales estilo creador',
-    },
-    'product-videos': {
-      en: 'clean product storytelling',
-      fr: 'un storytelling produit propre',
-      es: 'storytelling de producto limpio',
-    },
-    'lipsync-dialogue': {
-      en: 'speaking character control',
-      fr: 'le contrôle de personnages parlants',
-      es: 'control de personajes con diálogo',
-    },
-    'fast-drafts': {
-      en: 'fast iteration loops',
-      fr: 'des boucles d’itération rapides',
-      es: 'ciclos rápidos de iteración',
-    },
-    'stylized-anime': {
-      en: 'stylized motion',
-      fr: 'du mouvement stylisé',
-      es: 'movimiento estilizado',
-    },
-    'image-to-video': {
-      en: 'motion from approved images',
-      fr: 'l’animation depuis images validées',
-      es: 'movimiento desde imágenes aprobadas',
-    },
-  };
-  const prefix = prefixes[locale]?.[Math.min(rank - 1, 2)] ?? prefixes.en[Math.min(rank - 1, 2)];
-  const suffix = suffixes[usecaseSlug]?.[locale] ?? suffixes[usecaseSlug]?.en ?? (locale === 'fr' ? 'ce cas d’usage' : locale === 'es' ? 'este objetivo' : 'this use case');
-  const connector = locale === 'en' ? 'for' : locale === 'es' ? 'en' : 'sur';
-  return `${prefix} ${criterion.toLowerCase()} ${connector} ${suffix}.`;
-}
-
-function buildPickBullets(locale: AppLocale, criteria: string[], rank: number) {
-  const primary = criteria[(rank - 1) % criteria.length] ?? criteria[0] ?? 'Use-case fit';
-  const secondary = criteria[rank % criteria.length] ?? criteria[1] ?? 'Reliable output';
-  const tertiary = criteria[(rank + 1) % criteria.length] ?? criteria[2] ?? 'Efficient review loop';
-  const labels: Record<AppLocale, [string, string, string]> = {
-    en: ['Strong', 'Good', 'Practical'],
-    fr: ['Fort sur', 'Bon sur', 'Pratique pour'],
-    es: ['Fuerte en', 'Bueno en', 'Práctico para'],
-  };
-  const [first, second, third] = labels[locale] ?? labels.en;
-  return [`${first} ${primary.toLowerCase()}`, `${second} ${secondary.toLowerCase()}`, `${third} ${tertiary.toLowerCase()}`];
-}
-
-function getPublishedRelatedComparisons(entry: BestForEntry) {
-  return Array.from(
-    new Set(
-      (entry.relatedComparisons ?? [])
-        .filter((slug) => isPublishedComparisonSlug(slug))
-        .map((slug) => canonicalizePublishedCompareSlug(slug))
-    )
-  );
-}
-
-function pickComparisonSlug(picks: RankedPick[], relatedComparisons: string[]) {
-  const explicit = relatedComparisons.find((slug) => isPublishedComparisonSlug(slug));
-  if (explicit) return canonicalizePublishedCompareSlug(explicit);
-  for (let index = 0; index < picks.length; index += 1) {
-    for (let nextIndex = index + 1; nextIndex < picks.length; nextIndex += 1) {
-      const candidate = `${picks[index].slug}-vs-${picks[nextIndex].slug}`;
-      if (isPublishedComparisonSlug(candidate)) {
-        return canonicalizePublishedCompareSlug(candidate);
-      }
-    }
-  }
-  return null;
-}
-
-function findComparisonForPick(slug: string, relatedComparisons: string[]) {
-  return relatedComparisons.find((comparison) => comparison.split('-vs-').includes(slug)) ?? null;
-}
-
-function getExamplesSlug(pick: RankedPick) {
-  return pick.engine?.family ?? pick.slug;
-}
-
-function getTopPicksTitle(locale: AppLocale, slug: string) {
-  const labels: Record<string, Record<AppLocale, string>> = {
-    'cinematic-realism': {
-      en: 'Top picks for cinematic shots',
-      fr: 'Meilleurs choix pour plans cinéma',
-      es: 'Mejores opciones para planos cinematográficos',
-    },
-    'character-reference': {
-      en: 'Top picks for character reference',
-      fr: 'Meilleurs choix pour character reference',
-      es: 'Mejores opciones para character reference',
-    },
-    'reference-to-video': {
-      en: 'Top picks for reference-to-video',
-      fr: 'Meilleurs choix pour reference-to-video',
-      es: 'Mejores opciones para reference-to-video',
-    },
-    'multi-shot-video': {
-      en: 'Top picks for multi-shot video',
-      fr: 'Meilleurs choix pour multi-shot',
-      es: 'Mejores opciones para multi-shot',
-    },
-    '4k-video': {
-      en: 'Top picks for 4K delivery',
-      fr: 'Meilleurs choix pour livraison 4K',
-      es: 'Mejores opciones para entrega 4K',
-    },
-    ads: {
-      en: 'Top picks for ads',
-      fr: 'Meilleurs choix pour publicités',
-      es: 'Mejores opciones para anuncios',
-    },
-    'ugc-ads': {
-      en: 'Top picks for UGC videos',
-      fr: 'Meilleurs choix pour vidéos UGC',
-      es: 'Mejores opciones para videos UGC',
-    },
-    'product-videos': {
-      en: 'Top picks for product videos',
-      fr: 'Meilleurs choix pour vidéos produit',
-      es: 'Mejores opciones para videos de producto',
-    },
-    'lipsync-dialogue': {
-      en: 'Top picks for dialogue',
-      fr: 'Meilleurs choix pour dialogue',
-      es: 'Mejores opciones para diálogo',
-    },
-    'fast-drafts': {
-      en: 'Top picks for fast drafts',
-      fr: 'Meilleurs choix pour tests rapides',
-      es: 'Mejores opciones para borradores rápidos',
-    },
-    'stylized-anime': {
-      en: 'Top picks for stylized video',
-      fr: 'Meilleurs choix pour vidéo stylisée',
-      es: 'Mejores opciones para video estilizado',
-    },
-    'image-to-video': {
-      en: 'Top picks for image-to-video',
-      fr: 'Meilleurs choix image vers vidéo',
-      es: 'Mejores opciones de imagen a video',
-    },
-  };
-  return labels[slug]?.[locale] ?? labels[slug]?.en ?? (locale === 'fr' ? 'Meilleurs choix' : locale === 'es' ? 'Mejores opciones' : 'Top picks');
-}
-
-function getRelatedBestForGuides(slug: string) {
-  const relatedBySlug: Record<string, string[]> = {
-    'cinematic-realism': ['fast-drafts', 'multi-shot-video', 'product-videos', 'character-reference', '4k-video'],
-    'image-to-video': ['reference-to-video', 'product-videos', 'character-reference', 'ads'],
-    'character-reference': ['reference-to-video', 'ugc-ads', 'multi-shot-video', 'product-videos'],
-    'reference-to-video': ['image-to-video', 'character-reference', 'product-videos', 'ads'],
-    'multi-shot-video': ['cinematic-realism', 'character-reference', 'ads', 'fast-drafts'],
-    '4k-video': ['cinematic-realism', 'product-videos', 'ads', 'fast-drafts'],
-    ads: ['ugc-ads', 'product-videos', 'cinematic-realism', 'reference-to-video'],
-    'ugc-ads': ['ads', 'lipsync-dialogue', 'character-reference', 'fast-drafts'],
-    'product-videos': ['ads', 'image-to-video', 'reference-to-video', '4k-video'],
-    'lipsync-dialogue': ['ugc-ads', 'character-reference', 'cinematic-realism', 'fast-drafts'],
-    'fast-drafts': ['cinematic-realism', 'ads', 'multi-shot-video', '4k-video'],
-    'stylized-anime': ['fast-drafts', 'image-to-video', 'multi-shot-video', 'character-reference'],
-  };
-  const targets = relatedBySlug[slug] ?? BEST_FOR_PAGES.filter((entry) => entry.slug !== slug).slice(0, 4).map((entry) => entry.slug);
-  return targets.map((target) => getEntry(target)).filter((entry): entry is BestForEntry => Boolean(entry)).slice(0, 5);
-}
-
-async function resolveRelatedBestForGuides(locale: AppLocale, slug: string): Promise<RelatedGuideEntry[]> {
-  const guides = getRelatedBestForGuides(slug);
-  const localizedRoot = locale === defaultLocale ? 'content/en/best-for' : `content/${locale}/best-for`;
-  const [localizedEntries, englishEntries] = await Promise.all([
-    getContentEntries(localizedRoot),
-    locale === defaultLocale ? Promise.resolve([]) : getContentEntries('content/en/best-for'),
-  ]);
-  const localizedBySlug = new Map(localizedEntries.map((entry) => [entry.slug, entry]));
-  const englishBySlug = new Map(englishEntries.map((entry) => [entry.slug, entry]));
-
-  return guides.map((guide) => {
-    const content = localizedBySlug.get(guide.slug) ?? englishBySlug.get(guide.slug);
-    return {
-      ...guide,
-      displayTitle: content?.title ?? guide.title,
-    };
-  });
-}
-
-function getAlsoAvailableModels(slug: string, topPicks: string[]) {
-  const preferred: Record<string, string[]> = {
-    'cinematic-realism': ['ltx-2-3-fast', 'wan-2-6', 'pika-text-to-video', 'happy-horse-1-0'],
-    'image-to-video': ['sora-2-pro', 'veo-3-1-fast', 'pika-text-to-video', 'happy-horse-1-0'],
-    'character-reference': ['seedance-2-0', 'sora-2-pro', 'veo-3-1', 'happy-horse-1-0'],
-    'reference-to-video': ['sora-2-pro', 'veo-3-1-fast', 'wan-2-6', 'happy-horse-1-0'],
-    'multi-shot-video': ['ltx-2-3-pro', 'wan-2-6', 'pika-text-to-video', 'happy-horse-1-0'],
-    '4k-video': ['kling-3-pro', 'veo-3-1', 'sora-2-pro'],
-    ads: ['veo-3-1-fast', 'sora-2-pro', 'pika-text-to-video', 'happy-horse-1-0'],
-    'ugc-ads': ['ltx-2-3-pro', 'veo-3-1-fast', 'pika-text-to-video', 'happy-horse-1-0'],
-    'product-videos': ['kling-3-4k', 'veo-3-1-fast', 'pika-text-to-video', 'happy-horse-1-0'],
-    'lipsync-dialogue': ['ltx-2-3-pro', 'sora-2', 'pika-text-to-video', 'happy-horse-1-0'],
-    'fast-drafts': ['pika-text-to-video', 'minimax-hailuo-02-text', 'wan-2-6'],
-    'stylized-anime': ['seedance-2-0', 'wan-2-6', 'ltx-2-3-fast'],
-  };
-  return (preferred[slug] ?? [])
-    .filter((modelSlug) => !topPicks.includes(modelSlug))
-    .map((modelSlug) => ENGINE_BY_SLUG.get(modelSlug))
-    .filter((engine): engine is EngineCatalogEntry => Boolean(engine))
-    .slice(0, 3);
-}
-
-function buildReasonSentence(locale: AppLocale, usecaseSlug: string, pick: RankedPick) {
-  const usecaseLabel = getUsecaseLabel(locale, usecaseSlug);
-  if (locale === 'fr') {
-    return `est classé ici car il donne aux utilisateurs MaxVideoAI une route pratique vers ${pick.criterion.toLowerCase()}, tout en gardant le flux adapté à ${usecaseLabel}.`;
-  }
-  if (locale === 'es') {
-    return `está aquí porque da a los usuarios de MaxVideoAI una ruta práctica hacia ${pick.criterion.toLowerCase()}, manteniendo el flujo adecuado para ${usecaseLabel}.`;
-  }
-  return `ranks here because it gives MaxVideoAI users a practical route to ${pick.criterion.toLowerCase()} while keeping the workflow suitable for ${usecaseLabel}.`;
-}
-
-function serializeJsonLd(data: unknown): string {
-  return JSON.stringify(data).replace(/</g, '\\u003c');
-}
-
-function buildBreadcrumbJsonLd(locale: AppLocale, entry: BestForEntry, title: string, canonicalUrl: string) {
-  return {
-    '@context': 'https://schema.org',
-    '@type': 'BreadcrumbList',
-    itemListElement: [
-      {
-        '@type': 'ListItem',
-        position: 1,
-        name: 'Best for',
-        item: getLocalizedUrl(locale, '/ai-video-engines/best-for'),
-      },
-      {
-        '@type': 'ListItem',
-        position: 2,
-        name: title || entry.title,
-        item: canonicalUrl,
-      },
-    ],
-  };
-}
-
-function buildBestForItemListJsonLd(locale: AppLocale, picks: RankedPick[], canonicalUrl: string) {
-  return {
-    '@context': 'https://schema.org',
-    '@type': 'ItemList',
-    name: `Ranked AI video engines for ${canonicalUrl.split('/').pop()?.replace(/-/g, ' ') ?? 'this use case'}`,
-    itemListOrder: 'https://schema.org/ItemListOrderAscending',
-    itemListElement: picks.map((pick) => ({
-      '@type': 'ListItem',
-      position: pick.rank,
-      name: pick.engine?.marketingName ?? pick.slug,
-      url: getLocalizedUrl(locale, `/models/${pick.slug}`),
-    })),
-  };
-}
-
-function buildBestForWebPageJsonLd(title: string, description: string, canonicalUrl: string) {
-  return {
-    '@context': 'https://schema.org',
-    '@type': 'WebPage',
-    name: title,
-    url: canonicalUrl,
-    description,
-  };
-}
-
-function getFitScore(slug: string, score?: EngineScore) {
-  if (!score) return undefined;
-  const weights = USECASE_WEIGHTS[slug] ?? {};
-  const value = scoreEngineForUsecase(score, weights);
-  return value > 0 ? value : undefined;
-}
-
-function getUsecaseCriteria(locale: AppLocale, slug: string) {
-  return USECASE_CRITERIA[slug]?.[locale] ?? USECASE_CRITERIA[slug]?.en ?? USECASE_CRITERIA['image-to-video'].en;
-}
-
-function getUsecaseChips(locale: AppLocale, slug: string, fallback: string[]) {
-  return USECASE_CHIPS[slug]?.[locale] ?? USECASE_CHIPS[slug]?.en ?? fallback;
-}
-
-function getUsecaseLabel(locale: AppLocale, slug: string) {
-  const labels: Record<string, Record<AppLocale, string>> = {
-    'cinematic-realism': { en: 'cinematic realism', fr: 'un rendu cinématique', es: 'realismo cinematográfico' },
-    'character-reference': { en: 'character reference', fr: 'la référence personnage', es: 'referencia de personaje' },
-    'reference-to-video': { en: 'reference-to-video', fr: 'la vidéo guidée par référence', es: 'video guiado por referencia' },
-    'multi-shot-video': { en: 'multi-shot video', fr: 'la vidéo multi-plan', es: 'video multi-plano' },
-    '4k-video': { en: '4K video', fr: 'la vidéo 4K', es: 'video 4K' },
-    ads: { en: 'ads', fr: 'les publicités', es: 'anuncios' },
-    'ugc-ads': { en: 'UGC videos', fr: 'les vidéos UGC', es: 'videos UGC' },
-    'product-videos': { en: 'product videos', fr: 'les vidéos produit', es: 'videos de producto' },
-    'lipsync-dialogue': { en: 'lip sync and dialogue', fr: 'la synchronisation labiale et le dialogue', es: 'sincronización labial y diálogo' },
-    'fast-drafts': { en: 'fast drafts', fr: 'les tests rapides', es: 'borradores rápidos' },
-    'stylized-anime': { en: 'anime and stylized video', fr: 'la vidéo anime et stylisée', es: 'anime y video estilizado' },
-    'image-to-video': { en: 'image-to-video', fr: "l'image vers vidéo", es: 'imagen a video' },
-  };
-  return labels[slug]?.[locale] ?? labels[slug]?.en ?? slug.replace(/-/g, ' ');
-}
-
-function getEngineAccent(slug: string) {
-  if (slug.includes('kling')) return '#7c3aed';
-  if (slug.includes('seedance')) return '#0ea5e9';
-  if (slug.includes('veo')) return '#22c55e';
-  if (slug.includes('sora')) return '#111827';
-  if (slug.includes('ltx')) return '#f59e0b';
-  if (slug.includes('pika')) return '#ec4899';
-  if (slug.includes('minimax')) return '#f97316';
-  if (slug.includes('wan')) return '#6366f1';
-  return '#6366f1';
 }

--- a/tests/best-for-detail-architecture.test.ts
+++ b/tests/best-for-detail-architecture.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const routePath = 'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/best-for/[usecase]/page.tsx';
+const pageSource = readFileSync(routePath, 'utf8');
+const configSource = readFileSync(
+  'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/best-for/[usecase]/_lib/best-for-detail-config.ts',
+  'utf8'
+);
+const helperSource = readFileSync(
+  'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/best-for/[usecase]/_lib/best-for-detail-helpers.ts',
+  'utf8'
+);
+
+test('best-for detail page delegates editorial config and data helpers', () => {
+  const lineCount = pageSource.split('\n').length;
+
+  assert.ok(lineCount < 800, `best-for detail page should stay under 800 lines after split, got ${lineCount}`);
+  assert.ok(pageSource.includes("from './_lib/best-for-detail-config'"));
+  assert.ok(pageSource.includes("from './_lib/best-for-detail-helpers'"));
+  assert.doesNotMatch(pageSource, /const DETAIL_COPY/);
+  assert.doesNotMatch(pageSource, /const USECASE_CRITERIA/);
+  assert.doesNotMatch(pageSource, /async function loadEngineScores/);
+});
+
+test('best-for detail helper modules own config, rankings, related guides, and schema builders', () => {
+  assert.match(configSource, /export const DETAIL_COPY/);
+  assert.match(configSource, /export const USECASE_CRITERIA/);
+  assert.match(helperSource, /export function resolveTopPicks/);
+  assert.match(helperSource, /export function buildRankedPick/);
+  assert.match(helperSource, /export async function resolveRelatedBestForGuides/);
+  assert.match(helperSource, /export function buildBestForItemListJsonLd/);
+});


### PR DESCRIPTION
## Summary
- move Best-for detail editorial copy, config, rankings, and schema builders into route-local _lib modules
- keep page.tsx focused on metadata, data orchestration, and section rendering
- add an architecture contract so the best-for detail route stays below 800 lines

## Checks
- node --test tests/best-for-detail-architecture.test.ts
- npm exec eslint -- "app/(localized)/[locale]/(marketing)/ai-video-engines/best-for/[usecase]/page.tsx" "app/(localized)/[locale]/(marketing)/ai-video-engines/best-for/[usecase]/_lib/best-for-detail-config.ts" "app/(localized)/[locale]/(marketing)/ai-video-engines/best-for/[usecase]/_lib/best-for-detail-helpers.ts"
- npm exec tsc -- --noEmit
- npm --prefix frontend run lint
- npm run lint:exposure
- node --test tests/premerge-seo-routes.test.ts

## Note
- node --test tests/localized-fallback-seo.test.ts is not runnable directly in this repo setup because Node cannot resolve extensionless TS/path aliases for frontend/lib/seo/localizedFallback.