### PR TITLE
[codex] Split upscale pricing preview hook

### DIFF
--- a/frontend/src/components/tools/UpscaleWorkspace.tsx
+++ b/frontend/src/components/tools/UpscaleWorkspace.tsx
@@ -3,7 +3,6 @@
 /* eslint-disable @next/next/no-img-element */
 
 import Link from 'next/link';
-import useSWR from 'swr';
 import { useEffect, useMemo, useRef, useState, type ChangeEvent, type PointerEvent } from 'react';
 import {
   ArrowLeft,
@@ -45,10 +44,6 @@ import {
   DEFAULT_UPSCALE_VIDEO_ENGINE_ID,
   listUpscaleToolEngines,
 } from '@/config/tools-upscale-engines';
-import {
-  buildUpscalePricingPreview,
-  type UpscaleVideoPricingMetadata,
-} from '@/lib/tools-upscale';
 import type {
   UpscaleMediaType,
   UpscaleMode,
@@ -69,7 +64,6 @@ import {
   mediaTypeFromMime,
   parseRecentImageVariantIndex,
   PREVIEW_ZOOM_OPTIONS,
-  readVideoPricingMetadata,
   resolveGeneratedImageSource,
   resolveRecentUpscaleJobFromGroup,
   resolveRecentUpscaleMedia,
@@ -81,8 +75,8 @@ import {
   uploadSourceFile,
 } from './upscale/_lib/upscale-workspace-helpers';
 import { useUpscaleLibraryAssets } from './upscale/_hooks/useUpscaleLibraryAssets';
+import { useUpscalePricingPreview } from './upscale/_hooks/useUpscalePricingPreview';
 import type {
-  BillingProductResponse,
   JobDetailResponse,
   PreviewMode,
   PreviewZoom,
@@ -141,8 +135,6 @@ export default function UpscaleWorkspace() {
   const [result, setResult] = useState<UpscaleToolResponse | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [videoMetadata, setVideoMetadata] = useState<UpscaleVideoPricingMetadata | null>(null);
-  const [videoMetadataLoading, setVideoMetadataLoading] = useState(false);
   const [comparePosition, setComparePosition] = useState(50);
   const [compareDragging, setCompareDragging] = useState(false);
   const [previewMode, setPreviewMode] = useState<PreviewMode>('source');
@@ -172,60 +164,21 @@ export default function UpscaleWorkspace() {
 
   const engines = useMemo(() => listUpscaleToolEngines(mediaType), [mediaType]);
   const engine = useMemo(() => engines.find((entry) => entry.id === engineId) ?? engines[0], [engineId, engines]);
-  const billingProductKey = engine?.billingProductKey ?? null;
   const {
-    data: billingProductData,
-    error: billingProductError,
-    isLoading: billingProductLoading,
-  } = useSWR(
-    billingProductKey ? `/api/billing-products?productKey=${encodeURIComponent(billingProductKey)}` : null,
-    async (url: string) => {
-      const response = await authFetch(url);
-      const payload = (await response.json().catch(() => null)) as BillingProductResponse | null;
-      if (!response.ok || !payload?.ok || !payload.product) {
-        throw new Error(payload?.error ?? copy.priceUnavailable);
-      }
-      return payload.product;
-    },
-    { keepPreviousData: true }
-  );
+    priceHint,
+    priceLabel,
+  } = useUpscalePricingPreview({
+    copy,
+    engine,
+    locale,
+    mediaType,
+    mediaUrl,
+    mode,
+    source,
+    targetResolution,
+    upscaleFactor,
+  });
   const output = result?.output ?? null;
-  const pricePreview = useMemo(
-    () =>
-      buildUpscalePricingPreview({
-        mediaType,
-        engineId: engine.id,
-        unitPriceCents: billingProductData?.unitPriceCents ?? null,
-        currency: billingProductData?.currency ?? 'USD',
-        imageWidth: mediaType === 'image' ? source?.width ?? null : null,
-        imageHeight: mediaType === 'image' ? source?.height ?? null : null,
-        videoMetadata: mediaType === 'video' ? videoMetadata : null,
-        targetResolution: mode === 'target' ? targetResolution : null,
-        upscaleFactor,
-      }),
-    [
-      billingProductData?.currency,
-      billingProductData?.unitPriceCents,
-      engine.id,
-      mediaType,
-      mode,
-      source?.height,
-      source?.width,
-      targetResolution,
-      upscaleFactor,
-      videoMetadata,
-    ]
-  );
-  const priceLabel = formatCurrency(pricePreview.totalCents, pricePreview.currency, locale);
-  const priceHint = billingProductLoading
-    ? copy.priceLoading
-    : billingProductError
-      ? copy.priceUnavailable
-      : mediaType === 'video' && videoMetadataLoading
-        ? copy.priceVideoLoading
-        : mediaType === 'video' && !pricePreview.ready
-          ? copy.priceVideoMissing
-          : copy.priceReady;
   const canRun = Boolean(user && mediaUrl.trim() && engine && !running && !uploading);
   const hasResult = Boolean(output?.url);
   const hasSourcePreview = Boolean(mediaUrl.trim());
@@ -276,33 +229,6 @@ export default function UpscaleWorkspace() {
     }
     return null;
   }, [recentGeneratedImageJobs]);
-
-  useEffect(() => {
-    const url = mediaUrl.trim();
-    if (mediaType !== 'video' || !url) {
-      setVideoMetadata(null);
-      setVideoMetadataLoading(false);
-      return;
-    }
-
-    let cancelled = false;
-    setVideoMetadata(null);
-    setVideoMetadataLoading(true);
-    readVideoPricingMetadata(url)
-      .then((metadata) => {
-        if (!cancelled) setVideoMetadata(metadata);
-      })
-      .catch(() => {
-        if (!cancelled) setVideoMetadata(null);
-      })
-      .finally(() => {
-        if (!cancelled) setVideoMetadataLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [mediaType, mediaUrl]);
 
   useEffect(() => {
     if (typeof window === 'undefined' || !pendingRecentJobKey) return undefined;
@@ -554,7 +480,6 @@ export default function UpscaleWorkspace() {
     setUpscaleFactor(resolved.defaultUpscaleFactor);
     setTargetResolution(resolved.defaultTargetResolution ?? '1080p');
     setOutputFormat(resolved.defaultOutputFormat);
-    setVideoMetadata(null);
   }
 
   async function resolveRecentSelectionWithSource(group: GroupSummary): Promise<RecentUpscaleMedia | null> {

--- a/frontend/src/components/tools/upscale/_hooks/useUpscalePricingPreview.ts
+++ b/frontend/src/components/tools/upscale/_hooks/useUpscalePricingPreview.ts
@@ -1,0 +1,143 @@
+import { useEffect, useMemo, useState } from 'react';
+import useSWR from 'swr';
+import { authFetch } from '@/lib/authFetch';
+import {
+  buildUpscalePricingPreview,
+  type UpscaleVideoPricingMetadata,
+} from '@/lib/tools-upscale';
+import type { UpscaleToolEngineDefinition } from '@/types/tools-upscale';
+import type {
+  UpscaleMediaType,
+  UpscaleMode,
+  UpscaleTargetResolution,
+} from '@/types/tools-upscale';
+import {
+  formatCurrency,
+  readVideoPricingMetadata,
+} from '../_lib/upscale-workspace-helpers';
+import type {
+  BillingProductResponse,
+  UploadedAsset,
+} from '../_lib/upscale-workspace-types';
+
+interface UseUpscalePricingPreviewParams {
+  copy: {
+    priceLoading: string;
+    priceReady: string;
+    priceUnavailable: string;
+    priceVideoLoading: string;
+    priceVideoMissing: string;
+  };
+  engine: UpscaleToolEngineDefinition;
+  locale: string;
+  mediaType: UpscaleMediaType;
+  mediaUrl: string;
+  mode: UpscaleMode;
+  source: UploadedAsset | null;
+  targetResolution: UpscaleTargetResolution;
+  upscaleFactor: number;
+}
+
+export function useUpscalePricingPreview({
+  copy,
+  engine,
+  locale,
+  mediaType,
+  mediaUrl,
+  mode,
+  source,
+  targetResolution,
+  upscaleFactor,
+}: UseUpscalePricingPreviewParams) {
+  const [videoMetadata, setVideoMetadata] = useState<UpscaleVideoPricingMetadata | null>(null);
+  const [videoMetadataLoading, setVideoMetadataLoading] = useState(false);
+  const billingProductKey = engine?.billingProductKey ?? null;
+  const {
+    data: billingProductData,
+    error: billingProductError,
+    isLoading: billingProductLoading,
+  } = useSWR(
+    billingProductKey ? `/api/billing-products?productKey=${encodeURIComponent(billingProductKey)}` : null,
+    async (url: string) => {
+      const response = await authFetch(url);
+      const payload = (await response.json().catch(() => null)) as BillingProductResponse | null;
+      if (!response.ok || !payload?.ok || !payload.product) {
+        throw new Error(payload?.error ?? copy.priceUnavailable);
+      }
+      return payload.product;
+    },
+    { keepPreviousData: true }
+  );
+
+  useEffect(() => {
+    const url = mediaUrl.trim();
+    if (mediaType !== 'video' || !url) {
+      setVideoMetadata(null);
+      setVideoMetadataLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setVideoMetadata(null);
+    setVideoMetadataLoading(true);
+    readVideoPricingMetadata(url)
+      .then((metadata) => {
+        if (!cancelled) setVideoMetadata(metadata);
+      })
+      .catch(() => {
+        if (!cancelled) setVideoMetadata(null);
+      })
+      .finally(() => {
+        if (!cancelled) setVideoMetadataLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [mediaType, mediaUrl]);
+
+  const pricePreview = useMemo(
+    () =>
+      buildUpscalePricingPreview({
+        mediaType,
+        engineId: engine.id,
+        unitPriceCents: billingProductData?.unitPriceCents ?? null,
+        currency: billingProductData?.currency ?? 'USD',
+        imageWidth: mediaType === 'image' ? source?.width ?? null : null,
+        imageHeight: mediaType === 'image' ? source?.height ?? null : null,
+        videoMetadata: mediaType === 'video' ? videoMetadata : null,
+        targetResolution: mode === 'target' ? targetResolution : null,
+        upscaleFactor,
+      }),
+    [
+      billingProductData?.currency,
+      billingProductData?.unitPriceCents,
+      engine.id,
+      mediaType,
+      mode,
+      source?.height,
+      source?.width,
+      targetResolution,
+      upscaleFactor,
+      videoMetadata,
+    ]
+  );
+  const priceLabel = formatCurrency(pricePreview.totalCents, pricePreview.currency, locale);
+  const priceHint = billingProductLoading
+    ? copy.priceLoading
+    : billingProductError
+      ? copy.priceUnavailable
+      : mediaType === 'video' && videoMetadataLoading
+        ? copy.priceVideoLoading
+        : mediaType === 'video' && !pricePreview.ready
+          ? copy.priceVideoMissing
+          : copy.priceReady;
+
+  return {
+    priceHint,
+    priceLabel,
+    pricePreview,
+    videoMetadata,
+    videoMetadataLoading,
+  };
+}

--- a/tests/upscale-workspace-architecture.test.ts
+++ b/tests/upscale-workspace-architecture.test.ts
@@ -9,6 +9,7 @@ const copyPath = join(root, 'frontend/src/components/tools/upscale/_lib/upscale-
 const typesPath = join(root, 'frontend/src/components/tools/upscale/_lib/upscale-workspace-types.ts');
 const helpersPath = join(root, 'frontend/src/components/tools/upscale/_lib/upscale-workspace-helpers.ts');
 const libraryHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscaleLibraryAssets.ts');
+const pricingHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscalePricingPreview.ts');
 
 const workspaceSource = readFileSync(workspacePath, 'utf8');
 
@@ -17,11 +18,13 @@ test('upscale workspace delegates copy, local types, and helper logic', () => {
   assert.ok(existsSync(typesPath), 'upscale workspace local contracts should live in a colocated type module');
   assert.ok(existsSync(helpersPath), 'upscale workspace helper logic should live in a colocated helper module');
   assert.ok(existsSync(libraryHookPath), 'upscale library asset loading should live in a colocated hook');
+  assert.ok(existsSync(pricingHookPath), 'upscale pricing preview should live in a colocated hook');
 
   assert.match(workspaceSource, /from '\.\/upscale\/_lib\/upscale-workspace-copy'/, 'workspace should import upscale copy');
   assert.match(workspaceSource, /from '\.\/upscale\/_lib\/upscale-workspace-types'/, 'workspace should import upscale local types');
   assert.match(workspaceSource, /from '\.\/upscale\/_lib\/upscale-workspace-helpers'/, 'workspace should import upscale helpers');
   assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscaleLibraryAssets'/, 'workspace should import library hook');
+  assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscalePricingPreview'/, 'workspace should import pricing hook');
 });
 
 test('upscale workspace does not regain extracted ownership', () => {
@@ -33,9 +36,12 @@ test('upscale workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /UserAssetsResponse/, 'library asset response parsing belongs in useUpscaleLibraryAssets');
   assert.doesNotMatch(workspaceSource, /JobsLibraryResponse/, 'generated video library merging belongs in useUpscaleLibraryAssets');
   assert.doesNotMatch(workspaceSource, /buildLibraryCacheKey/, 'library cache key orchestration belongs in useUpscaleLibraryAssets');
+  assert.doesNotMatch(workspaceSource, /buildUpscalePricingPreview/, 'pricing preview orchestration belongs in useUpscalePricingPreview');
+  assert.doesNotMatch(workspaceSource, /readVideoPricingMetadata/, 'video pricing metadata loading belongs in useUpscalePricingPreview');
+  assert.doesNotMatch(workspaceSource, /BillingProductResponse/, 'billing product parsing belongs in useUpscalePricingPreview');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 1260, `UpscaleWorkspace should stay below 1260 lines after library hook extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 1195, `UpscaleWorkspace should stay below 1195 lines after pricing hook extraction, got ${lineCount}`);
 });
 
 test('upscale helper modules expose the expected workspace contract', () => {
@@ -43,6 +49,7 @@ test('upscale helper modules expose the expected workspace contract', () => {
   const typesSource = readFileSync(typesPath, 'utf8');
   const helpersSource = readFileSync(helpersPath, 'utf8');
   const libraryHookSource = readFileSync(libraryHookPath, 'utf8');
+  const pricingHookSource = readFileSync(pricingHookPath, 'utf8');
 
   assert.match(copySource, /export const DEFAULT_UPSCALE_COPY =/, 'copy module should export default copy');
 
@@ -74,4 +81,8 @@ test('upscale helper modules expose the expected workspace contract', () => {
   assert.match(libraryHookSource, /buildLibraryCacheKey/, 'library hook should own cache key usage');
   assert.match(libraryHookSource, /UserAssetsResponse/, 'library hook should parse saved asset responses');
   assert.match(libraryHookSource, /JobsLibraryResponse/, 'library hook should merge generated video jobs');
+  assert.match(pricingHookSource, /export function useUpscalePricingPreview/, 'pricing hook should be exported');
+  assert.match(pricingHookSource, /buildUpscalePricingPreview/, 'pricing hook should build the preview');
+  assert.match(pricingHookSource, /readVideoPricingMetadata/, 'pricing hook should load video metadata');
+  assert.match(pricingHookSource, /BillingProductResponse/, 'pricing hook should parse billing products');
 });


### PR DESCRIPTION
## Summary
- move Upscale billing product fetch, video metadata loading, and price preview labels into useUpscalePricingPreview
- keep UpscaleWorkspace focused on tool state, actions, and rendering
- update the architecture contract to protect the new pricing hook boundary

## Checks
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/upscale-workspace-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (from frontend)
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- scoped changed files

## Notes
- existing local edits in frontend/src/lib/stripe-checkout.ts and tests/wallet-checkout-session.test.ts were left unstaged and are not part of this PR.