### PR TITLE
[codex] Split upscale library assets hook

### DIFF
--- a/frontend/src/components/tools/UpscaleWorkspace.tsx
+++ b/frontend/src/components/tools/UpscaleWorkspace.tsx
@@ -4,7 +4,7 @@
 
 import Link from 'next/link';
 import useSWR from 'swr';
-import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type PointerEvent } from 'react';
+import { useEffect, useMemo, useRef, useState, type ChangeEvent, type PointerEvent } from 'react';
 import {
   ArrowLeft,
   ArrowRight,
@@ -31,7 +31,6 @@ import { SelectMenu } from '@/components/ui/SelectMenu';
 import {
   AssetLibraryBrowser,
   type AssetBrowserAsset,
-  type AssetLibrarySource,
 } from '@/components/library/AssetLibraryBrowser';
 import { authFetch } from '@/lib/authFetch';
 import { getJobStatus, runUpscaleTool, saveAssetToLibrary, useInfiniteJobs } from '@/lib/api';
@@ -62,7 +61,6 @@ import type { GroupSummary } from '@/types/groups';
 import type { Job } from '@/types/jobs';
 import { DEFAULT_UPSCALE_COPY } from './upscale/_lib/upscale-workspace-copy';
 import {
-  buildLibraryCacheKey,
   clampComparePosition,
   formatCurrency,
   hasRenderableUpscaleJobMedia,
@@ -82,15 +80,14 @@ import {
   SOURCE_FALLBACK_WIDTH,
   uploadSourceFile,
 } from './upscale/_lib/upscale-workspace-helpers';
+import { useUpscaleLibraryAssets } from './upscale/_hooks/useUpscaleLibraryAssets';
 import type {
   BillingProductResponse,
   JobDetailResponse,
-  JobsLibraryResponse,
   PreviewMode,
   PreviewZoom,
   RecentUpscaleMedia,
   UploadedAsset,
-  UserAssetsResponse,
 } from './upscale/_lib/upscale-workspace-types';
 
 function Label({ children }: { children: React.ReactNode }) {
@@ -150,12 +147,22 @@ export default function UpscaleWorkspace() {
   const [compareDragging, setCompareDragging] = useState(false);
   const [previewMode, setPreviewMode] = useState<PreviewMode>('source');
   const [previewZoom, setPreviewZoom] = useState<PreviewZoom>('fit');
-  const [libraryModalOpen, setLibraryModalOpen] = useState(false);
-  const [libraryAssets, setLibraryAssets] = useState<AssetBrowserAsset[]>([]);
-  const [libraryLoading, setLibraryLoading] = useState(false);
-  const [libraryError, setLibraryError] = useState<string | null>(null);
-  const [librarySource, setLibrarySource] = useState<AssetLibrarySource>('all');
-  const [libraryLoadedKey, setLibraryLoadedKey] = useState<string | null>(null);
+  const {
+    fetchLibraryAssets,
+    libraryError,
+    libraryLoading,
+    libraryModalOpen,
+    librarySource,
+    librarySourceOptions,
+    openLibraryModal,
+    resetLibraryState,
+    setLibraryModalOpen,
+    visibleLibraryAssets,
+  } = useUpscaleLibraryAssets({
+    libraryErrorCopy: copy.libraryError,
+    mediaType,
+    user,
+  });
   const [activeRecentGroupId, setActiveRecentGroupId] = useState<string | null>(null);
   const [savingRecentGroupId, setSavingRecentGroupId] = useState<string | null>(null);
   const previewScrollerRef = useRef<HTMLDivElement | null>(null);
@@ -242,23 +249,6 @@ export default function UpscaleWorkspace() {
   const zoomCanvasWidth = activePreviewMode === 'source' ? sourceWidth : outputWidth;
   const zoomCanvasHeight = activePreviewMode === 'source' ? sourceHeight : outputHeight;
   const mediaTypeLabel = mediaType === 'video' ? 'Video' : 'Image';
-  const libraryCacheKey = libraryModalOpen ? buildLibraryCacheKey(mediaType, librarySource) : null;
-  const librarySourceOptions = useMemo(
-    () =>
-      mediaType === 'video'
-        ? (['all', 'upload', 'generated', 'upscale'] as const)
-        : (['all', 'upload', 'generated', 'character', 'angle', 'upscale'] as const),
-    [mediaType]
-  );
-  const visibleLibraryAssets = useMemo(
-    () =>
-      libraryAssets.filter((asset) =>
-        mediaType === 'video'
-          ? asset.kind === 'video' || asset.mime?.startsWith('video/')
-          : asset.kind === 'image' || !asset.mime || asset.mime.startsWith('image/')
-      ),
-    [libraryAssets, mediaType]
-  );
   const recentGroups = useMemo(() => {
     const jobs = recentJobs.map((job) => (!job.videoUrl && job.readyVideoUrl ? { ...job, videoUrl: job.readyVideoUrl } : job));
     return normalizeGroupSummaries(groupJobsIntoSummaries(jobs, { includeSinglesAsGroups: true }).groups);
@@ -386,119 +376,6 @@ export default function UpscaleWorkspace() {
     return () => window.cancelAnimationFrame(frame);
   }, [activePreviewMode, isPixelZoom, previewZoom, resultPreviewUrl, sourcePreviewUrl]);
 
-  const fetchLibraryAssets = useCallback(
-    async (options?: { source?: AssetLibrarySource; kind?: UpscaleMediaType }) => {
-      const sourceFilter = options?.source ?? librarySource;
-      const kind = options?.kind ?? mediaType;
-      const requestKey = buildLibraryCacheKey(kind, sourceFilter);
-      setLibraryLoading(true);
-      setLibraryError(null);
-      try {
-        if (!user) {
-          setLibraryAssets([]);
-          setLibraryError(kind === 'video' ? 'Sign in to access your video library.' : 'Sign in to access your image library.');
-          setLibraryLoadedKey(requestKey);
-          return;
-        }
-
-        const assetUrl =
-          sourceFilter === 'all'
-            ? '/api/user-assets?limit=80'
-            : `/api/user-assets?limit=80&source=${encodeURIComponent(sourceFilter)}`;
-        const requests: Array<Promise<Response>> = [authFetch(assetUrl)];
-        if (kind === 'video' && sourceFilter !== 'upload') {
-          const jobsUrl = sourceFilter === 'upscale' ? '/api/jobs?limit=80&surface=upscale' : '/api/jobs?limit=80&type=video';
-          requests.push(authFetch(jobsUrl));
-        }
-
-        const [assetsResponse, jobsResponse] = await Promise.all(requests);
-        if (assetsResponse.status === 401 || jobsResponse?.status === 401) {
-          setLibraryAssets([]);
-          setLibraryError(kind === 'video' ? 'Sign in to access your video library.' : 'Sign in to access your image library.');
-          setLibraryLoadedKey(requestKey);
-          return;
-        }
-
-        const assetsPayload = (await assetsResponse.json().catch(() => null)) as UserAssetsResponse | null;
-        if (!assetsResponse.ok || !assetsPayload?.ok) {
-          throw new Error(assetsPayload?.error ?? copy.libraryError);
-        }
-
-        const savedAssets = Array.isArray(assetsPayload.assets)
-          ? assetsPayload.assets.map((asset) => {
-              const mime = asset.mime ?? null;
-              return {
-                id: asset.id,
-                url: asset.url,
-                kind: mime?.startsWith('video/') ? 'video' : 'image',
-                width: asset.width ?? null,
-                height: asset.height ?? null,
-                size: asset.size ?? null,
-                mime,
-                source: asset.source ?? null,
-                createdAt: asset.createdAt,
-                canDelete: false,
-              } satisfies AssetBrowserAsset;
-            })
-          : [];
-        const filteredAssets = savedAssets.filter((asset) =>
-          kind === 'video'
-            ? asset.kind === 'video' || asset.mime?.startsWith('video/')
-            : asset.kind === 'image' || !asset.mime || asset.mime.startsWith('image/')
-        );
-
-        let generatedVideos: AssetBrowserAsset[] = [];
-        if (kind === 'video' && jobsResponse) {
-          const jobsPayload = (await jobsResponse.json().catch(() => null)) as JobsLibraryResponse | null;
-          if (jobsResponse.ok && Array.isArray(jobsPayload?.jobs)) {
-            generatedVideos = jobsPayload.jobs
-              .map((job) => ({
-                id: `job:${job.jobId}`,
-                url: job.videoUrl ?? job.readyVideoUrl ?? '',
-                kind: 'video' as const,
-                mime: 'video/mp4',
-                source: 'generated',
-                createdAt: job.createdAt,
-                canDelete: false,
-              }))
-              .filter((asset) => asset.url.trim().length > 0);
-          }
-        }
-
-        const combined = kind === 'video' ? [...filteredAssets, ...generatedVideos] : filteredAssets;
-        const deduped = combined.filter(
-          (asset, index, list) => list.findIndex((entry) => entry.url === asset.url) === index
-        );
-        setLibraryAssets(deduped);
-        setLibraryLoadedKey(requestKey);
-      } catch (libraryLoadError) {
-        console.error('[upscale] failed to load library assets', libraryLoadError);
-        setLibraryAssets([]);
-        setLibraryError(libraryLoadError instanceof Error ? libraryLoadError.message : copy.libraryError);
-        setLibraryLoadedKey(requestKey);
-      } finally {
-        setLibraryLoading(false);
-      }
-    },
-    [copy.libraryError, librarySource, mediaType, user]
-  );
-
-  useEffect(() => {
-    if (!libraryModalOpen || !libraryCacheKey || libraryLoading) return;
-    if (libraryLoadedKey === libraryCacheKey) return;
-    setLibraryAssets([]);
-    setLibraryError(null);
-    void fetchLibraryAssets({ kind: mediaType, source: librarySource });
-  }, [
-    fetchLibraryAssets,
-    libraryCacheKey,
-    libraryLoadedKey,
-    libraryLoading,
-    libraryModalOpen,
-    librarySource,
-    mediaType,
-  ]);
-
   function changeMediaType(next: UpscaleMediaType) {
     setMediaType(next);
     const nextEngine = next === 'video' ? DEFAULT_UPSCALE_VIDEO_ENGINE_ID : DEFAULT_UPSCALE_IMAGE_ENGINE_ID;
@@ -514,10 +391,7 @@ export default function UpscaleWorkspace() {
     setError(null);
     setMessage(null);
     setPreviewMode('source');
-    setLibraryAssets([]);
-    setLibraryError(null);
-    setLibraryLoadedKey(null);
-    setLibrarySource(next === 'video' ? 'generated' : 'all');
+    resetLibraryState(next === 'video' ? 'generated' : 'all');
   }
 
   function changeEngine(nextId: UpscaleToolEngineId) {
@@ -605,17 +479,6 @@ export default function UpscaleWorkspace() {
   function handleDownload() {
     if (!output?.url) return;
     triggerAppDownload(output.url, suggestDownloadFilename(output.url, `upscale-${mediaType}`));
-  }
-
-  function openLibraryModal() {
-    const nextSource: AssetLibrarySource = mediaType === 'video' ? 'generated' : 'all';
-    if (librarySource !== nextSource) {
-      setLibrarySource(nextSource);
-      setLibraryAssets([]);
-      setLibraryError(null);
-      setLibraryLoadedKey(null);
-    }
-    setLibraryModalOpen(true);
   }
 
   function selectLibraryAsset(asset: AssetBrowserAsset) {
@@ -1350,10 +1213,7 @@ export default function UpscaleWorkspace() {
             sourceLabels={copy.libraryTabs}
             onSourceChange={(nextSource) => {
               if (nextSource === librarySource) return;
-              setLibrarySource(nextSource);
-              setLibraryAssets([]);
-              setLibraryError(null);
-              setLibraryLoadedKey(null);
+              resetLibraryState(nextSource);
             }}
             searchPlaceholder={copy.librarySearch}
             sourcesTitle={copy.librarySourcesTitle}

--- a/frontend/src/components/tools/upscale/_hooks/useUpscaleLibraryAssets.ts
+++ b/frontend/src/components/tools/upscale/_hooks/useUpscaleLibraryAssets.ts
@@ -1,0 +1,192 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  type AssetBrowserAsset,
+  type AssetLibrarySource,
+} from '@/components/library/AssetLibraryBrowser';
+import { authFetch } from '@/lib/authFetch';
+import type { UpscaleMediaType } from '@/types/tools-upscale';
+import { buildLibraryCacheKey } from '../_lib/upscale-workspace-helpers';
+import type {
+  JobsLibraryResponse,
+  UserAssetsResponse,
+} from '../_lib/upscale-workspace-types';
+
+type UseUpscaleLibraryAssetsParams = {
+  libraryErrorCopy: string;
+  mediaType: UpscaleMediaType;
+  user: unknown;
+};
+
+export function useUpscaleLibraryAssets({
+  libraryErrorCopy,
+  mediaType,
+  user,
+}: UseUpscaleLibraryAssetsParams) {
+  const [libraryModalOpen, setLibraryModalOpen] = useState(false);
+  const [libraryAssets, setLibraryAssets] = useState<AssetBrowserAsset[]>([]);
+  const [libraryLoading, setLibraryLoading] = useState(false);
+  const [libraryError, setLibraryError] = useState<string | null>(null);
+  const [librarySource, setLibrarySource] = useState<AssetLibrarySource>('all');
+  const [libraryLoadedKey, setLibraryLoadedKey] = useState<string | null>(null);
+
+  const libraryCacheKey = libraryModalOpen ? buildLibraryCacheKey(mediaType, librarySource) : null;
+  const librarySourceOptions = useMemo(
+    () =>
+      mediaType === 'video'
+        ? (['all', 'upload', 'generated', 'upscale'] as const)
+        : (['all', 'upload', 'generated', 'character', 'angle', 'upscale'] as const),
+    [mediaType]
+  );
+  const visibleLibraryAssets = useMemo(
+    () =>
+      libraryAssets.filter((asset) =>
+        mediaType === 'video'
+          ? asset.kind === 'video' || asset.mime?.startsWith('video/')
+          : asset.kind === 'image' || !asset.mime || asset.mime.startsWith('image/')
+      ),
+    [libraryAssets, mediaType]
+  );
+
+  const resetLibraryState = useCallback((nextSource?: AssetLibrarySource) => {
+    setLibraryAssets([]);
+    setLibraryError(null);
+    setLibraryLoadedKey(null);
+    if (nextSource) {
+      setLibrarySource(nextSource);
+    }
+  }, []);
+
+  const fetchLibraryAssets = useCallback(
+    async (options?: { source?: AssetLibrarySource; kind?: UpscaleMediaType }) => {
+      const sourceFilter = options?.source ?? librarySource;
+      const kind = options?.kind ?? mediaType;
+      const requestKey = buildLibraryCacheKey(kind, sourceFilter);
+      setLibraryLoading(true);
+      setLibraryError(null);
+      try {
+        if (!user) {
+          setLibraryAssets([]);
+          setLibraryError(kind === 'video' ? 'Sign in to access your video library.' : 'Sign in to access your image library.');
+          setLibraryLoadedKey(requestKey);
+          return;
+        }
+
+        const assetUrl =
+          sourceFilter === 'all'
+            ? '/api/user-assets?limit=80'
+            : `/api/user-assets?limit=80&source=${encodeURIComponent(sourceFilter)}`;
+        const requests: Array<Promise<Response>> = [authFetch(assetUrl)];
+        if (kind === 'video' && sourceFilter !== 'upload') {
+          const jobsUrl = sourceFilter === 'upscale' ? '/api/jobs?limit=80&surface=upscale' : '/api/jobs?limit=80&type=video';
+          requests.push(authFetch(jobsUrl));
+        }
+
+        const [assetsResponse, jobsResponse] = await Promise.all(requests);
+        if (assetsResponse.status === 401 || jobsResponse?.status === 401) {
+          setLibraryAssets([]);
+          setLibraryError(kind === 'video' ? 'Sign in to access your video library.' : 'Sign in to access your image library.');
+          setLibraryLoadedKey(requestKey);
+          return;
+        }
+
+        const assetsPayload = (await assetsResponse.json().catch(() => null)) as UserAssetsResponse | null;
+        if (!assetsResponse.ok || !assetsPayload?.ok) {
+          throw new Error(assetsPayload?.error ?? libraryErrorCopy);
+        }
+
+        const savedAssets = Array.isArray(assetsPayload.assets)
+          ? assetsPayload.assets.map((asset) => {
+              const mime = asset.mime ?? null;
+              return {
+                id: asset.id,
+                url: asset.url,
+                kind: mime?.startsWith('video/') ? 'video' : 'image',
+                width: asset.width ?? null,
+                height: asset.height ?? null,
+                size: asset.size ?? null,
+                mime,
+                source: asset.source ?? null,
+                createdAt: asset.createdAt,
+                canDelete: false,
+              } satisfies AssetBrowserAsset;
+            })
+          : [];
+        const filteredAssets = savedAssets.filter((asset) =>
+          kind === 'video'
+            ? asset.kind === 'video' || asset.mime?.startsWith('video/')
+            : asset.kind === 'image' || !asset.mime || asset.mime.startsWith('image/')
+        );
+
+        let generatedVideos: AssetBrowserAsset[] = [];
+        if (kind === 'video' && jobsResponse) {
+          const jobsPayload = (await jobsResponse.json().catch(() => null)) as JobsLibraryResponse | null;
+          if (jobsResponse.ok && Array.isArray(jobsPayload?.jobs)) {
+            generatedVideos = jobsPayload.jobs
+              .map((job) => ({
+                id: `job:${job.jobId}`,
+                url: job.videoUrl ?? job.readyVideoUrl ?? '',
+                kind: 'video' as const,
+                mime: 'video/mp4',
+                source: 'generated',
+                createdAt: job.createdAt,
+                canDelete: false,
+              }))
+              .filter((asset) => asset.url.trim().length > 0);
+          }
+        }
+
+        const combined = kind === 'video' ? [...filteredAssets, ...generatedVideos] : filteredAssets;
+        const deduped = combined.filter(
+          (asset, index, list) => list.findIndex((entry) => entry.url === asset.url) === index
+        );
+        setLibraryAssets(deduped);
+        setLibraryLoadedKey(requestKey);
+      } catch (libraryLoadError) {
+        console.error('[upscale] failed to load library assets', libraryLoadError);
+        setLibraryAssets([]);
+        setLibraryError(libraryLoadError instanceof Error ? libraryLoadError.message : libraryErrorCopy);
+        setLibraryLoadedKey(requestKey);
+      } finally {
+        setLibraryLoading(false);
+      }
+    },
+    [libraryErrorCopy, librarySource, mediaType, user]
+  );
+
+  useEffect(() => {
+    if (!libraryModalOpen || !libraryCacheKey || libraryLoading) return;
+    if (libraryLoadedKey === libraryCacheKey) return;
+    setLibraryAssets([]);
+    setLibraryError(null);
+    void fetchLibraryAssets({ kind: mediaType, source: librarySource });
+  }, [
+    fetchLibraryAssets,
+    libraryCacheKey,
+    libraryLoadedKey,
+    libraryLoading,
+    libraryModalOpen,
+    librarySource,
+    mediaType,
+  ]);
+
+  const openLibraryModal = useCallback(() => {
+    const nextSource: AssetLibrarySource = mediaType === 'video' ? 'generated' : 'all';
+    if (librarySource !== nextSource) {
+      resetLibraryState(nextSource);
+    }
+    setLibraryModalOpen(true);
+  }, [librarySource, mediaType, resetLibraryState]);
+
+  return {
+    fetchLibraryAssets,
+    libraryError,
+    libraryLoading,
+    libraryModalOpen,
+    librarySource,
+    librarySourceOptions,
+    openLibraryModal,
+    resetLibraryState,
+    setLibraryModalOpen,
+    visibleLibraryAssets,
+  };
+}

--- a/tests/upscale-workspace-architecture.test.ts
+++ b/tests/upscale-workspace-architecture.test.ts
@@ -8,6 +8,7 @@ const workspacePath = join(root, 'frontend/src/components/tools/UpscaleWorkspace
 const copyPath = join(root, 'frontend/src/components/tools/upscale/_lib/upscale-workspace-copy.ts');
 const typesPath = join(root, 'frontend/src/components/tools/upscale/_lib/upscale-workspace-types.ts');
 const helpersPath = join(root, 'frontend/src/components/tools/upscale/_lib/upscale-workspace-helpers.ts');
+const libraryHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscaleLibraryAssets.ts');
 
 const workspaceSource = readFileSync(workspacePath, 'utf8');
 
@@ -15,10 +16,12 @@ test('upscale workspace delegates copy, local types, and helper logic', () => {
   assert.ok(existsSync(copyPath), 'upscale workspace copy should live in a colocated copy module');
   assert.ok(existsSync(typesPath), 'upscale workspace local contracts should live in a colocated type module');
   assert.ok(existsSync(helpersPath), 'upscale workspace helper logic should live in a colocated helper module');
+  assert.ok(existsSync(libraryHookPath), 'upscale library asset loading should live in a colocated hook');
 
   assert.match(workspaceSource, /from '\.\/upscale\/_lib\/upscale-workspace-copy'/, 'workspace should import upscale copy');
   assert.match(workspaceSource, /from '\.\/upscale\/_lib\/upscale-workspace-types'/, 'workspace should import upscale local types');
   assert.match(workspaceSource, /from '\.\/upscale\/_lib\/upscale-workspace-helpers'/, 'workspace should import upscale helpers');
+  assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscaleLibraryAssets'/, 'workspace should import library hook');
 });
 
 test('upscale workspace does not regain extracted ownership', () => {
@@ -27,15 +30,19 @@ test('upscale workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /function resolveRecentUpscaleMedia\(/, 'recent media resolution belongs in _lib/upscale-workspace-helpers.ts');
   assert.doesNotMatch(workspaceSource, /function uploadSourceFile\(/, 'upload helper belongs in _lib/upscale-workspace-helpers.ts');
   assert.doesNotMatch(workspaceSource, /function readVideoPricingMetadata\(/, 'video metadata reader belongs in _lib/upscale-workspace-helpers.ts');
+  assert.doesNotMatch(workspaceSource, /UserAssetsResponse/, 'library asset response parsing belongs in useUpscaleLibraryAssets');
+  assert.doesNotMatch(workspaceSource, /JobsLibraryResponse/, 'generated video library merging belongs in useUpscaleLibraryAssets');
+  assert.doesNotMatch(workspaceSource, /buildLibraryCacheKey/, 'library cache key orchestration belongs in useUpscaleLibraryAssets');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 1520, `UpscaleWorkspace should stay below 1520 lines after helper extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 1260, `UpscaleWorkspace should stay below 1260 lines after library hook extraction, got ${lineCount}`);
 });
 
 test('upscale helper modules expose the expected workspace contract', () => {
   const copySource = readFileSync(copyPath, 'utf8');
   const typesSource = readFileSync(typesPath, 'utf8');
   const helpersSource = readFileSync(helpersPath, 'utf8');
+  const libraryHookSource = readFileSync(libraryHookPath, 'utf8');
 
   assert.match(copySource, /export const DEFAULT_UPSCALE_COPY =/, 'copy module should export default copy');
 
@@ -62,4 +69,9 @@ test('upscale helper modules expose the expected workspace contract', () => {
   ]) {
     assert.match(helpersSource, new RegExp(`export (const|function|async function) ${exportName}`), `${exportName} should be exported`);
   }
+
+  assert.match(libraryHookSource, /export function useUpscaleLibraryAssets/, 'library hook should be exported');
+  assert.match(libraryHookSource, /buildLibraryCacheKey/, 'library hook should own cache key usage');
+  assert.match(libraryHookSource, /UserAssetsResponse/, 'library hook should parse saved asset responses');
+  assert.match(libraryHookSource, /JobsLibraryResponse/, 'library hook should merge generated video jobs');
 });


### PR DESCRIPTION
## Summary
- Move Upscale library asset loading, cache-key checks, source filtering, and generated video merging into useUpscaleLibraryAssets.
- Keep UpscaleWorkspace focused on media controls, preview, job actions, and modal wiring.
- Tighten the Upscale workspace architecture test and lower the workspace line-count guard.

## Validation
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/upscale-workspace-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (from frontend/)
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- frontend/src/components/tools/UpscaleWorkspace.tsx frontend/src/components/tools/upscale/_hooks/useUpscaleLibraryAssets.ts tests/upscale-workspace-architecture.test.ts