### PR TITLE
[codex] Split image composer persistence hook

### DIFF
--- a/frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx
+++ b/frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx
@@ -54,8 +54,8 @@ import { useImageSettingsFields } from './_hooks/useImageSettingsFields';
 import { useImageWorkspaceDesktopLayout } from './_hooks/useImageWorkspaceDesktopLayout';
 import { useImagePreviewActions } from './_hooks/useImagePreviewActions';
 import { useImageReferenceSlots } from './_hooks/useImageReferenceSlots';
+import { useImageComposerPersistence } from './_hooks/useImageComposerPersistence';
 import {
-  createCharacterReferenceSlot,
   mergeCharacterReferencesIntoSlots,
   parseCharacterReferenceEntry,
 } from './_lib/image-workspace-character-references';
@@ -69,19 +69,14 @@ import {
   buildCompletedGroup,
   buildPendingGroup,
 } from './_lib/image-workspace-history';
-import { parsePersistedImageComposerState } from './_lib/image-workspace-persistence';
 import {
   buildCustomImageSize,
   findImageEngine,
 } from './_lib/image-workspace-utils';
 import {
-  IMAGE_COMPOSER_STORAGE_DEBOUNCE_MS,
-  IMAGE_COMPOSER_STORAGE_KEY,
-  IMAGE_COMPOSER_STORAGE_VERSION,
   MAX_REFERENCE_SLOTS,
   type HistoryEntry,
   type ImageEngineOption,
-  type PersistedImageComposerState,
   type ReferenceSlotValue,
 } from './_lib/image-workspace-types';
 
@@ -110,11 +105,7 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
     const base = pathname ?? '/app/image';
     return params ? `${base}?${params}` : base;
   }, [pathname, searchParams]);
-  const hasHydratedStorageRef = useRef(false);
   const hydratedJobRef = useRef<string | null>(null);
-  const persistTimerRef = useRef<number | null>(null);
-  const persistedSignatureRef = useRef<string | null>(null);
-  const [storageHydrated, setStorageHydrated] = useState(false);
   const [engineId, setEngineId] = useState(() => engines[0]?.id ?? '');
   const [mode, setMode] = useState<ImageGenerationMode>('t2i');
   const [prompt, setPrompt] = useState('');
@@ -304,123 +295,41 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
     });
   }, []);
 
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    if (!engines.length) return;
-    if (hasHydratedStorageRef.current) return;
-    hasHydratedStorageRef.current = true;
-    let parsed: PersistedImageComposerState | null = null;
-    try {
-      const stored = window.localStorage.getItem(IMAGE_COMPOSER_STORAGE_KEY);
-      if (stored) {
-        parsed = parsePersistedImageComposerState(stored);
-        if (parsed) {
-          persistedSignatureRef.current = stored;
-        }
-      }
-    } catch {
-      // ignore storage failures
-    }
-
-    if (parsed && engines.length) {
-      const engineMatch = findImageEngine(engines, parsed.engineId) ?? engines[0] ?? null;
-      if (engineMatch) {
-        setEngineId(engineMatch.id);
-        const nextMode = engineMatch.modes.includes(parsed.mode) ? parsed.mode : engineMatch.modes[0] ?? 't2i';
-        setMode(nextMode);
-        setPrompt(parsed.prompt);
-        setNumImages(clampRequestedImageCount(engineMatch.engineCaps, nextMode, parsed.numImages));
-        const allowedResolutions = getImageFieldValues(
-          engineMatch.engineCaps,
-          'resolution',
-          nextMode,
-          Array.isArray(engineMatch.engineCaps?.resolutions) ? [...engineMatch.engineCaps.resolutions] : []
-        );
-        const defaultResolution = getImageInputField(engineMatch.engineCaps, 'resolution', nextMode)
-          ? getDefaultResolution(engineMatch.engineCaps, nextMode)
-          : null;
-        const nextResolution =
-          parsed.resolution && allowedResolutions.includes(parsed.resolution) ? parsed.resolution : defaultResolution;
-        setResolution(nextResolution);
-        const parsedSizeFromResolution = parseGptImage2SizeKey(nextResolution);
-        const restoredCustomSize = parsed.customImageSize ?? parsedSizeFromResolution;
-        const defaultCustomWidth =
-          getImageFieldDefaultNumber(engineMatch.engineCaps, 'image_width', nextMode) ??
-          GPT_IMAGE_2_SIZE_CONSTRAINTS.defaultWidth;
-        const defaultCustomHeight =
-          getImageFieldDefaultNumber(engineMatch.engineCaps, 'image_height', nextMode) ??
-          GPT_IMAGE_2_SIZE_CONSTRAINTS.defaultHeight;
-        setCustomImageWidth(String(restoredCustomSize?.width ?? defaultCustomWidth));
-        setCustomImageHeight(String(restoredCustomSize?.height ?? defaultCustomHeight));
-        const allowedAspectRatios = getAspectRatioOptions(engineMatch.engineCaps, nextMode);
-        const defaultAspectRatio = getDefaultAspectRatio(engineMatch.engineCaps, nextMode);
-        setAspectRatio(
-          parsed.aspectRatio && allowedAspectRatios.includes(parsed.aspectRatio) ? parsed.aspectRatio : defaultAspectRatio
-        );
-        const seedDefault = getImageFieldDefaultNumber(engineMatch.engineCaps, 'seed', nextMode);
-        setSeed(parsed.seed == null ? (seedDefault == null ? '' : String(seedDefault)) : String(parsed.seed));
-        const outputFormats = getImageFieldValues(engineMatch.engineCaps, 'output_format', nextMode);
-        const defaultOutputFormat =
-          getImageFieldDefaultString(engineMatch.engineCaps, 'output_format', nextMode) ?? outputFormats[0] ?? null;
-        setOutputFormat(
-          parsed.outputFormat && outputFormats.includes(parsed.outputFormat) ? parsed.outputFormat : defaultOutputFormat
-        );
-        const qualityValues = getImageFieldValues(engineMatch.engineCaps, 'quality', nextMode);
-        const defaultQuality =
-          getImageFieldDefaultString(engineMatch.engineCaps, 'quality', nextMode) ?? qualityValues[0] ?? null;
-        setQuality(parsed.quality && qualityValues.includes(parsed.quality) ? parsed.quality : defaultQuality);
-        setMaskUrl(getImageInputField(engineMatch.engineCaps, 'mask_url', nextMode) ? parsed.maskUrl ?? '' : '');
-        setEnableWebSearch(
-          getImageInputField(engineMatch.engineCaps, 'enable_web_search', nextMode)
-            ? parsed.enableWebSearch
-            : false
-        );
-        const thinkingLevels = getImageFieldValues(engineMatch.engineCaps, 'thinking_level', nextMode);
-        const defaultThinkingLevel =
-          getImageFieldDefaultString(engineMatch.engineCaps, 'thinking_level', nextMode) ?? thinkingLevels[0] ?? null;
-        setThinkingLevel(
-          parsed.thinkingLevel && thinkingLevels.includes(parsed.thinkingLevel)
-            ? parsed.thinkingLevel
-            : defaultThinkingLevel
-        );
-        setLimitGenerations(
-          getImageInputField(engineMatch.engineCaps, 'limit_generations', nextMode)
-            ? parsed.limitGenerations
-            : false
-        );
-      }
-
-      if (parsed.referenceSlots.length || (parsed.characterReferences?.length ?? 0) > 0) {
-        setReferenceSlots((previous) => {
-          const next = Array(MAX_REFERENCE_SLOTS).fill(null) as Array<ReferenceSlotValue | null>;
-          parsed.referenceSlots.slice(0, MAX_REFERENCE_SLOTS).forEach((slot, index) => {
-            if (!slot) return;
-            next[index] = slot.characterReference
-              ? createCharacterReferenceSlot(slot.characterReference, `stored-${index}`)
-              : {
-                  id: `stored-${index}`,
-                  url: slot.url,
-                  previewUrl: slot.url,
-                  status: 'ready',
-                  source: slot.source ?? 'library',
-                  width: slot.width ?? null,
-                  height: slot.height ?? null,
-                };
-          });
-          const migratedNext = mergeCharacterReferencesIntoSlots(next, parsed.characterReferences ?? [], MAX_REFERENCE_SLOTS);
-          const changed = migratedNext.some((slot, idx) => {
-            const prior = previous[idx];
-            if (!slot && !prior) return false;
-            if (!slot || !prior) return true;
-            return slot.url !== prior.url || slot.status !== prior.status;
-          });
-          return changed ? migratedNext : previous;
-        });
-      }
-    }
-
-    setStorageHydrated(true);
-  }, [engines, setReferenceSlots]);
+  useImageComposerPersistence({
+    engines,
+    engineId,
+    mode,
+    prompt,
+    numImages,
+    aspectRatio,
+    resolution,
+    customImageWidth,
+    customImageHeight,
+    seed,
+    outputFormat,
+    quality,
+    maskUrl,
+    enableWebSearch,
+    thinkingLevel,
+    limitGenerations,
+    persistableReferenceSlots,
+    setEngineId,
+    setMode,
+    setPrompt,
+    setNumImages,
+    setAspectRatio,
+    setResolution,
+    setCustomImageWidth,
+    setCustomImageHeight,
+    setSeed,
+    setOutputFormat,
+    setQuality,
+    setMaskUrl,
+    setEnableWebSearch,
+    setThinkingLevel,
+    setLimitGenerations,
+    setReferenceSlots,
+  });
 
   const requestedJobId = useMemo(() => {
     const raw = searchParams?.get('job');
@@ -651,73 +560,6 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
         setError(error instanceof Error ? error.message : resolvedCopy.errors.generic);
       });
   }, [applyImageSettingsSnapshot, requestedJobId, resolvedCopy.errors.generic]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    if (!storageHydrated) return;
-    const payload: PersistedImageComposerState = {
-      version: IMAGE_COMPOSER_STORAGE_VERSION,
-      engineId: engineId || engines[0]?.id || '',
-      mode,
-      prompt,
-      numImages,
-      aspectRatio,
-      resolution,
-      customImageSize: resolution === 'custom' ? buildCustomImageSize(customImageWidth, customImageHeight) : null,
-      seed: seed.trim().length ? Math.round(Number(seed)) : null,
-      outputFormat,
-      quality,
-      maskUrl: maskUrl.trim().length ? maskUrl.trim() : null,
-      enableWebSearch,
-      thinkingLevel,
-      limitGenerations,
-      referenceSlots: persistableReferenceSlots,
-    };
-    if (!payload.engineId) return;
-    let serialized: string;
-    try {
-      serialized = JSON.stringify(payload);
-    } catch {
-      return;
-    }
-    if (serialized === persistedSignatureRef.current) return;
-    if (persistTimerRef.current !== null) {
-      window.clearTimeout(persistTimerRef.current);
-    }
-    persistTimerRef.current = window.setTimeout(() => {
-      try {
-        window.localStorage.setItem(IMAGE_COMPOSER_STORAGE_KEY, serialized);
-        persistedSignatureRef.current = serialized;
-      } catch {
-        // ignore storage failures
-      }
-    }, IMAGE_COMPOSER_STORAGE_DEBOUNCE_MS);
-    return () => {
-      if (persistTimerRef.current !== null) {
-        window.clearTimeout(persistTimerRef.current);
-        persistTimerRef.current = null;
-      }
-    };
-  }, [
-    aspectRatio,
-    customImageHeight,
-    customImageWidth,
-    enableWebSearch,
-    engineId,
-    engines,
-    limitGenerations,
-    maskUrl,
-    mode,
-    numImages,
-    outputFormat,
-    persistableReferenceSlots,
-    prompt,
-    quality,
-    resolution,
-    seed,
-    storageHydrated,
-    thinkingLevel,
-  ]);
 
   const setNumImagesPreset = useCallback((value: number) => {
     setNumImages(clampRequestedImageCount(selectedEngineCaps ?? null, mode, value));

--- a/frontend/app/(core)/(workspace)/app/image/_hooks/useImageComposerPersistence.ts
+++ b/frontend/app/(core)/(workspace)/app/image/_hooks/useImageComposerPersistence.ts
@@ -1,0 +1,315 @@
+import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
+import type { ImageGenerationMode } from '@/types/image-generation';
+import {
+  clampRequestedImageCount,
+  getAspectRatioOptions,
+  getDefaultAspectRatio,
+  getDefaultResolution,
+  getImageFieldDefaultNumber,
+  getImageFieldDefaultString,
+  getImageFieldValues,
+  getImageInputField,
+} from '@/lib/image/inputSchema';
+import {
+  GPT_IMAGE_2_SIZE_CONSTRAINTS,
+  parseGptImage2SizeKey,
+} from '@/lib/image/gptImage2';
+import {
+  createCharacterReferenceSlot,
+  mergeCharacterReferencesIntoSlots,
+} from '../_lib/image-workspace-character-references';
+import { parsePersistedImageComposerState } from '../_lib/image-workspace-persistence';
+import {
+  buildCustomImageSize,
+  findImageEngine,
+} from '../_lib/image-workspace-utils';
+import {
+  IMAGE_COMPOSER_STORAGE_DEBOUNCE_MS,
+  IMAGE_COMPOSER_STORAGE_KEY,
+  IMAGE_COMPOSER_STORAGE_VERSION,
+  MAX_REFERENCE_SLOTS,
+  type ImageEngineOption,
+  type PersistedImageComposerState,
+  type PersistedReferenceSlot,
+  type ReferenceSlotValue,
+} from '../_lib/image-workspace-types';
+
+type UseImageComposerPersistenceParams = {
+  engines: ImageEngineOption[];
+  engineId: string;
+  mode: ImageGenerationMode;
+  prompt: string;
+  numImages: number;
+  aspectRatio: string | null;
+  resolution: string | null;
+  customImageWidth: string;
+  customImageHeight: string;
+  seed: string;
+  outputFormat: string | null;
+  quality: string | null;
+  maskUrl: string;
+  enableWebSearch: boolean;
+  thinkingLevel: string | null;
+  limitGenerations: boolean;
+  persistableReferenceSlots: PersistedReferenceSlot[];
+  setEngineId: Dispatch<SetStateAction<string>>;
+  setMode: Dispatch<SetStateAction<ImageGenerationMode>>;
+  setPrompt: Dispatch<SetStateAction<string>>;
+  setNumImages: Dispatch<SetStateAction<number>>;
+  setAspectRatio: Dispatch<SetStateAction<string | null>>;
+  setResolution: Dispatch<SetStateAction<string | null>>;
+  setCustomImageWidth: Dispatch<SetStateAction<string>>;
+  setCustomImageHeight: Dispatch<SetStateAction<string>>;
+  setSeed: Dispatch<SetStateAction<string>>;
+  setOutputFormat: Dispatch<SetStateAction<string | null>>;
+  setQuality: Dispatch<SetStateAction<string | null>>;
+  setMaskUrl: Dispatch<SetStateAction<string>>;
+  setEnableWebSearch: Dispatch<SetStateAction<boolean>>;
+  setThinkingLevel: Dispatch<SetStateAction<string | null>>;
+  setLimitGenerations: Dispatch<SetStateAction<boolean>>;
+  setReferenceSlots: Dispatch<SetStateAction<Array<ReferenceSlotValue | null>>>;
+};
+
+export function useImageComposerPersistence({
+  engines,
+  engineId,
+  mode,
+  prompt,
+  numImages,
+  aspectRatio,
+  resolution,
+  customImageWidth,
+  customImageHeight,
+  seed,
+  outputFormat,
+  quality,
+  maskUrl,
+  enableWebSearch,
+  thinkingLevel,
+  limitGenerations,
+  persistableReferenceSlots,
+  setEngineId,
+  setMode,
+  setPrompt,
+  setNumImages,
+  setAspectRatio,
+  setResolution,
+  setCustomImageWidth,
+  setCustomImageHeight,
+  setSeed,
+  setOutputFormat,
+  setQuality,
+  setMaskUrl,
+  setEnableWebSearch,
+  setThinkingLevel,
+  setLimitGenerations,
+  setReferenceSlots,
+}: UseImageComposerPersistenceParams) {
+  const hasHydratedStorageRef = useRef(false);
+  const persistTimerRef = useRef<number | null>(null);
+  const persistedSignatureRef = useRef<string | null>(null);
+  const [storageHydrated, setStorageHydrated] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!engines.length) return;
+    if (hasHydratedStorageRef.current) return;
+    hasHydratedStorageRef.current = true;
+    let parsed: PersistedImageComposerState | null = null;
+    try {
+      const stored = window.localStorage.getItem(IMAGE_COMPOSER_STORAGE_KEY);
+      if (stored) {
+        parsed = parsePersistedImageComposerState(stored);
+        if (parsed) {
+          persistedSignatureRef.current = stored;
+        }
+      }
+    } catch {
+      // ignore storage failures
+    }
+
+    if (parsed && engines.length) {
+      const engineMatch = findImageEngine(engines, parsed.engineId) ?? engines[0] ?? null;
+      if (engineMatch) {
+        setEngineId(engineMatch.id);
+        const nextMode = engineMatch.modes.includes(parsed.mode) ? parsed.mode : engineMatch.modes[0] ?? 't2i';
+        setMode(nextMode);
+        setPrompt(parsed.prompt);
+        setNumImages(clampRequestedImageCount(engineMatch.engineCaps, nextMode, parsed.numImages));
+        const allowedResolutions = getImageFieldValues(
+          engineMatch.engineCaps,
+          'resolution',
+          nextMode,
+          Array.isArray(engineMatch.engineCaps?.resolutions) ? [...engineMatch.engineCaps.resolutions] : []
+        );
+        const defaultResolution = getImageInputField(engineMatch.engineCaps, 'resolution', nextMode)
+          ? getDefaultResolution(engineMatch.engineCaps, nextMode)
+          : null;
+        const nextResolution =
+          parsed.resolution && allowedResolutions.includes(parsed.resolution) ? parsed.resolution : defaultResolution;
+        setResolution(nextResolution);
+        const parsedSizeFromResolution = parseGptImage2SizeKey(nextResolution);
+        const restoredCustomSize = parsed.customImageSize ?? parsedSizeFromResolution;
+        const defaultCustomWidth =
+          getImageFieldDefaultNumber(engineMatch.engineCaps, 'image_width', nextMode) ??
+          GPT_IMAGE_2_SIZE_CONSTRAINTS.defaultWidth;
+        const defaultCustomHeight =
+          getImageFieldDefaultNumber(engineMatch.engineCaps, 'image_height', nextMode) ??
+          GPT_IMAGE_2_SIZE_CONSTRAINTS.defaultHeight;
+        setCustomImageWidth(String(restoredCustomSize?.width ?? defaultCustomWidth));
+        setCustomImageHeight(String(restoredCustomSize?.height ?? defaultCustomHeight));
+        const allowedAspectRatios = getAspectRatioOptions(engineMatch.engineCaps, nextMode);
+        const defaultAspectRatio = getDefaultAspectRatio(engineMatch.engineCaps, nextMode);
+        setAspectRatio(
+          parsed.aspectRatio && allowedAspectRatios.includes(parsed.aspectRatio) ? parsed.aspectRatio : defaultAspectRatio
+        );
+        const seedDefault = getImageFieldDefaultNumber(engineMatch.engineCaps, 'seed', nextMode);
+        setSeed(parsed.seed == null ? (seedDefault == null ? '' : String(seedDefault)) : String(parsed.seed));
+        const outputFormats = getImageFieldValues(engineMatch.engineCaps, 'output_format', nextMode);
+        const defaultOutputFormat =
+          getImageFieldDefaultString(engineMatch.engineCaps, 'output_format', nextMode) ?? outputFormats[0] ?? null;
+        setOutputFormat(
+          parsed.outputFormat && outputFormats.includes(parsed.outputFormat) ? parsed.outputFormat : defaultOutputFormat
+        );
+        const qualityValues = getImageFieldValues(engineMatch.engineCaps, 'quality', nextMode);
+        const defaultQuality =
+          getImageFieldDefaultString(engineMatch.engineCaps, 'quality', nextMode) ?? qualityValues[0] ?? null;
+        setQuality(parsed.quality && qualityValues.includes(parsed.quality) ? parsed.quality : defaultQuality);
+        setMaskUrl(getImageInputField(engineMatch.engineCaps, 'mask_url', nextMode) ? parsed.maskUrl ?? '' : '');
+        setEnableWebSearch(
+          getImageInputField(engineMatch.engineCaps, 'enable_web_search', nextMode)
+            ? parsed.enableWebSearch
+            : false
+        );
+        const thinkingLevels = getImageFieldValues(engineMatch.engineCaps, 'thinking_level', nextMode);
+        const defaultThinkingLevel =
+          getImageFieldDefaultString(engineMatch.engineCaps, 'thinking_level', nextMode) ?? thinkingLevels[0] ?? null;
+        setThinkingLevel(
+          parsed.thinkingLevel && thinkingLevels.includes(parsed.thinkingLevel)
+            ? parsed.thinkingLevel
+            : defaultThinkingLevel
+        );
+        setLimitGenerations(
+          getImageInputField(engineMatch.engineCaps, 'limit_generations', nextMode)
+            ? parsed.limitGenerations
+            : false
+        );
+      }
+
+      if (parsed.referenceSlots.length || (parsed.characterReferences?.length ?? 0) > 0) {
+        setReferenceSlots((previous) => {
+          const next = Array(MAX_REFERENCE_SLOTS).fill(null) as Array<ReferenceSlotValue | null>;
+          parsed.referenceSlots.slice(0, MAX_REFERENCE_SLOTS).forEach((slot, index) => {
+            if (!slot) return;
+            next[index] = slot.characterReference
+              ? createCharacterReferenceSlot(slot.characterReference, `stored-${index}`)
+              : {
+                  id: `stored-${index}`,
+                  url: slot.url,
+                  previewUrl: slot.url,
+                  status: 'ready',
+                  source: slot.source ?? 'library',
+                  width: slot.width ?? null,
+                  height: slot.height ?? null,
+                };
+          });
+          const migratedNext = mergeCharacterReferencesIntoSlots(next, parsed.characterReferences ?? [], MAX_REFERENCE_SLOTS);
+          const changed = migratedNext.some((slot, idx) => {
+            const prior = previous[idx];
+            if (!slot && !prior) return false;
+            if (!slot || !prior) return true;
+            return slot.url !== prior.url || slot.status !== prior.status;
+          });
+          return changed ? migratedNext : previous;
+        });
+      }
+    }
+
+    setStorageHydrated(true);
+  }, [
+    engines,
+    setAspectRatio,
+    setCustomImageHeight,
+    setCustomImageWidth,
+    setEnableWebSearch,
+    setEngineId,
+    setLimitGenerations,
+    setMaskUrl,
+    setMode,
+    setNumImages,
+    setOutputFormat,
+    setPrompt,
+    setQuality,
+    setReferenceSlots,
+    setResolution,
+    setSeed,
+    setThinkingLevel,
+  ]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!storageHydrated) return;
+    const payload: PersistedImageComposerState = {
+      version: IMAGE_COMPOSER_STORAGE_VERSION,
+      engineId: engineId || engines[0]?.id || '',
+      mode,
+      prompt,
+      numImages,
+      aspectRatio,
+      resolution,
+      customImageSize: resolution === 'custom' ? buildCustomImageSize(customImageWidth, customImageHeight) : null,
+      seed: seed.trim().length ? Math.round(Number(seed)) : null,
+      outputFormat,
+      quality,
+      maskUrl: maskUrl.trim().length ? maskUrl.trim() : null,
+      enableWebSearch,
+      thinkingLevel,
+      limitGenerations,
+      referenceSlots: persistableReferenceSlots,
+    };
+    if (!payload.engineId) return;
+    let serialized: string;
+    try {
+      serialized = JSON.stringify(payload);
+    } catch {
+      return;
+    }
+    if (serialized === persistedSignatureRef.current) return;
+    if (persistTimerRef.current !== null) {
+      window.clearTimeout(persistTimerRef.current);
+    }
+    persistTimerRef.current = window.setTimeout(() => {
+      try {
+        window.localStorage.setItem(IMAGE_COMPOSER_STORAGE_KEY, serialized);
+        persistedSignatureRef.current = serialized;
+      } catch {
+        // ignore storage failures
+      }
+    }, IMAGE_COMPOSER_STORAGE_DEBOUNCE_MS);
+    return () => {
+      if (persistTimerRef.current !== null) {
+        window.clearTimeout(persistTimerRef.current);
+        persistTimerRef.current = null;
+      }
+    };
+  }, [
+    aspectRatio,
+    customImageHeight,
+    customImageWidth,
+    enableWebSearch,
+    engineId,
+    engines,
+    limitGenerations,
+    maskUrl,
+    mode,
+    numImages,
+    outputFormat,
+    persistableReferenceSlots,
+    prompt,
+    quality,
+    resolution,
+    seed,
+    storageHydrated,
+    thinkingLevel,
+  ]);
+}

--- a/tests/image-workspace-split-contract.test.ts
+++ b/tests/image-workspace-split-contract.test.ts
@@ -6,10 +6,12 @@ import path from 'node:path';
 const root = process.cwd();
 const imageDir = path.join(root, 'frontend/app/(core)/(workspace)/app/image');
 const workspacePath = path.join(imageDir, 'ImageWorkspace.tsx');
+const composerPersistenceHookPath = path.join(imageDir, '_hooks/useImageComposerPersistence.ts');
 
 const splitFiles = [
   '_components/ImageAuthGateModal.tsx',
   '_components/ImageLibraryModal.tsx',
+  '_hooks/useImageComposerPersistence.ts',
   '_hooks/useImageWorkspaceHistory.ts',
   '_hooks/useImageWorkspacePricing.ts',
   '_hooks/useImageWorkspaceDesktopLayout.ts',
@@ -27,6 +29,7 @@ function readImageWorkspace() {
 
 test('image workspace foundations are split from the route orchestrator', () => {
   const source = readImageWorkspace();
+  const composerPersistenceHookSource = readFileSync(composerPersistenceHookPath, 'utf8');
 
   for (const file of splitFiles) {
     statSync(path.join(imageDir, file));
@@ -34,12 +37,12 @@ test('image workspace foundations are split from the route orchestrator', () => 
 
   assert.match(source, /from '\.\/_components\/ImageLibraryModal'/);
   assert.match(source, /from '\.\/_components\/ImageAuthGateModal'/);
+  assert.match(source, /from '\.\/_hooks\/useImageComposerPersistence'/);
   assert.match(source, /from '\.\/_hooks\/useImageWorkspaceHistory'/);
   assert.match(source, /from '\.\/_hooks\/useImageWorkspacePricing'/);
   assert.match(source, /from '\.\/_hooks\/useImageWorkspaceDesktopLayout'/);
   assert.match(source, /from '\.\/_lib\/image-workspace-copy'/);
   assert.match(source, /from '\.\/_lib\/image-workspace-history'/);
-  assert.match(source, /from '\.\/_lib\/image-workspace-persistence'/);
   assert.match(source, /from '\.\/_lib\/image-workspace-utils'/);
 
   assert.doesNotMatch(source, /const DEFAULT_COPY: ImageWorkspaceCopy =/);
@@ -53,7 +56,15 @@ test('image workspace foundations are split from the route orchestrator', () => 
   assert.doesNotMatch(source, /useSWR\(/, 'pricing SWR orchestration belongs in useImageWorkspacePricing');
   assert.doesNotMatch(source, /useInfiniteJobs\(24, \{ surface: 'image' \}\)/, 'image job feed orchestration belongs in useImageWorkspaceHistory');
   assert.doesNotMatch(source, /const remoteImageJobs =/, 'remote image history derivation belongs in useImageWorkspaceHistory');
+  assert.doesNotMatch(source, /parsePersistedImageComposerState/, 'composer storage parsing belongs in useImageComposerPersistence');
+  assert.doesNotMatch(source, /IMAGE_COMPOSER_STORAGE_KEY/, 'composer storage constants belong in useImageComposerPersistence');
+
+  assert.match(composerPersistenceHookSource, /export function useImageComposerPersistence/);
+  assert.match(composerPersistenceHookSource, /parsePersistedImageComposerState/);
+  assert.match(composerPersistenceHookSource, /IMAGE_COMPOSER_STORAGE_DEBOUNCE_MS/);
+  assert.match(composerPersistenceHookSource, /localStorage\.getItem\(IMAGE_COMPOSER_STORAGE_KEY\)/);
+  assert.match(composerPersistenceHookSource, /localStorage\.setItem\(IMAGE_COMPOSER_STORAGE_KEY, serialized\)/);
 
   const lineCount = source.split('\n').length;
-  assert.ok(lineCount <= 1460, `ImageWorkspace should stay below 1460 lines after auth modal extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 1300, `ImageWorkspace should stay below 1300 lines after composer persistence extraction, got ${lineCount}`);
 });


### PR DESCRIPTION
## Summary
- Move image composer localStorage hydration and debounce persistence into a route-local hook.
- Keep ImageWorkspace focused on route orchestration, preview, generation, and gallery wiring.
- Tighten the image workspace architecture contract so storage ownership stays out of the component.

## Validation
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/image-workspace-split-contract.test.ts tests/image-reference-slots-hook-contract.test.ts tests/image-settings-fields-hook-contract.test.ts tests/image-preview-actions-hook-contract.test.ts tests/supabase-browser-session-cleanup.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (from frontend/)
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check