### PR TITLE
[codex] Split character builder derivation hooks

### DIFF
--- a/frontend/src/components/tools/CharacterBuilderWorkspace.tsx
+++ b/frontend/src/components/tools/CharacterBuilderWorkspace.tsx
@@ -22,32 +22,14 @@ import { authFetch } from '@/lib/authFetch';
 import { suggestDownloadFilename, triggerAppDownload } from '@/lib/download';
 import { useI18n } from '@/lib/i18n/I18nProvider';
 import {
-  ACCESSORY_OPTIONS,
-  AGE_RANGE_OPTIONS,
   AUTO_TRAIT_KEYS,
-  BODY_BUILD_OPTIONS,
   CHARACTER_BUILDER_STORAGE_KEY,
-  CHARACTER_CONSISTENCY_OPTIONS,
-  CHARACTER_OUTPUT_OPTIONS,
-  CHARACTER_QUALITY_OPTIONS,
-  CHARACTER_REFERENCE_STRENGTH_OPTIONS,
   createDefaultCharacterBuilderState,
-  DISTINCTIVE_FEATURE_OPTIONS,
-  EYE_COLOR_OPTIONS,
-  FACE_CUES_OPTIONS,
-  GENDER_PRESENTATION_OPTIONS,
-  HAIR_COLOR_OPTIONS,
-  HAIR_LENGTH_OPTIONS,
-  HAIRSTYLE_OPTIONS,
-  getAvailableCharacterFormatOptions,
   getCharacterFormatMultiplier,
   normalizeCharacterFormatMode,
   normalizeTraitsForSourceMode,
-  OUTFIT_STYLE_OPTIONS,
-  REALISM_STYLE_OPTIONS,
-  SKIN_TONE_OPTIONS,
 } from '@/lib/character-builder';
-import { runCharacterBuilderTool, saveImageToLibrary, useInfiniteJobs } from '@/lib/api';
+import { runCharacterBuilderTool, saveImageToLibrary } from '@/lib/api';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { FEATURES } from '@/content/feature-flags';
 import type {
@@ -80,6 +62,8 @@ import {
   StyleChoiceCard,
   type BuildLookSectionKey,
 } from './character-builder/_components/character-builder-workspace-components';
+import { useCharacterBuilderHistoricalResults } from './character-builder/_hooks/useCharacterBuilderHistoricalResults';
+import { useCharacterBuilderOptions } from './character-builder/_hooks/useCharacterBuilderOptions';
 import { DEFAULT_CHARACTER_COPY, type CharacterCopy } from './character-builder/_lib/character-builder-copy';
 import {
   buildRecoveredRunFromJob,
@@ -164,152 +148,37 @@ export default function CharacterBuilderPage() {
     setAuthModalOpen(true);
   }, []);
 
-  const genderOptions = useMemo(
-    () => GENDER_PRESENTATION_OPTIONS.map((option) => ({ ...option, label: copy.options.gender[option.id as keyof typeof copy.options.gender] ?? option.label })),
-    [copy]
-  );
-  const ageOptions = useMemo(
-    () => AGE_RANGE_OPTIONS.map((option) => ({ ...option, label: copy.options.age[option.id as keyof typeof copy.options.age] ?? option.label })),
-    [copy]
-  );
-  const skinToneOptions = useMemo(
-    () => SKIN_TONE_OPTIONS.map((option) => ({ ...option, label: copy.options.skinTone[option.id as keyof typeof copy.options.skinTone] ?? option.label })),
-    [copy]
-  );
-  const faceCueOptions = useMemo(
-    () => FACE_CUES_OPTIONS.map((option) => ({ ...option, label: copy.options.faceCues[option.id as keyof typeof copy.options.faceCues] ?? option.label })),
-    [copy]
-  );
-  const hairColorOptions = useMemo(
-    () => HAIR_COLOR_OPTIONS.map((option) => ({ ...option, label: copy.options.hairColor[option.id as keyof typeof copy.options.hairColor] ?? option.label })),
-    [copy]
-  );
-  const hairLengthOptions = useMemo(
-    () => HAIR_LENGTH_OPTIONS.map((option) => ({ ...option, label: copy.options.hairLength[option.id as keyof typeof copy.options.hairLength] ?? option.label })),
-    [copy]
-  );
-  const hairstyleOptions = useMemo(
-    () => HAIRSTYLE_OPTIONS.map((option) => ({ ...option, label: copy.options.hairstyle[option.id as keyof typeof copy.options.hairstyle] ?? option.label })),
-    [copy]
-  );
-  const eyeColorOptions = useMemo(
-    () => EYE_COLOR_OPTIONS.map((option) => ({ ...option, label: copy.options.eyeColor[option.id as keyof typeof copy.options.eyeColor] ?? option.label })),
-    [copy]
-  );
-  const bodyBuildOptions = useMemo(
-    () => BODY_BUILD_OPTIONS.map((option) => ({ ...option, label: copy.options.bodyBuild[option.id as keyof typeof copy.options.bodyBuild] ?? option.label })),
-    [copy]
-  );
-  const outfitOptions = useMemo(
-    () => OUTFIT_STYLE_OPTIONS.map((option) => ({ ...option, label: copy.options.outfit[option.id as keyof typeof copy.options.outfit] ?? option.label })),
-    [copy]
-  );
-  const realismOptions = useMemo(
-    () => REALISM_STYLE_OPTIONS.map((option) => ({ ...option, label: copy.options.realism[option.id as keyof typeof copy.options.realism] ?? option.label })),
-    [copy]
-  );
-  const accessoryOptions = useMemo(
-    () => ACCESSORY_OPTIONS.map((option) => ({ ...option, label: copy.options.accessories[option.id as keyof typeof copy.options.accessories] ?? option.label })),
-    [copy]
-  );
-  const distinctiveOptions = useMemo(
-    () => DISTINCTIVE_FEATURE_OPTIONS.map((option) => ({ ...option, label: copy.options.distinctive[option.id as keyof typeof copy.options.distinctive] ?? option.label })),
-    [copy]
-  );
-  const outputModeOptions = useMemo(
-    () =>
-      CHARACTER_OUTPUT_OPTIONS.map((option) => ({
-        ...option,
-        label: copy.options.outputMode[option.id].label,
-        description: copy.options.outputMode[option.id].description,
-      })),
-    [copy]
-  );
-  const consistencyOptions = useMemo(
-    () =>
-      CHARACTER_CONSISTENCY_OPTIONS.map((option) => ({
-        ...option,
-        label: copy.options.consistency[option.id].label,
-        description: copy.options.consistency[option.id].description,
-      })),
-    [copy]
-  );
-  const referenceStrengthOptions = useMemo(
-    () =>
-      CHARACTER_REFERENCE_STRENGTH_OPTIONS.map((option) => ({
-        ...option,
-        label: copy.options.referenceStrength[option.id].label,
-        description: copy.options.referenceStrength[option.id].description,
-      })),
-    [copy]
-  );
-  const qualityOptions = useMemo(
-    () =>
-      CHARACTER_QUALITY_OPTIONS.map((option) => ({
-        ...option,
-        label: copy.options.quality[option.id].label,
-        description: copy.options.quality[option.id].description,
-      })),
-    [copy]
-  );
-  const formatOptions = useMemo(
-    () =>
-      getAvailableCharacterFormatOptions(state.qualityMode).map((option) => ({
-        ...option,
-        label: getFormatDisplayLabel(copy, option.id, state.qualityMode),
-        description: copy.options.format[option.id].description,
-      })),
-    [copy, state.qualityMode]
-  );
   const {
-    data: historicalJobPages,
-    stableJobs: historicalJobs,
-    mutate: mutateHistoricalJobs,
-    setSize: setHistoricalSize,
-    isLoading: historicalJobsLoading,
-    isValidating: historicalJobsValidating,
-  } = useInfiniteJobs(18, { surface: 'character' });
-
+    genderOptions,
+    ageOptions,
+    skinToneOptions,
+    faceCueOptions,
+    hairColorOptions,
+    hairLengthOptions,
+    hairstyleOptions,
+    eyeColorOptions,
+    bodyBuildOptions,
+    outfitOptions,
+    realismOptions,
+    accessoryOptions,
+    distinctiveOptions,
+    outputModeOptions,
+    consistencyOptions,
+    referenceStrengthOptions,
+    qualityOptions,
+    outputModeLabelOptions,
+    qualityLabelOptions,
+    formatLabelOptions,
+  } = useCharacterBuilderOptions(copy, state.qualityMode);
   const flattenedResults = getFlattenedResults(state.runs);
-  const outputModeLabelOptions = useMemo(
-    () => outputModeOptions.map((option) => ({ id: option.id, label: option.label })),
-    [outputModeOptions]
-  );
-  const qualityLabelOptions = useMemo(
-    () => qualityOptions.map((option) => ({ id: option.id, label: option.label })),
-    [qualityOptions]
-  );
-  const formatLabelOptions = useMemo(
-    () => formatOptions.map((option) => ({ id: option.id, label: option.label })),
-    [formatOptions]
-  );
-  const localResultUrls = useMemo(
-    () => new Set(flattenedResults.map((result) => result.url).filter((value): value is string => Boolean(value))),
-    [flattenedResults]
-  );
-  const historicalResults = useMemo<HistoricalCharacterGalleryItem[]>(() => {
-    return historicalJobs.flatMap<HistoricalCharacterGalleryItem>((job) => {
-      const renderIds = Array.isArray(job.renderIds) ? job.renderIds.filter((value): value is string => typeof value === 'string' && value.length > 0) : [];
-      if (!renderIds.length) return [];
-      const renderThumbUrls = Array.isArray(job.renderThumbUrls)
-        ? job.renderThumbUrls.filter((value): value is string => typeof value === 'string' && value.length > 0)
-        : [];
-
-      return renderIds.reduce<HistoricalCharacterGalleryItem[]>((acc, imageUrl, index) => {
-        if (localResultUrls.has(imageUrl)) return acc;
-        acc.push({
-          id: `${job.jobId}:historical:${index + 1}`,
-          jobId: job.jobId,
-          imageUrl,
-          thumbUrl: renderThumbUrls[index] ?? imageUrl,
-          engineLabel: job.engineLabel,
-          createdAt: job.createdAt,
-          prompt: job.prompt ?? null,
-        });
-        return acc;
-      }, []);
-    });
-  }, [historicalJobs, localResultUrls]);
+  const {
+    historicalResults,
+    historicalHasMore,
+    historicalIsFetchingMore,
+    historicalJobsLoading,
+    loadMoreHistoricalResults,
+    mutateHistoricalJobs,
+  } = useCharacterBuilderHistoricalResults(flattenedResults);
   const identityReference = getRefByRole(state.referenceImages, 'identity');
   const styleReference = getRefByRole(state.referenceImages, 'style');
   const hasIdentityReference = Boolean(identityReference);
@@ -353,14 +222,6 @@ export default function CharacterBuilderPage() {
       ? Number(((billingProductData.unitPriceCents * getCharacterFormatMultiplier(state.formatMode, state.qualityMode)) / 100).toFixed(2))
       : null;
   const isActionLoading = (key: LoadingRequestKey): boolean => (loadingActions[key] ?? 0) > 0;
-  const historicalLastPage = historicalJobPages?.[historicalJobPages.length - 1];
-  const historicalHasMore = Boolean(historicalLastPage?.nextCursor);
-  const historicalIsFetchingMore = historicalJobsValidating && Boolean(historicalJobPages?.length);
-  const loadMoreHistoricalResults = useCallback(() => {
-    if (!historicalHasMore || historicalJobsLoading || historicalIsFetchingMore) return;
-    void setHistoricalSize((current) => current + 1);
-  }, [historicalHasMore, historicalIsFetchingMore, historicalJobsLoading, setHistoricalSize]);
-
   useEffect(() => {
     const persisted = readPersistedState();
     if (persisted) {

--- a/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderHistoricalResults.ts
+++ b/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderHistoricalResults.ts
@@ -1,0 +1,61 @@
+import { useCallback, useMemo } from 'react';
+import { useInfiniteJobs } from '@/lib/api';
+import type { CharacterBuilderResult } from '@/types/character-builder';
+import type { HistoricalCharacterGalleryItem } from '../_lib/character-builder-types';
+
+export function useCharacterBuilderHistoricalResults(flattenedResults: CharacterBuilderResult[]) {
+  const {
+    data: historicalJobPages,
+    stableJobs: historicalJobs,
+    mutate: mutateHistoricalJobs,
+    setSize: setHistoricalSize,
+    isLoading: historicalJobsLoading,
+    isValidating: historicalJobsValidating,
+  } = useInfiniteJobs(18, { surface: 'character' });
+
+  const localResultUrls = useMemo(
+    () => new Set(flattenedResults.map((result) => result.url).filter((value): value is string => Boolean(value))),
+    [flattenedResults]
+  );
+
+  const historicalResults = useMemo<HistoricalCharacterGalleryItem[]>(() => {
+    return historicalJobs.flatMap<HistoricalCharacterGalleryItem>((job) => {
+      const renderIds = Array.isArray(job.renderIds) ? job.renderIds.filter((value): value is string => typeof value === 'string' && value.length > 0) : [];
+      if (!renderIds.length) return [];
+      const renderThumbUrls = Array.isArray(job.renderThumbUrls)
+        ? job.renderThumbUrls.filter((value): value is string => typeof value === 'string' && value.length > 0)
+        : [];
+
+      return renderIds.reduce<HistoricalCharacterGalleryItem[]>((acc, imageUrl, index) => {
+        if (localResultUrls.has(imageUrl)) return acc;
+        acc.push({
+          id: `${job.jobId}:historical:${index + 1}`,
+          jobId: job.jobId,
+          imageUrl,
+          thumbUrl: renderThumbUrls[index] ?? imageUrl,
+          engineLabel: job.engineLabel,
+          createdAt: job.createdAt,
+          prompt: job.prompt ?? null,
+        });
+        return acc;
+      }, []);
+    });
+  }, [historicalJobs, localResultUrls]);
+
+  const historicalLastPage = historicalJobPages?.[historicalJobPages.length - 1];
+  const historicalHasMore = Boolean(historicalLastPage?.nextCursor);
+  const historicalIsFetchingMore = historicalJobsValidating && Boolean(historicalJobPages?.length);
+  const loadMoreHistoricalResults = useCallback(() => {
+    if (!historicalHasMore || historicalJobsLoading || historicalIsFetchingMore) return;
+    void setHistoricalSize((current) => current + 1);
+  }, [historicalHasMore, historicalIsFetchingMore, historicalJobsLoading, setHistoricalSize]);
+
+  return {
+    historicalResults,
+    historicalHasMore,
+    historicalIsFetchingMore,
+    historicalJobsLoading,
+    loadMoreHistoricalResults,
+    mutateHistoricalJobs,
+  };
+}

--- a/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderOptions.ts
+++ b/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderOptions.ts
@@ -1,0 +1,161 @@
+import { useMemo } from 'react';
+import {
+  ACCESSORY_OPTIONS,
+  AGE_RANGE_OPTIONS,
+  BODY_BUILD_OPTIONS,
+  CHARACTER_CONSISTENCY_OPTIONS,
+  CHARACTER_OUTPUT_OPTIONS,
+  CHARACTER_QUALITY_OPTIONS,
+  CHARACTER_REFERENCE_STRENGTH_OPTIONS,
+  DISTINCTIVE_FEATURE_OPTIONS,
+  EYE_COLOR_OPTIONS,
+  FACE_CUES_OPTIONS,
+  GENDER_PRESENTATION_OPTIONS,
+  HAIR_COLOR_OPTIONS,
+  HAIR_LENGTH_OPTIONS,
+  HAIRSTYLE_OPTIONS,
+  getAvailableCharacterFormatOptions,
+  OUTFIT_STYLE_OPTIONS,
+  REALISM_STYLE_OPTIONS,
+  SKIN_TONE_OPTIONS,
+} from '@/lib/character-builder';
+import type { CharacterBuilderState } from '@/types/character-builder';
+import { getFormatDisplayLabel } from '../_lib/character-builder-helpers';
+import type { CharacterCopy } from '../_lib/character-builder-copy';
+
+export function useCharacterBuilderOptions(copy: CharacterCopy, qualityMode: CharacterBuilderState['qualityMode']) {
+  const genderOptions = useMemo(
+    () => GENDER_PRESENTATION_OPTIONS.map((option) => ({ ...option, label: copy.options.gender[option.id as keyof typeof copy.options.gender] ?? option.label })),
+    [copy]
+  );
+  const ageOptions = useMemo(
+    () => AGE_RANGE_OPTIONS.map((option) => ({ ...option, label: copy.options.age[option.id as keyof typeof copy.options.age] ?? option.label })),
+    [copy]
+  );
+  const skinToneOptions = useMemo(
+    () => SKIN_TONE_OPTIONS.map((option) => ({ ...option, label: copy.options.skinTone[option.id as keyof typeof copy.options.skinTone] ?? option.label })),
+    [copy]
+  );
+  const faceCueOptions = useMemo(
+    () => FACE_CUES_OPTIONS.map((option) => ({ ...option, label: copy.options.faceCues[option.id as keyof typeof copy.options.faceCues] ?? option.label })),
+    [copy]
+  );
+  const hairColorOptions = useMemo(
+    () => HAIR_COLOR_OPTIONS.map((option) => ({ ...option, label: copy.options.hairColor[option.id as keyof typeof copy.options.hairColor] ?? option.label })),
+    [copy]
+  );
+  const hairLengthOptions = useMemo(
+    () => HAIR_LENGTH_OPTIONS.map((option) => ({ ...option, label: copy.options.hairLength[option.id as keyof typeof copy.options.hairLength] ?? option.label })),
+    [copy]
+  );
+  const hairstyleOptions = useMemo(
+    () => HAIRSTYLE_OPTIONS.map((option) => ({ ...option, label: copy.options.hairstyle[option.id as keyof typeof copy.options.hairstyle] ?? option.label })),
+    [copy]
+  );
+  const eyeColorOptions = useMemo(
+    () => EYE_COLOR_OPTIONS.map((option) => ({ ...option, label: copy.options.eyeColor[option.id as keyof typeof copy.options.eyeColor] ?? option.label })),
+    [copy]
+  );
+  const bodyBuildOptions = useMemo(
+    () => BODY_BUILD_OPTIONS.map((option) => ({ ...option, label: copy.options.bodyBuild[option.id as keyof typeof copy.options.bodyBuild] ?? option.label })),
+    [copy]
+  );
+  const outfitOptions = useMemo(
+    () => OUTFIT_STYLE_OPTIONS.map((option) => ({ ...option, label: copy.options.outfit[option.id as keyof typeof copy.options.outfit] ?? option.label })),
+    [copy]
+  );
+  const realismOptions = useMemo(
+    () => REALISM_STYLE_OPTIONS.map((option) => ({ ...option, label: copy.options.realism[option.id as keyof typeof copy.options.realism] ?? option.label })),
+    [copy]
+  );
+  const accessoryOptions = useMemo(
+    () => ACCESSORY_OPTIONS.map((option) => ({ ...option, label: copy.options.accessories[option.id as keyof typeof copy.options.accessories] ?? option.label })),
+    [copy]
+  );
+  const distinctiveOptions = useMemo(
+    () => DISTINCTIVE_FEATURE_OPTIONS.map((option) => ({ ...option, label: copy.options.distinctive[option.id as keyof typeof copy.options.distinctive] ?? option.label })),
+    [copy]
+  );
+  const outputModeOptions = useMemo(
+    () =>
+      CHARACTER_OUTPUT_OPTIONS.map((option) => ({
+        ...option,
+        label: copy.options.outputMode[option.id].label,
+        description: copy.options.outputMode[option.id].description,
+      })),
+    [copy]
+  );
+  const consistencyOptions = useMemo(
+    () =>
+      CHARACTER_CONSISTENCY_OPTIONS.map((option) => ({
+        ...option,
+        label: copy.options.consistency[option.id].label,
+        description: copy.options.consistency[option.id].description,
+      })),
+    [copy]
+  );
+  const referenceStrengthOptions = useMemo(
+    () =>
+      CHARACTER_REFERENCE_STRENGTH_OPTIONS.map((option) => ({
+        ...option,
+        label: copy.options.referenceStrength[option.id].label,
+        description: copy.options.referenceStrength[option.id].description,
+      })),
+    [copy]
+  );
+  const qualityOptions = useMemo(
+    () =>
+      CHARACTER_QUALITY_OPTIONS.map((option) => ({
+        ...option,
+        label: copy.options.quality[option.id].label,
+        description: copy.options.quality[option.id].description,
+      })),
+    [copy]
+  );
+  const formatOptions = useMemo(
+    () =>
+      getAvailableCharacterFormatOptions(qualityMode).map((option) => ({
+        ...option,
+        label: getFormatDisplayLabel(copy, option.id, qualityMode),
+        description: copy.options.format[option.id].description,
+      })),
+    [copy, qualityMode]
+  );
+
+  const outputModeLabelOptions = useMemo(
+    () => outputModeOptions.map((option) => ({ id: option.id, label: option.label })),
+    [outputModeOptions]
+  );
+  const qualityLabelOptions = useMemo(
+    () => qualityOptions.map((option) => ({ id: option.id, label: option.label })),
+    [qualityOptions]
+  );
+  const formatLabelOptions = useMemo(
+    () => formatOptions.map((option) => ({ id: option.id, label: option.label })),
+    [formatOptions]
+  );
+
+  return {
+    genderOptions,
+    ageOptions,
+    skinToneOptions,
+    faceCueOptions,
+    hairColorOptions,
+    hairLengthOptions,
+    hairstyleOptions,
+    eyeColorOptions,
+    bodyBuildOptions,
+    outfitOptions,
+    realismOptions,
+    accessoryOptions,
+    distinctiveOptions,
+    outputModeOptions,
+    consistencyOptions,
+    referenceStrengthOptions,
+    qualityOptions,
+    formatOptions,
+    outputModeLabelOptions,
+    qualityLabelOptions,
+    formatLabelOptions,
+  };
+}

--- a/tests/character-builder-workspace-architecture.test.ts
+++ b/tests/character-builder-workspace-architecture.test.ts
@@ -14,6 +14,8 @@ const generateDockPath = join(root, 'frontend/src/components/tools/character-bui
 const formControlsPath = join(root, 'frontend/src/components/tools/character-builder/_components/character-builder-form-controls.tsx');
 const referenceLibraryPath = join(root, 'frontend/src/components/tools/character-builder/_components/character-builder-reference-library.tsx');
 const resultCardsPath = join(root, 'frontend/src/components/tools/character-builder/_components/character-builder-result-cards.tsx');
+const optionsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderOptions.ts');
+const historicalResultsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderHistoricalResults.ts');
 
 const workspaceSource = readFileSync(workspacePath, 'utf8');
 
@@ -27,8 +29,12 @@ test('character builder workspace delegates copy, local types, and helper logic'
   assert.ok(existsSync(formControlsPath), 'form controls should live in a focused component module');
   assert.ok(existsSync(referenceLibraryPath), 'reference library components should live in a focused component module');
   assert.ok(existsSync(resultCardsPath), 'result card components should live in a focused component module');
+  assert.ok(existsSync(optionsHookPath), 'localized option derivation should live in a focused hook');
+  assert.ok(existsSync(historicalResultsHookPath), 'historical result derivation should live in a focused hook');
 
   assert.match(workspaceSource, /from '\.\/character-builder\/_components\/character-builder-workspace-components'/, 'workspace should import UI components');
+  assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderOptions'/, 'workspace should import localized options hook');
+  assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderHistoricalResults'/, 'workspace should import historical results hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_lib\/character-builder-copy'/, 'workspace should import character copy');
   assert.match(workspaceSource, /from '\.\/character-builder\/_lib\/character-builder-types'/, 'workspace should import local types');
   assert.match(workspaceSource, /from '\.\/character-builder\/_lib\/character-builder-helpers'/, 'workspace should import helpers');
@@ -44,9 +50,12 @@ test('character builder workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /function HairEditorPanel\(/, 'hair editor UI belongs in _components/character-builder-workspace-components.tsx');
   assert.doesNotMatch(workspaceSource, /function CharacterReferenceLibraryModal\(/, 'library modal UI belongs in _components/character-builder-workspace-components.tsx');
   assert.doesNotMatch(workspaceSource, /function ResultCard\(/, 'result card UI belongs in _components/character-builder-workspace-components.tsx');
+  assert.doesNotMatch(workspaceSource, /GENDER_PRESENTATION_OPTIONS\.map/, 'localized option derivation belongs in useCharacterBuilderOptions');
+  assert.doesNotMatch(workspaceSource, /useInfiniteJobs\(18, \{ surface: 'character' \}\)/, 'historical result feed belongs in useCharacterBuilderHistoricalResults');
+  assert.doesNotMatch(workspaceSource, /localResultUrls/, 'historical duplicate filtering belongs in useCharacterBuilderHistoricalResults');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 1950, `CharacterBuilderWorkspace should stay below 1950 lines after component extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 1800, `CharacterBuilderWorkspace should stay below 1800 lines after hook extraction, got ${lineCount}`);
 });
 
 test('character builder helper modules expose the expected workspace contract', () => {
@@ -59,6 +68,8 @@ test('character builder helper modules expose the expected workspace contract', 
   const formControlsSource = readFileSync(formControlsPath, 'utf8');
   const referenceLibrarySource = readFileSync(referenceLibraryPath, 'utf8');
   const resultCardsSource = readFileSync(resultCardsPath, 'utf8');
+  const optionsHookSource = readFileSync(optionsHookPath, 'utf8');
+  const historicalResultsHookSource = readFileSync(historicalResultsHookPath, 'utf8');
 
   assert.match(copySource, /export const DEFAULT_CHARACTER_COPY =/, 'copy module should export default copy');
   assert.match(copySource, /export type CharacterCopy =/, 'copy module should export copy type');
@@ -153,4 +164,9 @@ test('character builder helper modules expose the expected workspace contract', 
   ]) {
     assert.match(resultCardsSource, new RegExp(`export function ${exportName}`), `${exportName} should be exported`);
   }
+
+  assert.match(optionsHookSource, /export function useCharacterBuilderOptions/, 'options hook should be exported');
+  assert.match(optionsHookSource, /getAvailableCharacterFormatOptions/, 'options hook should own format option derivation');
+  assert.match(historicalResultsHookSource, /export function useCharacterBuilderHistoricalResults/, 'historical results hook should be exported');
+  assert.match(historicalResultsHookSource, /useInfiniteJobs\(18, \{ surface: 'character' \}\)/, 'historical results hook should own the character feed');
 });


### PR DESCRIPTION
## Summary
- Move localized Character Builder option derivation into useCharacterBuilderOptions.
- Move historical character result feed derivation and pagination state into useCharacterBuilderHistoricalResults.
- Tighten the CharacterBuilderWorkspace architecture contract so these responsibilities stay outside the workspace component.

## Validation
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/character-builder-workspace-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (from frontend/)
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check