### PR TITLE
[codex] Split audio workspace runtime hooks

### DIFF
--- a/frontend/app/(core)/(workspace)/app/audio/AudioWorkspace.tsx
+++ b/frontend/app/(core)/(workspace)/app/audio/AudioWorkspace.tsx
@@ -22,7 +22,7 @@ import {
 
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { authFetch } from '@/lib/authFetch';
-import { getJobStatus, runAudioGenerate } from '@/lib/api';
+import { runAudioGenerate } from '@/lib/api';
 import { useI18n } from '@/lib/i18n/I18nProvider';
 import type { Job } from '@/types/jobs';
 import { Button, ButtonLink } from '@/components/ui/Button';
@@ -60,6 +60,8 @@ import {
 import AudioLatestRendersRail from './AudioLatestRendersRail';
 import { AudioGeneratedVideoPickerModal } from './_components/audio-generated-video-picker';
 import { AudioModePicker, AudioSelectControl, ToggleRow } from './_components/audio-workspace-controls';
+import { useAudioActiveJobPolling } from './_hooks/useAudioActiveJobPolling';
+import { useAudioGeneratedVideos } from './_hooks/useAudioGeneratedVideos';
 import {
   AUDIO_VOICE_GENDER_VALUES,
   DEFAULT_INTENSITY,
@@ -124,9 +126,15 @@ export default function AudioWorkspace() {
   const [result, setResult] = useState<AudioResultState | null>(null);
   const [activeJob, setActiveJob] = useState<ActiveAudioJobState | null>(null);
   const [generatedPickerOpen, setGeneratedPickerOpen] = useState(false);
-  const [generatedVideos, setGeneratedVideos] = useState<GeneratedSourceVideo[]>([]);
-  const [isGeneratedVideosLoading, setIsGeneratedVideosLoading] = useState(false);
-  const [generatedVideosError, setGeneratedVideosError] = useState<string | null>(null);
+  const {
+    generatedVideos,
+    generatedVideosError,
+    isGeneratedVideosLoading,
+  } = useAudioGeneratedVideos({
+    loadErrorMessage: copy.messages.loadGeneratedVideos,
+    open: generatedPickerOpen,
+    user,
+  });
   const sourceInputRef = useRef<HTMLInputElement | null>(null);
   const voiceInputRef = useRef<HTMLInputElement | null>(null);
   const restoredQueryJobRef = useRef<string | null>(null);
@@ -342,38 +350,6 @@ export default function AudioWorkspace() {
     [hydrateSourceVideo]
   );
 
-  const fetchGeneratedVideos = useCallback(async () => {
-    setIsGeneratedVideosLoading(true);
-    setGeneratedVideosError(null);
-    try {
-      const response = await authFetch('/api/jobs?surface=video&limit=60');
-      const payload = (await response.json().catch(() => null)) as
-        | { ok?: boolean; error?: string; jobs?: Job[] }
-        | null;
-      if (!response.ok || !payload?.ok || !Array.isArray(payload.jobs)) {
-        throw new Error(payload?.error ?? copy.messages.loadGeneratedVideos);
-      }
-      const next = payload.jobs
-        .filter((job) => typeof job.videoUrl === 'string' && job.videoUrl.trim().length > 0)
-        .map((job) => ({
-          jobId: job.jobId,
-          url: job.videoUrl as string,
-          thumbUrl: job.thumbUrl ?? null,
-          durationSec: typeof job.durationSec === 'number' ? job.durationSec : null,
-          aspectRatio: job.aspectRatio ?? null,
-          label: job.engineLabel?.trim().length ? job.engineLabel : `Job ${job.jobId}`,
-          createdAt: job.createdAt,
-          hasAudio: Boolean(job.hasAudio),
-        }))
-        .filter((job, index, list) => list.findIndex((entry) => entry.jobId === job.jobId) === index);
-      setGeneratedVideos(next);
-    } catch (error) {
-      setGeneratedVideosError(resolveUiErrorMessage(error, copy.messages.loadGeneratedVideos, ['Unable to load generated videos.']));
-    } finally {
-      setIsGeneratedVideosLoading(false);
-    }
-  }, [copy.messages.loadGeneratedVideos]);
-
   useEffect(() => {
     if (!queryJobId || !user) return;
     if (restoredQueryJobRef.current === queryJobId) return;
@@ -447,60 +423,11 @@ export default function AudioWorkspace() {
     };
   }, [copy, queryJobId, restoreAudioJob, user]);
 
-  useEffect(() => {
-    if (!activeJob || (activeJob.status !== 'pending' && activeJob.status !== 'running')) {
-      return;
-    }
-    let cancelled = false;
-    const poll = async () => {
-      try {
-        const status = await getJobStatus(activeJob.jobId);
-        if (cancelled) return;
-        const nextOutputKind = inferOutputKind({
-          videoUrl: status.videoUrl ?? null,
-          audioUrl: status.audioUrl ?? null,
-        });
-        const nextStatus: ActiveAudioJobState = {
-          jobId: status.jobId,
-          status: status.videoUrl || status.audioUrl ? 'completed' : status.status,
-          progress: status.progress,
-          message: status.message ?? null,
-          videoUrl: status.videoUrl ?? null,
-          audioUrl: status.audioUrl ?? null,
-          thumbUrl: status.thumbUrl ?? null,
-          outputKind: nextOutputKind,
-        };
-        setActiveJob(nextStatus);
-        if (status.videoUrl || status.audioUrl) {
-          setResult({
-            jobId: status.jobId,
-            videoUrl: status.videoUrl ?? null,
-            audioUrl: status.audioUrl ?? null,
-            thumbUrl: status.thumbUrl ?? null,
-            outputKind: nextOutputKind,
-          });
-        }
-      } catch {
-        // Keep current state and retry on the next interval.
-      }
-    };
-
-    void poll();
-    const interval = window.setInterval(() => {
-      void poll();
-    }, 5000);
-
-    return () => {
-      cancelled = true;
-      window.clearInterval(interval);
-    };
-  }, [activeJob]);
-
-  useEffect(() => {
-    if (!generatedPickerOpen || !user) return;
-    if (generatedVideos.length || isGeneratedVideosLoading) return;
-    void fetchGeneratedVideos();
-  }, [fetchGeneratedVideos, generatedPickerOpen, generatedVideos.length, isGeneratedVideosLoading, user]);
+  useAudioActiveJobPolling({
+    activeJob,
+    setActiveJob,
+    setResult,
+  });
 
   const estimatedDurationSec = useMemo(() => {
     if (pack === 'voice_only') {

--- a/frontend/app/(core)/(workspace)/app/audio/_hooks/useAudioActiveJobPolling.ts
+++ b/frontend/app/(core)/(workspace)/app/audio/_hooks/useAudioActiveJobPolling.ts
@@ -1,0 +1,68 @@
+import { useEffect, type Dispatch, type SetStateAction } from 'react';
+import { getJobStatus } from '@/lib/api';
+import { inferOutputKind } from '../_lib/audio-workspace-helpers';
+import type {
+  ActiveAudioJobState,
+  AudioResultState,
+} from '../_lib/audio-workspace-types';
+
+interface UseAudioActiveJobPollingParams {
+  activeJob: ActiveAudioJobState | null;
+  setActiveJob: Dispatch<SetStateAction<ActiveAudioJobState | null>>;
+  setResult: Dispatch<SetStateAction<AudioResultState | null>>;
+}
+
+export function useAudioActiveJobPolling({
+  activeJob,
+  setActiveJob,
+  setResult,
+}: UseAudioActiveJobPollingParams) {
+  useEffect(() => {
+    if (!activeJob || (activeJob.status !== 'pending' && activeJob.status !== 'running')) {
+      return;
+    }
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const status = await getJobStatus(activeJob.jobId);
+        if (cancelled) return;
+        const nextOutputKind = inferOutputKind({
+          videoUrl: status.videoUrl ?? null,
+          audioUrl: status.audioUrl ?? null,
+        });
+        const nextStatus: ActiveAudioJobState = {
+          jobId: status.jobId,
+          status: status.videoUrl || status.audioUrl ? 'completed' : status.status,
+          progress: status.progress,
+          message: status.message ?? null,
+          videoUrl: status.videoUrl ?? null,
+          audioUrl: status.audioUrl ?? null,
+          thumbUrl: status.thumbUrl ?? null,
+          outputKind: nextOutputKind,
+        };
+        setActiveJob(nextStatus);
+        if (status.videoUrl || status.audioUrl) {
+          setResult({
+            jobId: status.jobId,
+            videoUrl: status.videoUrl ?? null,
+            audioUrl: status.audioUrl ?? null,
+            thumbUrl: status.thumbUrl ?? null,
+            outputKind: nextOutputKind,
+          });
+        }
+      } catch {
+        // Keep current state and retry on the next interval.
+      }
+    };
+
+    void poll();
+    const interval = window.setInterval(() => {
+      void poll();
+    }, 5000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [activeJob, setActiveJob, setResult]);
+}

--- a/frontend/app/(core)/(workspace)/app/audio/_hooks/useAudioGeneratedVideos.ts
+++ b/frontend/app/(core)/(workspace)/app/audio/_hooks/useAudioGeneratedVideos.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useState } from 'react';
+import { authFetch } from '@/lib/authFetch';
+import type { Job } from '@/types/jobs';
+import { resolveUiErrorMessage } from '../_lib/audio-workspace-helpers';
+import type { GeneratedSourceVideo } from '../_lib/audio-workspace-types';
+
+interface UseAudioGeneratedVideosParams {
+  loadErrorMessage: string;
+  open: boolean;
+  user: unknown;
+}
+
+export function useAudioGeneratedVideos({
+  loadErrorMessage,
+  open,
+  user,
+}: UseAudioGeneratedVideosParams) {
+  const [generatedVideos, setGeneratedVideos] = useState<GeneratedSourceVideo[]>([]);
+  const [isGeneratedVideosLoading, setIsGeneratedVideosLoading] = useState(false);
+  const [generatedVideosError, setGeneratedVideosError] = useState<string | null>(null);
+
+  const fetchGeneratedVideos = useCallback(async () => {
+    setIsGeneratedVideosLoading(true);
+    setGeneratedVideosError(null);
+    try {
+      const response = await authFetch('/api/jobs?surface=video&limit=60');
+      const payload = (await response.json().catch(() => null)) as
+        | { ok?: boolean; error?: string; jobs?: Job[] }
+        | null;
+      if (!response.ok || !payload?.ok || !Array.isArray(payload.jobs)) {
+        throw new Error(payload?.error ?? loadErrorMessage);
+      }
+      const next = payload.jobs
+        .filter((job) => typeof job.videoUrl === 'string' && job.videoUrl.trim().length > 0)
+        .map((job) => ({
+          jobId: job.jobId,
+          url: job.videoUrl as string,
+          thumbUrl: job.thumbUrl ?? null,
+          durationSec: typeof job.durationSec === 'number' ? job.durationSec : null,
+          aspectRatio: job.aspectRatio ?? null,
+          label: job.engineLabel?.trim().length ? job.engineLabel : `Job ${job.jobId}`,
+          createdAt: job.createdAt,
+          hasAudio: Boolean(job.hasAudio),
+        }))
+        .filter((job, index, list) => list.findIndex((entry) => entry.jobId === job.jobId) === index);
+      setGeneratedVideos(next);
+    } catch (error) {
+      setGeneratedVideosError(resolveUiErrorMessage(error, loadErrorMessage, ['Unable to load generated videos.']));
+    } finally {
+      setIsGeneratedVideosLoading(false);
+    }
+  }, [loadErrorMessage]);
+
+  useEffect(() => {
+    if (!open || !user) return;
+    if (generatedVideos.length || isGeneratedVideosLoading) return;
+    void fetchGeneratedVideos();
+  }, [fetchGeneratedVideos, generatedVideos.length, isGeneratedVideosLoading, open, user]);
+
+  return {
+    generatedVideos,
+    generatedVideosError,
+    isGeneratedVideosLoading,
+  };
+}

--- a/tests/audio-workspace-architecture.test.ts
+++ b/tests/audio-workspace-architecture.test.ts
@@ -10,6 +10,8 @@ const controlsPath = join(audioDir, '_components/audio-workspace-controls.tsx');
 const generatedPickerPath = join(audioDir, '_components/audio-generated-video-picker.tsx');
 const helpersPath = join(audioDir, '_lib/audio-workspace-helpers.ts');
 const typesPath = join(audioDir, '_lib/audio-workspace-types.ts');
+const activeJobHookPath = join(audioDir, '_hooks/useAudioActiveJobPolling.ts');
+const generatedVideosHookPath = join(audioDir, '_hooks/useAudioGeneratedVideos.ts');
 
 const workspaceSource = readFileSync(workspacePath, 'utf8');
 
@@ -18,9 +20,13 @@ test('audio workspace delegates local controls, helpers, and contracts', () => {
   assert.ok(existsSync(generatedPickerPath), 'generated video picker should live in a route-local component module');
   assert.ok(existsSync(helpersPath), 'audio browser/API helpers should live in a route-local helper module');
   assert.ok(existsSync(typesPath), 'audio local contracts should live in a route-local type module');
+  assert.ok(existsSync(activeJobHookPath), 'active audio job polling should live in a route-local hook');
+  assert.ok(existsSync(generatedVideosHookPath), 'generated video loading should live in a route-local hook');
 
   assert.match(workspaceSource, /from '\.\/_components\/audio-workspace-controls'/);
   assert.match(workspaceSource, /from '\.\/_components\/audio-generated-video-picker'/);
+  assert.match(workspaceSource, /from '\.\/_hooks\/useAudioActiveJobPolling'/);
+  assert.match(workspaceSource, /from '\.\/_hooks\/useAudioGeneratedVideos'/);
   assert.match(workspaceSource, /from '\.\/_lib\/audio-workspace-helpers'/);
   assert.match(workspaceSource, /from '\.\/_lib\/audio-workspace-types'/);
 });
@@ -35,9 +41,11 @@ test('audio workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /function AudioSelectControl\(/, 'audio controls belong in _components/audio-workspace-controls.tsx');
   assert.doesNotMatch(workspaceSource, /generated-source-skeleton/, 'generated video picker UI belongs in _components/audio-generated-video-picker.tsx');
   assert.doesNotMatch(workspaceSource, /copy\.picker\.audioBadge/, 'generated video picker card UI belongs in _components/audio-generated-video-picker.tsx');
+  assert.doesNotMatch(workspaceSource, /getJobStatus/, 'active job polling belongs in useAudioActiveJobPolling');
+  assert.doesNotMatch(workspaceSource, /surface=video&limit=60/, 'generated video loading belongs in useAudioGeneratedVideos');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 1160, `AudioWorkspace should stay below 1160 lines after generated picker extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 1075, `AudioWorkspace should stay below 1075 lines after runtime hook extraction, got ${lineCount}`);
 });
 
 test('audio helper modules expose the expected workspace contract', () => {
@@ -45,6 +53,8 @@ test('audio helper modules expose the expected workspace contract', () => {
   const generatedPickerSource = readFileSync(generatedPickerPath, 'utf8');
   const helpersSource = readFileSync(helpersPath, 'utf8');
   const typesSource = readFileSync(typesPath, 'utf8');
+  const activeJobHookSource = readFileSync(activeJobHookPath, 'utf8');
+  const generatedVideosHookSource = readFileSync(generatedVideosHookPath, 'utf8');
 
   for (const exportName of [
     'AudioModePicker',
@@ -59,6 +69,10 @@ test('audio helper modules expose the expected workspace contract', () => {
     /export function AudioGeneratedVideoPickerModal/,
     'AudioGeneratedVideoPickerModal should be exported'
   );
+  assert.match(activeJobHookSource, /export function useAudioActiveJobPolling/, 'active job polling hook should be exported');
+  assert.match(activeJobHookSource, /getJobStatus/, 'active job polling hook should poll job status');
+  assert.match(generatedVideosHookSource, /export function useAudioGeneratedVideos/, 'generated videos hook should be exported');
+  assert.match(generatedVideosHookSource, /surface=video&limit=60/, 'generated videos hook should load video jobs');
 
   for (const exportName of [
     'DEFAULT_PACK',


### PR DESCRIPTION
## Summary
- move active audio job polling into useAudioActiveJobPolling
- move generated video picker loading into useAudioGeneratedVideos
- keep AudioWorkspace focused on form state, generation actions, and rendering
- update the audio architecture contract for these hook boundaries

## Checks
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/audio-workspace-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (from frontend)
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- scoped changed files

## Notes
- existing local edits in frontend/src/lib/stripe-checkout.ts and tests/wallet-checkout-session.test.ts were left unstaged and are not part of this PR.