### PR TITLE
[codex] Split image generation runner hook

### DIFF
--- a/frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx
+++ b/frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx
@@ -7,14 +7,13 @@ import dynamic from 'next/dynamic';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { Plus } from 'lucide-react';
-import type { FormEvent } from 'react';
 import { GalleryRail } from '@/components/GalleryRail';
 import { Button } from '@/components/ui/Button';
 import { EngineSelect } from '@/components/ui/EngineSelect';
 import { Composer, type AssetFieldConfig, type ComposerAttachment } from '@/components/Composer';
 import { ImageSettingsBar } from '@/components/ImageSettingsBar';
 import { ImageAdvancedSettings } from '@/components/ImageAdvancedSettings';
-import { runImageGeneration, saveImageToLibrary } from '@/lib/api';
+import { saveImageToLibrary } from '@/lib/api';
 import type { ImageGenerationMode } from '@/types/image-generation';
 import type { GroupSummary } from '@/types/groups';
 import type { VideoGroup } from '@/types/video-groups';
@@ -31,14 +30,11 @@ import {
 import {
   GPT_IMAGE_2_SIZE_CONSTRAINTS,
   parseGptImage2SizeKey,
-  validateGptImage2CustomImageSize,
 } from '@/lib/image/gptImage2';
 import { authFetch } from '@/lib/authFetch';
-import { readLastKnownUserId } from '@/lib/last-known';
-import { readBrowserSession } from '@/lib/supabase-auth-cleanup';
-import { hasSupabaseAuthCookie } from '@/lib/supabase-session-hint';
 import { ImageAuthGateModal } from './_components/ImageAuthGateModal';
 import { ImageLibraryModal } from './_components/ImageLibraryModal';
+import { useImageGenerationRunner } from './_hooks/useImageGenerationRunner';
 import { useImageWorkspaceHistory } from './_hooks/useImageWorkspaceHistory';
 import { useImageWorkspacePricing } from './_hooks/useImageWorkspacePricing';
 import { useImageSettingsFields } from './_hooks/useImageSettingsFields';
@@ -54,11 +50,6 @@ import {
   type ImageWorkspaceCopy,
 } from './_lib/image-workspace-copy';
 import {
-  buildCompletedGroup,
-  buildPendingGroup,
-} from './_lib/image-workspace-history';
-import {
-  buildCustomImageSize,
   findImageEngine,
 } from './_lib/image-workspace-utils';
 import {
@@ -355,174 +346,45 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
     }
   }, []);
 
-  const handleRun = useCallback(
-    async (event?: FormEvent<HTMLFormElement> | null) => {
-      event?.preventDefault();
-      if (!selectedEngine) return;
-      if (!readLastKnownUserId() && !hasSupabaseAuthCookie()) {
-        setAuthModalOpen(true);
-        return;
-      }
-      const session = await readBrowserSession();
-      if (!session?.access_token) {
-        setAuthModalOpen(true);
-        return;
-      }
-      const trimmedPrompt = prompt.trim();
-      if (!trimmedPrompt) {
-        setError(resolvedCopy.errors.promptMissing);
-        return;
-      }
-      if (referenceMinRequired > 0 && combinedReferenceUrls.length < referenceMinRequired) {
-        setError(resolvedCopy.errors.referenceMissing);
-        return;
-      }
-      const trimmedMaskUrl = maskUrlField ? maskUrl.trim() : '';
-      if (trimmedMaskUrl && !/^https?:\/\//i.test(trimmedMaskUrl)) {
-        setError('Mask URL must be an absolute http(s) URL.');
-        return;
-      }
-      const customImageSize = resolution === 'custom' ? buildCustomImageSize(customImageWidth, customImageHeight) : null;
-      if (resolution === 'custom') {
-        const customSizeResult = validateGptImage2CustomImageSize(customImageSize);
-        if (!customSizeResult.ok) {
-          setError(customSizeResult.message);
-          return;
-        }
-      }
-      setError(null);
-      setStatusMessage(null);
-      const pendingId = `img_${crypto.randomUUID()}`;
-      const pendingCreatedAt = Date.now();
-      setPendingGroups((prev) => [
-        buildPendingGroup({
-          id: pendingId,
-          engineId: selectedEngine.id,
-          engineLabel: selectedEngine.name,
-          prompt: trimmedPrompt,
-          count: numImages,
-          createdAt: pendingCreatedAt,
-        }),
-        ...prev,
-      ]);
-      let keepActiveGroup = false;
-      try {
-        const appliedAspectRatio = aspectRatioField
-          ? aspectRatio ?? getDefaultAspectRatio(selectedEngine.engineCaps, mode) ?? undefined
-          : undefined;
-        const normalizedSeed = (() => {
-          const trimmed = seed.trim();
-          if (!trimmed.length) return undefined;
-          const parsed = Number(trimmed);
-          return Number.isFinite(parsed) ? Math.round(parsed) : undefined;
-        })();
-        const response = await runImageGeneration({
-          jobId: pendingId,
-          engineId: selectedEngine.id,
-          mode,
-          prompt: trimmedPrompt,
-          numImages,
-          imageUrls: mode === 'i2i' ? readyReferenceUrls : undefined,
-          referenceImageSizes: mode === 'i2i' ? readyReferenceSizes : undefined,
-          characterReferences: mode === 'i2i' ? selectedCharacterReferences : undefined,
-          aspectRatio: appliedAspectRatio,
-          resolution: resolution ?? undefined,
-          customImageSize,
-          seed: seedField ? normalizedSeed : undefined,
-          outputFormat: outputFormatField
-            ? ((outputFormat ?? undefined) as 'jpeg' | 'png' | 'webp' | undefined)
-            : undefined,
-          quality: qualityField ? ((quality ?? undefined) as 'low' | 'medium' | 'high' | undefined) : undefined,
-          maskUrl: trimmedMaskUrl || undefined,
-          enableWebSearch: enableWebSearchField ? enableWebSearch : undefined,
-          thinkingLevel: thinkingLevelField
-            ? ((thinkingLevel ?? undefined) as 'minimal' | 'high' | undefined)
-            : undefined,
-          limitGenerations: limitGenerationsField ? limitGenerations : undefined,
-        });
-        const entry: HistoryEntry = {
-          id: response.jobId ?? response.requestId ?? crypto.randomUUID(),
-          jobId: response.jobId ?? response.requestId ?? null,
-          engineId: response.engineId ?? selectedEngine.id,
-          engineLabel: response.engineLabel ?? selectedEngine.name,
-          mode,
-          prompt: trimmedPrompt,
-          createdAt: Date.now(),
-          description: response.description,
-          images: response.images,
-          aspectRatio: response.aspectRatio ?? appliedAspectRatio ?? null,
-        };
-        setLocalHistory((prev) => [entry, ...prev].slice(0, 24));
-        setSelectedPreviewEntryId(entry.id);
-        setSelectedPreviewImageIndex(0);
-        const suffix = response.images.length === 1 ? '' : 's';
-        setStatusMessage(
-          formatTemplate(resolvedCopy.messages.success, { count: response.images.length, suffix })
-        );
-        const resolvedGroupId = response.jobId ?? pendingId;
-        if (response.images.length > 0) {
-          keepActiveGroup = true;
-          setPendingGroups((prev) => [
-            buildCompletedGroup({
-              id: resolvedGroupId,
-              engineId: response.engineId ?? selectedEngine.id,
-              engineLabel: response.engineLabel ?? selectedEngine.name,
-              prompt: trimmedPrompt,
-              aspectRatio: response.aspectRatio ?? appliedAspectRatio ?? null,
-              images: response.images,
-              createdAt: pendingCreatedAt,
-              totalPriceCents: response.pricing?.totalCents ?? response.costCents ?? null,
-              currency: response.pricing?.currency ?? response.currency ?? null,
-            }),
-            ...prev.filter((group) => group.id !== pendingId && group.id !== resolvedGroupId),
-          ]);
-        }
-        void mutateJobs();
-      } catch (err) {
-        setError(err instanceof Error ? err.message : resolvedCopy.errors.generic);
-      } finally {
-        if (!keepActiveGroup) {
-          setPendingGroups((prev) => prev.filter((group) => group.id !== pendingId));
-        }
-      }
-    },
-    [
-      mode,
-      numImages,
-      prompt,
-      combinedReferenceUrls,
-      resolvedCopy.errors.generic,
-      resolvedCopy.errors.promptMissing,
-      resolvedCopy.errors.referenceMissing,
-      resolvedCopy.messages.success,
-      aspectRatio,
-      aspectRatioField,
-      customImageHeight,
-      customImageWidth,
-      enableWebSearch,
-      enableWebSearchField,
-      limitGenerations,
-      limitGenerationsField,
-      referenceMinRequired,
-      resolution,
-      seed,
-      seedField,
-      selectedEngine,
-      outputFormat,
-      outputFormatField,
-      quality,
-      qualityField,
-      readyReferenceSizes,
-      readyReferenceUrls,
-      selectedCharacterReferences,
-      maskUrl,
-      maskUrlField,
-      thinkingLevel,
-      thinkingLevelField,
-      mutateJobs,
-      setPendingGroups,
-    ]
-  );
+  const handleRun = useImageGenerationRunner({
+    aspectRatio,
+    combinedReferenceUrls,
+    customImageHeight,
+    customImageWidth,
+    enableWebSearch,
+    hasAspectRatioField: Boolean(aspectRatioField),
+    hasEnableWebSearchField: Boolean(enableWebSearchField),
+    hasLimitGenerationsField: Boolean(limitGenerationsField),
+    hasMaskUrlField: Boolean(maskUrlField),
+    hasOutputFormatField: Boolean(outputFormatField),
+    hasQualityField: Boolean(qualityField),
+    hasSeedField: Boolean(seedField),
+    hasThinkingLevelField: Boolean(thinkingLevelField),
+    limitGenerations,
+    maskUrl,
+    mode,
+    mutateJobs,
+    numImages,
+    outputFormat,
+    prompt,
+    quality,
+    readyReferenceSizes,
+    readyReferenceUrls,
+    referenceMinRequired,
+    resolution,
+    resolvedCopy,
+    seed,
+    selectedCharacterReferences,
+    selectedEngine,
+    setAuthModalOpen,
+    setError,
+    setLocalHistory,
+    setPendingGroups,
+    setSelectedPreviewEntryId,
+    setSelectedPreviewImageIndex,
+    setStatusMessage,
+    thinkingLevel,
+  });
 
   const handleSelectGalleryGroup = useCallback(
     (group: GroupSummary) => {

--- a/frontend/app/(core)/(workspace)/app/image/_hooks/useImageGenerationRunner.ts
+++ b/frontend/app/(core)/(workspace)/app/image/_hooks/useImageGenerationRunner.ts
@@ -1,0 +1,285 @@
+'use client';
+
+import { useCallback, type Dispatch, type FormEvent, type SetStateAction } from 'react';
+import { runImageGeneration } from '@/lib/api';
+import { getDefaultAspectRatio } from '@/lib/image/inputSchema';
+import { validateGptImage2CustomImageSize } from '@/lib/image/gptImage2';
+import { readLastKnownUserId } from '@/lib/last-known';
+import { readBrowserSession } from '@/lib/supabase-auth-cleanup';
+import { hasSupabaseAuthCookie } from '@/lib/supabase-session-hint';
+import type {
+  CharacterReferenceSelection,
+  ImageGenerationMode,
+  ImageGenerationRequest,
+} from '@/types/image-generation';
+import type { GroupSummary } from '@/types/groups';
+import {
+  buildCompletedGroup,
+  buildPendingGroup,
+} from '../_lib/image-workspace-history';
+import {
+  buildCustomImageSize,
+} from '../_lib/image-workspace-utils';
+import {
+  formatTemplate,
+  type ImageWorkspaceCopy,
+} from '../_lib/image-workspace-copy';
+import type {
+  HistoryEntry,
+  ImageEngineOption,
+} from '../_lib/image-workspace-types';
+
+interface UseImageGenerationRunnerParams {
+  aspectRatio: string | null;
+  combinedReferenceUrls: string[];
+  customImageHeight: string;
+  customImageWidth: string;
+  enableWebSearch: boolean;
+  hasAspectRatioField: boolean;
+  hasEnableWebSearchField: boolean;
+  hasLimitGenerationsField: boolean;
+  hasMaskUrlField: boolean;
+  hasOutputFormatField: boolean;
+  hasQualityField: boolean;
+  hasSeedField: boolean;
+  hasThinkingLevelField: boolean;
+  limitGenerations: boolean;
+  maskUrl: string;
+  mode: ImageGenerationMode;
+  mutateJobs: () => Promise<unknown>;
+  numImages: number;
+  outputFormat: string | null;
+  prompt: string;
+  quality: string | null;
+  readyReferenceSizes: NonNullable<ImageGenerationRequest['referenceImageSizes']>;
+  readyReferenceUrls: string[];
+  referenceMinRequired: number;
+  resolution: string | null;
+  resolvedCopy: ImageWorkspaceCopy;
+  seed: string;
+  selectedCharacterReferences: CharacterReferenceSelection[];
+  selectedEngine: ImageEngineOption | undefined;
+  setAuthModalOpen: Dispatch<SetStateAction<boolean>>;
+  setError: Dispatch<SetStateAction<string | null>>;
+  setLocalHistory: Dispatch<SetStateAction<HistoryEntry[]>>;
+  setPendingGroups: Dispatch<SetStateAction<GroupSummary[]>>;
+  setSelectedPreviewEntryId: Dispatch<SetStateAction<string | null>>;
+  setSelectedPreviewImageIndex: Dispatch<SetStateAction<number>>;
+  setStatusMessage: Dispatch<SetStateAction<string | null>>;
+  thinkingLevel: string | null;
+}
+
+export function useImageGenerationRunner({
+  aspectRatio,
+  combinedReferenceUrls,
+  customImageHeight,
+  customImageWidth,
+  enableWebSearch,
+  hasAspectRatioField,
+  hasEnableWebSearchField,
+  hasLimitGenerationsField,
+  hasMaskUrlField,
+  hasOutputFormatField,
+  hasQualityField,
+  hasSeedField,
+  hasThinkingLevelField,
+  limitGenerations,
+  maskUrl,
+  mode,
+  mutateJobs,
+  numImages,
+  outputFormat,
+  prompt,
+  quality,
+  readyReferenceSizes,
+  readyReferenceUrls,
+  referenceMinRequired,
+  resolution,
+  resolvedCopy,
+  seed,
+  selectedCharacterReferences,
+  selectedEngine,
+  setAuthModalOpen,
+  setError,
+  setLocalHistory,
+  setPendingGroups,
+  setSelectedPreviewEntryId,
+  setSelectedPreviewImageIndex,
+  setStatusMessage,
+  thinkingLevel,
+}: UseImageGenerationRunnerParams) {
+  return useCallback(
+    async (event?: FormEvent<HTMLFormElement> | null) => {
+      event?.preventDefault();
+      if (!selectedEngine) return;
+      if (!readLastKnownUserId() && !hasSupabaseAuthCookie()) {
+        setAuthModalOpen(true);
+        return;
+      }
+      const session = await readBrowserSession();
+      if (!session?.access_token) {
+        setAuthModalOpen(true);
+        return;
+      }
+      const trimmedPrompt = prompt.trim();
+      if (!trimmedPrompt) {
+        setError(resolvedCopy.errors.promptMissing);
+        return;
+      }
+      if (referenceMinRequired > 0 && combinedReferenceUrls.length < referenceMinRequired) {
+        setError(resolvedCopy.errors.referenceMissing);
+        return;
+      }
+      const trimmedMaskUrl = hasMaskUrlField ? maskUrl.trim() : '';
+      if (trimmedMaskUrl && !/^https?:\/\//i.test(trimmedMaskUrl)) {
+        setError('Mask URL must be an absolute http(s) URL.');
+        return;
+      }
+      const customImageSize = resolution === 'custom' ? buildCustomImageSize(customImageWidth, customImageHeight) : null;
+      if (resolution === 'custom') {
+        const customSizeResult = validateGptImage2CustomImageSize(customImageSize);
+        if (!customSizeResult.ok) {
+          setError(customSizeResult.message);
+          return;
+        }
+      }
+      setError(null);
+      setStatusMessage(null);
+      const pendingId = `img_${crypto.randomUUID()}`;
+      const pendingCreatedAt = Date.now();
+      setPendingGroups((prev) => [
+        buildPendingGroup({
+          id: pendingId,
+          engineId: selectedEngine.id,
+          engineLabel: selectedEngine.name,
+          prompt: trimmedPrompt,
+          count: numImages,
+          createdAt: pendingCreatedAt,
+        }),
+        ...prev,
+      ]);
+      let keepActiveGroup = false;
+      try {
+        const appliedAspectRatio = hasAspectRatioField
+          ? aspectRatio ?? getDefaultAspectRatio(selectedEngine.engineCaps, mode) ?? undefined
+          : undefined;
+        const normalizedSeed = (() => {
+          const trimmed = seed.trim();
+          if (!trimmed.length) return undefined;
+          const parsed = Number(trimmed);
+          return Number.isFinite(parsed) ? Math.round(parsed) : undefined;
+        })();
+        const response = await runImageGeneration({
+          jobId: pendingId,
+          engineId: selectedEngine.id,
+          mode,
+          prompt: trimmedPrompt,
+          numImages,
+          imageUrls: mode === 'i2i' ? readyReferenceUrls : undefined,
+          referenceImageSizes: mode === 'i2i' ? readyReferenceSizes : undefined,
+          characterReferences: mode === 'i2i' ? selectedCharacterReferences : undefined,
+          aspectRatio: appliedAspectRatio,
+          resolution: resolution ?? undefined,
+          customImageSize,
+          seed: hasSeedField ? normalizedSeed : undefined,
+          outputFormat: hasOutputFormatField
+            ? ((outputFormat ?? undefined) as 'jpeg' | 'png' | 'webp' | undefined)
+            : undefined,
+          quality: hasQualityField ? ((quality ?? undefined) as 'low' | 'medium' | 'high' | undefined) : undefined,
+          maskUrl: trimmedMaskUrl || undefined,
+          enableWebSearch: hasEnableWebSearchField ? enableWebSearch : undefined,
+          thinkingLevel: hasThinkingLevelField
+            ? ((thinkingLevel ?? undefined) as 'minimal' | 'high' | undefined)
+            : undefined,
+          limitGenerations: hasLimitGenerationsField ? limitGenerations : undefined,
+        });
+        const entry: HistoryEntry = {
+          id: response.jobId ?? response.requestId ?? crypto.randomUUID(),
+          jobId: response.jobId ?? response.requestId ?? null,
+          engineId: response.engineId ?? selectedEngine.id,
+          engineLabel: response.engineLabel ?? selectedEngine.name,
+          mode,
+          prompt: trimmedPrompt,
+          createdAt: Date.now(),
+          description: response.description,
+          images: response.images,
+          aspectRatio: response.aspectRatio ?? appliedAspectRatio ?? null,
+        };
+        setLocalHistory((prev) => [entry, ...prev].slice(0, 24));
+        setSelectedPreviewEntryId(entry.id);
+        setSelectedPreviewImageIndex(0);
+        const suffix = response.images.length === 1 ? '' : 's';
+        setStatusMessage(
+          formatTemplate(resolvedCopy.messages.success, { count: response.images.length, suffix })
+        );
+        const resolvedGroupId = response.jobId ?? pendingId;
+        if (response.images.length > 0) {
+          keepActiveGroup = true;
+          setPendingGroups((prev) => [
+            buildCompletedGroup({
+              id: resolvedGroupId,
+              engineId: response.engineId ?? selectedEngine.id,
+              engineLabel: response.engineLabel ?? selectedEngine.name,
+              prompt: trimmedPrompt,
+              aspectRatio: response.aspectRatio ?? appliedAspectRatio ?? null,
+              images: response.images,
+              createdAt: pendingCreatedAt,
+              totalPriceCents: response.pricing?.totalCents ?? response.costCents ?? null,
+              currency: response.pricing?.currency ?? response.currency ?? null,
+            }),
+            ...prev.filter((group) => group.id !== pendingId && group.id !== resolvedGroupId),
+          ]);
+        }
+        void mutateJobs();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : resolvedCopy.errors.generic);
+      } finally {
+        if (!keepActiveGroup) {
+          setPendingGroups((prev) => prev.filter((group) => group.id !== pendingId));
+        }
+      }
+    },
+    [
+      aspectRatio,
+      combinedReferenceUrls,
+      customImageHeight,
+      customImageWidth,
+      enableWebSearch,
+      hasAspectRatioField,
+      hasEnableWebSearchField,
+      hasLimitGenerationsField,
+      hasMaskUrlField,
+      hasOutputFormatField,
+      hasQualityField,
+      hasSeedField,
+      hasThinkingLevelField,
+      limitGenerations,
+      maskUrl,
+      mode,
+      mutateJobs,
+      numImages,
+      outputFormat,
+      prompt,
+      quality,
+      readyReferenceSizes,
+      readyReferenceUrls,
+      referenceMinRequired,
+      resolution,
+      resolvedCopy.errors.generic,
+      resolvedCopy.errors.promptMissing,
+      resolvedCopy.errors.referenceMissing,
+      resolvedCopy.messages.success,
+      seed,
+      selectedCharacterReferences,
+      selectedEngine,
+      setAuthModalOpen,
+      setError,
+      setLocalHistory,
+      setPendingGroups,
+      setSelectedPreviewEntryId,
+      setSelectedPreviewImageIndex,
+      setStatusMessage,
+      thinkingLevel,
+    ]
+  );
+}

--- a/tests/image-workspace-split-contract.test.ts
+++ b/tests/image-workspace-split-contract.test.ts
@@ -8,6 +8,7 @@ const imageDir = path.join(root, 'frontend/app/(core)/(workspace)/app/image');
 const workspacePath = path.join(imageDir, 'ImageWorkspace.tsx');
 const composerPersistenceHookPath = path.join(imageDir, '_hooks/useImageComposerPersistence.ts');
 const queryHydrationHookPath = path.join(imageDir, '_hooks/useImageWorkspaceQueryHydration.ts');
+const generationRunnerHookPath = path.join(imageDir, '_hooks/useImageGenerationRunner.ts');
 
 const splitFiles = [
   '_components/ImageAuthGateModal.tsx',
@@ -17,6 +18,7 @@ const splitFiles = [
   '_hooks/useImageWorkspacePricing.ts',
   '_hooks/useImageWorkspaceDesktopLayout.ts',
   '_hooks/useImageWorkspaceQueryHydration.ts',
+  '_hooks/useImageGenerationRunner.ts',
   '_lib/image-workspace-character-references.ts',
   '_lib/image-workspace-copy.ts',
   '_lib/image-workspace-history.ts',
@@ -33,6 +35,7 @@ test('image workspace foundations are split from the route orchestrator', () => 
   const source = readImageWorkspace();
   const composerPersistenceHookSource = readFileSync(composerPersistenceHookPath, 'utf8');
   const queryHydrationHookSource = readFileSync(queryHydrationHookPath, 'utf8');
+  const generationRunnerHookSource = readFileSync(generationRunnerHookPath, 'utf8');
 
   for (const file of splitFiles) {
     statSync(path.join(imageDir, file));
@@ -45,8 +48,8 @@ test('image workspace foundations are split from the route orchestrator', () => 
   assert.match(source, /from '\.\/_hooks\/useImageWorkspacePricing'/);
   assert.match(source, /from '\.\/_hooks\/useImageWorkspaceDesktopLayout'/);
   assert.match(source, /from '\.\/_hooks\/useImageWorkspaceQueryHydration'/);
+  assert.match(source, /from '\.\/_hooks\/useImageGenerationRunner'/);
   assert.match(source, /from '\.\/_lib\/image-workspace-copy'/);
-  assert.match(source, /from '\.\/_lib\/image-workspace-history'/);
   assert.match(source, /from '\.\/_lib\/image-workspace-utils'/);
 
   assert.doesNotMatch(source, /const DEFAULT_COPY: ImageWorkspaceCopy =/);
@@ -65,6 +68,9 @@ test('image workspace foundations are split from the route orchestrator', () => 
   assert.doesNotMatch(source, /const requestedJobId = useMemo/, 'query job hydration belongs in useImageWorkspaceQueryHydration');
   assert.doesNotMatch(source, /const requestedEngineId = useMemo/, 'query engine hydration belongs in useImageWorkspaceQueryHydration');
   assert.doesNotMatch(source, /Job settings snapshot missing/, 'snapshot application belongs in useImageWorkspaceQueryHydration');
+  assert.doesNotMatch(source, /runImageGeneration/, 'generation submission belongs in useImageGenerationRunner');
+  assert.doesNotMatch(source, /readBrowserSession/, 'auth preflight belongs in useImageGenerationRunner');
+  assert.doesNotMatch(source, /validateGptImage2CustomImageSize/, 'custom size validation belongs in useImageGenerationRunner');
 
   assert.match(composerPersistenceHookSource, /export function useImageComposerPersistence/);
   assert.match(composerPersistenceHookSource, /parsePersistedImageComposerState/);
@@ -75,7 +81,13 @@ test('image workspace foundations are split from the route orchestrator', () => 
   assert.match(queryHydrationHookSource, /const requestedJobId = useMemo/);
   assert.match(queryHydrationHookSource, /const requestedEngineId = useMemo/);
   assert.match(queryHydrationHookSource, /applyImageSettingsSnapshot/);
+  assert.match(generationRunnerHookSource, /export function useImageGenerationRunner/);
+  assert.match(generationRunnerHookSource, /runImageGeneration/);
+  assert.match(generationRunnerHookSource, /readBrowserSession/);
+  assert.match(generationRunnerHookSource, /from '\.\.\/_lib\/image-workspace-history'/);
+  assert.match(generationRunnerHookSource, /buildPendingGroup/);
+  assert.match(generationRunnerHookSource, /buildCompletedGroup/);
 
   const lineCount = source.split('\n').length;
-  assert.ok(lineCount <= 1085, `ImageWorkspace should stay below 1085 lines after query hydration extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 950, `ImageWorkspace should stay below 950 lines after generation runner extraction, got ${lineCount}`);
 });


### PR DESCRIPTION
## Summary\n- move ImageWorkspace generation submission into a focused route-local hook\n- keep auth preflight, validation, pending group creation, API submission, and completed history insertion together\n- update the image workspace contract to prevent runner logic from drifting back into the route orchestrator\n\n## Verification\n- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/image-workspace-split-contract.test.ts tests/image-generation-atomic.test.ts\n- ./node_modules/.bin/tsc --noEmit --pretty false\n- npm --prefix frontend run lint\n- npm run lint:exposure