### PR TITLE
[codex] Split upscale source media hook

### DIFF
--- a/frontend/src/components/tools/UpscaleWorkspace.tsx
+++ b/frontend/src/components/tools/UpscaleWorkspace.tsx
@@ -3,7 +3,7 @@
 /* eslint-disable @next/next/no-img-element */
 
 import Link from 'next/link';
-import { useEffect, useMemo, useRef, useState, type ChangeEvent, type PointerEvent } from 'react';
+import { useEffect, useMemo, useRef, useState, type PointerEvent } from 'react';
 import {
   ArrowLeft,
   ArrowRight,
@@ -27,10 +27,7 @@ import { Button, ButtonLink } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
 import { SelectMenu } from '@/components/ui/SelectMenu';
-import {
-  AssetLibraryBrowser,
-  type AssetBrowserAsset,
-} from '@/components/library/AssetLibraryBrowser';
+import { AssetLibraryBrowser } from '@/components/library/AssetLibraryBrowser';
 import { authFetch } from '@/lib/authFetch';
 import { runUpscaleTool, saveAssetToLibrary } from '@/lib/api';
 import { suggestDownloadFilename, triggerAppDownload } from '@/lib/download';
@@ -56,9 +53,7 @@ import { DEFAULT_UPSCALE_COPY } from './upscale/_lib/upscale-workspace-copy';
 import {
   clampComparePosition,
   formatCurrency,
-  inferMimeType,
   isOutputVideo,
-  mediaTypeFromMime,
   parseRecentImageVariantIndex,
   PREVIEW_ZOOM_OPTIONS,
   resolveRecentUpscaleJobFromGroup,
@@ -68,11 +63,11 @@ import {
   SAMPLE_IMAGE_URL,
   SOURCE_FALLBACK_HEIGHT,
   SOURCE_FALLBACK_WIDTH,
-  uploadSourceFile,
 } from './upscale/_lib/upscale-workspace-helpers';
 import { useUpscaleLibraryAssets } from './upscale/_hooks/useUpscaleLibraryAssets';
 import { useUpscalePricingPreview } from './upscale/_hooks/useUpscalePricingPreview';
 import { useUpscaleRecentJobs } from './upscale/_hooks/useUpscaleRecentJobs';
+import { useUpscaleSourceMedia } from './upscale/_hooks/useUpscaleSourceMedia';
 import type {
   JobDetailResponse,
   PreviewMode,
@@ -208,32 +203,21 @@ export default function UpscaleWorkspace() {
     source,
     user,
   });
-
-  useEffect(() => {
-    const url = mediaUrl.trim();
-    if (mediaType !== 'image' || !url) return undefined;
-    if (source?.url === url && source.width && source.height) return undefined;
-
-    let cancelled = false;
-    const image = new window.Image();
-    image.onload = () => {
-      if (cancelled || !image.naturalWidth || !image.naturalHeight) return;
-      setSource((current) => {
-        if (current?.url && current.url !== url) return current;
-        return {
-          ...(current ?? {}),
-          url,
-          width: current?.width ?? image.naturalWidth,
-          height: current?.height ?? image.naturalHeight,
-          mime: current?.mime ?? inferMimeType(url, 'image'),
-        };
-      });
-    };
-    image.src = url;
-    return () => {
-      cancelled = true;
-    };
-  }, [mediaType, mediaUrl, source?.height, source?.url, source?.width]);
+  const { handleUpload, selectLibraryAsset } = useUpscaleSourceMedia({
+    changeMediaType,
+    copy,
+    mediaType,
+    mediaUrl,
+    setError,
+    setLibraryModalOpen,
+    setMediaUrl,
+    setMessage,
+    setPreviewMode,
+    setResult,
+    setSource,
+    setUploading,
+    source,
+  });
 
   useEffect(() => {
     const scroller = previewScrollerRef.current;
@@ -276,30 +260,6 @@ export default function UpscaleWorkspace() {
     setUpscaleFactor(nextEngine.defaultUpscaleFactor);
     setTargetResolution(nextEngine.defaultTargetResolution ?? '1080p');
     setOutputFormat(nextEngine.defaultOutputFormat);
-  }
-
-  async function handleUpload(event: ChangeEvent<HTMLInputElement>) {
-    const file = event.target.files?.[0];
-    event.target.value = '';
-    if (!file) return;
-    const detectedType = mediaTypeFromMime(file.type);
-    const nextMediaType = detectedType ?? mediaType;
-    if (nextMediaType !== mediaType) changeMediaType(nextMediaType);
-    setUploading(true);
-    setError(null);
-    setMessage(null);
-    try {
-      const uploaded = await uploadSourceFile(file, nextMediaType);
-      setSource(uploaded);
-      setMediaUrl(uploaded.url);
-      setResult(null);
-      setPreviewMode('source');
-      setMessage(uploaded.name ?? file.name);
-    } catch (uploadError) {
-      setError(uploadError instanceof Error ? uploadError.message : copy.uploadFailed);
-    } finally {
-      setUploading(false);
-    }
   }
 
   async function handleRun() {
@@ -353,37 +313,6 @@ export default function UpscaleWorkspace() {
   function handleDownload() {
     if (!output?.url) return;
     triggerAppDownload(output.url, suggestDownloadFilename(output.url, `upscale-${mediaType}`));
-  }
-
-  function selectLibraryAsset(asset: AssetBrowserAsset) {
-    const nextMediaType: UpscaleMediaType = asset.kind === 'video' || asset.mime?.startsWith('video/') ? 'video' : 'image';
-    if (nextMediaType !== mediaType) {
-      setMediaType(nextMediaType);
-      const nextEngine = nextMediaType === 'video' ? DEFAULT_UPSCALE_VIDEO_ENGINE_ID : DEFAULT_UPSCALE_IMAGE_ENGINE_ID;
-      const resolved =
-        listUpscaleToolEngines(nextMediaType).find((entry) => entry.id === nextEngine) ??
-        listUpscaleToolEngines(nextMediaType)[0];
-      setEngineId(resolved.id);
-      setMode(resolved.defaultMode);
-      setUpscaleFactor(resolved.defaultUpscaleFactor);
-      setTargetResolution(resolved.defaultTargetResolution ?? '1080p');
-      setOutputFormat(resolved.defaultOutputFormat);
-    }
-    setSource({
-      id: asset.id.startsWith('job:') ? null : asset.id,
-      jobId: asset.id.startsWith('job:') ? asset.id.slice(4) : null,
-      url: asset.url,
-      width: asset.width ?? null,
-      height: asset.height ?? null,
-      mime: asset.mime ?? (nextMediaType === 'video' ? 'video/mp4' : 'image/png'),
-      name: asset.source ? `${asset.source} asset` : copy.library,
-    });
-    setMediaUrl(asset.url);
-    setResult(null);
-    setPreviewMode('source');
-    setError(null);
-    setMessage(asset.source ? `${copy.library}: ${asset.source}` : copy.library);
-    setLibraryModalOpen(false);
   }
 
   function buildRecentUpscaleResult(selection: RecentUpscaleMedia): UpscaleToolResponse {

--- a/frontend/src/components/tools/upscale/_hooks/useUpscaleSourceMedia.ts
+++ b/frontend/src/components/tools/upscale/_hooks/useUpscaleSourceMedia.ts
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, type ChangeEvent, type Dispatch, type SetStateAction } from 'react';
+import type { AssetBrowserAsset } from '@/components/library/AssetLibraryBrowser';
+import type {
+  UpscaleMediaType,
+  UpscaleToolResponse,
+} from '@/types/tools-upscale';
+import {
+  inferMimeType,
+  mediaTypeFromMime,
+  uploadSourceFile,
+} from '../_lib/upscale-workspace-helpers';
+import type {
+  PreviewMode,
+  UploadedAsset,
+} from '../_lib/upscale-workspace-types';
+
+interface UseUpscaleSourceMediaParams {
+  changeMediaType: (next: UpscaleMediaType) => void;
+  copy: {
+    library: string;
+    uploadFailed: string;
+  };
+  mediaType: UpscaleMediaType;
+  mediaUrl: string;
+  setError: Dispatch<SetStateAction<string | null>>;
+  setLibraryModalOpen: Dispatch<SetStateAction<boolean>>;
+  setMediaUrl: Dispatch<SetStateAction<string>>;
+  setMessage: Dispatch<SetStateAction<string | null>>;
+  setPreviewMode: Dispatch<SetStateAction<PreviewMode>>;
+  setResult: Dispatch<SetStateAction<UpscaleToolResponse | null>>;
+  setSource: Dispatch<SetStateAction<UploadedAsset | null>>;
+  setUploading: Dispatch<SetStateAction<boolean>>;
+  source: UploadedAsset | null;
+}
+
+export function useUpscaleSourceMedia({
+  changeMediaType,
+  copy,
+  mediaType,
+  mediaUrl,
+  setError,
+  setLibraryModalOpen,
+  setMediaUrl,
+  setMessage,
+  setPreviewMode,
+  setResult,
+  setSource,
+  setUploading,
+  source,
+}: UseUpscaleSourceMediaParams) {
+  useEffect(() => {
+    const url = mediaUrl.trim();
+    if (mediaType !== 'image' || !url) return undefined;
+    if (source?.url === url && source.width && source.height) return undefined;
+
+    let cancelled = false;
+    const image = new window.Image();
+    image.onload = () => {
+      if (cancelled || !image.naturalWidth || !image.naturalHeight) return;
+      setSource((current) => {
+        if (current?.url && current.url !== url) return current;
+        return {
+          ...(current ?? {}),
+          url,
+          width: current?.width ?? image.naturalWidth,
+          height: current?.height ?? image.naturalHeight,
+          mime: current?.mime ?? inferMimeType(url, 'image'),
+        };
+      });
+    };
+    image.src = url;
+    return () => {
+      cancelled = true;
+    };
+  }, [mediaType, mediaUrl, setSource, source?.height, source?.url, source?.width]);
+
+  const handleUpload = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      event.target.value = '';
+      if (!file) return;
+      const detectedType = mediaTypeFromMime(file.type);
+      const nextMediaType = detectedType ?? mediaType;
+      if (nextMediaType !== mediaType) changeMediaType(nextMediaType);
+      setUploading(true);
+      setError(null);
+      setMessage(null);
+      try {
+        const uploaded = await uploadSourceFile(file, nextMediaType);
+        setSource(uploaded);
+        setMediaUrl(uploaded.url);
+        setResult(null);
+        setPreviewMode('source');
+        setMessage(uploaded.name ?? file.name);
+      } catch (uploadError) {
+        setError(uploadError instanceof Error ? uploadError.message : copy.uploadFailed);
+      } finally {
+        setUploading(false);
+      }
+    },
+    [
+      changeMediaType,
+      copy.uploadFailed,
+      mediaType,
+      setError,
+      setMediaUrl,
+      setMessage,
+      setPreviewMode,
+      setResult,
+      setSource,
+      setUploading,
+    ]
+  );
+
+  const selectLibraryAsset = useCallback(
+    (asset: AssetBrowserAsset) => {
+      const nextMediaType: UpscaleMediaType = asset.kind === 'video' || asset.mime?.startsWith('video/') ? 'video' : 'image';
+      if (nextMediaType !== mediaType) {
+        changeMediaType(nextMediaType);
+      }
+      setSource({
+        id: asset.id.startsWith('job:') ? null : asset.id,
+        jobId: asset.id.startsWith('job:') ? asset.id.slice(4) : null,
+        url: asset.url,
+        width: asset.width ?? null,
+        height: asset.height ?? null,
+        mime: asset.mime ?? (nextMediaType === 'video' ? 'video/mp4' : 'image/png'),
+        name: asset.source ? `${asset.source} asset` : copy.library,
+      });
+      setMediaUrl(asset.url);
+      setResult(null);
+      setPreviewMode('source');
+      setError(null);
+      setMessage(asset.source ? `${copy.library}: ${asset.source}` : copy.library);
+      setLibraryModalOpen(false);
+    },
+    [
+      changeMediaType,
+      copy.library,
+      mediaType,
+      setError,
+      setLibraryModalOpen,
+      setMediaUrl,
+      setMessage,
+      setPreviewMode,
+      setResult,
+      setSource,
+    ]
+  );
+
+  return {
+    handleUpload,
+    selectLibraryAsset,
+  };
+}

--- a/tests/upscale-workspace-architecture.test.ts
+++ b/tests/upscale-workspace-architecture.test.ts
@@ -11,6 +11,7 @@ const helpersPath = join(root, 'frontend/src/components/tools/upscale/_lib/upsca
 const libraryHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscaleLibraryAssets.ts');
 const pricingHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscalePricingPreview.ts');
 const recentJobsHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscaleRecentJobs.ts');
+const sourceMediaHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscaleSourceMedia.ts');
 
 const workspaceSource = readFileSync(workspacePath, 'utf8');
 
@@ -21,6 +22,7 @@ test('upscale workspace delegates copy, local types, and helper logic', () => {
   assert.ok(existsSync(libraryHookPath), 'upscale library asset loading should live in a colocated hook');
   assert.ok(existsSync(pricingHookPath), 'upscale pricing preview should live in a colocated hook');
   assert.ok(existsSync(recentJobsHookPath), 'upscale recent jobs orchestration should live in a colocated hook');
+  assert.ok(existsSync(sourceMediaHookPath), 'upscale source media orchestration should live in a colocated hook');
 
   assert.match(workspaceSource, /from '\.\/upscale\/_lib\/upscale-workspace-copy'/, 'workspace should import upscale copy');
   assert.match(workspaceSource, /from '\.\/upscale\/_lib\/upscale-workspace-types'/, 'workspace should import upscale local types');
@@ -28,6 +30,7 @@ test('upscale workspace delegates copy, local types, and helper logic', () => {
   assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscaleLibraryAssets'/, 'workspace should import library hook');
   assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscalePricingPreview'/, 'workspace should import pricing hook');
   assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscaleRecentJobs'/, 'workspace should import recent jobs hook');
+  assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscaleSourceMedia'/, 'workspace should import source media hook');
 });
 
 test('upscale workspace does not regain extracted ownership', () => {
@@ -45,9 +48,12 @@ test('upscale workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /useInfiniteJobs\(12, \{ surface: 'upscale' \}\)/, 'recent upscale feed belongs in useUpscaleRecentJobs');
   assert.doesNotMatch(workspaceSource, /getJobStatus/, 'recent job polling belongs in useUpscaleRecentJobs');
   assert.doesNotMatch(workspaceSource, /defaultGeneratedImageAppliedRef/, 'default generated image hydration belongs in useUpscaleRecentJobs');
+  assert.doesNotMatch(workspaceSource, /mediaTypeFromMime/, 'source media MIME detection belongs in useUpscaleSourceMedia');
+  assert.doesNotMatch(workspaceSource, /new window\.Image/, 'source image dimension hydration belongs in useUpscaleSourceMedia');
+  assert.doesNotMatch(workspaceSource, /function selectLibraryAsset\(/, 'library source selection belongs in useUpscaleSourceMedia');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 1130, `UpscaleWorkspace should stay below 1130 lines after recent jobs hook extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 1060, `UpscaleWorkspace should stay below 1060 lines after source media hook extraction, got ${lineCount}`);
 });
 
 test('upscale helper modules expose the expected workspace contract', () => {
@@ -57,6 +63,7 @@ test('upscale helper modules expose the expected workspace contract', () => {
   const libraryHookSource = readFileSync(libraryHookPath, 'utf8');
   const pricingHookSource = readFileSync(pricingHookPath, 'utf8');
   const recentJobsHookSource = readFileSync(recentJobsHookPath, 'utf8');
+  const sourceMediaHookSource = readFileSync(sourceMediaHookPath, 'utf8');
 
   assert.match(copySource, /export const DEFAULT_UPSCALE_COPY =/, 'copy module should export default copy');
 
@@ -96,4 +103,8 @@ test('upscale helper modules expose the expected workspace contract', () => {
   assert.match(recentJobsHookSource, /useInfiniteJobs\(12, \{ surface: 'upscale' \}\)/, 'recent jobs hook should own the upscale feed');
   assert.match(recentJobsHookSource, /getJobStatus/, 'recent jobs hook should poll pending jobs');
   assert.match(recentJobsHookSource, /resolveGeneratedImageSource/, 'recent jobs hook should hydrate the default generated image source');
+  assert.match(sourceMediaHookSource, /export function useUpscaleSourceMedia/, 'source media hook should be exported');
+  assert.match(sourceMediaHookSource, /uploadSourceFile/, 'source media hook should own source uploads');
+  assert.match(sourceMediaHookSource, /mediaTypeFromMime/, 'source media hook should own MIME detection');
+  assert.match(sourceMediaHookSource, /new window\.Image/, 'source media hook should hydrate image dimensions');
 });


### PR DESCRIPTION
## Summary\n- move Upscale source upload, source image dimension hydration, and library asset selection into a focused hook\n- keep UpscaleWorkspace as the route-level orchestrator for controls, preview, and actions\n- extend the architecture contract so source-media responsibilities do not drift back into the workspace\n\n## Verification\n- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/upscale-workspace-architecture.test.ts tests/upscale-pricing-preview.test.ts\n- ./node_modules/.bin/tsc --noEmit --pretty false\n- npm --prefix frontend run lint\n- npm run lint:exposure