### PR TITLE
[codex] Split audio generation runner hook

### DIFF
--- a/frontend/app/(core)/(workspace)/app/audio/AudioWorkspace.tsx
+++ b/frontend/app/(core)/(workspace)/app/audio/AudioWorkspace.tsx
@@ -22,7 +22,6 @@ import {
 
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { authFetch } from '@/lib/authFetch';
-import { runAudioGenerate } from '@/lib/api';
 import { useI18n } from '@/lib/i18n/I18nProvider';
 import type { Job } from '@/types/jobs';
 import { Button, ButtonLink } from '@/components/ui/Button';
@@ -61,6 +60,7 @@ import AudioLatestRendersRail from './AudioLatestRendersRail';
 import { AudioGeneratedVideoPickerModal } from './_components/audio-generated-video-picker';
 import { AudioModePicker, AudioSelectControl, ToggleRow } from './_components/audio-workspace-controls';
 import { useAudioActiveJobPolling } from './_hooks/useAudioActiveJobPolling';
+import { useAudioGenerationRunner } from './_hooks/useAudioGenerationRunner';
 import { useAudioGeneratedVideos } from './_hooks/useAudioGeneratedVideos';
 import {
   AUDIO_VOICE_GENDER_VALUES,
@@ -541,84 +541,40 @@ export default function AudioWorkspace() {
     }
   }, []);
 
-  const handleGenerate = useCallback(async () => {
-    if (!canGenerate) return;
-    setIsGenerating(true);
-    setNotice(null);
-    try {
-      const response = await runAudioGenerate({
-        sourceVideoUrl: sourceVideo?.url ?? undefined,
-        sourceJobId: sourceVideo?.jobId ?? undefined,
-        pack,
-        prompt: !showVoiceFields ? prompt.trim() : undefined,
-        mood: showMood ? mood : undefined,
-        intensity: showIntensity ? intensity : undefined,
-        script: packConfig.requiresScript ? script.trim() : undefined,
-        voiceSampleUrl: showVoiceFields ? voiceSample?.url : undefined,
-        voiceGender: showVoiceFields ? voiceGender : undefined,
-        voiceProfile: showVoiceFields ? voiceProfile : undefined,
-        voiceDelivery: showVoiceFields ? voiceDelivery : undefined,
-        language: showVoiceFields ? language : undefined,
-        durationSec: pack === 'music_only' && !sourceVideo?.url ? manualDurationSec : undefined,
-        musicEnabled: showMusicToggle ? musicEnabled : undefined,
-        exportAudioFile: showExportToggle ? exportAudioFile : undefined,
-        locale,
-      });
-      const nextResult: AudioResultState = {
-        jobId: response.jobId,
-        videoUrl: response.videoUrl,
-        audioUrl: response.audioUrl ?? null,
-        thumbUrl: response.thumbUrl,
-        outputKind: response.outputKind,
-      };
-      setResult(nextResult);
-      setActiveJob({
-        jobId: response.jobId,
-        status: response.status,
-        progress: response.progress,
-        message: copy.messages.processing.complete,
-        videoUrl: response.videoUrl,
-        audioUrl: response.audioUrl ?? null,
-        thumbUrl: response.thumbUrl,
-        outputKind: response.outputKind,
-      });
-      router.replace(`${pathname}?job=${encodeURIComponent(response.jobId)}`, { scroll: false });
-      setNotice(copy.messages.renderComplete);
-    } catch (error) {
-      setNotice(resolveUiErrorMessage(error, copy.messages.generationFailed));
-    } finally {
-      setIsGenerating(false);
-    }
-  }, [
+  const handleGeneratedJobId = useCallback((jobId: string) => {
+    router.replace(`${pathname}?job=${encodeURIComponent(jobId)}`, { scroll: false });
+  }, [pathname, router]);
+
+  const handleGenerate = useAudioGenerationRunner({
     canGenerate,
+    copy,
     exportAudioFile,
     intensity,
     language,
+    locale,
     manualDurationSec,
     mood,
     musicEnabled,
+    onGeneratedJobId: handleGeneratedJobId,
     pack,
-    packConfig.requiresScript,
     prompt,
-    pathname,
-    router,
+    requiresScript: packConfig.requiresScript,
     script,
+    setActiveJob,
+    setIsGenerating,
+    setNotice,
+    setResult,
     showExportToggle,
     showIntensity,
     showMood,
     showMusicToggle,
     showVoiceFields,
-    sourceVideo?.jobId,
-    sourceVideo?.url,
-    copy.messages.generationFailed,
-    copy.messages.processing.complete,
-    copy.messages.renderComplete,
+    sourceVideo,
     voiceDelivery,
     voiceGender,
     voiceProfile,
-    voiceSample?.url,
-    locale,
-  ]);
+    voiceSample,
+  });
 
   const handleSelectLatestJob = useCallback(
     (jobId: string) => {

--- a/frontend/app/(core)/(workspace)/app/audio/_hooks/useAudioGenerationRunner.ts
+++ b/frontend/app/(core)/(workspace)/app/audio/_hooks/useAudioGenerationRunner.ts
@@ -1,0 +1,164 @@
+'use client';
+
+import { useCallback, type Dispatch, type SetStateAction } from 'react';
+import { runAudioGenerate } from '@/lib/api';
+import type {
+  AudioIntensity,
+  AudioLanguage,
+  AudioMood,
+  AudioPackId,
+  AudioVoiceDelivery,
+  AudioVoiceGender,
+  AudioVoiceProfile,
+} from '@/lib/audio-generation';
+import { resolveUiErrorMessage } from '../_lib/audio-workspace-helpers';
+import type {
+  ActiveAudioJobState,
+  AudioResultState,
+  SourceVideoState,
+} from '../_lib/audio-workspace-types';
+import type { AudioWorkspaceCopy } from '../copy';
+
+interface UseAudioGenerationRunnerParams {
+  canGenerate: boolean;
+  copy: AudioWorkspaceCopy;
+  exportAudioFile: boolean;
+  intensity: AudioIntensity;
+  language: AudioLanguage;
+  locale: string;
+  manualDurationSec: number;
+  mood: AudioMood;
+  musicEnabled: boolean;
+  onGeneratedJobId: (jobId: string) => void;
+  pack: AudioPackId;
+  prompt: string;
+  requiresScript: boolean;
+  script: string;
+  setActiveJob: Dispatch<SetStateAction<ActiveAudioJobState | null>>;
+  setIsGenerating: Dispatch<SetStateAction<boolean>>;
+  setNotice: Dispatch<SetStateAction<string | null>>;
+  setResult: Dispatch<SetStateAction<AudioResultState | null>>;
+  showExportToggle: boolean;
+  showIntensity: boolean;
+  showMood: boolean;
+  showMusicToggle: boolean;
+  showVoiceFields: boolean;
+  sourceVideo: SourceVideoState | null;
+  voiceDelivery: AudioVoiceDelivery;
+  voiceGender: AudioVoiceGender;
+  voiceProfile: AudioVoiceProfile;
+  voiceSample: { url: string; name: string } | null;
+}
+
+export function useAudioGenerationRunner({
+  canGenerate,
+  copy,
+  exportAudioFile,
+  intensity,
+  language,
+  locale,
+  manualDurationSec,
+  mood,
+  musicEnabled,
+  onGeneratedJobId,
+  pack,
+  prompt,
+  requiresScript,
+  script,
+  setActiveJob,
+  setIsGenerating,
+  setNotice,
+  setResult,
+  showExportToggle,
+  showIntensity,
+  showMood,
+  showMusicToggle,
+  showVoiceFields,
+  sourceVideo,
+  voiceDelivery,
+  voiceGender,
+  voiceProfile,
+  voiceSample,
+}: UseAudioGenerationRunnerParams) {
+  return useCallback(async () => {
+    if (!canGenerate) return;
+    setIsGenerating(true);
+    setNotice(null);
+    try {
+      const response = await runAudioGenerate({
+        sourceVideoUrl: sourceVideo?.url ?? undefined,
+        sourceJobId: sourceVideo?.jobId ?? undefined,
+        pack,
+        prompt: !showVoiceFields ? prompt.trim() : undefined,
+        mood: showMood ? mood : undefined,
+        intensity: showIntensity ? intensity : undefined,
+        script: requiresScript ? script.trim() : undefined,
+        voiceSampleUrl: showVoiceFields ? voiceSample?.url : undefined,
+        voiceGender: showVoiceFields ? voiceGender : undefined,
+        voiceProfile: showVoiceFields ? voiceProfile : undefined,
+        voiceDelivery: showVoiceFields ? voiceDelivery : undefined,
+        language: showVoiceFields ? language : undefined,
+        durationSec: pack === 'music_only' && !sourceVideo?.url ? manualDurationSec : undefined,
+        musicEnabled: showMusicToggle ? musicEnabled : undefined,
+        exportAudioFile: showExportToggle ? exportAudioFile : undefined,
+        locale,
+      });
+      const nextResult: AudioResultState = {
+        jobId: response.jobId,
+        videoUrl: response.videoUrl,
+        audioUrl: response.audioUrl ?? null,
+        thumbUrl: response.thumbUrl,
+        outputKind: response.outputKind,
+      };
+      setResult(nextResult);
+      setActiveJob({
+        jobId: response.jobId,
+        status: response.status,
+        progress: response.progress,
+        message: copy.messages.processing.complete,
+        videoUrl: response.videoUrl,
+        audioUrl: response.audioUrl ?? null,
+        thumbUrl: response.thumbUrl,
+        outputKind: response.outputKind,
+      });
+      onGeneratedJobId(response.jobId);
+      setNotice(copy.messages.renderComplete);
+    } catch (error) {
+      setNotice(resolveUiErrorMessage(error, copy.messages.generationFailed));
+    } finally {
+      setIsGenerating(false);
+    }
+  }, [
+    canGenerate,
+    copy.messages.generationFailed,
+    copy.messages.processing.complete,
+    copy.messages.renderComplete,
+    exportAudioFile,
+    intensity,
+    language,
+    locale,
+    manualDurationSec,
+    mood,
+    musicEnabled,
+    onGeneratedJobId,
+    pack,
+    prompt,
+    requiresScript,
+    script,
+    setActiveJob,
+    setIsGenerating,
+    setNotice,
+    setResult,
+    showExportToggle,
+    showIntensity,
+    showMood,
+    showMusicToggle,
+    showVoiceFields,
+    sourceVideo?.jobId,
+    sourceVideo?.url,
+    voiceDelivery,
+    voiceGender,
+    voiceProfile,
+    voiceSample?.url,
+  ]);
+}

--- a/tests/audio-workspace-architecture.test.ts
+++ b/tests/audio-workspace-architecture.test.ts
@@ -12,6 +12,7 @@ const helpersPath = join(audioDir, '_lib/audio-workspace-helpers.ts');
 const typesPath = join(audioDir, '_lib/audio-workspace-types.ts');
 const activeJobHookPath = join(audioDir, '_hooks/useAudioActiveJobPolling.ts');
 const generatedVideosHookPath = join(audioDir, '_hooks/useAudioGeneratedVideos.ts');
+const generationRunnerHookPath = join(audioDir, '_hooks/useAudioGenerationRunner.ts');
 
 const workspaceSource = readFileSync(workspacePath, 'utf8');
 
@@ -22,11 +23,13 @@ test('audio workspace delegates local controls, helpers, and contracts', () => {
   assert.ok(existsSync(typesPath), 'audio local contracts should live in a route-local type module');
   assert.ok(existsSync(activeJobHookPath), 'active audio job polling should live in a route-local hook');
   assert.ok(existsSync(generatedVideosHookPath), 'generated video loading should live in a route-local hook');
+  assert.ok(existsSync(generationRunnerHookPath), 'audio generation runner should live in a route-local hook');
 
   assert.match(workspaceSource, /from '\.\/_components\/audio-workspace-controls'/);
   assert.match(workspaceSource, /from '\.\/_components\/audio-generated-video-picker'/);
   assert.match(workspaceSource, /from '\.\/_hooks\/useAudioActiveJobPolling'/);
   assert.match(workspaceSource, /from '\.\/_hooks\/useAudioGeneratedVideos'/);
+  assert.match(workspaceSource, /from '\.\/_hooks\/useAudioGenerationRunner'/);
   assert.match(workspaceSource, /from '\.\/_lib\/audio-workspace-helpers'/);
   assert.match(workspaceSource, /from '\.\/_lib\/audio-workspace-types'/);
 });
@@ -43,9 +46,11 @@ test('audio workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /copy\.picker\.audioBadge/, 'generated video picker card UI belongs in _components/audio-generated-video-picker.tsx');
   assert.doesNotMatch(workspaceSource, /getJobStatus/, 'active job polling belongs in useAudioActiveJobPolling');
   assert.doesNotMatch(workspaceSource, /surface=video&limit=60/, 'generated video loading belongs in useAudioGeneratedVideos');
+  assert.doesNotMatch(workspaceSource, /runAudioGenerate/, 'audio generation submission belongs in useAudioGenerationRunner');
+  assert.doesNotMatch(workspaceSource, /resolveUiErrorMessage\(error, copy\.messages\.generationFailed/, 'generation failure mapping belongs in useAudioGenerationRunner');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 1075, `AudioWorkspace should stay below 1075 lines after runtime hook extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 1030, `AudioWorkspace should stay below 1030 lines after generation runner extraction, got ${lineCount}`);
 });
 
 test('audio helper modules expose the expected workspace contract', () => {
@@ -55,6 +60,7 @@ test('audio helper modules expose the expected workspace contract', () => {
   const typesSource = readFileSync(typesPath, 'utf8');
   const activeJobHookSource = readFileSync(activeJobHookPath, 'utf8');
   const generatedVideosHookSource = readFileSync(generatedVideosHookPath, 'utf8');
+  const generationRunnerHookSource = readFileSync(generationRunnerHookPath, 'utf8');
 
   for (const exportName of [
     'AudioModePicker',
@@ -73,6 +79,9 @@ test('audio helper modules expose the expected workspace contract', () => {
   assert.match(activeJobHookSource, /getJobStatus/, 'active job polling hook should poll job status');
   assert.match(generatedVideosHookSource, /export function useAudioGeneratedVideos/, 'generated videos hook should be exported');
   assert.match(generatedVideosHookSource, /surface=video&limit=60/, 'generated videos hook should load video jobs');
+  assert.match(generationRunnerHookSource, /export function useAudioGenerationRunner/, 'generation runner hook should be exported');
+  assert.match(generationRunnerHookSource, /runAudioGenerate/, 'generation runner hook should submit generation requests');
+  assert.match(generationRunnerHookSource, /resolveUiErrorMessage/, 'generation runner hook should map generation failures');
 
   for (const exportName of [
     'DEFAULT_PACK',


### PR DESCRIPTION
## Summary\n- move AudioWorkspace generation submission into a focused route-local hook\n- keep runAudioGenerate, active job/result updates, URL replacement callback, and generation failure mapping out of the route component\n- extend the audio workspace architecture contract for the new runner hook\n\n## Verification\n- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/audio-workspace-architecture.test.ts tests/audio-generate-validation.test.ts\n- ./node_modules/.bin/tsc --noEmit --pretty false\n- npm --prefix frontend run lint\n- npm run lint:exposure