### PR TITLE
[codex] Split image workspace query hydration

### DIFF
--- a/frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx
+++ b/frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx
@@ -4,7 +4,7 @@
 
 import clsx from 'clsx';
 import dynamic from 'next/dynamic';
-import { useCallback, useEffect, useMemo, useState, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { Plus } from 'lucide-react';
 import type { FormEvent } from 'react';
@@ -15,10 +15,7 @@ import { Composer, type AssetFieldConfig, type ComposerAttachment } from '@/comp
 import { ImageSettingsBar } from '@/components/ImageSettingsBar';
 import { ImageAdvancedSettings } from '@/components/ImageAdvancedSettings';
 import { runImageGeneration, saveImageToLibrary } from '@/lib/api';
-import type {
-  CharacterReferenceSelection,
-  ImageGenerationMode,
-} from '@/types/image-generation';
+import type { ImageGenerationMode } from '@/types/image-generation';
 import type { GroupSummary } from '@/types/groups';
 import type { VideoGroup } from '@/types/video-groups';
 import type { MediaLightboxEntry } from '@/components/MediaLightbox';
@@ -30,17 +27,11 @@ import {
   clampRequestedImageCount,
   getAspectRatioOptions,
   getDefaultAspectRatio,
-  getDefaultResolution,
-  getImageFieldDefaultNumber,
-  getImageFieldDefaultString,
-  getImageFieldValues,
-  getImageInputField,
 } from '@/lib/image/inputSchema';
 import {
   GPT_IMAGE_2_SIZE_CONSTRAINTS,
   parseGptImage2SizeKey,
   validateGptImage2CustomImageSize,
-  type GptImage2ImageSize,
 } from '@/lib/image/gptImage2';
 import { authFetch } from '@/lib/authFetch';
 import { readLastKnownUserId } from '@/lib/last-known';
@@ -53,12 +44,9 @@ import { useImageWorkspacePricing } from './_hooks/useImageWorkspacePricing';
 import { useImageSettingsFields } from './_hooks/useImageSettingsFields';
 import { useImageWorkspaceDesktopLayout } from './_hooks/useImageWorkspaceDesktopLayout';
 import { useImagePreviewActions } from './_hooks/useImagePreviewActions';
+import { useImageWorkspaceQueryHydration } from './_hooks/useImageWorkspaceQueryHydration';
 import { useImageReferenceSlots } from './_hooks/useImageReferenceSlots';
 import { useImageComposerPersistence } from './_hooks/useImageComposerPersistence';
-import {
-  mergeCharacterReferencesIntoSlots,
-  parseCharacterReferenceEntry,
-} from './_lib/image-workspace-character-references';
 import {
   DEFAULT_COPY,
   formatTemplate,
@@ -74,10 +62,8 @@ import {
   findImageEngine,
 } from './_lib/image-workspace-utils';
 import {
-  MAX_REFERENCE_SLOTS,
   type HistoryEntry,
   type ImageEngineOption,
-  type ReferenceSlotValue,
 } from './_lib/image-workspace-types';
 
 export type { ImageEngineOption } from './_lib/image-workspace-types';
@@ -105,7 +91,6 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
     const base = pathname ?? '/app/image';
     return params ? `${base}?${params}` : base;
   }, [pathname, searchParams]);
-  const hydratedJobRef = useRef<string | null>(null);
   const [engineId, setEngineId] = useState(() => engines[0]?.id ?? '');
   const [mode, setMode] = useState<ImageGenerationMode>('t2i');
   const [prompt, setPrompt] = useState('');
@@ -331,235 +316,31 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
     setReferenceSlots,
   });
 
-  const requestedJobId = useMemo(() => {
-    const raw = searchParams?.get('job');
-    if (!raw) return null;
-    const trimmed = raw.trim();
-    return trimmed.length ? trimmed : null;
-  }, [searchParams]);
-
-  const requestedEngineId = useMemo(() => {
-    const raw = searchParams?.get('engine');
-    if (!raw) return null;
-    const trimmed = raw.trim();
-    return trimmed.length ? trimmed : null;
-  }, [searchParams]);
-
-  useEffect(() => {
-    if (!requestedEngineId) return;
-    const engineMatch = findImageEngine(engines, requestedEngineId);
-    if (!engineMatch) return;
-    setEngineId(engineMatch.id);
-    setMode((previous) => (engineMatch.modes.includes(previous) ? previous : engineMatch.modes[0] ?? 't2i'));
-  }, [engines, requestedEngineId]);
-
-  const applyImageSettingsSnapshot = useCallback(
-    (snapshot: unknown, { selectJobId }: { selectJobId?: string } = {}) => {
-      if (!snapshot || typeof snapshot !== 'object') {
-        throw new Error('Job settings snapshot missing');
-      }
-      const record = snapshot as {
-        schemaVersion?: unknown;
-        surface?: unknown;
-        engineId?: unknown;
-        inputMode?: unknown;
-        prompt?: unknown;
-        core?: unknown;
-        refs?: unknown;
-      };
-      if (record.schemaVersion !== 1) {
-        throw new Error('Unsupported job snapshot version');
-      }
-      if (record.surface !== 'image') {
-        throw new Error('This snapshot is not for image');
-      }
-      const snapshotEngineId = typeof record.engineId === 'string' ? record.engineId : null;
-      const engineMatch = snapshotEngineId ? findImageEngine(engines, snapshotEngineId) : null;
-      const snapshotMode = record.inputMode === 't2i' || record.inputMode === 'i2i' ? record.inputMode : null;
-      if (engineMatch) {
-        setEngineId(engineMatch.id);
-        if (snapshotMode) {
-          setMode(engineMatch.modes.includes(snapshotMode) ? snapshotMode : engineMatch.modes[0] ?? 't2i');
-        }
-      } else if (snapshotMode) {
-        setMode(snapshotMode);
-      }
-      const snapshotPrompt = typeof record.prompt === 'string' ? record.prompt : null;
-      if (snapshotPrompt !== null) {
-        setPrompt(snapshotPrompt);
-      }
-
-      const core = record.core && typeof record.core === 'object' ? (record.core as Record<string, unknown>) : {};
-      const numImagesRaw = core.numImages;
-      if (typeof numImagesRaw === 'number' && Number.isFinite(numImagesRaw)) {
-        setNumImages(
-          engineMatch
-            ? clampRequestedImageCount(
-                engineMatch.engineCaps,
-                snapshotMode && engineMatch.modes.includes(snapshotMode) ? snapshotMode : engineMatch.modes[0] ?? 't2i',
-                numImagesRaw
-              )
-            : Math.max(1, Math.round(numImagesRaw))
-        );
-      }
-      const aspectRatioRaw = typeof core.aspectRatio === 'string' ? core.aspectRatio : null;
-      const resolutionRaw = typeof core.resolution === 'string' ? core.resolution : null;
-      const customImageSizeRaw =
-        core.customImageSize && typeof core.customImageSize === 'object'
-          ? (core.customImageSize as Partial<GptImage2ImageSize>)
-          : null;
-      const customImageSizeRawParsed =
-        typeof customImageSizeRaw?.width === 'number' &&
-        Number.isFinite(customImageSizeRaw.width) &&
-        typeof customImageSizeRaw?.height === 'number' &&
-        Number.isFinite(customImageSizeRaw.height)
-          ? {
-              width: Math.round(customImageSizeRaw.width),
-              height: Math.round(customImageSizeRaw.height),
-            }
-          : null;
-      const seedRaw =
-        typeof core.seed === 'number' && Number.isFinite(core.seed) ? Math.round(core.seed) : null;
-      const outputFormatRaw = typeof core.outputFormat === 'string' ? core.outputFormat : null;
-      const qualityRaw = typeof core.quality === 'string' ? core.quality : null;
-      const maskUrlRaw = typeof core.maskUrl === 'string' ? core.maskUrl : null;
-      const enableWebSearchRaw = core.enableWebSearch === true;
-      const thinkingLevelRaw = typeof core.thinkingLevel === 'string' ? core.thinkingLevel : null;
-      const limitGenerationsRaw = core.limitGenerations === true;
-      if (engineMatch) {
-        const resolvedMode =
-          snapshotMode && engineMatch.modes.includes(snapshotMode) ? snapshotMode : engineMatch.modes[0] ?? 't2i';
-        const allowedResolutions = getImageFieldValues(
-          engineMatch.engineCaps,
-          'resolution',
-          resolvedMode,
-          Array.isArray(engineMatch.engineCaps?.resolutions) ? [...engineMatch.engineCaps.resolutions] : []
-        );
-        const defaultResolution = getImageInputField(engineMatch.engineCaps, 'resolution', resolvedMode)
-          ? getDefaultResolution(engineMatch.engineCaps, resolvedMode)
-          : null;
-        const nextResolution =
-          resolutionRaw && allowedResolutions.includes(resolutionRaw) ? resolutionRaw : defaultResolution;
-        setResolution(nextResolution);
-        const parsedSizeFromResolution = parseGptImage2SizeKey(nextResolution);
-        const restoredCustomSize = customImageSizeRawParsed ?? parsedSizeFromResolution;
-        const defaultCustomWidth =
-          getImageFieldDefaultNumber(engineMatch.engineCaps, 'image_width', resolvedMode) ??
-          GPT_IMAGE_2_SIZE_CONSTRAINTS.defaultWidth;
-        const defaultCustomHeight =
-          getImageFieldDefaultNumber(engineMatch.engineCaps, 'image_height', resolvedMode) ??
-          GPT_IMAGE_2_SIZE_CONSTRAINTS.defaultHeight;
-        setCustomImageWidth(String(restoredCustomSize?.width ?? defaultCustomWidth));
-        setCustomImageHeight(String(restoredCustomSize?.height ?? defaultCustomHeight));
-        const allowedAspectRatios = getAspectRatioOptions(engineMatch.engineCaps, resolvedMode);
-        const defaultAspectRatio = getDefaultAspectRatio(engineMatch.engineCaps, resolvedMode);
-        setAspectRatio(
-          aspectRatioRaw && allowedAspectRatios.includes(aspectRatioRaw) ? aspectRatioRaw : defaultAspectRatio
-        );
-        const seedDefault = getImageFieldDefaultNumber(engineMatch.engineCaps, 'seed', resolvedMode);
-        setSeed(seedRaw == null ? (seedDefault == null ? '' : String(seedDefault)) : String(seedRaw));
-        const outputFormats = getImageFieldValues(engineMatch.engineCaps, 'output_format', resolvedMode);
-        const defaultOutputFormat =
-          getImageFieldDefaultString(engineMatch.engineCaps, 'output_format', resolvedMode) ?? outputFormats[0] ?? null;
-        setOutputFormat(
-          outputFormatRaw && outputFormats.includes(outputFormatRaw) ? outputFormatRaw : defaultOutputFormat
-        );
-        const qualityValues = getImageFieldValues(engineMatch.engineCaps, 'quality', resolvedMode);
-        const defaultQuality =
-          getImageFieldDefaultString(engineMatch.engineCaps, 'quality', resolvedMode) ?? qualityValues[0] ?? null;
-        setQuality(qualityRaw && qualityValues.includes(qualityRaw) ? qualityRaw : defaultQuality);
-        setMaskUrl(getImageInputField(engineMatch.engineCaps, 'mask_url', resolvedMode) ? maskUrlRaw ?? '' : '');
-        setEnableWebSearch(
-          getImageInputField(engineMatch.engineCaps, 'enable_web_search', resolvedMode)
-            ? enableWebSearchRaw
-            : false
-        );
-        const thinkingLevels = getImageFieldValues(engineMatch.engineCaps, 'thinking_level', resolvedMode);
-        const defaultThinkingLevel =
-          getImageFieldDefaultString(engineMatch.engineCaps, 'thinking_level', resolvedMode) ??
-          thinkingLevels[0] ??
-          null;
-        setThinkingLevel(
-          thinkingLevelRaw && thinkingLevels.includes(thinkingLevelRaw) ? thinkingLevelRaw : defaultThinkingLevel
-        );
-        setLimitGenerations(
-          getImageInputField(engineMatch.engineCaps, 'limit_generations', resolvedMode)
-            ? limitGenerationsRaw
-            : false
-        );
-      } else {
-        setResolution(resolutionRaw);
-        const restoredCustomSize = customImageSizeRawParsed ?? parseGptImage2SizeKey(resolutionRaw);
-        setCustomImageWidth(restoredCustomSize ? String(restoredCustomSize.width) : '');
-        setCustomImageHeight(restoredCustomSize ? String(restoredCustomSize.height) : '');
-        setAspectRatio(aspectRatioRaw);
-        setSeed(seedRaw == null ? '' : String(seedRaw));
-        setOutputFormat(outputFormatRaw);
-        setQuality(qualityRaw);
-        setMaskUrl(maskUrlRaw ?? '');
-        setEnableWebSearch(enableWebSearchRaw);
-        setThinkingLevel(thinkingLevelRaw);
-        setLimitGenerations(limitGenerationsRaw);
-      }
-
-      const refs = record.refs && typeof record.refs === 'object' ? (record.refs as Record<string, unknown>) : {};
-      const imageUrlsRaw = refs.imageUrls;
-      const imageUrls = Array.isArray(imageUrlsRaw)
-        ? imageUrlsRaw.map((entry) => (typeof entry === 'string' ? entry.trim() : '')).filter((entry) => entry.length)
-        : [];
-      setReferenceSlots(() => {
-        const next = Array(MAX_REFERENCE_SLOTS).fill(null) as Array<ReferenceSlotValue | null>;
-        imageUrls.slice(0, MAX_REFERENCE_SLOTS).forEach((url, index) => {
-          next[index] = {
-            id: `snapshot-${index}`,
-            url,
-            previewUrl: url,
-            status: 'ready',
-            source: 'library',
-          };
-        });
-        const characterReferencesRaw = Array.isArray(refs.characterReferences) ? refs.characterReferences : [];
-        const characterReferences = characterReferencesRaw.reduce<CharacterReferenceSelection[]>((acc, entry) => {
-          const parsedEntry = parseCharacterReferenceEntry(entry);
-          if (!parsedEntry) return acc;
-          acc.push(parsedEntry);
-          return acc;
-        }, []);
-        return mergeCharacterReferencesIntoSlots(next, characterReferences, MAX_REFERENCE_SLOTS);
-      });
-
-      if (selectJobId) {
-        setSelectedPreviewEntryId(selectJobId);
-        setSelectedPreviewImageIndex(0);
-      }
-    },
-    [engines, setReferenceSlots]
-  );
-
-  useEffect(() => {
-    if (!requestedJobId) return;
-    if (hydratedJobRef.current === requestedJobId) return;
-    hydratedJobRef.current = requestedJobId;
-    setError(null);
-    setStatusMessage(null);
-    void authFetch(`/api/jobs/${encodeURIComponent(requestedJobId)}`)
-      .then(async (response) => {
-        const payload = (await response.json().catch(() => null)) as
-          | {
-              ok?: boolean;
-              error?: string;
-              settingsSnapshot?: unknown;
-            }
-          | null;
-        if (!response.ok || !payload?.ok) {
-          throw new Error(payload?.error ?? `Failed to load job (${response.status})`);
-        }
-        applyImageSettingsSnapshot(payload.settingsSnapshot, { selectJobId: requestedJobId });
-      })
-      .catch((error) => {
-        setError(error instanceof Error ? error.message : resolvedCopy.errors.generic);
-      });
-  }, [applyImageSettingsSnapshot, requestedJobId, resolvedCopy.errors.generic]);
+  const { applyImageSettingsSnapshot } = useImageWorkspaceQueryHydration({
+    engines,
+    genericError: resolvedCopy.errors.generic,
+    searchParams,
+    setAspectRatio,
+    setCustomImageHeight,
+    setCustomImageWidth,
+    setEnableWebSearch,
+    setEngineId,
+    setError,
+    setLimitGenerations,
+    setMaskUrl,
+    setMode,
+    setNumImages,
+    setOutputFormat,
+    setPrompt,
+    setQuality,
+    setReferenceSlots,
+    setResolution,
+    setSeed,
+    setSelectedPreviewEntryId,
+    setSelectedPreviewImageIndex,
+    setStatusMessage,
+    setThinkingLevel,
+  });
 
   const setNumImagesPreset = useCallback((value: number) => {
     setNumImages(clampRequestedImageCount(selectedEngineCaps ?? null, mode, value));

--- a/frontend/app/(core)/(workspace)/app/image/_hooks/useImageWorkspaceQueryHydration.ts
+++ b/frontend/app/(core)/(workspace)/app/image/_hooks/useImageWorkspaceQueryHydration.ts
@@ -1,0 +1,343 @@
+import { useCallback, useEffect, useMemo, useRef, type Dispatch, type SetStateAction } from 'react';
+import { authFetch } from '@/lib/authFetch';
+import {
+  clampRequestedImageCount,
+  getAspectRatioOptions,
+  getDefaultAspectRatio,
+  getDefaultResolution,
+  getImageFieldDefaultNumber,
+  getImageFieldDefaultString,
+  getImageFieldValues,
+  getImageInputField,
+} from '@/lib/image/inputSchema';
+import {
+  GPT_IMAGE_2_SIZE_CONSTRAINTS,
+  parseGptImage2SizeKey,
+  type GptImage2ImageSize,
+} from '@/lib/image/gptImage2';
+import type {
+  CharacterReferenceSelection,
+  ImageGenerationMode,
+} from '@/types/image-generation';
+import {
+  mergeCharacterReferencesIntoSlots,
+  parseCharacterReferenceEntry,
+} from '../_lib/image-workspace-character-references';
+import { findImageEngine } from '../_lib/image-workspace-utils';
+import {
+  MAX_REFERENCE_SLOTS,
+  type ImageEngineOption,
+  type ReferenceSlotValue,
+} from '../_lib/image-workspace-types';
+
+type SearchParamsReader = {
+  get(name: string): string | null;
+} | null | undefined;
+
+interface UseImageWorkspaceQueryHydrationParams {
+  engines: ImageEngineOption[];
+  genericError: string;
+  searchParams: SearchParamsReader;
+  setAspectRatio: Dispatch<SetStateAction<string | null>>;
+  setCustomImageHeight: Dispatch<SetStateAction<string>>;
+  setCustomImageWidth: Dispatch<SetStateAction<string>>;
+  setEnableWebSearch: Dispatch<SetStateAction<boolean>>;
+  setEngineId: Dispatch<SetStateAction<string>>;
+  setError: Dispatch<SetStateAction<string | null>>;
+  setLimitGenerations: Dispatch<SetStateAction<boolean>>;
+  setMaskUrl: Dispatch<SetStateAction<string>>;
+  setMode: Dispatch<SetStateAction<ImageGenerationMode>>;
+  setNumImages: Dispatch<SetStateAction<number>>;
+  setOutputFormat: Dispatch<SetStateAction<string | null>>;
+  setPrompt: Dispatch<SetStateAction<string>>;
+  setQuality: Dispatch<SetStateAction<string | null>>;
+  setReferenceSlots: Dispatch<SetStateAction<Array<ReferenceSlotValue | null>>>;
+  setResolution: Dispatch<SetStateAction<string | null>>;
+  setSeed: Dispatch<SetStateAction<string>>;
+  setSelectedPreviewEntryId: Dispatch<SetStateAction<string | null>>;
+  setSelectedPreviewImageIndex: Dispatch<SetStateAction<number>>;
+  setStatusMessage: Dispatch<SetStateAction<string | null>>;
+  setThinkingLevel: Dispatch<SetStateAction<string | null>>;
+}
+
+export function useImageWorkspaceQueryHydration({
+  engines,
+  genericError,
+  searchParams,
+  setAspectRatio,
+  setCustomImageHeight,
+  setCustomImageWidth,
+  setEnableWebSearch,
+  setEngineId,
+  setError,
+  setLimitGenerations,
+  setMaskUrl,
+  setMode,
+  setNumImages,
+  setOutputFormat,
+  setPrompt,
+  setQuality,
+  setReferenceSlots,
+  setResolution,
+  setSeed,
+  setSelectedPreviewEntryId,
+  setSelectedPreviewImageIndex,
+  setStatusMessage,
+  setThinkingLevel,
+}: UseImageWorkspaceQueryHydrationParams) {
+  const hydratedJobRef = useRef<string | null>(null);
+
+  const requestedJobId = useMemo(() => {
+    const raw = searchParams?.get('job');
+    if (!raw) return null;
+    const trimmed = raw.trim();
+    return trimmed.length ? trimmed : null;
+  }, [searchParams]);
+
+  const requestedEngineId = useMemo(() => {
+    const raw = searchParams?.get('engine');
+    if (!raw) return null;
+    const trimmed = raw.trim();
+    return trimmed.length ? trimmed : null;
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (!requestedEngineId) return;
+    const engineMatch = findImageEngine(engines, requestedEngineId);
+    if (!engineMatch) return;
+    setEngineId(engineMatch.id);
+    setMode((previous) => (engineMatch.modes.includes(previous) ? previous : engineMatch.modes[0] ?? 't2i'));
+  }, [engines, requestedEngineId, setEngineId, setMode]);
+
+  const applyImageSettingsSnapshot = useCallback(
+    (snapshot: unknown, { selectJobId }: { selectJobId?: string } = {}) => {
+      if (!snapshot || typeof snapshot !== 'object') {
+        throw new Error('Job settings snapshot missing');
+      }
+      const record = snapshot as {
+        schemaVersion?: unknown;
+        surface?: unknown;
+        engineId?: unknown;
+        inputMode?: unknown;
+        prompt?: unknown;
+        core?: unknown;
+        refs?: unknown;
+      };
+      if (record.schemaVersion !== 1) {
+        throw new Error('Unsupported job snapshot version');
+      }
+      if (record.surface !== 'image') {
+        throw new Error('This snapshot is not for image');
+      }
+      const snapshotEngineId = typeof record.engineId === 'string' ? record.engineId : null;
+      const engineMatch = snapshotEngineId ? findImageEngine(engines, snapshotEngineId) : null;
+      const snapshotMode = record.inputMode === 't2i' || record.inputMode === 'i2i' ? record.inputMode : null;
+      if (engineMatch) {
+        setEngineId(engineMatch.id);
+        if (snapshotMode) {
+          setMode(engineMatch.modes.includes(snapshotMode) ? snapshotMode : engineMatch.modes[0] ?? 't2i');
+        }
+      } else if (snapshotMode) {
+        setMode(snapshotMode);
+      }
+      const snapshotPrompt = typeof record.prompt === 'string' ? record.prompt : null;
+      if (snapshotPrompt !== null) {
+        setPrompt(snapshotPrompt);
+      }
+
+      const core = record.core && typeof record.core === 'object' ? (record.core as Record<string, unknown>) : {};
+      const numImagesRaw = core.numImages;
+      if (typeof numImagesRaw === 'number' && Number.isFinite(numImagesRaw)) {
+        setNumImages(
+          engineMatch
+            ? clampRequestedImageCount(
+                engineMatch.engineCaps,
+                snapshotMode && engineMatch.modes.includes(snapshotMode) ? snapshotMode : engineMatch.modes[0] ?? 't2i',
+                numImagesRaw
+              )
+            : Math.max(1, Math.round(numImagesRaw))
+        );
+      }
+      const aspectRatioRaw = typeof core.aspectRatio === 'string' ? core.aspectRatio : null;
+      const resolutionRaw = typeof core.resolution === 'string' ? core.resolution : null;
+      const customImageSizeRaw =
+        core.customImageSize && typeof core.customImageSize === 'object'
+          ? (core.customImageSize as Partial<GptImage2ImageSize>)
+          : null;
+      const customImageSizeRawParsed =
+        typeof customImageSizeRaw?.width === 'number' &&
+        Number.isFinite(customImageSizeRaw.width) &&
+        typeof customImageSizeRaw?.height === 'number' &&
+        Number.isFinite(customImageSizeRaw.height)
+          ? {
+              width: Math.round(customImageSizeRaw.width),
+              height: Math.round(customImageSizeRaw.height),
+            }
+          : null;
+      const seedRaw =
+        typeof core.seed === 'number' && Number.isFinite(core.seed) ? Math.round(core.seed) : null;
+      const outputFormatRaw = typeof core.outputFormat === 'string' ? core.outputFormat : null;
+      const qualityRaw = typeof core.quality === 'string' ? core.quality : null;
+      const maskUrlRaw = typeof core.maskUrl === 'string' ? core.maskUrl : null;
+      const enableWebSearchRaw = core.enableWebSearch === true;
+      const thinkingLevelRaw = typeof core.thinkingLevel === 'string' ? core.thinkingLevel : null;
+      const limitGenerationsRaw = core.limitGenerations === true;
+      if (engineMatch) {
+        const resolvedMode =
+          snapshotMode && engineMatch.modes.includes(snapshotMode) ? snapshotMode : engineMatch.modes[0] ?? 't2i';
+        const allowedResolutions = getImageFieldValues(
+          engineMatch.engineCaps,
+          'resolution',
+          resolvedMode,
+          Array.isArray(engineMatch.engineCaps?.resolutions) ? [...engineMatch.engineCaps.resolutions] : []
+        );
+        const defaultResolution = getImageInputField(engineMatch.engineCaps, 'resolution', resolvedMode)
+          ? getDefaultResolution(engineMatch.engineCaps, resolvedMode)
+          : null;
+        const nextResolution =
+          resolutionRaw && allowedResolutions.includes(resolutionRaw) ? resolutionRaw : defaultResolution;
+        setResolution(nextResolution);
+        const parsedSizeFromResolution = parseGptImage2SizeKey(nextResolution);
+        const restoredCustomSize = customImageSizeRawParsed ?? parsedSizeFromResolution;
+        const defaultCustomWidth =
+          getImageFieldDefaultNumber(engineMatch.engineCaps, 'image_width', resolvedMode) ??
+          GPT_IMAGE_2_SIZE_CONSTRAINTS.defaultWidth;
+        const defaultCustomHeight =
+          getImageFieldDefaultNumber(engineMatch.engineCaps, 'image_height', resolvedMode) ??
+          GPT_IMAGE_2_SIZE_CONSTRAINTS.defaultHeight;
+        setCustomImageWidth(String(restoredCustomSize?.width ?? defaultCustomWidth));
+        setCustomImageHeight(String(restoredCustomSize?.height ?? defaultCustomHeight));
+        const allowedAspectRatios = getAspectRatioOptions(engineMatch.engineCaps, resolvedMode);
+        const defaultAspectRatio = getDefaultAspectRatio(engineMatch.engineCaps, resolvedMode);
+        setAspectRatio(
+          aspectRatioRaw && allowedAspectRatios.includes(aspectRatioRaw) ? aspectRatioRaw : defaultAspectRatio
+        );
+        const seedDefault = getImageFieldDefaultNumber(engineMatch.engineCaps, 'seed', resolvedMode);
+        setSeed(seedRaw == null ? (seedDefault == null ? '' : String(seedDefault)) : String(seedRaw));
+        const outputFormats = getImageFieldValues(engineMatch.engineCaps, 'output_format', resolvedMode);
+        const defaultOutputFormat =
+          getImageFieldDefaultString(engineMatch.engineCaps, 'output_format', resolvedMode) ?? outputFormats[0] ?? null;
+        setOutputFormat(
+          outputFormatRaw && outputFormats.includes(outputFormatRaw) ? outputFormatRaw : defaultOutputFormat
+        );
+        const qualityValues = getImageFieldValues(engineMatch.engineCaps, 'quality', resolvedMode);
+        const defaultQuality =
+          getImageFieldDefaultString(engineMatch.engineCaps, 'quality', resolvedMode) ?? qualityValues[0] ?? null;
+        setQuality(qualityRaw && qualityValues.includes(qualityRaw) ? qualityRaw : defaultQuality);
+        setMaskUrl(getImageInputField(engineMatch.engineCaps, 'mask_url', resolvedMode) ? maskUrlRaw ?? '' : '');
+        setEnableWebSearch(
+          getImageInputField(engineMatch.engineCaps, 'enable_web_search', resolvedMode)
+            ? enableWebSearchRaw
+            : false
+        );
+        const thinkingLevels = getImageFieldValues(engineMatch.engineCaps, 'thinking_level', resolvedMode);
+        const defaultThinkingLevel =
+          getImageFieldDefaultString(engineMatch.engineCaps, 'thinking_level', resolvedMode) ??
+          thinkingLevels[0] ??
+          null;
+        setThinkingLevel(
+          thinkingLevelRaw && thinkingLevels.includes(thinkingLevelRaw) ? thinkingLevelRaw : defaultThinkingLevel
+        );
+        setLimitGenerations(
+          getImageInputField(engineMatch.engineCaps, 'limit_generations', resolvedMode)
+            ? limitGenerationsRaw
+            : false
+        );
+      } else {
+        setResolution(resolutionRaw);
+        const restoredCustomSize = customImageSizeRawParsed ?? parseGptImage2SizeKey(resolutionRaw);
+        setCustomImageWidth(restoredCustomSize ? String(restoredCustomSize.width) : '');
+        setCustomImageHeight(restoredCustomSize ? String(restoredCustomSize.height) : '');
+        setAspectRatio(aspectRatioRaw);
+        setSeed(seedRaw == null ? '' : String(seedRaw));
+        setOutputFormat(outputFormatRaw);
+        setQuality(qualityRaw);
+        setMaskUrl(maskUrlRaw ?? '');
+        setEnableWebSearch(enableWebSearchRaw);
+        setThinkingLevel(thinkingLevelRaw);
+        setLimitGenerations(limitGenerationsRaw);
+      }
+
+      const refs = record.refs && typeof record.refs === 'object' ? (record.refs as Record<string, unknown>) : {};
+      const imageUrlsRaw = refs.imageUrls;
+      const imageUrls = Array.isArray(imageUrlsRaw)
+        ? imageUrlsRaw.map((entry) => (typeof entry === 'string' ? entry.trim() : '')).filter((entry) => entry.length)
+        : [];
+      setReferenceSlots(() => {
+        const next = Array(MAX_REFERENCE_SLOTS).fill(null) as Array<ReferenceSlotValue | null>;
+        imageUrls.slice(0, MAX_REFERENCE_SLOTS).forEach((url, index) => {
+          next[index] = {
+            id: `snapshot-${index}`,
+            url,
+            previewUrl: url,
+            status: 'ready',
+            source: 'library',
+          };
+        });
+        const characterReferencesRaw = Array.isArray(refs.characterReferences) ? refs.characterReferences : [];
+        const characterReferences = characterReferencesRaw.reduce<CharacterReferenceSelection[]>((acc, entry) => {
+          const parsedEntry = parseCharacterReferenceEntry(entry);
+          if (!parsedEntry) return acc;
+          acc.push(parsedEntry);
+          return acc;
+        }, []);
+        return mergeCharacterReferencesIntoSlots(next, characterReferences, MAX_REFERENCE_SLOTS);
+      });
+
+      if (selectJobId) {
+        setSelectedPreviewEntryId(selectJobId);
+        setSelectedPreviewImageIndex(0);
+      }
+    },
+    [
+      engines,
+      setAspectRatio,
+      setCustomImageHeight,
+      setCustomImageWidth,
+      setEnableWebSearch,
+      setEngineId,
+      setLimitGenerations,
+      setMaskUrl,
+      setMode,
+      setNumImages,
+      setOutputFormat,
+      setPrompt,
+      setQuality,
+      setReferenceSlots,
+      setResolution,
+      setSeed,
+      setSelectedPreviewEntryId,
+      setSelectedPreviewImageIndex,
+      setThinkingLevel,
+    ]
+  );
+
+  useEffect(() => {
+    if (!requestedJobId) return;
+    if (hydratedJobRef.current === requestedJobId) return;
+    hydratedJobRef.current = requestedJobId;
+    setError(null);
+    setStatusMessage(null);
+    void authFetch(`/api/jobs/${encodeURIComponent(requestedJobId)}`)
+      .then(async (response) => {
+        const payload = (await response.json().catch(() => null)) as
+          | {
+              ok?: boolean;
+              error?: string;
+              settingsSnapshot?: unknown;
+            }
+          | null;
+        if (!response.ok || !payload?.ok) {
+          throw new Error(payload?.error ?? `Failed to load job (${response.status})`);
+        }
+        applyImageSettingsSnapshot(payload.settingsSnapshot, { selectJobId: requestedJobId });
+      })
+      .catch((error) => {
+        setError(error instanceof Error ? error.message : genericError);
+      });
+  }, [applyImageSettingsSnapshot, genericError, requestedJobId, setError, setStatusMessage]);
+
+  return {
+    applyImageSettingsSnapshot,
+  };
+}

--- a/tests/image-workspace-split-contract.test.ts
+++ b/tests/image-workspace-split-contract.test.ts
@@ -7,6 +7,7 @@ const root = process.cwd();
 const imageDir = path.join(root, 'frontend/app/(core)/(workspace)/app/image');
 const workspacePath = path.join(imageDir, 'ImageWorkspace.tsx');
 const composerPersistenceHookPath = path.join(imageDir, '_hooks/useImageComposerPersistence.ts');
+const queryHydrationHookPath = path.join(imageDir, '_hooks/useImageWorkspaceQueryHydration.ts');
 
 const splitFiles = [
   '_components/ImageAuthGateModal.tsx',
@@ -15,6 +16,7 @@ const splitFiles = [
   '_hooks/useImageWorkspaceHistory.ts',
   '_hooks/useImageWorkspacePricing.ts',
   '_hooks/useImageWorkspaceDesktopLayout.ts',
+  '_hooks/useImageWorkspaceQueryHydration.ts',
   '_lib/image-workspace-character-references.ts',
   '_lib/image-workspace-copy.ts',
   '_lib/image-workspace-history.ts',
@@ -30,6 +32,7 @@ function readImageWorkspace() {
 test('image workspace foundations are split from the route orchestrator', () => {
   const source = readImageWorkspace();
   const composerPersistenceHookSource = readFileSync(composerPersistenceHookPath, 'utf8');
+  const queryHydrationHookSource = readFileSync(queryHydrationHookPath, 'utf8');
 
   for (const file of splitFiles) {
     statSync(path.join(imageDir, file));
@@ -41,6 +44,7 @@ test('image workspace foundations are split from the route orchestrator', () => 
   assert.match(source, /from '\.\/_hooks\/useImageWorkspaceHistory'/);
   assert.match(source, /from '\.\/_hooks\/useImageWorkspacePricing'/);
   assert.match(source, /from '\.\/_hooks\/useImageWorkspaceDesktopLayout'/);
+  assert.match(source, /from '\.\/_hooks\/useImageWorkspaceQueryHydration'/);
   assert.match(source, /from '\.\/_lib\/image-workspace-copy'/);
   assert.match(source, /from '\.\/_lib\/image-workspace-history'/);
   assert.match(source, /from '\.\/_lib\/image-workspace-utils'/);
@@ -58,13 +62,20 @@ test('image workspace foundations are split from the route orchestrator', () => 
   assert.doesNotMatch(source, /const remoteImageJobs =/, 'remote image history derivation belongs in useImageWorkspaceHistory');
   assert.doesNotMatch(source, /parsePersistedImageComposerState/, 'composer storage parsing belongs in useImageComposerPersistence');
   assert.doesNotMatch(source, /IMAGE_COMPOSER_STORAGE_KEY/, 'composer storage constants belong in useImageComposerPersistence');
+  assert.doesNotMatch(source, /const requestedJobId = useMemo/, 'query job hydration belongs in useImageWorkspaceQueryHydration');
+  assert.doesNotMatch(source, /const requestedEngineId = useMemo/, 'query engine hydration belongs in useImageWorkspaceQueryHydration');
+  assert.doesNotMatch(source, /Job settings snapshot missing/, 'snapshot application belongs in useImageWorkspaceQueryHydration');
 
   assert.match(composerPersistenceHookSource, /export function useImageComposerPersistence/);
   assert.match(composerPersistenceHookSource, /parsePersistedImageComposerState/);
   assert.match(composerPersistenceHookSource, /IMAGE_COMPOSER_STORAGE_DEBOUNCE_MS/);
   assert.match(composerPersistenceHookSource, /localStorage\.getItem\(IMAGE_COMPOSER_STORAGE_KEY\)/);
   assert.match(composerPersistenceHookSource, /localStorage\.setItem\(IMAGE_COMPOSER_STORAGE_KEY, serialized\)/);
+  assert.match(queryHydrationHookSource, /export function useImageWorkspaceQueryHydration/);
+  assert.match(queryHydrationHookSource, /const requestedJobId = useMemo/);
+  assert.match(queryHydrationHookSource, /const requestedEngineId = useMemo/);
+  assert.match(queryHydrationHookSource, /applyImageSettingsSnapshot/);
 
   const lineCount = source.split('\n').length;
-  assert.ok(lineCount <= 1300, `ImageWorkspace should stay below 1300 lines after composer persistence extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 1085, `ImageWorkspace should stay below 1085 lines after query hydration extraction, got ${lineCount}`);
 });


### PR DESCRIPTION
## Summary
- move Image Workspace ?engine= and ?job= hydration into useImageWorkspaceQueryHydration
- keep snapshot application reusable for gallery selections while reducing ImageWorkspace route orchestration
- update the image workspace contract test to lock the new hook boundary

## Checks
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/image-workspace-split-contract.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (from frontend)
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- scoped changed files

## Notes
- existing local edits in frontend/src/lib/stripe-checkout.ts and tests/wallet-checkout-session.test.ts were left unstaged and are not part of this PR.