### PR TITLE
[codex] Split character builder generation runner

### DIFF
--- a/frontend/src/components/tools/CharacterBuilderWorkspace.tsx
+++ b/frontend/src/components/tools/CharacterBuilderWorkspace.tsx
@@ -28,11 +28,10 @@ import {
   normalizeCharacterFormatMode,
   normalizeTraitsForSourceMode,
 } from '@/lib/character-builder';
-import { runCharacterBuilderTool, saveImageToLibrary } from '@/lib/api';
+import { saveImageToLibrary } from '@/lib/api';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { FEATURES } from '@/content/feature-flags';
 import type {
-  CharacterBuilderAction,
   CharacterBuilderResult,
   CharacterBuilderSettingsSnapshot,
   CharacterBuilderState,
@@ -62,6 +61,7 @@ import {
 } from './character-builder/_components/character-builder-workspace-components';
 import { useCharacterBuilderHistoricalResults } from './character-builder/_hooks/useCharacterBuilderHistoricalResults';
 import { useCharacterBuilderJobSnapshotLoader } from './character-builder/_hooks/useCharacterBuilderJobSnapshotLoader';
+import { useCharacterBuilderGenerationRunner } from './character-builder/_hooks/useCharacterBuilderGenerationRunner';
 import { useCharacterBuilderOptions } from './character-builder/_hooks/useCharacterBuilderOptions';
 import { useCharacterBuilderPersistence } from './character-builder/_hooks/useCharacterBuilderPersistence';
 import { useCharacterBuilderPendingRunsSync } from './character-builder/_hooks/useCharacterBuilderPendingRunsSync';
@@ -70,23 +70,18 @@ import {
   buildReferenceImage,
   buildResetCharacterBuilderState,
   countConfiguredSecondaryControls,
-  decrementLoadingRequestCount,
-  emitClientMetric,
   findChoiceLabel,
   getCharacterBillingProductKey,
   getFlattenedResults,
   getFormatDisplayLabel,
   getHairSummary,
-  getLoadingRequestKey,
   getOutfitSummary,
   getRefByRole,
   getResultActionLabel,
   hasCustomOutfitSettings,
   hasCustomHairSettings,
-  incrementLoadingRequestCount,
   INITIAL_LOADING_REQUEST_COUNTS,
   isAuthRequiredError,
-  normalizeHairAndOutfitModes,
   normalizeTag,
   parseCharacterBuilderSnapshot,
   removeReferenceImage,
@@ -174,6 +169,7 @@ export default function CharacterBuilderPage() {
   } = useCharacterBuilderHistoricalResults(flattenedResults);
   const identityReference = getRefByRole(state.referenceImages, 'identity');
   const styleReference = getRefByRole(state.referenceImages, 'style');
+  const hasIdentityReference = Boolean(identityReference);
   useCharacterBuilderPersistence({
     authLoading,
     hydrated,
@@ -194,7 +190,19 @@ export default function CharacterBuilderPage() {
     styleReference,
     user,
   });
-  const hasIdentityReference = Boolean(identityReference);
+  const handleRun = useCharacterBuilderGenerationRunner({
+    copy,
+    hasIdentityReference,
+    mutateHistoricalJobs,
+    openAuthGate,
+    setError,
+    setLoadingActions,
+    setPendingRuns,
+    setState,
+    setStatusMessage,
+    state,
+    user,
+  });
   const hasCompletedResults = flattenedResults.length > 0;
   const hasResults = hasCompletedResults || pendingRuns.length > 0 || historicalResults.length > 0;
   const secondaryControlsCount = countConfiguredSecondaryControls(state, hasIdentityReference);
@@ -477,125 +485,6 @@ export default function CharacterBuilderPage() {
     }));
     setAdvancedOpen(Boolean(snapshot.builder.advancedNotes));
     setStatusMessage(copy.duplicateDone);
-  }
-
-  async function handleRun(action: CharacterBuilderAction, generateCount?: 1 | 4) {
-    if (!user) {
-      openAuthGate();
-      return;
-    }
-    setError(null);
-    setStatusMessage(null);
-    const loadingKey = getLoadingRequestKey(action, generateCount);
-    const clientJobId =
-      typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-        ? `img_${crypto.randomUUID()}`
-        : `img_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
-    const requestTraits = normalizeHairAndOutfitModes(state.traits);
-    const pendingCreatedAt = new Date().toISOString();
-    const pendingRun: PendingCharacterRun = {
-      id: clientJobId,
-      jobId: clientJobId,
-      createdAt: pendingCreatedAt,
-      action,
-      outputMode: state.outputMode,
-      qualityMode: state.qualityMode,
-      formatMode: state.formatMode,
-      generateCount: generateCount ?? 1,
-    };
-
-    setLoadingActions((previous) => incrementLoadingRequestCount(previous, loadingKey));
-    setPendingRuns((previous) => [pendingRun, ...previous].slice(0, 12));
-
-    emitClientMetric('tool_start', {
-      tool_name: 'character_builder',
-      tool_surface: 'workspace',
-      logged_in: true,
-      action: action.replace(/-/g, '_'),
-      source_mode: state.sourceMode,
-      output_mode: state.outputMode.replace(/-/g, '_'),
-      quality_mode: state.qualityMode,
-      format_mode: state.formatMode.replace(/-/g, '_'),
-      generate_count: generateCount ?? 1,
-    });
-
-    try {
-      const response = await runCharacterBuilderTool({
-        jobId: clientJobId,
-        action,
-        sourceMode: state.sourceMode,
-        outputMode: state.outputMode,
-        consistencyMode: state.consistencyMode,
-        referenceStrength: hasIdentityReference ? state.referenceStrength : null,
-        qualityMode: state.qualityMode,
-        formatMode: state.formatMode,
-        referenceImages: state.referenceImages,
-        traits: requestTraits,
-        outputOptions: state.outputOptions,
-        advancedNotes: state.advancedNotes,
-        mustRemainVisible: state.mustRemainVisible,
-        generateCount: generateCount ?? 1,
-        selectedResultId: null,
-        selectedResultUrl: null,
-        pinnedReferenceResultId: null,
-        pinnedReferenceResultUrl: null,
-        lineage: {
-          parentResultId: null,
-          parentRunId: null,
-          pinnedReferenceResultId: null,
-        },
-      });
-
-      if (!response.run) {
-        throw new Error(copy.missingRun);
-      }
-
-      setPendingRuns((previous) => previous.filter((entry) => entry.id !== clientJobId));
-      setState((previous) => {
-        const nextRuns = [response.run!, ...previous.runs].slice(0, 12);
-        const firstResultId = response.run!.results[0]?.id ?? null;
-
-        return {
-          ...previous,
-          runs: nextRuns,
-          selectedResultId: firstResultId,
-          pinnedReferenceResultId: null,
-          refinementHistory: previous.refinementHistory,
-        };
-      });
-
-      setStatusMessage(
-        action === 'generate'
-          ? generateCount === 4
-            ? copy.runGenerateFourDone
-            : copy.runGenerateOneDone
-          : action === 'full-body-fix'
-            ? copy.runFullBodyDone
-            : copy.runLightingDone
-      );
-      emitClientMetric('tool_complete', {
-        tool_name: 'character_builder',
-        tool_surface: 'workspace',
-        logged_in: true,
-        action: action.replace(/-/g, '_'),
-        source_mode: state.sourceMode,
-        output_mode: state.outputMode.replace(/-/g, '_'),
-        quality_mode: state.qualityMode,
-        format_mode: state.formatMode.replace(/-/g, '_'),
-        generate_count: generateCount ?? 1,
-        result_count: response.run.results.length,
-      });
-      void mutateHistoricalJobs(undefined, { revalidate: true });
-    } catch (runError) {
-      setPendingRuns((previous) => previous.filter((entry) => entry.id !== clientJobId));
-      if (isAuthRequiredError(runError)) {
-        openAuthGate();
-        return;
-      }
-      setError(runError instanceof Error ? runError.message : copy.runFailed);
-    } finally {
-      setLoadingActions((previous) => decrementLoadingRequestCount(previous, loadingKey));
-    }
   }
 
   async function handleSaveResult(result: CharacterBuilderResult) {

--- a/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderGenerationRunner.ts
+++ b/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderGenerationRunner.ts
@@ -1,0 +1,188 @@
+import { useCallback, type Dispatch, type SetStateAction } from 'react';
+import type { SWRInfiniteKeyedMutator } from 'swr/infinite';
+import { runCharacterBuilderTool } from '@/lib/api';
+import type {
+  CharacterBuilderAction,
+  CharacterBuilderState,
+} from '@/types/character-builder';
+import type { JobsPage } from '@/types/jobs';
+import {
+  decrementLoadingRequestCount,
+  emitClientMetric,
+  getLoadingRequestKey,
+  incrementLoadingRequestCount,
+  isAuthRequiredError,
+  normalizeHairAndOutfitModes,
+} from '../_lib/character-builder-helpers';
+import type { CharacterCopy } from '../_lib/character-builder-copy';
+import type {
+  LoadingRequestCounts,
+  PendingCharacterRun,
+} from '../_lib/character-builder-types';
+
+interface UseCharacterBuilderGenerationRunnerOptions {
+  copy: CharacterCopy;
+  hasIdentityReference: boolean;
+  mutateHistoricalJobs: SWRInfiniteKeyedMutator<JobsPage[]>;
+  openAuthGate: () => void;
+  setError: Dispatch<SetStateAction<string | null>>;
+  setLoadingActions: Dispatch<SetStateAction<LoadingRequestCounts>>;
+  setPendingRuns: Dispatch<SetStateAction<PendingCharacterRun[]>>;
+  setState: Dispatch<SetStateAction<CharacterBuilderState>>;
+  setStatusMessage: Dispatch<SetStateAction<string | null>>;
+  state: CharacterBuilderState;
+  user: unknown;
+}
+
+export function useCharacterBuilderGenerationRunner({
+  copy,
+  hasIdentityReference,
+  mutateHistoricalJobs,
+  openAuthGate,
+  setError,
+  setLoadingActions,
+  setPendingRuns,
+  setState,
+  setStatusMessage,
+  state,
+  user,
+}: UseCharacterBuilderGenerationRunnerOptions) {
+  return useCallback(
+    async (action: CharacterBuilderAction, generateCount?: 1 | 4) => {
+      if (!user) {
+        openAuthGate();
+        return;
+      }
+      setError(null);
+      setStatusMessage(null);
+      const loadingKey = getLoadingRequestKey(action, generateCount);
+      const clientJobId =
+        typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+          ? `img_${crypto.randomUUID()}`
+          : `img_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+      const requestTraits = normalizeHairAndOutfitModes(state.traits);
+      const pendingCreatedAt = new Date().toISOString();
+      const pendingRun: PendingCharacterRun = {
+        id: clientJobId,
+        jobId: clientJobId,
+        createdAt: pendingCreatedAt,
+        action,
+        outputMode: state.outputMode,
+        qualityMode: state.qualityMode,
+        formatMode: state.formatMode,
+        generateCount: generateCount ?? 1,
+      };
+
+      setLoadingActions((previous) => incrementLoadingRequestCount(previous, loadingKey));
+      setPendingRuns((previous) => [pendingRun, ...previous].slice(0, 12));
+
+      emitClientMetric('tool_start', {
+        tool_name: 'character_builder',
+        tool_surface: 'workspace',
+        logged_in: true,
+        action: action.replace(/-/g, '_'),
+        source_mode: state.sourceMode,
+        output_mode: state.outputMode.replace(/-/g, '_'),
+        quality_mode: state.qualityMode,
+        format_mode: state.formatMode.replace(/-/g, '_'),
+        generate_count: generateCount ?? 1,
+      });
+
+      try {
+        const response = await runCharacterBuilderTool({
+          jobId: clientJobId,
+          action,
+          sourceMode: state.sourceMode,
+          outputMode: state.outputMode,
+          consistencyMode: state.consistencyMode,
+          referenceStrength: hasIdentityReference ? state.referenceStrength : null,
+          qualityMode: state.qualityMode,
+          formatMode: state.formatMode,
+          referenceImages: state.referenceImages,
+          traits: requestTraits,
+          outputOptions: state.outputOptions,
+          advancedNotes: state.advancedNotes,
+          mustRemainVisible: state.mustRemainVisible,
+          generateCount: generateCount ?? 1,
+          selectedResultId: null,
+          selectedResultUrl: null,
+          pinnedReferenceResultId: null,
+          pinnedReferenceResultUrl: null,
+          lineage: {
+            parentResultId: null,
+            parentRunId: null,
+            pinnedReferenceResultId: null,
+          },
+        });
+
+        if (!response.run) {
+          throw new Error(copy.missingRun);
+        }
+
+        setPendingRuns((previous) => previous.filter((entry) => entry.id !== clientJobId));
+        setState((previous) => {
+          const nextRuns = [response.run!, ...previous.runs].slice(0, 12);
+          const firstResultId = response.run!.results[0]?.id ?? null;
+
+          return {
+            ...previous,
+            runs: nextRuns,
+            selectedResultId: firstResultId,
+            pinnedReferenceResultId: null,
+            refinementHistory: previous.refinementHistory,
+          };
+        });
+
+        setStatusMessage(
+          action === 'generate'
+            ? generateCount === 4
+              ? copy.runGenerateFourDone
+              : copy.runGenerateOneDone
+            : action === 'full-body-fix'
+              ? copy.runFullBodyDone
+              : copy.runLightingDone
+        );
+        emitClientMetric('tool_complete', {
+          tool_name: 'character_builder',
+          tool_surface: 'workspace',
+          logged_in: true,
+          action: action.replace(/-/g, '_'),
+          source_mode: state.sourceMode,
+          output_mode: state.outputMode.replace(/-/g, '_'),
+          quality_mode: state.qualityMode,
+          format_mode: state.formatMode.replace(/-/g, '_'),
+          generate_count: generateCount ?? 1,
+          result_count: response.run.results.length,
+        });
+        void mutateHistoricalJobs(undefined, { revalidate: true });
+      } catch (runError) {
+        setPendingRuns((previous) => previous.filter((entry) => entry.id !== clientJobId));
+        if (isAuthRequiredError(runError)) {
+          openAuthGate();
+          return;
+        }
+        setError(runError instanceof Error ? runError.message : copy.runFailed);
+      } finally {
+        setLoadingActions((previous) => decrementLoadingRequestCount(previous, loadingKey));
+      }
+    },
+    [
+      copy.missingRun,
+      copy.runFailed,
+      copy.runFullBodyDone,
+      copy.runGenerateFourDone,
+      copy.runGenerateOneDone,
+      copy.runLightingDone,
+      hasIdentityReference,
+      mutateHistoricalJobs,
+      openAuthGate,
+      setError,
+      setLoadingActions,
+      setPendingRuns,
+      setState,
+      setStatusMessage,
+      state,
+      user,
+    ]
+  );
+}

--- a/tests/character-builder-workspace-architecture.test.ts
+++ b/tests/character-builder-workspace-architecture.test.ts
@@ -18,6 +18,7 @@ const optionsHookPath = join(root, 'frontend/src/components/tools/character-buil
 const historicalResultsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderHistoricalResults.ts');
 const pendingRunsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderPendingRunsSync.ts');
 const jobSnapshotHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderJobSnapshotLoader.ts');
+const generationRunnerHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderGenerationRunner.ts');
 const persistenceHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderPersistence.ts');
 
 const workspaceSource = readFileSync(workspacePath, 'utf8');
@@ -36,6 +37,7 @@ test('character builder workspace delegates copy, local types, and helper logic'
   assert.ok(existsSync(historicalResultsHookPath), 'historical result derivation should live in a focused hook');
   assert.ok(existsSync(pendingRunsHookPath), 'pending run polling should live in a focused hook');
   assert.ok(existsSync(jobSnapshotHookPath), 'job snapshot loading should live in a focused hook');
+  assert.ok(existsSync(generationRunnerHookPath), 'generation submission should live in a focused hook');
   assert.ok(existsSync(persistenceHookPath), 'local persistence should live in a focused hook');
 
   assert.match(workspaceSource, /from '\.\/character-builder\/_components\/character-builder-workspace-components'/, 'workspace should import UI components');
@@ -43,6 +45,7 @@ test('character builder workspace delegates copy, local types, and helper logic'
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderHistoricalResults'/, 'workspace should import historical results hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderPendingRunsSync'/, 'workspace should import pending run sync hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderJobSnapshotLoader'/, 'workspace should import job snapshot loader hook');
+  assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderGenerationRunner'/, 'workspace should import generation runner hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderPersistence'/, 'workspace should import persistence hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_lib\/character-builder-copy'/, 'workspace should import character copy');
   assert.match(workspaceSource, /from '\.\/character-builder\/_lib\/character-builder-types'/, 'workspace should import local types');
@@ -64,12 +67,15 @@ test('character builder workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /localResultUrls/, 'historical duplicate filtering belongs in useCharacterBuilderHistoricalResults');
   assert.doesNotMatch(workspaceSource, /function syncPendingRuns\(/, 'pending run polling belongs in useCharacterBuilderPendingRunsSync');
   assert.doesNotMatch(workspaceSource, /function loadFromJob\(/, 'job query hydration belongs in useCharacterBuilderJobSnapshotLoader');
+  assert.doesNotMatch(workspaceSource, /async function handleRun\(/, 'generation submission belongs in useCharacterBuilderGenerationRunner');
+  assert.doesNotMatch(workspaceSource, /runCharacterBuilderTool/, 'generation API calls belong in useCharacterBuilderGenerationRunner');
+  assert.doesNotMatch(workspaceSource, /emitClientMetric\('tool_start'/, 'generation analytics belong in useCharacterBuilderGenerationRunner');
   assert.doesNotMatch(workspaceSource, /readPersistedState\(\)/, 'local hydration belongs in useCharacterBuilderPersistence');
   assert.doesNotMatch(workspaceSource, /writePersistedPendingRuns/, 'pending run persistence belongs in useCharacterBuilderPersistence');
   assert.doesNotMatch(workspaceSource, /visitorSanitizedRef/, 'visitor cleanup tracking belongs in useCharacterBuilderPersistence');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 1660, `CharacterBuilderWorkspace should stay below 1660 lines after runtime hook extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 1560, `CharacterBuilderWorkspace should stay below 1560 lines after generation runner extraction, got ${lineCount}`);
 });
 
 test('character builder helper modules expose the expected workspace contract', () => {
@@ -86,6 +92,7 @@ test('character builder helper modules expose the expected workspace contract', 
   const historicalResultsHookSource = readFileSync(historicalResultsHookPath, 'utf8');
   const pendingRunsHookSource = readFileSync(pendingRunsHookPath, 'utf8');
   const jobSnapshotHookSource = readFileSync(jobSnapshotHookPath, 'utf8');
+  const generationRunnerHookSource = readFileSync(generationRunnerHookPath, 'utf8');
   const persistenceHookSource = readFileSync(persistenceHookPath, 'utf8');
 
   assert.match(copySource, /export const DEFAULT_CHARACTER_COPY =/, 'copy module should export default copy');
@@ -190,6 +197,10 @@ test('character builder helper modules expose the expected workspace contract', 
   assert.match(pendingRunsHookSource, /buildRecoveredRunFromJob/, 'pending run sync hook should recover completed runs');
   assert.match(jobSnapshotHookSource, /export function useCharacterBuilderJobSnapshotLoader/, 'job snapshot loader hook should be exported');
   assert.match(jobSnapshotHookSource, /parseCharacterBuilderSnapshot/, 'job snapshot loader hook should own query hydration parsing');
+  assert.match(generationRunnerHookSource, /export function useCharacterBuilderGenerationRunner/, 'generation runner hook should be exported');
+  assert.match(generationRunnerHookSource, /runCharacterBuilderTool/, 'generation runner hook should submit character jobs');
+  assert.match(generationRunnerHookSource, /emitClientMetric\('tool_start'/, 'generation runner hook should own generation analytics');
+  assert.match(generationRunnerHookSource, /normalizeHairAndOutfitModes/, 'generation runner hook should own request trait normalization');
   assert.match(persistenceHookSource, /export function useCharacterBuilderPersistence/, 'persistence hook should be exported');
   assert.match(persistenceHookSource, /readPersistedState/, 'persistence hook should own local hydration');
   assert.match(persistenceHookSource, /writePersistedPendingRuns/, 'persistence hook should own pending run persistence');


### PR DESCRIPTION
## Summary\n- move character builder generation submission into a focused route-local hook\n- keep CharacterBuilderWorkspace as UI orchestration instead of owning API submission, pending run creation, and generation analytics\n- extend the architecture contract to prevent generation runner logic from drifting back into the workspace\n\n## Verification\n- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/character-builder-workspace-architecture.test.ts\n- ./node_modules/.bin/tsc --noEmit --pretty false\n- npm --prefix frontend run lint\n- npm run lint:exposure