### PR TITLE
[codex] Split upscale recent jobs hook

### DIFF
--- a/frontend/src/components/tools/UpscaleWorkspace.tsx
+++ b/frontend/src/components/tools/UpscaleWorkspace.tsx
@@ -32,11 +32,9 @@ import {
   type AssetBrowserAsset,
 } from '@/components/library/AssetLibraryBrowser';
 import { authFetch } from '@/lib/authFetch';
-import { getJobStatus, runUpscaleTool, saveAssetToLibrary, useInfiniteJobs } from '@/lib/api';
+import { runUpscaleTool, saveAssetToLibrary } from '@/lib/api';
 import { suggestDownloadFilename, triggerAppDownload } from '@/lib/download';
-import { groupJobsIntoSummaries } from '@/lib/job-groups';
 import { useI18n } from '@/lib/i18n/I18nProvider';
-import { normalizeGroupSummaries } from '@/lib/normalize-group-summary';
 import { FEATURES } from '@/content/feature-flags';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import {
@@ -58,13 +56,11 @@ import { DEFAULT_UPSCALE_COPY } from './upscale/_lib/upscale-workspace-copy';
 import {
   clampComparePosition,
   formatCurrency,
-  hasRenderableUpscaleJobMedia,
   inferMimeType,
   isOutputVideo,
   mediaTypeFromMime,
   parseRecentImageVariantIndex,
   PREVIEW_ZOOM_OPTIONS,
-  resolveGeneratedImageSource,
   resolveRecentUpscaleJobFromGroup,
   resolveRecentUpscaleMedia,
   resolveRecentUpscaleMediaFromGroup,
@@ -76,6 +72,7 @@ import {
 } from './upscale/_lib/upscale-workspace-helpers';
 import { useUpscaleLibraryAssets } from './upscale/_hooks/useUpscaleLibraryAssets';
 import { useUpscalePricingPreview } from './upscale/_hooks/useUpscalePricingPreview';
+import { useUpscaleRecentJobs } from './upscale/_hooks/useUpscaleRecentJobs';
 import type {
   JobDetailResponse,
   PreviewMode,
@@ -158,9 +155,6 @@ export default function UpscaleWorkspace() {
   const [activeRecentGroupId, setActiveRecentGroupId] = useState<string | null>(null);
   const [savingRecentGroupId, setSavingRecentGroupId] = useState<string | null>(null);
   const previewScrollerRef = useRef<HTMLDivElement | null>(null);
-  const defaultGeneratedImageAppliedRef = useRef(false);
-  const { stableJobs: recentJobs, mutate } = useInfiniteJobs(12, { surface: 'upscale' });
-  const { stableJobs: recentGeneratedImageJobs } = useInfiniteJobs(8, { surface: 'image' });
 
   const engines = useMemo(() => listUpscaleToolEngines(mediaType), [mediaType]);
   const engine = useMemo(() => engines.find((entry) => entry.id === engineId) ?? engines[0], [engineId, engines]);
@@ -202,53 +196,18 @@ export default function UpscaleWorkspace() {
   const zoomCanvasWidth = activePreviewMode === 'source' ? sourceWidth : outputWidth;
   const zoomCanvasHeight = activePreviewMode === 'source' ? sourceHeight : outputHeight;
   const mediaTypeLabel = mediaType === 'video' ? 'Video' : 'Image';
-  const recentGroups = useMemo(() => {
-    const jobs = recentJobs.map((job) => (!job.videoUrl && job.readyVideoUrl ? { ...job, videoUrl: job.readyVideoUrl } : job));
-    return normalizeGroupSummaries(groupJobsIntoSummaries(jobs, { includeSinglesAsGroups: true }).groups);
-  }, [recentJobs]);
-  const pendingRecentJobIds = useMemo(
-    () =>
-      recentJobs
-        .filter((job) => {
-          const status = typeof job.status === 'string' ? job.status.toLowerCase() : '';
-          if (status === 'failed' || status === 'cancelled' || status === 'canceled') return false;
-          return status !== 'completed' || !hasRenderableUpscaleJobMedia(job);
-        })
-        .map((job) => job.jobId)
-        .filter((jobId): jobId is string => typeof jobId === 'string' && jobId.length > 0),
-    [recentJobs]
-  );
-  const pendingRecentJobKey = pendingRecentJobIds.join('|');
-  const defaultGeneratedImageSource = useMemo(() => {
-    const sortedJobs = [...recentGeneratedImageJobs].sort(
-      (a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt)
-    );
-    for (const job of sortedJobs) {
-      const candidate = resolveGeneratedImageSource(job);
-      if (candidate) return candidate;
-    }
-    return null;
-  }, [recentGeneratedImageJobs]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined' || !pendingRecentJobKey) return undefined;
-    let cancelled = false;
-    const jobIds = pendingRecentJobKey.split('|').filter(Boolean);
-    const pollPendingJobs = async () => {
-      await Promise.all(jobIds.map((jobId) => getJobStatus(jobId).catch(() => null)));
-      if (!cancelled) {
-        void mutate();
-      }
-    };
-    void pollPendingJobs();
-    const interval = window.setInterval(() => {
-      void pollPendingJobs();
-    }, 5_000);
-    return () => {
-      cancelled = true;
-      window.clearInterval(interval);
-    };
-  }, [mutate, pendingRecentJobKey]);
+  const { mutate, recentGroups } = useUpscaleRecentJobs({
+    hasResult,
+    mediaType,
+    mediaUrl,
+    setMediaUrl,
+    setMessage,
+    setPreviewMode,
+    setPreviewZoom,
+    setSource,
+    source,
+    user,
+  });
 
   useEffect(() => {
     const url = mediaUrl.trim();
@@ -275,17 +234,6 @@ export default function UpscaleWorkspace() {
       cancelled = true;
     };
   }, [mediaType, mediaUrl, source?.height, source?.url, source?.width]);
-
-  useEffect(() => {
-    if (defaultGeneratedImageAppliedRef.current) return;
-    if (!user || mediaType !== 'image' || source || result || mediaUrl.trim() || !defaultGeneratedImageSource) return;
-    defaultGeneratedImageAppliedRef.current = true;
-    setSource(defaultGeneratedImageSource);
-    setMediaUrl(defaultGeneratedImageSource.url);
-    setPreviewMode('source');
-    setPreviewZoom('100');
-    setMessage(defaultGeneratedImageSource.name ?? null);
-  }, [defaultGeneratedImageSource, mediaType, mediaUrl, result, source, user]);
 
   useEffect(() => {
     const scroller = previewScrollerRef.current;

--- a/frontend/src/components/tools/upscale/_hooks/useUpscaleRecentJobs.ts
+++ b/frontend/src/components/tools/upscale/_hooks/useUpscaleRecentJobs.ts
@@ -1,0 +1,121 @@
+import { useEffect, useMemo, useRef, type Dispatch, type SetStateAction } from 'react';
+import { getJobStatus, useInfiniteJobs } from '@/lib/api';
+import { groupJobsIntoSummaries } from '@/lib/job-groups';
+import { normalizeGroupSummaries } from '@/lib/normalize-group-summary';
+import type { UpscaleMediaType } from '@/types/tools-upscale';
+import {
+  hasRenderableUpscaleJobMedia,
+  resolveGeneratedImageSource,
+} from '../_lib/upscale-workspace-helpers';
+import type {
+  PreviewMode,
+  PreviewZoom,
+  UploadedAsset,
+} from '../_lib/upscale-workspace-types';
+
+interface UseUpscaleRecentJobsParams {
+  hasResult: boolean;
+  mediaType: UpscaleMediaType;
+  mediaUrl: string;
+  setMediaUrl: Dispatch<SetStateAction<string>>;
+  setMessage: Dispatch<SetStateAction<string | null>>;
+  setPreviewMode: Dispatch<SetStateAction<PreviewMode>>;
+  setPreviewZoom: Dispatch<SetStateAction<PreviewZoom>>;
+  setSource: Dispatch<SetStateAction<UploadedAsset | null>>;
+  source: UploadedAsset | null;
+  user: unknown;
+}
+
+export function useUpscaleRecentJobs({
+  hasResult,
+  mediaType,
+  mediaUrl,
+  setMediaUrl,
+  setMessage,
+  setPreviewMode,
+  setPreviewZoom,
+  setSource,
+  source,
+  user,
+}: UseUpscaleRecentJobsParams) {
+  const defaultGeneratedImageAppliedRef = useRef(false);
+  const { stableJobs: recentJobs, mutate } = useInfiniteJobs(12, { surface: 'upscale' });
+  const { stableJobs: recentGeneratedImageJobs } = useInfiniteJobs(8, { surface: 'image' });
+
+  const recentGroups = useMemo(() => {
+    const jobs = recentJobs.map((job) => (!job.videoUrl && job.readyVideoUrl ? { ...job, videoUrl: job.readyVideoUrl } : job));
+    return normalizeGroupSummaries(groupJobsIntoSummaries(jobs, { includeSinglesAsGroups: true }).groups);
+  }, [recentJobs]);
+
+  const pendingRecentJobIds = useMemo(
+    () =>
+      recentJobs
+        .filter((job) => {
+          const status = typeof job.status === 'string' ? job.status.toLowerCase() : '';
+          if (status === 'failed' || status === 'cancelled' || status === 'canceled') return false;
+          return status !== 'completed' || !hasRenderableUpscaleJobMedia(job);
+        })
+        .map((job) => job.jobId)
+        .filter((jobId): jobId is string => typeof jobId === 'string' && jobId.length > 0),
+    [recentJobs]
+  );
+  const pendingRecentJobKey = pendingRecentJobIds.join('|');
+  const defaultGeneratedImageSource = useMemo(() => {
+    const sortedJobs = [...recentGeneratedImageJobs].sort(
+      (a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt)
+    );
+    for (const job of sortedJobs) {
+      const candidate = resolveGeneratedImageSource(job);
+      if (candidate) return candidate;
+    }
+    return null;
+  }, [recentGeneratedImageJobs]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !pendingRecentJobKey) return undefined;
+    let cancelled = false;
+    const jobIds = pendingRecentJobKey.split('|').filter(Boolean);
+    const pollPendingJobs = async () => {
+      await Promise.all(jobIds.map((jobId) => getJobStatus(jobId).catch(() => null)));
+      if (!cancelled) {
+        void mutate();
+      }
+    };
+    void pollPendingJobs();
+    const interval = window.setInterval(() => {
+      void pollPendingJobs();
+    }, 5_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [mutate, pendingRecentJobKey]);
+
+  useEffect(() => {
+    if (defaultGeneratedImageAppliedRef.current) return;
+    if (!user || mediaType !== 'image' || source || hasResult || mediaUrl.trim() || !defaultGeneratedImageSource) return;
+    defaultGeneratedImageAppliedRef.current = true;
+    setSource(defaultGeneratedImageSource);
+    setMediaUrl(defaultGeneratedImageSource.url);
+    setPreviewMode('source');
+    setPreviewZoom('100');
+    setMessage(defaultGeneratedImageSource.name ?? null);
+  }, [
+    defaultGeneratedImageSource,
+    hasResult,
+    mediaType,
+    mediaUrl,
+    setMediaUrl,
+    setMessage,
+    setPreviewMode,
+    setPreviewZoom,
+    setSource,
+    source,
+    user,
+  ]);
+
+  return {
+    mutate,
+    recentGroups,
+  };
+}

--- a/tests/upscale-workspace-architecture.test.ts
+++ b/tests/upscale-workspace-architecture.test.ts
@@ -10,6 +10,7 @@ const typesPath = join(root, 'frontend/src/components/tools/upscale/_lib/upscale
 const helpersPath = join(root, 'frontend/src/components/tools/upscale/_lib/upscale-workspace-helpers.ts');
 const libraryHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscaleLibraryAssets.ts');
 const pricingHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscalePricingPreview.ts');
+const recentJobsHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscaleRecentJobs.ts');
 
 const workspaceSource = readFileSync(workspacePath, 'utf8');
 
@@ -19,12 +20,14 @@ test('upscale workspace delegates copy, local types, and helper logic', () => {
   assert.ok(existsSync(helpersPath), 'upscale workspace helper logic should live in a colocated helper module');
   assert.ok(existsSync(libraryHookPath), 'upscale library asset loading should live in a colocated hook');
   assert.ok(existsSync(pricingHookPath), 'upscale pricing preview should live in a colocated hook');
+  assert.ok(existsSync(recentJobsHookPath), 'upscale recent jobs orchestration should live in a colocated hook');
 
   assert.match(workspaceSource, /from '\.\/upscale\/_lib\/upscale-workspace-copy'/, 'workspace should import upscale copy');
   assert.match(workspaceSource, /from '\.\/upscale\/_lib\/upscale-workspace-types'/, 'workspace should import upscale local types');
   assert.match(workspaceSource, /from '\.\/upscale\/_lib\/upscale-workspace-helpers'/, 'workspace should import upscale helpers');
   assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscaleLibraryAssets'/, 'workspace should import library hook');
   assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscalePricingPreview'/, 'workspace should import pricing hook');
+  assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscaleRecentJobs'/, 'workspace should import recent jobs hook');
 });
 
 test('upscale workspace does not regain extracted ownership', () => {
@@ -39,9 +42,12 @@ test('upscale workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /buildUpscalePricingPreview/, 'pricing preview orchestration belongs in useUpscalePricingPreview');
   assert.doesNotMatch(workspaceSource, /readVideoPricingMetadata/, 'video pricing metadata loading belongs in useUpscalePricingPreview');
   assert.doesNotMatch(workspaceSource, /BillingProductResponse/, 'billing product parsing belongs in useUpscalePricingPreview');
+  assert.doesNotMatch(workspaceSource, /useInfiniteJobs\(12, \{ surface: 'upscale' \}\)/, 'recent upscale feed belongs in useUpscaleRecentJobs');
+  assert.doesNotMatch(workspaceSource, /getJobStatus/, 'recent job polling belongs in useUpscaleRecentJobs');
+  assert.doesNotMatch(workspaceSource, /defaultGeneratedImageAppliedRef/, 'default generated image hydration belongs in useUpscaleRecentJobs');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 1195, `UpscaleWorkspace should stay below 1195 lines after pricing hook extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 1130, `UpscaleWorkspace should stay below 1130 lines after recent jobs hook extraction, got ${lineCount}`);
 });
 
 test('upscale helper modules expose the expected workspace contract', () => {
@@ -50,6 +56,7 @@ test('upscale helper modules expose the expected workspace contract', () => {
   const helpersSource = readFileSync(helpersPath, 'utf8');
   const libraryHookSource = readFileSync(libraryHookPath, 'utf8');
   const pricingHookSource = readFileSync(pricingHookPath, 'utf8');
+  const recentJobsHookSource = readFileSync(recentJobsHookPath, 'utf8');
 
   assert.match(copySource, /export const DEFAULT_UPSCALE_COPY =/, 'copy module should export default copy');
 
@@ -85,4 +92,8 @@ test('upscale helper modules expose the expected workspace contract', () => {
   assert.match(pricingHookSource, /buildUpscalePricingPreview/, 'pricing hook should build the preview');
   assert.match(pricingHookSource, /readVideoPricingMetadata/, 'pricing hook should load video metadata');
   assert.match(pricingHookSource, /BillingProductResponse/, 'pricing hook should parse billing products');
+  assert.match(recentJobsHookSource, /export function useUpscaleRecentJobs/, 'recent jobs hook should be exported');
+  assert.match(recentJobsHookSource, /useInfiniteJobs\(12, \{ surface: 'upscale' \}\)/, 'recent jobs hook should own the upscale feed');
+  assert.match(recentJobsHookSource, /getJobStatus/, 'recent jobs hook should poll pending jobs');
+  assert.match(recentJobsHookSource, /resolveGeneratedImageSource/, 'recent jobs hook should hydrate the default generated image source');
 });


### PR DESCRIPTION
## Summary
- move Upscale recent job feed derivation into useUpscaleRecentJobs
- move pending upscale polling and default generated-image hydration into the same runtime hook
- keep UpscaleWorkspace focused on render/action orchestration and update its architecture contract

## Checks
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/upscale-workspace-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (from frontend)
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- scoped changed files

## Notes
- existing local edits in frontend/src/lib/stripe-checkout.ts and tests/wallet-checkout-session.test.ts were left unstaged and are not part of this PR.