### PR TITLE
[codex] Split character builder runtime hooks

### DIFF
--- a/frontend/src/components/tools/CharacterBuilderWorkspace.tsx
+++ b/frontend/src/components/tools/CharacterBuilderWorkspace.tsx
@@ -23,7 +23,6 @@ import { suggestDownloadFilename, triggerAppDownload } from '@/lib/download';
 import { useI18n } from '@/lib/i18n/I18nProvider';
 import {
   AUTO_TRAIT_KEYS,
-  CHARACTER_BUILDER_STORAGE_KEY,
   createDefaultCharacterBuilderState,
   getCharacterFormatMultiplier,
   normalizeCharacterFormatMode,
@@ -35,7 +34,6 @@ import { FEATURES } from '@/content/feature-flags';
 import type {
   CharacterBuilderAction,
   CharacterBuilderResult,
-  CharacterBuilderRun,
   CharacterBuilderSettingsSnapshot,
   CharacterBuilderState,
   CharacterBuilderTraitSource,
@@ -63,13 +61,14 @@ import {
   type BuildLookSectionKey,
 } from './character-builder/_components/character-builder-workspace-components';
 import { useCharacterBuilderHistoricalResults } from './character-builder/_hooks/useCharacterBuilderHistoricalResults';
+import { useCharacterBuilderJobSnapshotLoader } from './character-builder/_hooks/useCharacterBuilderJobSnapshotLoader';
 import { useCharacterBuilderOptions } from './character-builder/_hooks/useCharacterBuilderOptions';
+import { useCharacterBuilderPersistence } from './character-builder/_hooks/useCharacterBuilderPersistence';
+import { useCharacterBuilderPendingRunsSync } from './character-builder/_hooks/useCharacterBuilderPendingRunsSync';
 import { DEFAULT_CHARACTER_COPY, type CharacterCopy } from './character-builder/_lib/character-builder-copy';
 import {
-  buildRecoveredRunFromJob,
   buildReferenceImage,
   buildResetCharacterBuilderState,
-  CHARACTER_BUILDER_PENDING_RUNS_STORAGE_KEY,
   countConfiguredSecondaryControls,
   decrementLoadingRequestCount,
   emitClientMetric,
@@ -90,19 +89,14 @@ import {
   normalizeHairAndOutfitModes,
   normalizeTag,
   parseCharacterBuilderSnapshot,
-  readPersistedPendingRuns,
-  readPersistedState,
   removeReferenceImage,
   serializeResettableCharacterBuilderState,
   summarizeCustomText,
   updateReferenceImage,
   uploadImage,
-  writePersistedPendingRuns,
-  writePersistedState,
 } from './character-builder/_lib/character-builder-helpers';
 import type {
   BillingProductResponse,
-  CharacterJobPayload,
   CharacterLibraryAsset,
   HistoricalCharacterGalleryItem,
   LoadingRequestCounts,
@@ -138,7 +132,6 @@ export default function CharacterBuilderPage() {
   const styleFileRef = useRef<HTMLInputElement | null>(null);
   const resultsScrollContainerRef = useRef<HTMLDivElement | null>(null);
   const resultsSentinelRef = useRef<HTMLDivElement | null>(null);
-  const visitorSanitizedRef = useRef(false);
   const loginRedirectTarget = useMemo(() => {
     const base = pathname || '/app/tools/character-builder';
     const search = searchParams?.toString();
@@ -181,6 +174,26 @@ export default function CharacterBuilderPage() {
   } = useCharacterBuilderHistoricalResults(flattenedResults);
   const identityReference = getRefByRole(state.referenceImages, 'identity');
   const styleReference = getRefByRole(state.referenceImages, 'style');
+  useCharacterBuilderPersistence({
+    authLoading,
+    hydrated,
+    pendingRuns,
+    setAdvancedOpen,
+    setError,
+    setHairOpen,
+    setHydrated,
+    setLightboxEntry,
+    setLoadingActions,
+    setMustRemainDraft,
+    setPendingRuns,
+    setSavingResultId,
+    setShowStyleReferenceSlot,
+    setState,
+    setStatusMessage,
+    state,
+    styleReference,
+    user,
+  });
   const hasIdentityReference = Boolean(identityReference);
   const hasCompletedResults = flattenedResults.length > 0;
   const hasResults = hasCompletedResults || pendingRuns.length > 0 || historicalResults.length > 0;
@@ -205,6 +218,23 @@ export default function CharacterBuilderPage() {
   const realismSummary = findChoiceLabel(realismOptions, state.traits.realismStyle) ?? copy.summary.photoreal;
   const jobIdFromQuery = searchParams?.get('job')?.trim() ?? null;
   const billingProductKey = getCharacterBillingProductKey(state.qualityMode);
+  useCharacterBuilderPendingRunsSync({
+    authLoading,
+    hydrated,
+    mutateHistoricalJobs,
+    pendingRuns,
+    setPendingRuns,
+    setState,
+    user,
+  });
+  useCharacterBuilderJobSnapshotLoader({
+    hydrated,
+    jobIdFromQuery,
+    loadFromJobDoneMessage: copy.loadFromJobDone,
+    setShowStyleReferenceSlot,
+    setState,
+    setStatusMessage,
+  });
   const { data: billingProductData } = useSWR(
     `/api/billing-products?productKey=${encodeURIComponent(billingProductKey)}`,
     async (url: string) => {
@@ -222,172 +252,6 @@ export default function CharacterBuilderPage() {
       ? Number(((billingProductData.unitPriceCents * getCharacterFormatMultiplier(state.formatMode, state.qualityMode)) / 100).toFixed(2))
       : null;
   const isActionLoading = (key: LoadingRequestKey): boolean => (loadingActions[key] ?? 0) > 0;
-  useEffect(() => {
-    const persisted = readPersistedState();
-    if (persisted) {
-      setState(persisted);
-      setAdvancedOpen(Boolean(persisted.advancedNotes));
-      setShowStyleReferenceSlot(Boolean(getRefByRole(persisted.referenceImages, 'style')));
-    }
-    const pending = readPersistedPendingRuns();
-    if (pending.length) {
-      setPendingRuns(pending);
-    }
-    setHydrated(true);
-  }, []);
-
-  useEffect(() => {
-    if (styleReference) {
-      setShowStyleReferenceSlot(true);
-    }
-  }, [styleReference]);
-
-  useEffect(() => {
-    if (!hydrated) return;
-    writePersistedState(state);
-  }, [hydrated, state]);
-
-  useEffect(() => {
-    if (!hydrated) return;
-    writePersistedPendingRuns(pendingRuns);
-  }, [hydrated, pendingRuns]);
-
-  useEffect(() => {
-    if (authLoading || !hydrated) return;
-    if (user) {
-      visitorSanitizedRef.current = false;
-      return;
-    }
-    if (visitorSanitizedRef.current) return;
-    visitorSanitizedRef.current = true;
-    if (typeof window !== 'undefined') {
-      try {
-        window.localStorage.removeItem(CHARACTER_BUILDER_STORAGE_KEY);
-        window.localStorage.removeItem(CHARACTER_BUILDER_PENDING_RUNS_STORAGE_KEY);
-      } catch {
-        // ignore storage failures
-      }
-    }
-    setState(createDefaultCharacterBuilderState());
-    setAdvancedOpen(false);
-    setHairOpen(false);
-    setShowStyleReferenceSlot(false);
-    setMustRemainDraft('');
-    setLoadingActions(INITIAL_LOADING_REQUEST_COUNTS);
-    setPendingRuns([]);
-    setSavingResultId(null);
-    setLightboxEntry(null);
-    setError(null);
-    setStatusMessage(null);
-  }, [authLoading, hydrated, user]);
-
-  useEffect(() => {
-    if (!hydrated || authLoading || !user || !pendingRuns.length) return undefined;
-
-    let cancelled = false;
-
-    async function syncPendingRuns() {
-      const completedRuns: CharacterBuilderRun[] = [];
-      const completedIds = new Set<string>();
-      const failedIds = new Set<string>();
-
-      await Promise.all(
-        pendingRuns.map(async (pendingRun) => {
-          try {
-            const response = await authFetch(`/api/jobs/${encodeURIComponent(pendingRun.jobId)}`);
-            const payload = (await response.json().catch(() => null)) as CharacterJobPayload | null;
-            if (!response.ok || !payload?.ok || cancelled) return;
-
-            const normalizedStatus = typeof payload.status === 'string' ? payload.status.toLowerCase() : '';
-            const recoveredRun = buildRecoveredRunFromJob(pendingRun, payload);
-            if (recoveredRun) {
-              completedRuns.push(recoveredRun);
-              completedIds.add(pendingRun.id);
-              return;
-            }
-
-            if (normalizedStatus === 'failed' || normalizedStatus === 'error' || normalizedStatus === 'cancelled' || normalizedStatus === 'canceled') {
-              failedIds.add(pendingRun.id);
-            }
-          } catch {
-            // ignore transient polling failures
-          }
-        })
-      );
-
-      if (cancelled) return;
-
-      if (completedIds.size || failedIds.size) {
-        setPendingRuns((previous) =>
-          previous.filter((entry) => !completedIds.has(entry.id) && !failedIds.has(entry.id))
-        );
-      }
-
-      if (completedRuns.length) {
-        setState((previous) => {
-          const seenJobIds = new Set(previous.runs.map((run) => run.jobId));
-          const freshRuns = completedRuns.filter((run) => !seenJobIds.has(run.jobId));
-          if (!freshRuns.length) return previous;
-          const nextRuns = [...freshRuns, ...previous.runs].slice(0, 12);
-          const firstResultId = freshRuns[0]?.results[0]?.id ?? previous.selectedResultId;
-          return {
-            ...previous,
-            runs: nextRuns,
-            selectedResultId: firstResultId,
-          };
-        });
-        void mutateHistoricalJobs(undefined, { revalidate: true });
-      }
-    }
-
-    void syncPendingRuns();
-    const intervalId = window.setInterval(() => {
-      void syncPendingRuns();
-    }, 8000);
-
-    return () => {
-      cancelled = true;
-      window.clearInterval(intervalId);
-    };
-  }, [authLoading, hydrated, mutateHistoricalJobs, pendingRuns, user]);
-
-  useEffect(() => {
-    const requestedJobId = jobIdFromQuery;
-    if (!hydrated || !requestedJobId) return;
-    const activeJobId: string = requestedJobId;
-    let cancelled = false;
-
-    async function loadFromJob() {
-      try {
-        const response = await authFetch(`/api/jobs/${encodeURIComponent(activeJobId)}`);
-        const payload = (await response.json().catch(() => null)) as
-          | {
-              ok?: boolean;
-              settingsSnapshot?: unknown;
-            }
-          | null;
-        if (!response.ok || !payload?.ok || !payload.settingsSnapshot || cancelled) return;
-        const snapshotState = parseCharacterBuilderSnapshot(payload.settingsSnapshot);
-        if (!snapshotState) return;
-        setState((previous) => ({
-          ...previous,
-          ...snapshotState,
-        }));
-        setShowStyleReferenceSlot(Boolean(snapshotState.referenceImages?.some((image) => image.role === 'style')));
-        setStatusMessage(copy.loadFromJobDone);
-      } catch (loadError) {
-        if (!cancelled) {
-          console.warn('[character-builder] failed to load job snapshot', loadError);
-        }
-      }
-    }
-
-    void loadFromJob();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [copy.loadFromJobDone, hydrated, jobIdFromQuery]);
 
   useEffect(() => {
     const sentinel = resultsSentinelRef.current;

--- a/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderJobSnapshotLoader.ts
+++ b/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderJobSnapshotLoader.ts
@@ -1,0 +1,61 @@
+import type { Dispatch, SetStateAction } from 'react';
+import { useEffect } from 'react';
+import { authFetch } from '@/lib/authFetch';
+import type { CharacterBuilderState } from '@/types/character-builder';
+import { parseCharacterBuilderSnapshot } from '../_lib/character-builder-helpers';
+
+interface UseCharacterBuilderJobSnapshotLoaderOptions {
+  hydrated: boolean;
+  jobIdFromQuery: string | null;
+  loadFromJobDoneMessage: string;
+  setShowStyleReferenceSlot: Dispatch<SetStateAction<boolean>>;
+  setState: Dispatch<SetStateAction<CharacterBuilderState>>;
+  setStatusMessage: Dispatch<SetStateAction<string | null>>;
+}
+
+export function useCharacterBuilderJobSnapshotLoader({
+  hydrated,
+  jobIdFromQuery,
+  loadFromJobDoneMessage,
+  setShowStyleReferenceSlot,
+  setState,
+  setStatusMessage,
+}: UseCharacterBuilderJobSnapshotLoaderOptions) {
+  useEffect(() => {
+    const requestedJobId = jobIdFromQuery;
+    if (!hydrated || !requestedJobId) return;
+    const activeJobId: string = requestedJobId;
+    let cancelled = false;
+
+    async function loadFromJob() {
+      try {
+        const response = await authFetch(`/api/jobs/${encodeURIComponent(activeJobId)}`);
+        const payload = (await response.json().catch(() => null)) as
+          | {
+              ok?: boolean;
+              settingsSnapshot?: unknown;
+            }
+          | null;
+        if (!response.ok || !payload?.ok || !payload.settingsSnapshot || cancelled) return;
+        const snapshotState = parseCharacterBuilderSnapshot(payload.settingsSnapshot);
+        if (!snapshotState) return;
+        setState((previous) => ({
+          ...previous,
+          ...snapshotState,
+        }));
+        setShowStyleReferenceSlot(Boolean(snapshotState.referenceImages?.some((image) => image.role === 'style')));
+        setStatusMessage(loadFromJobDoneMessage);
+      } catch (loadError) {
+        if (!cancelled) {
+          console.warn('[character-builder] failed to load job snapshot', loadError);
+        }
+      }
+    }
+
+    void loadFromJob();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hydrated, jobIdFromQuery, loadFromJobDoneMessage, setShowStyleReferenceSlot, setState, setStatusMessage]);
+}

--- a/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderPendingRunsSync.ts
+++ b/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderPendingRunsSync.ts
@@ -1,0 +1,100 @@
+import type { Dispatch, SetStateAction } from 'react';
+import { useEffect } from 'react';
+import type { SWRInfiniteKeyedMutator } from 'swr/infinite';
+import { authFetch } from '@/lib/authFetch';
+import type { JobsPage } from '@/types/jobs';
+import type { CharacterBuilderRun, CharacterBuilderState } from '@/types/character-builder';
+import { buildRecoveredRunFromJob } from '../_lib/character-builder-helpers';
+import type { CharacterJobPayload, PendingCharacterRun } from '../_lib/character-builder-types';
+
+type MutateHistoricalJobs = SWRInfiniteKeyedMutator<JobsPage[]>;
+
+interface UseCharacterBuilderPendingRunsSyncOptions {
+  authLoading: boolean;
+  hydrated: boolean;
+  mutateHistoricalJobs: MutateHistoricalJobs;
+  pendingRuns: PendingCharacterRun[];
+  setPendingRuns: Dispatch<SetStateAction<PendingCharacterRun[]>>;
+  setState: Dispatch<SetStateAction<CharacterBuilderState>>;
+  user: unknown;
+}
+
+export function useCharacterBuilderPendingRunsSync({
+  authLoading,
+  hydrated,
+  mutateHistoricalJobs,
+  pendingRuns,
+  setPendingRuns,
+  setState,
+  user,
+}: UseCharacterBuilderPendingRunsSyncOptions) {
+  useEffect(() => {
+    if (!hydrated || authLoading || !user || !pendingRuns.length) return undefined;
+
+    let cancelled = false;
+
+    async function syncPendingRuns() {
+      const completedRuns: CharacterBuilderRun[] = [];
+      const completedIds = new Set<string>();
+      const failedIds = new Set<string>();
+
+      await Promise.all(
+        pendingRuns.map(async (pendingRun) => {
+          try {
+            const response = await authFetch(`/api/jobs/${encodeURIComponent(pendingRun.jobId)}`);
+            const payload = (await response.json().catch(() => null)) as CharacterJobPayload | null;
+            if (!response.ok || !payload?.ok || cancelled) return;
+
+            const normalizedStatus = typeof payload.status === 'string' ? payload.status.toLowerCase() : '';
+            const recoveredRun = buildRecoveredRunFromJob(pendingRun, payload);
+            if (recoveredRun) {
+              completedRuns.push(recoveredRun);
+              completedIds.add(pendingRun.id);
+              return;
+            }
+
+            if (normalizedStatus === 'failed' || normalizedStatus === 'error' || normalizedStatus === 'cancelled' || normalizedStatus === 'canceled') {
+              failedIds.add(pendingRun.id);
+            }
+          } catch {
+            // ignore transient polling failures
+          }
+        })
+      );
+
+      if (cancelled) return;
+
+      if (completedIds.size || failedIds.size) {
+        setPendingRuns((previous) =>
+          previous.filter((entry) => !completedIds.has(entry.id) && !failedIds.has(entry.id))
+        );
+      }
+
+      if (completedRuns.length) {
+        setState((previous) => {
+          const seenJobIds = new Set(previous.runs.map((run) => run.jobId));
+          const freshRuns = completedRuns.filter((run) => !seenJobIds.has(run.jobId));
+          if (!freshRuns.length) return previous;
+          const nextRuns = [...freshRuns, ...previous.runs].slice(0, 12);
+          const firstResultId = freshRuns[0]?.results[0]?.id ?? previous.selectedResultId;
+          return {
+            ...previous,
+            runs: nextRuns,
+            selectedResultId: firstResultId,
+          };
+        });
+        void mutateHistoricalJobs(undefined, { revalidate: true });
+      }
+    }
+
+    void syncPendingRuns();
+    const intervalId = window.setInterval(() => {
+      void syncPendingRuns();
+    }, 8000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [authLoading, hydrated, mutateHistoricalJobs, pendingRuns, setPendingRuns, setState, user]);
+}

--- a/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderPersistence.ts
+++ b/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderPersistence.ts
@@ -1,0 +1,142 @@
+import type { Dispatch, SetStateAction } from 'react';
+import { useEffect, useRef } from 'react';
+import type { MediaLightboxEntry } from '@/components/MediaLightbox';
+import {
+  CHARACTER_BUILDER_STORAGE_KEY,
+  createDefaultCharacterBuilderState,
+} from '@/lib/character-builder';
+import type {
+  CharacterBuilderReferenceImage,
+  CharacterBuilderState,
+} from '@/types/character-builder';
+import {
+  CHARACTER_BUILDER_PENDING_RUNS_STORAGE_KEY,
+  getRefByRole,
+  INITIAL_LOADING_REQUEST_COUNTS,
+  readPersistedPendingRuns,
+  readPersistedState,
+  writePersistedPendingRuns,
+  writePersistedState,
+} from '../_lib/character-builder-helpers';
+import type {
+  LoadingRequestCounts,
+  PendingCharacterRun,
+} from '../_lib/character-builder-types';
+
+interface UseCharacterBuilderPersistenceOptions {
+  authLoading: boolean;
+  hydrated: boolean;
+  pendingRuns: PendingCharacterRun[];
+  setAdvancedOpen: Dispatch<SetStateAction<boolean>>;
+  setError: Dispatch<SetStateAction<string | null>>;
+  setHairOpen: Dispatch<SetStateAction<boolean>>;
+  setHydrated: Dispatch<SetStateAction<boolean>>;
+  setLightboxEntry: Dispatch<SetStateAction<MediaLightboxEntry | null>>;
+  setLoadingActions: Dispatch<SetStateAction<LoadingRequestCounts>>;
+  setMustRemainDraft: Dispatch<SetStateAction<string>>;
+  setPendingRuns: Dispatch<SetStateAction<PendingCharacterRun[]>>;
+  setSavingResultId: Dispatch<SetStateAction<string | null>>;
+  setShowStyleReferenceSlot: Dispatch<SetStateAction<boolean>>;
+  setState: Dispatch<SetStateAction<CharacterBuilderState>>;
+  setStatusMessage: Dispatch<SetStateAction<string | null>>;
+  state: CharacterBuilderState;
+  styleReference: CharacterBuilderReferenceImage | null | undefined;
+  user: unknown;
+}
+
+export function useCharacterBuilderPersistence({
+  authLoading,
+  hydrated,
+  pendingRuns,
+  setAdvancedOpen,
+  setError,
+  setHairOpen,
+  setHydrated,
+  setLightboxEntry,
+  setLoadingActions,
+  setMustRemainDraft,
+  setPendingRuns,
+  setSavingResultId,
+  setShowStyleReferenceSlot,
+  setState,
+  setStatusMessage,
+  state,
+  styleReference,
+  user,
+}: UseCharacterBuilderPersistenceOptions) {
+  const visitorSanitizedRef = useRef(false);
+
+  useEffect(() => {
+    const persisted = readPersistedState();
+    if (persisted) {
+      setState(persisted);
+      setAdvancedOpen(Boolean(persisted.advancedNotes));
+      setShowStyleReferenceSlot(Boolean(getRefByRole(persisted.referenceImages, 'style')));
+    }
+    const pending = readPersistedPendingRuns();
+    if (pending.length) {
+      setPendingRuns(pending);
+    }
+    setHydrated(true);
+  }, [setAdvancedOpen, setHydrated, setPendingRuns, setShowStyleReferenceSlot, setState]);
+
+  useEffect(() => {
+    if (styleReference) {
+      setShowStyleReferenceSlot(true);
+    }
+  }, [setShowStyleReferenceSlot, styleReference]);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    writePersistedState(state);
+  }, [hydrated, state]);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    writePersistedPendingRuns(pendingRuns);
+  }, [hydrated, pendingRuns]);
+
+  useEffect(() => {
+    if (authLoading || !hydrated) return;
+    if (user) {
+      visitorSanitizedRef.current = false;
+      return;
+    }
+    if (visitorSanitizedRef.current) return;
+    visitorSanitizedRef.current = true;
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.removeItem(CHARACTER_BUILDER_STORAGE_KEY);
+        window.localStorage.removeItem(CHARACTER_BUILDER_PENDING_RUNS_STORAGE_KEY);
+      } catch {
+        // ignore storage failures
+      }
+    }
+    setState(createDefaultCharacterBuilderState());
+    setAdvancedOpen(false);
+    setHairOpen(false);
+    setShowStyleReferenceSlot(false);
+    setMustRemainDraft('');
+    setLoadingActions(INITIAL_LOADING_REQUEST_COUNTS);
+    setPendingRuns([]);
+    setSavingResultId(null);
+    setLightboxEntry(null);
+    setError(null);
+    setStatusMessage(null);
+  }, [
+    authLoading,
+    hydrated,
+    setAdvancedOpen,
+    setError,
+    setHairOpen,
+    setLightboxEntry,
+    setLoadingActions,
+    setMustRemainDraft,
+    setPendingRuns,
+    setSavingResultId,
+    setShowStyleReferenceSlot,
+    setState,
+    setStatusMessage,
+    user,
+  ]);
+}

--- a/tests/character-builder-workspace-architecture.test.ts
+++ b/tests/character-builder-workspace-architecture.test.ts
@@ -16,6 +16,9 @@ const referenceLibraryPath = join(root, 'frontend/src/components/tools/character
 const resultCardsPath = join(root, 'frontend/src/components/tools/character-builder/_components/character-builder-result-cards.tsx');
 const optionsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderOptions.ts');
 const historicalResultsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderHistoricalResults.ts');
+const pendingRunsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderPendingRunsSync.ts');
+const jobSnapshotHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderJobSnapshotLoader.ts');
+const persistenceHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderPersistence.ts');
 
 const workspaceSource = readFileSync(workspacePath, 'utf8');
 
@@ -31,10 +34,16 @@ test('character builder workspace delegates copy, local types, and helper logic'
   assert.ok(existsSync(resultCardsPath), 'result card components should live in a focused component module');
   assert.ok(existsSync(optionsHookPath), 'localized option derivation should live in a focused hook');
   assert.ok(existsSync(historicalResultsHookPath), 'historical result derivation should live in a focused hook');
+  assert.ok(existsSync(pendingRunsHookPath), 'pending run polling should live in a focused hook');
+  assert.ok(existsSync(jobSnapshotHookPath), 'job snapshot loading should live in a focused hook');
+  assert.ok(existsSync(persistenceHookPath), 'local persistence should live in a focused hook');
 
   assert.match(workspaceSource, /from '\.\/character-builder\/_components\/character-builder-workspace-components'/, 'workspace should import UI components');
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderOptions'/, 'workspace should import localized options hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderHistoricalResults'/, 'workspace should import historical results hook');
+  assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderPendingRunsSync'/, 'workspace should import pending run sync hook');
+  assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderJobSnapshotLoader'/, 'workspace should import job snapshot loader hook');
+  assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderPersistence'/, 'workspace should import persistence hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_lib\/character-builder-copy'/, 'workspace should import character copy');
   assert.match(workspaceSource, /from '\.\/character-builder\/_lib\/character-builder-types'/, 'workspace should import local types');
   assert.match(workspaceSource, /from '\.\/character-builder\/_lib\/character-builder-helpers'/, 'workspace should import helpers');
@@ -53,9 +62,14 @@ test('character builder workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /GENDER_PRESENTATION_OPTIONS\.map/, 'localized option derivation belongs in useCharacterBuilderOptions');
   assert.doesNotMatch(workspaceSource, /useInfiniteJobs\(18, \{ surface: 'character' \}\)/, 'historical result feed belongs in useCharacterBuilderHistoricalResults');
   assert.doesNotMatch(workspaceSource, /localResultUrls/, 'historical duplicate filtering belongs in useCharacterBuilderHistoricalResults');
+  assert.doesNotMatch(workspaceSource, /function syncPendingRuns\(/, 'pending run polling belongs in useCharacterBuilderPendingRunsSync');
+  assert.doesNotMatch(workspaceSource, /function loadFromJob\(/, 'job query hydration belongs in useCharacterBuilderJobSnapshotLoader');
+  assert.doesNotMatch(workspaceSource, /readPersistedState\(\)/, 'local hydration belongs in useCharacterBuilderPersistence');
+  assert.doesNotMatch(workspaceSource, /writePersistedPendingRuns/, 'pending run persistence belongs in useCharacterBuilderPersistence');
+  assert.doesNotMatch(workspaceSource, /visitorSanitizedRef/, 'visitor cleanup tracking belongs in useCharacterBuilderPersistence');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 1800, `CharacterBuilderWorkspace should stay below 1800 lines after hook extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 1660, `CharacterBuilderWorkspace should stay below 1660 lines after runtime hook extraction, got ${lineCount}`);
 });
 
 test('character builder helper modules expose the expected workspace contract', () => {
@@ -70,6 +84,9 @@ test('character builder helper modules expose the expected workspace contract', 
   const resultCardsSource = readFileSync(resultCardsPath, 'utf8');
   const optionsHookSource = readFileSync(optionsHookPath, 'utf8');
   const historicalResultsHookSource = readFileSync(historicalResultsHookPath, 'utf8');
+  const pendingRunsHookSource = readFileSync(pendingRunsHookPath, 'utf8');
+  const jobSnapshotHookSource = readFileSync(jobSnapshotHookPath, 'utf8');
+  const persistenceHookSource = readFileSync(persistenceHookPath, 'utf8');
 
   assert.match(copySource, /export const DEFAULT_CHARACTER_COPY =/, 'copy module should export default copy');
   assert.match(copySource, /export type CharacterCopy =/, 'copy module should export copy type');
@@ -169,4 +186,11 @@ test('character builder helper modules expose the expected workspace contract', 
   assert.match(optionsHookSource, /getAvailableCharacterFormatOptions/, 'options hook should own format option derivation');
   assert.match(historicalResultsHookSource, /export function useCharacterBuilderHistoricalResults/, 'historical results hook should be exported');
   assert.match(historicalResultsHookSource, /useInfiniteJobs\(18, \{ surface: 'character' \}\)/, 'historical results hook should own the character feed');
+  assert.match(pendingRunsHookSource, /export function useCharacterBuilderPendingRunsSync/, 'pending run sync hook should be exported');
+  assert.match(pendingRunsHookSource, /buildRecoveredRunFromJob/, 'pending run sync hook should recover completed runs');
+  assert.match(jobSnapshotHookSource, /export function useCharacterBuilderJobSnapshotLoader/, 'job snapshot loader hook should be exported');
+  assert.match(jobSnapshotHookSource, /parseCharacterBuilderSnapshot/, 'job snapshot loader hook should own query hydration parsing');
+  assert.match(persistenceHookSource, /export function useCharacterBuilderPersistence/, 'persistence hook should be exported');
+  assert.match(persistenceHookSource, /readPersistedState/, 'persistence hook should own local hydration');
+  assert.match(persistenceHookSource, /writePersistedPendingRuns/, 'persistence hook should own pending run persistence');
 });


### PR DESCRIPTION
## Summary
- move Character Builder local persistence and visitor cleanup into useCharacterBuilderPersistence
- move pending run polling/recovery into useCharacterBuilderPendingRunsSync
- move ?job= snapshot hydration into useCharacterBuilderJobSnapshotLoader
- tighten the Character Builder architecture contract around these runtime responsibilities

## Checks
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/character-builder-workspace-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (from frontend)
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- scoped changed files

## Notes
- existing local edits in frontend/src/lib/stripe-checkout.ts and tests/wallet-checkout-session.test.ts were left unstaged and are not part of this PR.