### PR TITLE
[codex] Split settings control parts

### DIFF
--- a/frontend/components/SettingsControls.tsx
+++ b/frontend/components/SettingsControls.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import clsx from 'clsx';
-import Image from 'next/image';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { MutableRefObject, Ref } from 'react';
 import type { EngineCaps, EngineInputField, EngineModeUiCaps as CapabilityCaps, Mode } from '@/types/engines';
@@ -9,6 +8,8 @@ import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { useI18n } from '@/lib/i18n/I18nProvider';
 import { formatResolutionLabel } from '@/lib/resolution-labels';
+import { matchesDurationOptionValue, parseDurationOptionValue } from '@/components/settings-controls/settings-control-duration';
+import { FieldGroup, RangeWithInput } from '@/components/settings-controls/settings-control-parts';
 
 interface Props {
   engine: EngineCaps;
@@ -1194,129 +1195,4 @@ export function SettingsControls({
       </div>
     </Card>
   );
-}
-
-interface FieldGroupProps {
-  label: string;
-  options: (string | number)[];
-  value: string;
-  onChange: (value: string) => void;
-  focusRef?: Ref<HTMLDivElement>;
-  disabled?: boolean;
-  labelFor?: (option: string | number) => string;
-  iconFor?: (option: string | number) => string | undefined;
-}
-
-function FieldGroup({ label, options, value, onChange, focusRef, disabled = false, labelFor, iconFor }: FieldGroupProps) {
-  return (
-    <div
-      className={clsx(
-        'rounded-input border border-border bg-surface p-3 text-sm text-text-secondary',
-        focusRef && 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
-      )}
-      ref={focusRef}
-      tabIndex={focusRef ? -1 : undefined}
-    >
-      <span className="text-[12px] uppercase tracking-micro text-text-muted">{label}</span>
-      <div className="mt-3 flex flex-wrap gap-2">
-        {options.map((option) => (
-          <Button
-            key={option}
-            type="button"
-            size="sm"
-            variant="outline"
-            disabled={disabled}
-            onClick={() => onChange(String(option))}
-            className={clsx(
-              'min-h-0 h-auto px-3 py-1.5 text-[13px]',
-              disabled && 'cursor-not-allowed opacity-70',
-              String(option) === value
-                ? 'border-brand bg-brand text-on-brand'
-                : 'border-hairline bg-surface text-text-secondary hover:border-text-muted hover:bg-surface-2'
-            )}
-          >
-            {iconFor && iconFor(option) && (
-              <Image src={iconFor(option)!} alt="" width={14} height={14} className="mr-2 inline-block h-3.5 w-3.5 align-[-2px]" />
-            )}
-            {labelFor ? labelFor(option) : String(option)}
-          </Button>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function RangeWithInput({
-  value,
-  min = 0,
-  max = 1,
-  step = 0.05,
-  onChange,
-}: {
-  value: number;
-  min?: number;
-  max?: number;
-  step?: number;
-  onChange: (next: number) => void;
-}) {
-  return (
-    <div className="flex items-center gap-4">
-      <input
-        type="range"
-        min={min}
-        max={max}
-        step={step}
-        value={value}
-        onChange={(event) => onChange(Number(event.currentTarget.value))}
-        className="range-input h-1 flex-1 appearance-none overflow-hidden rounded-full bg-hairline"
-      />
-      <input
-        type="number"
-        min={min}
-        max={max}
-        step={step}
-        value={value}
-        onChange={(event) => onChange(Number(event.currentTarget.value))}
-        className="w-20 rounded-input border border-border bg-surface px-2 py-1 text-right text-sm text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      />
-    </div>
-  );
-}
-
-type DurationOptionMeta = {
-  raw: number | string;
-  value: number;
-  label: string;
-};
-
-function parseDurationOptionValue(option: number | string): DurationOptionMeta {
-  if (typeof option === 'number') {
-    return {
-      raw: option,
-      value: option,
-      label: `${option}s`,
-    };
-  }
-  const numeric = Number(option.replace(/[^\d.]/g, ''));
-  return {
-    raw: option,
-    value: Number.isFinite(numeric) ? numeric : 0,
-    label: option,
-  };
-}
-
-function matchesDurationOptionValue(option: DurationOptionMeta, raw: number | string | null | undefined, seconds: number): boolean {
-  if (raw != null) {
-    if (typeof raw === 'number') {
-      return Math.abs(option.value - raw) < 0.001;
-    }
-    if (typeof raw === 'string') {
-      if (raw === option.raw || raw === option.label) return true;
-      const numeric = Number(raw.replace(/[^\d.]/g, ''));
-      if (Number.isFinite(numeric)) {
-        return Math.abs(option.value - numeric) < 0.001;
-      }
-    }
-  }
-  return Math.abs(option.value - seconds) < 0.001;
 }

--- a/frontend/components/settings-controls/settings-control-duration.ts
+++ b/frontend/components/settings-controls/settings-control-duration.ts
@@ -1,0 +1,37 @@
+export type DurationOptionMeta = {
+  raw: number | string;
+  value: number;
+  label: string;
+};
+
+export function parseDurationOptionValue(option: number | string): DurationOptionMeta {
+  if (typeof option === 'number') {
+    return {
+      raw: option,
+      value: option,
+      label: `${option}s`,
+    };
+  }
+  const numeric = Number(option.replace(/[^\d.]/g, ''));
+  return {
+    raw: option,
+    value: Number.isFinite(numeric) ? numeric : 0,
+    label: option,
+  };
+}
+
+export function matchesDurationOptionValue(option: DurationOptionMeta, raw: number | string | null | undefined, seconds: number): boolean {
+  if (raw != null) {
+    if (typeof raw === 'number') {
+      return Math.abs(option.value - raw) < 0.001;
+    }
+    if (typeof raw === 'string') {
+      if (raw === option.raw || raw === option.label) return true;
+      const numeric = Number(raw.replace(/[^\d.]/g, ''));
+      if (Number.isFinite(numeric)) {
+        return Math.abs(option.value - numeric) < 0.001;
+      }
+    }
+  }
+  return Math.abs(option.value - seconds) < 0.001;
+}

--- a/frontend/components/settings-controls/settings-control-parts.tsx
+++ b/frontend/components/settings-controls/settings-control-parts.tsx
@@ -1,0 +1,91 @@
+import clsx from 'clsx';
+import Image from 'next/image';
+import type { Ref } from 'react';
+import { Button } from '@/components/ui/Button';
+
+type FieldGroupProps = {
+  label: string;
+  options: (string | number)[];
+  value: string;
+  onChange: (value: string) => void;
+  focusRef?: Ref<HTMLDivElement>;
+  disabled?: boolean;
+  labelFor?: (option: string | number) => string;
+  iconFor?: (option: string | number) => string | undefined;
+};
+
+export function FieldGroup({ label, options, value, onChange, focusRef, disabled = false, labelFor, iconFor }: FieldGroupProps) {
+  return (
+    <div
+      className={clsx(
+        'rounded-input border border-border bg-surface p-3 text-sm text-text-secondary',
+        focusRef && 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+      )}
+      ref={focusRef}
+      tabIndex={focusRef ? -1 : undefined}
+    >
+      <span className="text-[12px] uppercase tracking-micro text-text-muted">{label}</span>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {options.map((option) => (
+          <Button
+            key={option}
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={disabled}
+            onClick={() => onChange(String(option))}
+            className={clsx(
+              'min-h-0 h-auto px-3 py-1.5 text-[13px]',
+              disabled && 'cursor-not-allowed opacity-70',
+              String(option) === value
+                ? 'border-brand bg-brand text-on-brand'
+                : 'border-hairline bg-surface text-text-secondary hover:border-text-muted hover:bg-surface-2'
+            )}
+          >
+            {iconFor && iconFor(option) && (
+              <Image src={iconFor(option)!} alt="" width={14} height={14} className="mr-2 inline-block h-3.5 w-3.5 align-[-2px]" />
+            )}
+            {labelFor ? labelFor(option) : String(option)}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function RangeWithInput({
+  value,
+  min = 0,
+  max = 1,
+  step = 0.05,
+  onChange,
+}: {
+  value: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  onChange: (next: number) => void;
+}) {
+  return (
+    <div className="flex items-center gap-4">
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(event) => onChange(Number(event.currentTarget.value))}
+        className="range-input h-1 flex-1 appearance-none overflow-hidden rounded-full bg-hairline"
+      />
+      <input
+        type="number"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(event) => onChange(Number(event.currentTarget.value))}
+        className="w-20 rounded-input border border-border bg-surface px-2 py-1 text-right text-sm text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      />
+    </div>
+  );
+}

--- a/tests/settings-controls-architecture.test.ts
+++ b/tests/settings-controls-architecture.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const root = process.cwd();
+const controlsPath = join(root, 'frontend/components/SettingsControls.tsx');
+const partsPath = join(root, 'frontend/components/settings-controls/settings-control-parts.tsx');
+const durationPath = join(root, 'frontend/components/settings-controls/settings-control-duration.ts');
+
+const controlsSource = readFileSync(controlsPath, 'utf8');
+const partsSource = readFileSync(partsPath, 'utf8');
+const durationSource = readFileSync(durationPath, 'utf8');
+
+test('settings controls delegates reusable control parts and duration helpers', () => {
+  assert.ok(existsSync(partsPath), 'settings control subcomponents should live in a focused module');
+  assert.ok(existsSync(durationPath), 'settings duration helpers should live in a focused module');
+
+  assert.match(controlsSource, /from '@\/components\/settings-controls\/settings-control-parts'/);
+  assert.match(controlsSource, /from '@\/components\/settings-controls\/settings-control-duration'/);
+});
+
+test('settings controls does not regain extracted ownership', () => {
+  assert.doesNotMatch(controlsSource, /function FieldGroup\(/, 'FieldGroup belongs in settings-control-parts.tsx');
+  assert.doesNotMatch(controlsSource, /function RangeWithInput\(/, 'RangeWithInput belongs in settings-control-parts.tsx');
+  assert.doesNotMatch(controlsSource, /function parseDurationOptionValue\(/, 'duration parsing belongs in settings-control-duration.ts');
+  assert.doesNotMatch(controlsSource, /type DurationOptionMeta =/, 'duration option contracts belong in settings-control-duration.ts');
+
+  const lineCount = controlsSource.split('\n').length;
+  assert.ok(lineCount <= 1205, `SettingsControls should stay below 1205 lines after subcomponent extraction, got ${lineCount}`);
+});
+
+test('settings control helper modules expose the expected contract', () => {
+  assert.match(partsSource, /export function FieldGroup/);
+  assert.match(partsSource, /export function RangeWithInput/);
+  assert.match(durationSource, /export type DurationOptionMeta/);
+  assert.match(durationSource, /export function parseDurationOptionValue/);
+  assert.match(durationSource, /export function matchesDurationOptionValue/);
+});


### PR DESCRIPTION
## Summary
- Move reusable SettingsControls subcomponents into settings-control-parts.
- Move duration option parsing/matching into settings-control-duration.
- Add an architecture guard and keep the Kling locked-resolution source assertion intact.

## Validation
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/settings-controls-architecture.test.ts tests/kling-resolution.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (from frontend/)
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- frontend/components/SettingsControls.tsx frontend/components/settings-controls tests/settings-controls-architecture.test.ts