### PR TITLE
[codex] Split angle generation runner hook

### DIFF
--- a/frontend/src/components/tools/AngleWorkspace.tsx
+++ b/frontend/src/components/tools/AngleWorkspace.tsx
@@ -22,7 +22,7 @@ import { HeaderBar } from '@/components/HeaderBar';
 import { AppSidebar } from '@/components/AppSidebar';
 import { Button, ButtonLink } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
-import { runAngleTool, saveImageToLibrary, useInfiniteJobs } from '@/lib/api';
+import { saveImageToLibrary, useInfiniteJobs } from '@/lib/api';
 import { authFetch } from '@/lib/authFetch';
 import { suggestDownloadFilename, triggerAppDownload } from '@/lib/download';
 import { useI18n } from '@/lib/i18n/I18nProvider';
@@ -33,6 +33,7 @@ import type { AngleToolEngineId, AngleToolNumericParams, AngleToolResponse } fro
 import { AngleImageLibraryModal } from './angle/_components/angle-image-library-modal';
 import { AngleOrbitSelector } from './angle/_components/angle-orbit-selector';
 import { AngleOutputMosaic } from './angle/_components/angle-output-mosaic';
+import { useAngleGenerationRunner } from './angle/_hooks/useAngleGenerationRunner';
 import { DEFAULT_ANGLE_COPY, type AngleCopy } from './angle/_lib/angle-workspace-copy';
 import {
   ANGLE_GUEST_EXAMPLE_OUTPUT_URL,
@@ -41,7 +42,6 @@ import {
   cleanupSourcePreview,
   collectAnglePreviewImages,
   DEFAULT_ENGINE_ID,
-  emitClientMetric,
   ENGINES,
   formatUsdCompact,
   getAngleBillingProductKey,
@@ -394,70 +394,21 @@ export default function AngleToolPage() {
     setLibraryModalOpen(false);
   };
 
-  const handleGenerate = async () => {
-    if (!user) {
-      openAuthGate();
-      return;
-    }
-    if (!sourceImage?.url) {
-      setError(copy.missingSource);
-      return;
-    }
-
-    setGenerating(true);
-    setError(null);
-
-    emitClientMetric('tool_start', {
-      tool_name: 'angle',
-      tool_surface: 'workspace',
-      logged_in: true,
-      engine: engineId,
-      generate_best_angles: generateBestAngles,
-      rotation: params.rotation,
-      tilt: params.tilt,
-      zoom: params.zoom,
-    });
-
-    try {
-      const normalizedParams = sanitizeParams(params);
-      const resolvedEngineId = resolveAngleEngineForParams(engineId, normalizedParams);
-      setParams(normalizedParams);
-      const response = await runAngleTool({
-        imageUrl: sourceImage.url,
-        engineId: resolvedEngineId,
-        params: normalizedParams,
-        safeMode,
-        generateBestAngles,
-        imageWidth: sourceImage.width ?? undefined,
-        imageHeight: sourceImage.height ?? undefined,
-      });
-
-      setResult(response);
-      setSelectedOutputIndex(0);
-
-      emitClientMetric('tool_complete', {
-        tool_name: 'angle',
-        tool_surface: 'workspace',
-        logged_in: true,
-        engine: response.engineId,
-        latency_ms: response.latencyMs,
-        estimated_cost_usd: response.pricing.estimatedCostUsd,
-        actual_cost_usd: response.pricing.actualCostUsd ?? null,
-        estimated_credits: response.pricing.estimatedCredits,
-        actual_credits: response.pricing.actualCredits ?? null,
-        generate_best_angles: generateBestAngles,
-        output_count: response.requestedOutputCount,
-      });
-    } catch (runError) {
-      if (isAuthRequiredError(runError)) {
-        openAuthGate();
-        return;
-      }
-      setError(runError instanceof Error ? runError.message : copy.generationFailed);
-    } finally {
-      setGenerating(false);
-    }
-  };
+  const handleGenerate = useAngleGenerationRunner({
+    copy,
+    engineId,
+    generateBestAngles,
+    openAuthGate,
+    params,
+    safeMode,
+    setError,
+    setGenerating,
+    setParams,
+    setResult,
+    setSelectedOutputIndex,
+    sourceImage,
+    user,
+  });
 
   const handleAddOutputToLibrary = async (url: string, jobId?: string | null) => {
     if (!user) {

--- a/frontend/src/components/tools/angle/_hooks/useAngleGenerationRunner.ts
+++ b/frontend/src/components/tools/angle/_hooks/useAngleGenerationRunner.ts
@@ -1,0 +1,125 @@
+import { useCallback, type Dispatch, type SetStateAction } from 'react';
+import { runAngleTool } from '@/lib/api';
+import { resolveAngleEngineForParams } from '@/lib/tools-angle';
+import type { AngleToolEngineId, AngleToolNumericParams, AngleToolResponse } from '@/types/tools-angle';
+import type { AngleCopy } from '../_lib/angle-workspace-copy';
+import {
+  emitClientMetric,
+  isAuthRequiredError,
+  sanitizeParams,
+} from '../_lib/angle-workspace-helpers';
+import type { UploadedImage } from '../_lib/angle-workspace-types';
+
+interface UseAngleGenerationRunnerParams {
+  copy: AngleCopy;
+  engineId: AngleToolEngineId;
+  generateBestAngles: boolean;
+  openAuthGate: () => void;
+  params: AngleToolNumericParams;
+  safeMode: boolean;
+  setError: Dispatch<SetStateAction<string | null>>;
+  setGenerating: Dispatch<SetStateAction<boolean>>;
+  setParams: Dispatch<SetStateAction<AngleToolNumericParams>>;
+  setResult: Dispatch<SetStateAction<AngleToolResponse | null>>;
+  setSelectedOutputIndex: Dispatch<SetStateAction<number>>;
+  sourceImage: UploadedImage | null;
+  user: unknown;
+}
+
+export function useAngleGenerationRunner({
+  copy,
+  engineId,
+  generateBestAngles,
+  openAuthGate,
+  params,
+  safeMode,
+  setError,
+  setGenerating,
+  setParams,
+  setResult,
+  setSelectedOutputIndex,
+  sourceImage,
+  user,
+}: UseAngleGenerationRunnerParams) {
+  return useCallback(async () => {
+    if (!user) {
+      openAuthGate();
+      return;
+    }
+    if (!sourceImage?.url) {
+      setError(copy.missingSource);
+      return;
+    }
+
+    setGenerating(true);
+    setError(null);
+
+    emitClientMetric('tool_start', {
+      tool_name: 'angle',
+      tool_surface: 'workspace',
+      logged_in: true,
+      engine: engineId,
+      generate_best_angles: generateBestAngles,
+      rotation: params.rotation,
+      tilt: params.tilt,
+      zoom: params.zoom,
+    });
+
+    try {
+      const normalizedParams = sanitizeParams(params);
+      const resolvedEngineId = resolveAngleEngineForParams(engineId, normalizedParams);
+      setParams(normalizedParams);
+      const response = await runAngleTool({
+        imageUrl: sourceImage.url,
+        engineId: resolvedEngineId,
+        params: normalizedParams,
+        safeMode,
+        generateBestAngles,
+        imageWidth: sourceImage.width ?? undefined,
+        imageHeight: sourceImage.height ?? undefined,
+      });
+
+      setResult(response);
+      setSelectedOutputIndex(0);
+
+      emitClientMetric('tool_complete', {
+        tool_name: 'angle',
+        tool_surface: 'workspace',
+        logged_in: true,
+        engine: response.engineId,
+        latency_ms: response.latencyMs,
+        estimated_cost_usd: response.pricing.estimatedCostUsd,
+        actual_cost_usd: response.pricing.actualCostUsd ?? null,
+        estimated_credits: response.pricing.estimatedCredits,
+        actual_credits: response.pricing.actualCredits ?? null,
+        generate_best_angles: generateBestAngles,
+        output_count: response.requestedOutputCount,
+      });
+    } catch (runError) {
+      if (isAuthRequiredError(runError)) {
+        openAuthGate();
+        return;
+      }
+      setError(runError instanceof Error ? runError.message : copy.generationFailed);
+    } finally {
+      setGenerating(false);
+    }
+  }, [
+    copy.generationFailed,
+    copy.missingSource,
+    engineId,
+    generateBestAngles,
+    openAuthGate,
+    params,
+    safeMode,
+    setError,
+    setGenerating,
+    setParams,
+    setResult,
+    setSelectedOutputIndex,
+    sourceImage?.height,
+    sourceImage?.url,
+    sourceImage?.width,
+    user,
+  ]);
+}

--- a/tests/angle-workspace-architecture.test.ts
+++ b/tests/angle-workspace-architecture.test.ts
@@ -9,6 +9,7 @@ const componentsDir = join(root, 'frontend/src/components/tools/angle/_component
 const libraryModalPath = join(componentsDir, 'angle-image-library-modal.tsx');
 const orbitSelectorPath = join(componentsDir, 'angle-orbit-selector.tsx');
 const outputMosaicPath = join(componentsDir, 'angle-output-mosaic.tsx');
+const generationRunnerHookPath = join(root, 'frontend/src/components/tools/angle/_hooks/useAngleGenerationRunner.ts');
 const copyPath = join(root, 'frontend/src/components/tools/angle/_lib/angle-workspace-copy.ts');
 const typesPath = join(root, 'frontend/src/components/tools/angle/_lib/angle-workspace-types.ts');
 const helpersPath = join(root, 'frontend/src/components/tools/angle/_lib/angle-workspace-helpers.ts');
@@ -19,6 +20,7 @@ test('angle workspace delegates copy, local types, and helper logic', () => {
   assert.ok(existsSync(libraryModalPath), 'angle library modal should live in a colocated component module');
   assert.ok(existsSync(orbitSelectorPath), 'angle orbit selector should live in a colocated component module');
   assert.ok(existsSync(outputMosaicPath), 'angle output mosaic should live in a colocated component module');
+  assert.ok(existsSync(generationRunnerHookPath), 'angle generation runner should live in a colocated hook');
   assert.ok(existsSync(copyPath), 'angle workspace copy should live in a route-local copy module');
   assert.ok(existsSync(typesPath), 'angle workspace local contracts should live in a route-local type module');
   assert.ok(existsSync(helpersPath), 'angle workspace helper logic should live in a route-local helper module');
@@ -26,6 +28,7 @@ test('angle workspace delegates copy, local types, and helper logic', () => {
   assert.match(workspaceSource, /from '\.\/angle\/_components\/angle-image-library-modal'/, 'workspace should import angle library modal');
   assert.match(workspaceSource, /from '\.\/angle\/_components\/angle-orbit-selector'/, 'workspace should import angle orbit selector');
   assert.match(workspaceSource, /from '\.\/angle\/_components\/angle-output-mosaic'/, 'workspace should import angle output mosaic');
+  assert.match(workspaceSource, /from '\.\/angle\/_hooks\/useAngleGenerationRunner'/, 'workspace should import angle generation runner');
   assert.match(workspaceSource, /from '\.\/angle\/_lib\/angle-workspace-copy'/, 'workspace should import angle copy');
   assert.match(workspaceSource, /from '\.\/angle\/_lib\/angle-workspace-types'/, 'workspace should import angle local types');
   assert.match(workspaceSource, /from '\.\/angle\/_lib\/angle-workspace-helpers'/, 'workspace should import angle helpers');
@@ -41,15 +44,18 @@ test('angle workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /function AngleOrbitSelector\(/, 'orbit selector JSX belongs in _components/angle-orbit-selector.tsx');
   assert.doesNotMatch(workspaceSource, /function AngleOutputMosaic\(/, 'output mosaic JSX belongs in _components/angle-output-mosaic.tsx');
   assert.doesNotMatch(workspaceSource, /import dynamic from 'next\/dynamic'/, 'orbit canvas dynamic import belongs in angle orbit selector component');
+  assert.doesNotMatch(workspaceSource, /runAngleTool/, 'angle generation submission belongs in useAngleGenerationRunner');
+  assert.doesNotMatch(workspaceSource, /emitClientMetric\('tool_start'/, 'generation analytics belongs in useAngleGenerationRunner');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 1100, `AngleWorkspace should stay below 1100 lines after UI extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 1020, `AngleWorkspace should stay below 1020 lines after generation runner extraction, got ${lineCount}`);
 });
 
 test('angle helper modules expose the expected workspace contract', () => {
   const libraryModalSource = readFileSync(libraryModalPath, 'utf8');
   const orbitSelectorSource = readFileSync(orbitSelectorPath, 'utf8');
   const outputMosaicSource = readFileSync(outputMosaicPath, 'utf8');
+  const generationRunnerHookSource = readFileSync(generationRunnerHookPath, 'utf8');
   const copySource = readFileSync(copyPath, 'utf8');
   const typesSource = readFileSync(typesPath, 'utf8');
   const helpersSource = readFileSync(helpersPath, 'utf8');
@@ -58,6 +64,9 @@ test('angle helper modules expose the expected workspace contract', () => {
   assert.match(orbitSelectorSource, /export function AngleOrbitSelector/, 'orbit selector module should export AngleOrbitSelector');
   assert.match(orbitSelectorSource, /dynamic\(\(\) => import\('@\/components\/tools\/AngleOrbitCanvas'\)/, 'orbit selector should own the dynamic canvas import');
   assert.match(outputMosaicSource, /export function AngleOutputMosaic/, 'output mosaic module should export AngleOutputMosaic');
+  assert.match(generationRunnerHookSource, /export function useAngleGenerationRunner/, 'generation runner hook should be exported');
+  assert.match(generationRunnerHookSource, /runAngleTool/, 'generation runner hook should submit angle requests');
+  assert.match(generationRunnerHookSource, /emitClientMetric\('tool_start'/, 'generation runner hook should own generation analytics');
 
   assert.match(copySource, /export const DEFAULT_ANGLE_COPY =/, 'copy module should export default copy');
   assert.match(copySource, /export type AngleCopy =/, 'copy module should export the copy type');


### PR DESCRIPTION
## Summary\n- move AngleWorkspace generation submission into a focused colocated hook\n- keep runAngleTool, parameter sanitation, auth-required handling, and generation analytics out of the page-level component\n- extend the Angle workspace architecture contract for the runner hook\n\n## Verification\n- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/angle-workspace-architecture.test.ts tests/angle-atomic.test.ts\n- ./node_modules/.bin/tsc --noEmit --pretty false\n- npm --prefix frontend run lint\n- npm run lint:exposure