### PR TITLE
[codex] Split image reference normalization

### DIFF
--- a/frontend/src/server/images/execute-image-generation.ts
+++ b/frontend/src/server/images/execute-image-generation.ts
@@ -1,6 +1,5 @@
 import { ApiError, ValidationError } from '@fal-ai/client';
 import { randomUUID } from 'crypto';
-import sharp from 'sharp';
 import { listFalEngines } from '@/config/falEngines';
 import type {
   CharacterReferenceSelection,
@@ -11,7 +10,7 @@ import type {
 } from '@/types/image-generation';
 import { getFalClient } from '@/lib/fal-client';
 import { isDatabaseConfigured, query, type QueryExecutor, withDbTransaction } from '@/lib/db';
-import { ensureAssetSchema, ensureBillingSchema } from '@/lib/schema';
+import { ensureBillingSchema } from '@/lib/schema';
 import { computePricingSnapshot, getPlatformFeeCents } from '@/lib/pricing';
 import type { PricingSnapshot } from '@/types/engines';
 import { reserveWalletChargeInExecutor } from '@/lib/wallet';
@@ -22,10 +21,8 @@ import { getResultProviderMode } from '@/lib/result-provider';
 import {
   createSignedDownloadUrl,
   extractStorageKeyFromUrl,
-  isAllowedAssetHost,
   isStorageConfigured,
   recordUserAsset,
-  uploadImageToStorage,
 } from '@/server/storage';
 import { createImageThumbnailBatch } from '@/server/image-thumbnails';
 import { buildStoredImageRenderEntries, resolveHeroThumbFromRenders } from '@/lib/image-renders';
@@ -33,9 +30,6 @@ import { ensureReusableAsset, upsertLegacyJobOutputs } from '@/server/media-libr
 import {
   formatSupportedImageFormatsLabel,
   getSupportedImageFormats,
-  inferImageFormatFromUrl,
-  isSupportedImageFormat,
-  isSupportedImageMime,
 } from '@/lib/image/formats';
 import {
   canonicalizeImageFieldValue,
@@ -56,6 +50,12 @@ import {
 import { computeBillingProductSnapshot } from '@/lib/billing-products';
 import type { BillingProductKey, JobSurface } from '@/types/billing';
 import { buildResponseFromExistingJob, type ExistingImageJobRow } from './existing-image-job-response';
+import {
+  getStoredAssetInfoByUrl,
+  isReferenceImageSupported,
+  normalizeReferenceImageForEngine,
+  type StoredAssetInfo,
+} from './image-reference-normalization';
 
 export { buildResponseFromExistingJob } from './existing-image-job-response';
 
@@ -63,11 +63,6 @@ const DISPLAY_CURRENCY = 'USD';
 const DISPLAY_CURRENCY_LOWER: Currency = 'usd';
 const PLACEHOLDER_THUMB = '/assets/frames/thumb-1x1.svg';
 const SIGNED_REFERENCE_URL_TTL_SECONDS = 60 * 60;
-const NORMALIZED_REFERENCE_FETCH_TIMEOUT_MS = Number.parseInt(
-  process.env.NORMALIZED_REFERENCE_FETCH_TIMEOUT_MS ?? '12000',
-  10
-);
-
 type PendingReceipt = {
   userId: string;
   amountCents: number;
@@ -239,167 +234,6 @@ function buildCharacterReferencePrompt(prompt: string, characterReferences: Char
       : 'Treat the selected character references as distinct character identities. Preserve each separately, match cast order to selection order, and do not merge identities. If the user prompt implies fewer characters than selected, prioritize them in selection order.';
 
   return `${prompt}\n\nCharacter reference instructions:\n${instruction}`;
-}
-
-type StoredAssetInfo = {
-  mime?: string | null;
-  width?: number | null;
-  height?: number | null;
-};
-
-async function getStoredAssetInfoByUrl(userId: string, urls: string[]): Promise<Map<string, StoredAssetInfo>> {
-  if (!urls.length) {
-    return new Map();
-  }
-
-  try {
-    await ensureAssetSchema();
-    const rows = await query<{ url: string; mime_type: string | null; width: number | null; height: number | null }>(
-      `SELECT url, mime_type, width, height
-       FROM user_assets
-       WHERE user_id = $1
-         AND url = ANY($2::text[])`,
-      [userId, urls]
-    );
-    return new Map(
-      rows
-        .filter((row) => typeof row.url === 'string')
-        .map((row) => [
-          row.url,
-          {
-            mime: row.mime_type,
-            width: typeof row.width === 'number' ? row.width : null,
-            height: typeof row.height === 'number' ? row.height : null,
-          },
-        ])
-    );
-  } catch (error) {
-    console.warn('[images] unable to inspect stored asset formats', error);
-    return new Map();
-  }
-}
-
-function isReferenceImageSupported(
-  allowedFormats: string[],
-  url: string,
-  storedAssetInfoByUrl: Map<string, StoredAssetInfo>
-): boolean {
-  const storedMime = storedAssetInfoByUrl.get(url)?.mime ?? null;
-  const supportedByMime = isSupportedImageMime(allowedFormats, storedMime);
-  if (supportedByMime != null) {
-    return supportedByMime;
-  }
-  const inferredFormat = inferImageFormatFromUrl(url);
-  if (!inferredFormat) {
-    return true;
-  }
-  return isSupportedImageFormat(allowedFormats, inferredFormat);
-}
-
-function pickNormalizedReferenceMime(allowedFormats: string[], hasAlpha: boolean): string | null {
-  const formats = new Set(allowedFormats.map((entry) => entry.trim().toLowerCase()).filter(Boolean));
-  const supportsJpeg = formats.has('jpg') || formats.has('jpeg');
-  const supportsPng = formats.has('png');
-  const supportsWebp = formats.has('webp');
-  const supportsAvif = formats.has('avif');
-
-  if (hasAlpha) {
-    if (supportsWebp) return 'image/webp';
-    if (supportsPng) return 'image/png';
-    if (supportsJpeg) return 'image/jpeg';
-    if (supportsAvif) return 'image/avif';
-    return null;
-  }
-
-  if (supportsJpeg) return 'image/jpeg';
-  if (supportsWebp) return 'image/webp';
-  if (supportsPng) return 'image/png';
-  if (supportsAvif) return 'image/avif';
-  return null;
-}
-
-async function fetchBufferFromUrl(url: string, timeoutMs: number): Promise<Buffer> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const response = await fetch(url, { signal: controller.signal });
-    if (!response.ok) {
-      throw new Error(`source fetch failed (${response.status})`);
-    }
-    const payload = await response.arrayBuffer();
-    const buffer = Buffer.from(payload);
-    if (!buffer.length) {
-      throw new Error('source image is empty');
-    }
-    return buffer;
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-async function normalizeReferenceImageForEngine(params: {
-  userId: string;
-  url: string;
-  supportedFormats: string[];
-  engineId: string;
-}): Promise<{ url: string; mime: string }> {
-  if (!isAllowedAssetHost(params.url)) {
-    throw new Error('reference host is not eligible for server-side normalization');
-  }
-
-  const storageKey = extractStorageKeyFromUrl(params.url);
-  const sourceUrl =
-    storageKey && isStorageConfigured()
-      ? await createSignedDownloadUrl(storageKey, { expiresInSeconds: SIGNED_REFERENCE_URL_TTL_SECONDS })
-      : params.url;
-
-  const sourceBuffer = await fetchBufferFromUrl(sourceUrl, NORMALIZED_REFERENCE_FETCH_TIMEOUT_MS);
-  const metadata = await sharp(sourceBuffer, { failOn: 'none' }).metadata();
-  const targetMime = pickNormalizedReferenceMime(params.supportedFormats, metadata.hasAlpha === true);
-  if (!targetMime) {
-    throw new Error('no compatible target mime available for normalization');
-  }
-
-  let pipeline = sharp(sourceBuffer, { failOn: 'none' }).rotate();
-  if (targetMime === 'image/jpeg') {
-    pipeline = pipeline.jpeg({ quality: 90, mozjpeg: true });
-  } else if (targetMime === 'image/png') {
-    pipeline = pipeline.png();
-  } else if (targetMime === 'image/webp') {
-    pipeline = pipeline.webp({ quality: 90 });
-  } else if (targetMime === 'image/avif') {
-    pipeline = pipeline.avif({ quality: 72 });
-  }
-
-  const normalizedBuffer = await pipeline.toBuffer();
-  const upload = await uploadImageToStorage({
-    data: normalizedBuffer,
-    mime: targetMime,
-    userId: params.userId,
-    fileName: params.url.split('/').pop() ?? 'reference-image',
-    prefix: 'normalized-references',
-  });
-
-  try {
-    await recordUserAsset({
-      userId: params.userId,
-      url: upload.url,
-      mime: upload.mime,
-      width: upload.width,
-      height: upload.height,
-      size: upload.size,
-      source: 'normalized_reference',
-      metadata: {
-        originalUrl: params.url,
-        engineId: params.engineId,
-        supportedFormats: params.supportedFormats,
-      },
-    });
-  } catch (error) {
-    console.warn('[images] failed to record normalized reference asset', error);
-  }
-
-  return { url: upload.url, mime: upload.mime };
 }
 
 function extractImages(payload: unknown): GeneratedImage[] {

--- a/frontend/src/server/images/image-reference-normalization.ts
+++ b/frontend/src/server/images/image-reference-normalization.ts
@@ -1,0 +1,183 @@
+import sharp from 'sharp';
+import { query } from '@/lib/db';
+import { ensureAssetSchema } from '@/lib/schema';
+import {
+  createSignedDownloadUrl,
+  extractStorageKeyFromUrl,
+  isAllowedAssetHost,
+  isStorageConfigured,
+  recordUserAsset,
+  uploadImageToStorage,
+} from '@/server/storage';
+import {
+  inferImageFormatFromUrl,
+  isSupportedImageFormat,
+  isSupportedImageMime,
+} from '@/lib/image/formats';
+
+const SIGNED_REFERENCE_URL_TTL_SECONDS = 60 * 60;
+const NORMALIZED_REFERENCE_FETCH_TIMEOUT_MS = Number.parseInt(
+  process.env.NORMALIZED_REFERENCE_FETCH_TIMEOUT_MS ?? '12000',
+  10
+);
+
+export type StoredAssetInfo = {
+  mime?: string | null;
+  width?: number | null;
+  height?: number | null;
+};
+
+export async function getStoredAssetInfoByUrl(userId: string, urls: string[]): Promise<Map<string, StoredAssetInfo>> {
+  if (!urls.length) {
+    return new Map();
+  }
+
+  try {
+    await ensureAssetSchema();
+    const rows = await query<{ url: string; mime_type: string | null; width: number | null; height: number | null }>(
+      `SELECT url, mime_type, width, height
+       FROM user_assets
+       WHERE user_id = $1
+         AND url = ANY($2::text[])`,
+      [userId, urls]
+    );
+    return new Map(
+      rows
+        .filter((row) => typeof row.url === 'string')
+        .map((row) => [
+          row.url,
+          {
+            mime: row.mime_type,
+            width: typeof row.width === 'number' ? row.width : null,
+            height: typeof row.height === 'number' ? row.height : null,
+          },
+        ])
+    );
+  } catch (error) {
+    console.warn('[images] unable to inspect stored asset formats', error);
+    return new Map();
+  }
+}
+
+export function isReferenceImageSupported(
+  allowedFormats: string[],
+  url: string,
+  storedAssetInfoByUrl: Map<string, StoredAssetInfo>
+): boolean {
+  const storedMime = storedAssetInfoByUrl.get(url)?.mime ?? null;
+  const supportedByMime = isSupportedImageMime(allowedFormats, storedMime);
+  if (supportedByMime != null) {
+    return supportedByMime;
+  }
+  const inferredFormat = inferImageFormatFromUrl(url);
+  if (!inferredFormat) {
+    return true;
+  }
+  return isSupportedImageFormat(allowedFormats, inferredFormat);
+}
+
+export function pickNormalizedReferenceMime(allowedFormats: string[], hasAlpha: boolean): string | null {
+  const formats = new Set(allowedFormats.map((entry) => entry.trim().toLowerCase()).filter(Boolean));
+  const supportsJpeg = formats.has('jpg') || formats.has('jpeg');
+  const supportsPng = formats.has('png');
+  const supportsWebp = formats.has('webp');
+  const supportsAvif = formats.has('avif');
+
+  if (hasAlpha) {
+    if (supportsWebp) return 'image/webp';
+    if (supportsPng) return 'image/png';
+    if (supportsJpeg) return 'image/jpeg';
+    if (supportsAvif) return 'image/avif';
+    return null;
+  }
+
+  if (supportsJpeg) return 'image/jpeg';
+  if (supportsWebp) return 'image/webp';
+  if (supportsPng) return 'image/png';
+  if (supportsAvif) return 'image/avif';
+  return null;
+}
+
+async function fetchBufferFromUrl(url: string, timeoutMs: number): Promise<Buffer> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`source fetch failed (${response.status})`);
+    }
+    const payload = await response.arrayBuffer();
+    const buffer = Buffer.from(payload);
+    if (!buffer.length) {
+      throw new Error('source image is empty');
+    }
+    return buffer;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function normalizeReferenceImageForEngine(params: {
+  userId: string;
+  url: string;
+  supportedFormats: string[];
+  engineId: string;
+}): Promise<{ url: string; mime: string }> {
+  if (!isAllowedAssetHost(params.url)) {
+    throw new Error('reference host is not eligible for server-side normalization');
+  }
+
+  const storageKey = extractStorageKeyFromUrl(params.url);
+  const sourceUrl =
+    storageKey && isStorageConfigured()
+      ? await createSignedDownloadUrl(storageKey, { expiresInSeconds: SIGNED_REFERENCE_URL_TTL_SECONDS })
+      : params.url;
+
+  const sourceBuffer = await fetchBufferFromUrl(sourceUrl, NORMALIZED_REFERENCE_FETCH_TIMEOUT_MS);
+  const metadata = await sharp(sourceBuffer, { failOn: 'none' }).metadata();
+  const targetMime = pickNormalizedReferenceMime(params.supportedFormats, metadata.hasAlpha === true);
+  if (!targetMime) {
+    throw new Error('no compatible target mime available for normalization');
+  }
+
+  let pipeline = sharp(sourceBuffer, { failOn: 'none' }).rotate();
+  if (targetMime === 'image/jpeg') {
+    pipeline = pipeline.jpeg({ quality: 90, mozjpeg: true });
+  } else if (targetMime === 'image/png') {
+    pipeline = pipeline.png();
+  } else if (targetMime === 'image/webp') {
+    pipeline = pipeline.webp({ quality: 90 });
+  } else if (targetMime === 'image/avif') {
+    pipeline = pipeline.avif({ quality: 72 });
+  }
+
+  const normalizedBuffer = await pipeline.toBuffer();
+  const upload = await uploadImageToStorage({
+    data: normalizedBuffer,
+    mime: targetMime,
+    userId: params.userId,
+    fileName: params.url.split('/').pop() ?? 'reference-image',
+    prefix: 'normalized-references',
+  });
+
+  try {
+    await recordUserAsset({
+      userId: params.userId,
+      url: upload.url,
+      mime: upload.mime,
+      width: upload.width,
+      height: upload.height,
+      size: upload.size,
+      source: 'normalized_reference',
+      metadata: {
+        originalUrl: params.url,
+        engineId: params.engineId,
+        supportedFormats: params.supportedFormats,
+      },
+    });
+  } catch (error) {
+    console.warn('[images] failed to record normalized reference asset', error);
+  }
+
+  return { url: upload.url, mime: upload.mime };
+}

--- a/tests/image-generation-server-architecture.test.ts
+++ b/tests/image-generation-server-architecture.test.ts
@@ -6,13 +6,17 @@ import test from 'node:test';
 const root = process.cwd();
 const executorPath = join(root, 'frontend/src/server/images/execute-image-generation.ts');
 const existingJobResponsePath = join(root, 'frontend/src/server/images/existing-image-job-response.ts');
+const referenceNormalizationPath = join(root, 'frontend/src/server/images/image-reference-normalization.ts');
 
 const executorSource = readFileSync(executorPath, 'utf8');
 const existingJobResponseSource = readFileSync(existingJobResponsePath, 'utf8');
+const referenceNormalizationSource = readFileSync(referenceNormalizationPath, 'utf8');
 
 test('image generation executor delegates existing job response rebuilding', () => {
   assert.ok(existsSync(existingJobResponsePath), 'existing image job response helpers should live in a focused module');
+  assert.ok(existsSync(referenceNormalizationPath), 'image reference normalization should live in a focused module');
   assert.match(executorSource, /from '\.\/existing-image-job-response'/);
+  assert.match(executorSource, /from '\.\/image-reference-normalization'/);
   assert.match(executorSource, /export \{ buildResponseFromExistingJob \} from '\.\/existing-image-job-response'/);
 });
 
@@ -20,9 +24,12 @@ test('image generation executor does not regain existing job response ownership'
   assert.doesNotMatch(executorSource, /function buildImagesFromExistingJob\(/, 'stored render parsing belongs in existing-image-job-response.ts');
   assert.doesNotMatch(executorSource, /function parseResolutionFromSettingsSnapshot\(/, 'settings snapshot resolution parsing belongs in existing-image-job-response.ts');
   assert.doesNotMatch(executorSource, /parseStoredImageRenders/, 'stored render parsing belongs in existing-image-job-response.ts');
+  assert.doesNotMatch(executorSource, /function pickNormalizedReferenceMime\(/, 'reference mime selection belongs in image-reference-normalization.ts');
+  assert.doesNotMatch(executorSource, /function isReferenceImageSupported\(/, 'reference format checks belong in image-reference-normalization.ts');
+  assert.doesNotMatch(executorSource, /async function normalizeReferenceImageForEngine\(/, 'reference normalization belongs in image-reference-normalization.ts');
 
   const lineCount = executorSource.split('\n').length;
-  assert.ok(lineCount <= 1740, `image generation executor should stay below 1740 lines after existing-job response extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 1620, `image generation executor should stay below 1620 lines after reference normalization extraction, got ${lineCount}`);
 });
 
 test('existing image job response module exposes the expected contract', () => {
@@ -30,4 +37,9 @@ test('existing image job response module exposes the expected contract', () => {
   assert.match(existingJobResponseSource, /export function parseResolutionFromSettingsSnapshot/);
   assert.match(existingJobResponseSource, /export function buildResponseFromExistingJob/);
   assert.match(existingJobResponseSource, /parseStoredImageRenders/);
+  assert.match(referenceNormalizationSource, /export type StoredAssetInfo/);
+  assert.match(referenceNormalizationSource, /export async function getStoredAssetInfoByUrl/);
+  assert.match(referenceNormalizationSource, /export function isReferenceImageSupported/);
+  assert.match(referenceNormalizationSource, /export function pickNormalizedReferenceMime/);
+  assert.match(referenceNormalizationSource, /export async function normalizeReferenceImageForEngine/);
 });


### PR DESCRIPTION
## Summary
- move stored reference asset inspection, format support checks, sharp normalization, and normalized reference upload into image-reference-normalization.ts
- keep execute-image-generation focused on orchestration and billing/job flow
- extend the image generation architecture contract around the new server helper boundary

## Checks
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/image-generation-server-architecture.test.ts tests/image-generation-atomic.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (from frontend)
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- scoped changed files

## Notes
- existing local edits in frontend/src/lib/stripe-checkout.ts and tests/wallet-checkout-session.test.ts were left unstaged and are not part of this PR.