### PR TITLE
[codex] Split existing image job response helpers

### DIFF
--- a/frontend/src/server/images/execute-image-generation.ts
+++ b/frontend/src/server/images/execute-image-generation.ts
@@ -28,7 +28,7 @@ import {
   uploadImageToStorage,
 } from '@/server/storage';
 import { createImageThumbnailBatch } from '@/server/image-thumbnails';
-import { buildStoredImageRenderEntries, parseStoredImageRenders, resolveHeroThumbFromRenders } from '@/lib/image-renders';
+import { buildStoredImageRenderEntries, resolveHeroThumbFromRenders } from '@/lib/image-renders';
 import { ensureReusableAsset, upsertLegacyJobOutputs } from '@/server/media-library';
 import {
   formatSupportedImageFormatsLabel,
@@ -55,6 +55,9 @@ import {
 } from '@/lib/image/gptImage2';
 import { computeBillingProductSnapshot } from '@/lib/billing-products';
 import type { BillingProductKey, JobSurface } from '@/types/billing';
+import { buildResponseFromExistingJob, type ExistingImageJobRow } from './existing-image-job-response';
+
+export { buildResponseFromExistingJob } from './existing-image-job-response';
 
 const DISPLAY_CURRENCY = 'USD';
 const DISPLAY_CURRENCY_LOWER: Currency = 'usd';
@@ -78,25 +81,6 @@ type PendingReceipt = {
   vendorAccountId: string | null;
   stripePaymentIntentId?: string | null;
   stripeChargeId?: string | null;
-};
-
-export type ExistingImageJobRow = {
-  job_id: string;
-  user_id: string | null;
-  status: string;
-  progress: number;
-  provider_job_id: string | null;
-  thumb_url: string | null;
-  aspect_ratio: string | null;
-  pricing_snapshot: PricingSnapshot | null;
-  currency: string | null;
-  payment_status: string | null;
-  engine_id: string;
-  engine_label: string;
-  render_ids: unknown;
-  hero_render_id: string | null;
-  message: string | null;
-  settings_snapshot: unknown;
 };
 
 type ExistingImageChargeRow = {
@@ -619,69 +603,6 @@ function fail(
   extras?: Partial<ImageGenerationResponse>
 ): never {
   throw new ImageGenerationExecutionError(message, { mode, code, status, detail, extras });
-}
-
-export function parseResolutionFromSettingsSnapshot(snapshot: unknown): string | null {
-  if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot)) return null;
-  const core = (snapshot as Record<string, unknown>).core;
-  if (!core || typeof core !== 'object' || Array.isArray(core)) return null;
-  const resolution = (core as Record<string, unknown>).resolution;
-  return typeof resolution === 'string' && resolution.trim().length ? resolution : null;
-}
-
-function buildImagesFromExistingJob(job: ExistingImageJobRow): GeneratedImage[] {
-  const parsed = parseStoredImageRenders(job.render_ids);
-  if (parsed.entries.length) {
-    return parsed.entries.map((entry) => ({
-      url: entry.url,
-      thumbUrl: entry.thumbUrl ?? entry.url,
-      width: entry.width ?? null,
-      height: entry.height ?? null,
-      mimeType: entry.mimeType ?? null,
-    }));
-  }
-
-  const heroUrl = job.hero_render_id ? normalizeMediaUrl(job.hero_render_id) ?? job.hero_render_id : null;
-  const thumbUrl = job.thumb_url ? normalizeMediaUrl(job.thumb_url) ?? job.thumb_url : null;
-  if (!heroUrl) return [];
-
-  return [
-    {
-      url: heroUrl,
-      thumbUrl: thumbUrl ?? heroUrl,
-    },
-  ];
-}
-
-export function buildResponseFromExistingJob(args: {
-  job: ExistingImageJobRow;
-  mode: ImageGenerationMode;
-  engineId: string;
-  engineLabel: string;
-  pricing: PricingSnapshot;
-  resolvedAspectRatio: string | null;
-  resolution: string;
-}): ImageGenerationResponse {
-  const images = buildImagesFromExistingJob(args.job);
-  const thumbUrl = args.job.thumb_url ? normalizeMediaUrl(args.job.thumb_url) ?? args.job.thumb_url : null;
-  const pricing = args.job.pricing_snapshot ?? args.pricing;
-
-  return {
-    ok: true,
-    mode: args.mode,
-    images,
-    description: args.job.message ?? null,
-    jobId: args.job.job_id,
-    requestId: args.job.provider_job_id ?? undefined,
-    providerJobId: args.job.provider_job_id ?? undefined,
-    engineId: args.job.engine_id || args.engineId,
-    engineLabel: args.job.engine_label || args.engineLabel,
-    pricing,
-    paymentStatus: args.job.payment_status ?? 'paid_wallet',
-    thumbUrl,
-    aspectRatio: args.job.aspect_ratio ?? args.resolvedAspectRatio,
-    resolution: parseResolutionFromSettingsSnapshot(args.job.settings_snapshot) ?? args.resolution,
-  };
 }
 
 async function insertProvisionalImageJob(executor: QueryExecutor, params: ProvisionalImageJobInsert) {

--- a/frontend/src/server/images/existing-image-job-response.ts
+++ b/frontend/src/server/images/existing-image-job-response.ts
@@ -1,0 +1,90 @@
+import type {
+  GeneratedImage,
+  ImageGenerationMode,
+  ImageGenerationResponse,
+} from '@/types/image-generation';
+import type { PricingSnapshot } from '@/types/engines';
+import { normalizeMediaUrl } from '@/lib/media';
+import { parseStoredImageRenders } from '@/lib/image-renders';
+
+export type ExistingImageJobRow = {
+  job_id: string;
+  user_id: string | null;
+  status: string;
+  progress: number;
+  provider_job_id: string | null;
+  thumb_url: string | null;
+  aspect_ratio: string | null;
+  pricing_snapshot: PricingSnapshot | null;
+  currency: string | null;
+  payment_status: string | null;
+  engine_id: string;
+  engine_label: string;
+  render_ids: unknown;
+  hero_render_id: string | null;
+  message: string | null;
+  settings_snapshot: unknown;
+};
+
+export function parseResolutionFromSettingsSnapshot(snapshot: unknown): string | null {
+  if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot)) return null;
+  const core = (snapshot as Record<string, unknown>).core;
+  if (!core || typeof core !== 'object' || Array.isArray(core)) return null;
+  const resolution = (core as Record<string, unknown>).resolution;
+  return typeof resolution === 'string' && resolution.trim().length ? resolution : null;
+}
+
+function buildImagesFromExistingJob(job: ExistingImageJobRow): GeneratedImage[] {
+  const parsed = parseStoredImageRenders(job.render_ids);
+  if (parsed.entries.length) {
+    return parsed.entries.map((entry) => ({
+      url: entry.url,
+      thumbUrl: entry.thumbUrl ?? entry.url,
+      width: entry.width ?? null,
+      height: entry.height ?? null,
+      mimeType: entry.mimeType ?? null,
+    }));
+  }
+
+  const heroUrl = job.hero_render_id ? normalizeMediaUrl(job.hero_render_id) ?? job.hero_render_id : null;
+  const thumbUrl = job.thumb_url ? normalizeMediaUrl(job.thumb_url) ?? job.thumb_url : null;
+  if (!heroUrl) return [];
+
+  return [
+    {
+      url: heroUrl,
+      thumbUrl: thumbUrl ?? heroUrl,
+    },
+  ];
+}
+
+export function buildResponseFromExistingJob(args: {
+  job: ExistingImageJobRow;
+  mode: ImageGenerationMode;
+  engineId: string;
+  engineLabel: string;
+  pricing: PricingSnapshot;
+  resolvedAspectRatio: string | null;
+  resolution: string;
+}): ImageGenerationResponse {
+  const images = buildImagesFromExistingJob(args.job);
+  const thumbUrl = args.job.thumb_url ? normalizeMediaUrl(args.job.thumb_url) ?? args.job.thumb_url : null;
+  const pricing = args.job.pricing_snapshot ?? args.pricing;
+
+  return {
+    ok: true,
+    mode: args.mode,
+    images,
+    description: args.job.message ?? null,
+    jobId: args.job.job_id,
+    requestId: args.job.provider_job_id ?? undefined,
+    providerJobId: args.job.provider_job_id ?? undefined,
+    engineId: args.job.engine_id || args.engineId,
+    engineLabel: args.job.engine_label || args.engineLabel,
+    pricing,
+    paymentStatus: args.job.payment_status ?? 'paid_wallet',
+    thumbUrl,
+    aspectRatio: args.job.aspect_ratio ?? args.resolvedAspectRatio,
+    resolution: parseResolutionFromSettingsSnapshot(args.job.settings_snapshot) ?? args.resolution,
+  };
+}

--- a/tests/image-generation-server-architecture.test.ts
+++ b/tests/image-generation-server-architecture.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const root = process.cwd();
+const executorPath = join(root, 'frontend/src/server/images/execute-image-generation.ts');
+const existingJobResponsePath = join(root, 'frontend/src/server/images/existing-image-job-response.ts');
+
+const executorSource = readFileSync(executorPath, 'utf8');
+const existingJobResponseSource = readFileSync(existingJobResponsePath, 'utf8');
+
+test('image generation executor delegates existing job response rebuilding', () => {
+  assert.ok(existsSync(existingJobResponsePath), 'existing image job response helpers should live in a focused module');
+  assert.match(executorSource, /from '\.\/existing-image-job-response'/);
+  assert.match(executorSource, /export \{ buildResponseFromExistingJob \} from '\.\/existing-image-job-response'/);
+});
+
+test('image generation executor does not regain existing job response ownership', () => {
+  assert.doesNotMatch(executorSource, /function buildImagesFromExistingJob\(/, 'stored render parsing belongs in existing-image-job-response.ts');
+  assert.doesNotMatch(executorSource, /function parseResolutionFromSettingsSnapshot\(/, 'settings snapshot resolution parsing belongs in existing-image-job-response.ts');
+  assert.doesNotMatch(executorSource, /parseStoredImageRenders/, 'stored render parsing belongs in existing-image-job-response.ts');
+
+  const lineCount = executorSource.split('\n').length;
+  assert.ok(lineCount <= 1740, `image generation executor should stay below 1740 lines after existing-job response extraction, got ${lineCount}`);
+});
+
+test('existing image job response module exposes the expected contract', () => {
+  assert.match(existingJobResponseSource, /export type ExistingImageJobRow/);
+  assert.match(existingJobResponseSource, /export function parseResolutionFromSettingsSnapshot/);
+  assert.match(existingJobResponseSource, /export function buildResponseFromExistingJob/);
+  assert.match(existingJobResponseSource, /parseStoredImageRenders/);
+});


### PR DESCRIPTION
## Summary
- Move existing image job row contracts and response rebuilding into existing-image-job-response.
- Re-export buildResponseFromExistingJob from execute-image-generation to keep the tested public API stable.
- Add an architecture guard for the image generation executor split.

## Validation
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/image-generation-server-architecture.test.ts tests/image-generation-atomic.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (from frontend/)
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- frontend/src/server/images/execute-image-generation.ts frontend/src/server/images/existing-image-job-response.ts tests/image-generation-server-architecture.test.ts