### PR TITLE
[codex] Split home redesign type contracts

### DIFF
--- a/frontend/components/marketing/home/HomeRedesignSections.tsx
+++ b/frontend/components/marketing/home/HomeRedesignSections.tsx
@@ -30,226 +30,41 @@ import { ButtonLink } from '@/components/ui/Button';
 import { EngineIcon } from '@/components/ui/EngineIcon';
 import { UIIcon } from '@/components/ui/UIIcon';
 import { HeroVideoShowcase, type HeroVideoShowcaseItem } from '@/components/marketing/home/HeroVideoShowcase';
+import type {
+  ComparisonCard,
+  FaqItem,
+  HomeExampleCard,
+  HomeHeroContent,
+  ProofStat,
+  ProviderItem,
+  SectionCopy,
+  ShotTypeCard,
+  ToolCard,
+  ToolIconKey,
+  TrustCard,
+  WorkflowSeoSummaryCopy,
+  WorkflowStep,
+} from '@/components/marketing/home/home-redesign-types';
 
-type AnalyticsProps = {
-  'data-analytics-event'?: string;
-  'data-analytics-cta-name'?: string;
-  'data-analytics-cta-location'?: string;
-  'data-analytics-target-family'?: string;
-  'data-analytics-tool-name'?: string;
-  'data-analytics-tool-surface'?: string;
-};
-
-export type HomeCta = {
-  label: string;
-  href: LocalizedLinkHref;
-  analytics?: AnalyticsProps;
-};
-
-export type HomeHeroContent = {
-  eyebrow: string;
-  badgeChips: string[];
-  title: string;
-  subtitle: string;
-  primaryCta: string;
-  secondaryCta: string;
-  examplesCta: string;
-  trustBadges: string[];
-  valueCards: Array<{
-    title: string;
-    body: string;
-  }>;
-  mockup: {
-    promptLabel: string;
-    prompt: string;
-    shotTypeLabel: string;
-    shotTypes: string[];
-    engineLabel: string;
-    engineRecommendations: Array<{
-      engineId: string;
-      name: string;
-      provider: string;
-      bestFor: string;
-      fallbackPrice: string;
-      price?: string;
-      modeLabel?: string;
-      rateLabel?: string;
-      examplesHref?: LocalizedLinkHref;
-      modelHref?: LocalizedLinkHref;
-      examplesLabel?: string;
-      modelLabel?: string;
-      selected?: boolean;
-      scores: Array<{ label: string; value: number }>;
-      tags: string[];
-    }>;
-    quoteLabel: string;
-    quoteValue: string;
-    quoteMeta: string;
-    outputLabel: string;
-    queueLabel: string;
-    queueItems: string[];
-    generateCta: string;
-    refundNote: string;
-    playLabel: string;
-    pauseLabel: string;
-  };
-};
-
-export type ProofStat = {
-  id: string;
-  value: string;
-  label: string;
-  href?: LocalizedLinkHref;
-};
-
-export type BestForTopPick = {
-  slug: string;
-  label: string;
-  brandId?: string;
-  provider?: string;
-};
-
-export type ShotTypeCard = {
-  id: string;
-  slug: string;
-  title: string;
-  body: string;
-  cta: string;
-  href: LocalizedLinkHref;
-  tier: number;
-  topPicks: BestForTopPick[];
-};
-
-export type HomeExampleCard = {
-  id: string;
-  title: string;
-  engineId?: string;
-  engine: string;
-  mode: string;
-  duration: string;
-  price?: string | null;
-  useCase: string;
-  imageSrc: string;
-  videoSrc?: string | null;
-  imageAlt: string;
-  href: LocalizedLinkHref;
-  modelHref?: LocalizedLinkHref;
-  cloneHref?: LocalizedLinkHref;
-  ctaLabel: string;
-  examplesCtaVisible?: boolean;
-  modelCtaLabel?: string;
-  cloneLabel?: string;
-};
-
-export type ComparisonCard = {
-  id: string;
-  title: string;
-  body: string;
-  badges: string[];
-  cta: string;
-  href: LocalizedLinkHref;
-  imageSrc?: string;
-  imageAlt?: string;
-  media?: Array<{
-    imageSrc: string;
-    imageAlt: string;
-    label?: string;
-  }>;
-};
-
-export type WorkflowStep = {
-  title: string;
-  body: string;
-  toolLabel: string;
-  href: LocalizedLinkHref;
-};
-
-export type ToolCard = {
-  id: string;
-  title: string;
-  body: string;
-  shortBody?: string;
-  href: LocalizedLinkHref;
-  icon: ToolIconKey;
-};
-
-export type TrustCard = {
-  title: string;
-  body: string;
-};
-
-export type ProviderItem = {
-  provider: string;
-  model: string;
-  href?: LocalizedLinkHref;
-};
-
-export type FaqItem = {
-  question: string;
-  answer: string;
-};
-
-type SectionCopy = {
-  title: string;
-  subtitle: string;
-  eyebrow?: string;
-  cta?: string;
-  primaryCta?: string;
-  secondaryCta?: string;
-  scorecardTitle?: string;
-  scorecardSubtitle?: string;
-  scorecardLeftLabel?: string;
-  scorecardRightLabel?: string;
-  scorecardCriteriaLabel?: string;
-  scorecardRows?: Array<{ label: string; left: number; right: number }>;
-  featureCards?: Array<{ title: string; body: string }>;
-  modelsCta?: string;
-  libraryTitle?: string;
-  libraryBody?: string;
-  providerLabel?: string;
-  hubCtaTitle?: string;
-  hubCtaBody?: string;
-  guideLabel?: string;
-  topPicksLabel?: string;
-  moreGuidesTitle?: string;
-  supportingText?: string;
-  modelsLink?: string;
-  examplesLink?: string;
-  compareLink?: string;
-};
-
-export type WorkflowSeoSummaryCopy = {
-  heroParagraph?: string;
-  heroPoints?: string[];
-  definition?: {
-    title?: string;
-    body?: string;
-  };
-  generateWays?: {
-    title?: string;
-    items?: Array<{
-      title: string;
-      body: string;
-    }>;
-  };
-};
+export type {
+  ComparisonCard,
+  FaqItem,
+  HomeCta,
+  HomeExampleCard,
+  HomeHeroContent,
+  ProofStat,
+  ProviderItem,
+  ShotTypeCard,
+  ToolCard,
+  TrustCard,
+  WorkflowSeoSummaryCopy,
+  WorkflowStep,
+} from '@/components/marketing/home/home-redesign-types';
 
 function isWorkspaceHref(href: LocalizedLinkHref): boolean {
   const pathname = typeof href === 'string' ? href : 'pathname' in href && typeof href.pathname === 'string' ? href.pathname : '';
   return pathname === '/app' || pathname.startsWith('/app?') || pathname.startsWith('/app/');
 }
-
-type ToolIconKey =
-  | 'text'
-  | 'image'
-  | 'video'
-  | 'generateImage'
-  | 'character'
-  | 'angle'
-  | 'extend'
-  | 'retake'
-  | 'audio'
-  | 'compare';
 
 const TOOL_ICONS: Record<ToolIconKey, LucideIcon> = {
   text: Film,

--- a/frontend/components/marketing/home/home-redesign-types.ts
+++ b/frontend/components/marketing/home/home-redesign-types.ts
@@ -1,0 +1,216 @@
+import type { LocalizedLinkHref } from '@/i18n/navigation';
+
+export type AnalyticsProps = {
+  'data-analytics-event'?: string;
+  'data-analytics-cta-name'?: string;
+  'data-analytics-cta-location'?: string;
+  'data-analytics-target-family'?: string;
+  'data-analytics-tool-name'?: string;
+  'data-analytics-tool-surface'?: string;
+};
+
+export type HomeCta = {
+  label: string;
+  href: LocalizedLinkHref;
+  analytics?: AnalyticsProps;
+};
+
+export type HomeHeroContent = {
+  eyebrow: string;
+  badgeChips: string[];
+  title: string;
+  subtitle: string;
+  primaryCta: string;
+  secondaryCta: string;
+  examplesCta: string;
+  trustBadges: string[];
+  valueCards: Array<{
+    title: string;
+    body: string;
+  }>;
+  mockup: {
+    promptLabel: string;
+    prompt: string;
+    shotTypeLabel: string;
+    shotTypes: string[];
+    engineLabel: string;
+    engineRecommendations: Array<{
+      engineId: string;
+      name: string;
+      provider: string;
+      bestFor: string;
+      fallbackPrice: string;
+      price?: string;
+      modeLabel?: string;
+      rateLabel?: string;
+      examplesHref?: LocalizedLinkHref;
+      modelHref?: LocalizedLinkHref;
+      examplesLabel?: string;
+      modelLabel?: string;
+      selected?: boolean;
+      scores: Array<{ label: string; value: number }>;
+      tags: string[];
+    }>;
+    quoteLabel: string;
+    quoteValue: string;
+    quoteMeta: string;
+    outputLabel: string;
+    queueLabel: string;
+    queueItems: string[];
+    generateCta: string;
+    refundNote: string;
+    playLabel: string;
+    pauseLabel: string;
+  };
+};
+
+export type ProofStat = {
+  id: string;
+  value: string;
+  label: string;
+  href?: LocalizedLinkHref;
+};
+
+export type BestForTopPick = {
+  slug: string;
+  label: string;
+  brandId?: string;
+  provider?: string;
+};
+
+export type ShotTypeCard = {
+  id: string;
+  slug: string;
+  title: string;
+  body: string;
+  cta: string;
+  href: LocalizedLinkHref;
+  tier: number;
+  topPicks: BestForTopPick[];
+};
+
+export type HomeExampleCard = {
+  id: string;
+  title: string;
+  engineId?: string;
+  engine: string;
+  mode: string;
+  duration: string;
+  price?: string | null;
+  useCase: string;
+  imageSrc: string;
+  videoSrc?: string | null;
+  imageAlt: string;
+  href: LocalizedLinkHref;
+  modelHref?: LocalizedLinkHref;
+  cloneHref?: LocalizedLinkHref;
+  ctaLabel: string;
+  examplesCtaVisible?: boolean;
+  modelCtaLabel?: string;
+  cloneLabel?: string;
+};
+
+export type ComparisonCard = {
+  id: string;
+  title: string;
+  body: string;
+  badges: string[];
+  cta: string;
+  href: LocalizedLinkHref;
+  imageSrc?: string;
+  imageAlt?: string;
+  media?: Array<{
+    imageSrc: string;
+    imageAlt: string;
+    label?: string;
+  }>;
+};
+
+export type WorkflowStep = {
+  title: string;
+  body: string;
+  toolLabel: string;
+  href: LocalizedLinkHref;
+};
+
+export type ToolIconKey =
+  | 'text'
+  | 'image'
+  | 'video'
+  | 'generateImage'
+  | 'character'
+  | 'angle'
+  | 'extend'
+  | 'retake'
+  | 'audio'
+  | 'compare';
+
+export type ToolCard = {
+  id: string;
+  title: string;
+  body: string;
+  shortBody?: string;
+  href: LocalizedLinkHref;
+  icon: ToolIconKey;
+};
+
+export type TrustCard = {
+  title: string;
+  body: string;
+};
+
+export type ProviderItem = {
+  provider: string;
+  model: string;
+  href?: LocalizedLinkHref;
+};
+
+export type FaqItem = {
+  question: string;
+  answer: string;
+};
+
+export type SectionCopy = {
+  title: string;
+  subtitle: string;
+  eyebrow?: string;
+  cta?: string;
+  primaryCta?: string;
+  secondaryCta?: string;
+  scorecardTitle?: string;
+  scorecardSubtitle?: string;
+  scorecardLeftLabel?: string;
+  scorecardRightLabel?: string;
+  scorecardCriteriaLabel?: string;
+  scorecardRows?: Array<{ label: string; left: number; right: number }>;
+  featureCards?: Array<{ title: string; body: string }>;
+  modelsCta?: string;
+  libraryTitle?: string;
+  libraryBody?: string;
+  providerLabel?: string;
+  hubCtaTitle?: string;
+  hubCtaBody?: string;
+  guideLabel?: string;
+  topPicksLabel?: string;
+  moreGuidesTitle?: string;
+  supportingText?: string;
+  modelsLink?: string;
+  examplesLink?: string;
+  compareLink?: string;
+};
+
+export type WorkflowSeoSummaryCopy = {
+  heroParagraph?: string;
+  heroPoints?: string[];
+  definition?: {
+    title?: string;
+    body?: string;
+  };
+  generateWays?: {
+    title?: string;
+    items?: Array<{
+      title: string;
+      body: string;
+    }>;
+  };
+};

--- a/tests/home-redesign-architecture.test.ts
+++ b/tests/home-redesign-architecture.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const root = process.cwd();
+const sectionsPath = join(root, 'frontend/components/marketing/home/HomeRedesignSections.tsx');
+const typesPath = join(root, 'frontend/components/marketing/home/home-redesign-types.ts');
+
+const sectionsSource = readFileSync(sectionsPath, 'utf8');
+const typesSource = readFileSync(typesPath, 'utf8');
+
+test('home redesign sections delegate shared content contracts', () => {
+  assert.ok(existsSync(typesPath), 'home redesign contracts should live beside the home section components');
+  assert.match(
+    sectionsSource,
+    /from '@\/components\/marketing\/home\/home-redesign-types'/,
+    'home sections should import reusable content contracts from the local type module'
+  );
+  assert.match(
+    sectionsSource,
+    /export type \{[\s\S]*HomeHeroContent[\s\S]*WorkflowSeoSummaryCopy[\s\S]*\} from '@\/components\/marketing\/home\/home-redesign-types'/,
+    'home sections should keep its public type export surface stable for route imports'
+  );
+});
+
+test('home redesign sections do not regain extracted type ownership', () => {
+  for (const typeName of ['HomeHeroContent', 'HomeExampleCard', 'ComparisonCard', 'WorkflowSeoSummaryCopy']) {
+    assert.doesNotMatch(
+      sectionsSource,
+      new RegExp(`export type ${typeName}\\b`),
+      `${typeName} belongs in home-redesign-types.ts`
+    );
+    assert.match(typesSource, new RegExp(`export type ${typeName}\\b`), `${typeName} should be exported by the type module`);
+  }
+
+  const lineCount = sectionsSource.split('\n').length;
+  assert.ok(lineCount <= 1400, `HomeRedesignSections should stay below 1400 lines after type extraction, got ${lineCount}`);
+});


### PR DESCRIPTION
## Summary
- Move home redesign TypeScript content contracts into a colocated type module.
- Keep HomeRedesignSections public type re-exports stable for existing route imports.
- Add an architecture guard so the section component does not regain extracted type ownership.

## Validation
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/home-redesign-architecture.test.ts tests/home-seo-signals.test.ts tests/homepage-real-examples-preview.test.ts tests/premerge-seo-routes.test.ts
- npm --prefix frontend run lint
- npm run lint:exposure
- ./node_modules/.bin/tsc --noEmit --pretty false (from frontend/)
- git diff --check