### PR TITLE
[codex] Split character builder reference assets hook

### DIFF
--- a/frontend/src/components/tools/CharacterBuilderWorkspace.tsx
+++ b/frontend/src/components/tools/CharacterBuilderWorkspace.tsx
@@ -65,9 +65,9 @@ import { useCharacterBuilderGenerationRunner } from './character-builder/_hooks/
 import { useCharacterBuilderOptions } from './character-builder/_hooks/useCharacterBuilderOptions';
 import { useCharacterBuilderPersistence } from './character-builder/_hooks/useCharacterBuilderPersistence';
 import { useCharacterBuilderPendingRunsSync } from './character-builder/_hooks/useCharacterBuilderPendingRunsSync';
+import { useCharacterBuilderReferenceAssets } from './character-builder/_hooks/useCharacterBuilderReferenceAssets';
 import { DEFAULT_CHARACTER_COPY, type CharacterCopy } from './character-builder/_lib/character-builder-copy';
 import {
-  buildReferenceImage,
   buildResetCharacterBuilderState,
   countConfiguredSecondaryControls,
   findChoiceLabel,
@@ -87,12 +87,9 @@ import {
   removeReferenceImage,
   serializeResettableCharacterBuilderState,
   summarizeCustomText,
-  updateReferenceImage,
-  uploadImage,
 } from './character-builder/_lib/character-builder-helpers';
 import type {
   BillingProductResponse,
-  CharacterLibraryAsset,
   HistoricalCharacterGalleryItem,
   LoadingRequestCounts,
   LoadingRequestKey,
@@ -201,6 +198,20 @@ export default function CharacterBuilderPage() {
     setState,
     setStatusMessage,
     state,
+    user,
+  });
+  const {
+    handleLibrarySelect,
+    triggerUpload,
+  } = useCharacterBuilderReferenceAssets({
+    copy,
+    libraryModalRole,
+    openAuthGate,
+    setError,
+    setLibraryModalRole,
+    setShowStyleReferenceSlot,
+    setState,
+    setStatusMessage,
     user,
   });
   const hasCompletedResults = flattenedResults.length > 0;
@@ -370,83 +381,6 @@ export default function CharacterBuilderPage() {
     setError(null);
     setStatusMessage(copy.resetDone);
   }, [copy.resetDone, resetState]);
-
-  async function handleUpload(role: CharacterBuilderReferenceImage['role'], file: File) {
-    if (!user) {
-      openAuthGate();
-      return;
-    }
-    setError(null);
-    setStatusMessage(role === 'identity' ? copy.uploadIdentityStart : copy.uploadStyleStart);
-
-    try {
-      const asset = await uploadImage(file, copy);
-      const nextImage = buildReferenceImage(role, asset);
-      if (role === 'style') {
-        setShowStyleReferenceSlot(true);
-      }
-      setState((previous) => ({
-        ...previous,
-        sourceMode: role === 'identity' ? 'reference-image' : previous.sourceMode,
-        referenceStrength:
-          role === 'identity'
-            ? previous.referenceStrength ?? 'balanced'
-            : previous.referenceStrength,
-        referenceImages: updateReferenceImage(previous.referenceImages, nextImage),
-        traits: role === 'identity' ? normalizeTraitsForSourceMode(previous.traits, 'reference-image') : previous.traits,
-      }));
-      setStatusMessage(role === 'identity' ? copy.uploadIdentityDone : copy.uploadStyleDone);
-    } catch (uploadError) {
-      if (isAuthRequiredError(uploadError)) {
-        openAuthGate();
-        return;
-      }
-      setError(uploadError instanceof Error ? uploadError.message : copy.uploadFailed);
-      setStatusMessage(null);
-    }
-  }
-
-  async function triggerUpload(role: CharacterBuilderReferenceImage['role'], fileList: FileList | null) {
-    const file = fileList?.[0];
-    if (!file) return;
-    await handleUpload(role, file);
-  }
-
-  function handleLibrarySelect(asset: CharacterLibraryAsset) {
-    if (!user) {
-      openAuthGate();
-      return;
-    }
-    const role = libraryModalRole;
-    if (!role) return;
-
-    const nextImage: CharacterBuilderReferenceImage = {
-      id: asset.id,
-      url: asset.url,
-      role,
-      width: asset.width ?? null,
-      height: asset.height ?? null,
-      name: null,
-    };
-
-    if (role === 'style') {
-      setShowStyleReferenceSlot(true);
-    }
-
-    setState((previous) => ({
-      ...previous,
-      sourceMode: role === 'identity' ? 'reference-image' : previous.sourceMode,
-      referenceStrength:
-        role === 'identity'
-          ? previous.referenceStrength ?? 'balanced'
-          : previous.referenceStrength,
-      referenceImages: updateReferenceImage(previous.referenceImages, nextImage),
-      traits: role === 'identity' ? normalizeTraitsForSourceMode(previous.traits, 'reference-image') : previous.traits,
-    }));
-    setLibraryModalRole(null);
-    setStatusMessage(role === 'identity' ? copy.uploadIdentityDone : copy.uploadStyleDone);
-    setError(null);
-  }
 
   function addMustRemainTag() {
     const tag = normalizeTag(mustRemainDraft);

--- a/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderReferenceAssets.ts
+++ b/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderReferenceAssets.ts
@@ -1,0 +1,137 @@
+import { useCallback, type Dispatch, type SetStateAction } from 'react';
+import { normalizeTraitsForSourceMode } from '@/lib/character-builder';
+import type {
+  CharacterBuilderReferenceImage,
+  CharacterBuilderState,
+} from '@/types/character-builder';
+import {
+  buildReferenceImage,
+  isAuthRequiredError,
+  updateReferenceImage,
+  uploadImage,
+} from '../_lib/character-builder-helpers';
+import type { CharacterCopy } from '../_lib/character-builder-copy';
+import type { CharacterLibraryAsset } from '../_lib/character-builder-types';
+
+interface UseCharacterBuilderReferenceAssetsOptions {
+  copy: CharacterCopy;
+  libraryModalRole: CharacterBuilderReferenceImage['role'] | null;
+  openAuthGate: () => void;
+  setError: Dispatch<SetStateAction<string | null>>;
+  setLibraryModalRole: Dispatch<SetStateAction<CharacterBuilderReferenceImage['role'] | null>>;
+  setShowStyleReferenceSlot: Dispatch<SetStateAction<boolean>>;
+  setState: Dispatch<SetStateAction<CharacterBuilderState>>;
+  setStatusMessage: Dispatch<SetStateAction<string | null>>;
+  user: unknown;
+}
+
+export function useCharacterBuilderReferenceAssets({
+  copy,
+  libraryModalRole,
+  openAuthGate,
+  setError,
+  setLibraryModalRole,
+  setShowStyleReferenceSlot,
+  setState,
+  setStatusMessage,
+  user,
+}: UseCharacterBuilderReferenceAssetsOptions) {
+  const applyReferenceImage = useCallback(
+    (role: CharacterBuilderReferenceImage['role'], nextImage: CharacterBuilderReferenceImage) => {
+      if (role === 'style') {
+        setShowStyleReferenceSlot(true);
+      }
+      setState((previous) => ({
+        ...previous,
+        sourceMode: role === 'identity' ? 'reference-image' : previous.sourceMode,
+        referenceStrength:
+          role === 'identity'
+            ? previous.referenceStrength ?? 'balanced'
+            : previous.referenceStrength,
+        referenceImages: updateReferenceImage(previous.referenceImages, nextImage),
+        traits: role === 'identity' ? normalizeTraitsForSourceMode(previous.traits, 'reference-image') : previous.traits,
+      }));
+    },
+    [setShowStyleReferenceSlot, setState]
+  );
+
+  const handleUpload = useCallback(
+    async (role: CharacterBuilderReferenceImage['role'], file: File) => {
+      if (!user) {
+        openAuthGate();
+        return;
+      }
+      setError(null);
+      setStatusMessage(role === 'identity' ? copy.uploadIdentityStart : copy.uploadStyleStart);
+
+      try {
+        const asset = await uploadImage(file, copy);
+        applyReferenceImage(role, buildReferenceImage(role, asset));
+        setStatusMessage(role === 'identity' ? copy.uploadIdentityDone : copy.uploadStyleDone);
+      } catch (uploadError) {
+        if (isAuthRequiredError(uploadError)) {
+          openAuthGate();
+          return;
+        }
+        setError(uploadError instanceof Error ? uploadError.message : copy.uploadFailed);
+        setStatusMessage(null);
+      }
+    },
+    [
+      applyReferenceImage,
+      copy,
+      openAuthGate,
+      setError,
+      setStatusMessage,
+      user,
+    ]
+  );
+
+  const triggerUpload = useCallback(
+    async (role: CharacterBuilderReferenceImage['role'], fileList: FileList | null) => {
+      const file = fileList?.[0];
+      if (!file) return;
+      await handleUpload(role, file);
+    },
+    [handleUpload]
+  );
+
+  const handleLibrarySelect = useCallback(
+    (asset: CharacterLibraryAsset) => {
+      if (!user) {
+        openAuthGate();
+        return;
+      }
+      const role = libraryModalRole;
+      if (!role) return;
+
+      applyReferenceImage(role, {
+        id: asset.id,
+        url: asset.url,
+        role,
+        width: asset.width ?? null,
+        height: asset.height ?? null,
+        name: null,
+      });
+      setLibraryModalRole(null);
+      setStatusMessage(role === 'identity' ? copy.uploadIdentityDone : copy.uploadStyleDone);
+      setError(null);
+    },
+    [
+      applyReferenceImage,
+      copy.uploadIdentityDone,
+      copy.uploadStyleDone,
+      libraryModalRole,
+      openAuthGate,
+      setError,
+      setLibraryModalRole,
+      setStatusMessage,
+      user,
+    ]
+  );
+
+  return {
+    handleLibrarySelect,
+    triggerUpload,
+  };
+}

--- a/tests/character-builder-workspace-architecture.test.ts
+++ b/tests/character-builder-workspace-architecture.test.ts
@@ -19,6 +19,7 @@ const historicalResultsHookPath = join(root, 'frontend/src/components/tools/char
 const pendingRunsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderPendingRunsSync.ts');
 const jobSnapshotHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderJobSnapshotLoader.ts');
 const generationRunnerHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderGenerationRunner.ts');
+const referenceAssetsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderReferenceAssets.ts');
 const persistenceHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderPersistence.ts');
 
 const workspaceSource = readFileSync(workspacePath, 'utf8');
@@ -38,6 +39,7 @@ test('character builder workspace delegates copy, local types, and helper logic'
   assert.ok(existsSync(pendingRunsHookPath), 'pending run polling should live in a focused hook');
   assert.ok(existsSync(jobSnapshotHookPath), 'job snapshot loading should live in a focused hook');
   assert.ok(existsSync(generationRunnerHookPath), 'generation submission should live in a focused hook');
+  assert.ok(existsSync(referenceAssetsHookPath), 'reference asset upload and library selection should live in a focused hook');
   assert.ok(existsSync(persistenceHookPath), 'local persistence should live in a focused hook');
 
   assert.match(workspaceSource, /from '\.\/character-builder\/_components\/character-builder-workspace-components'/, 'workspace should import UI components');
@@ -46,6 +48,7 @@ test('character builder workspace delegates copy, local types, and helper logic'
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderPendingRunsSync'/, 'workspace should import pending run sync hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderJobSnapshotLoader'/, 'workspace should import job snapshot loader hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderGenerationRunner'/, 'workspace should import generation runner hook');
+  assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderReferenceAssets'/, 'workspace should import reference asset hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderPersistence'/, 'workspace should import persistence hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_lib\/character-builder-copy'/, 'workspace should import character copy');
   assert.match(workspaceSource, /from '\.\/character-builder\/_lib\/character-builder-types'/, 'workspace should import local types');
@@ -70,12 +73,15 @@ test('character builder workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /async function handleRun\(/, 'generation submission belongs in useCharacterBuilderGenerationRunner');
   assert.doesNotMatch(workspaceSource, /runCharacterBuilderTool/, 'generation API calls belong in useCharacterBuilderGenerationRunner');
   assert.doesNotMatch(workspaceSource, /emitClientMetric\('tool_start'/, 'generation analytics belong in useCharacterBuilderGenerationRunner');
+  assert.doesNotMatch(workspaceSource, /async function handleUpload\(/, 'reference upload handling belongs in useCharacterBuilderReferenceAssets');
+  assert.doesNotMatch(workspaceSource, /function handleLibrarySelect\(/, 'reference library selection belongs in useCharacterBuilderReferenceAssets');
+  assert.doesNotMatch(workspaceSource, /buildReferenceImage/, 'reference image construction belongs in useCharacterBuilderReferenceAssets');
   assert.doesNotMatch(workspaceSource, /readPersistedState\(\)/, 'local hydration belongs in useCharacterBuilderPersistence');
   assert.doesNotMatch(workspaceSource, /writePersistedPendingRuns/, 'pending run persistence belongs in useCharacterBuilderPersistence');
   assert.doesNotMatch(workspaceSource, /visitorSanitizedRef/, 'visitor cleanup tracking belongs in useCharacterBuilderPersistence');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 1560, `CharacterBuilderWorkspace should stay below 1560 lines after generation runner extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 1485, `CharacterBuilderWorkspace should stay below 1485 lines after reference asset hook extraction, got ${lineCount}`);
 });
 
 test('character builder helper modules expose the expected workspace contract', () => {
@@ -93,6 +99,7 @@ test('character builder helper modules expose the expected workspace contract', 
   const pendingRunsHookSource = readFileSync(pendingRunsHookPath, 'utf8');
   const jobSnapshotHookSource = readFileSync(jobSnapshotHookPath, 'utf8');
   const generationRunnerHookSource = readFileSync(generationRunnerHookPath, 'utf8');
+  const referenceAssetsHookSource = readFileSync(referenceAssetsHookPath, 'utf8');
   const persistenceHookSource = readFileSync(persistenceHookPath, 'utf8');
 
   assert.match(copySource, /export const DEFAULT_CHARACTER_COPY =/, 'copy module should export default copy');
@@ -201,6 +208,10 @@ test('character builder helper modules expose the expected workspace contract', 
   assert.match(generationRunnerHookSource, /runCharacterBuilderTool/, 'generation runner hook should submit character jobs');
   assert.match(generationRunnerHookSource, /emitClientMetric\('tool_start'/, 'generation runner hook should own generation analytics');
   assert.match(generationRunnerHookSource, /normalizeHairAndOutfitModes/, 'generation runner hook should own request trait normalization');
+  assert.match(referenceAssetsHookSource, /export function useCharacterBuilderReferenceAssets/, 'reference asset hook should be exported');
+  assert.match(referenceAssetsHookSource, /uploadImage/, 'reference asset hook should own uploads');
+  assert.match(referenceAssetsHookSource, /buildReferenceImage/, 'reference asset hook should build uploaded references');
+  assert.match(referenceAssetsHookSource, /updateReferenceImage/, 'reference asset hook should update reference slots');
   assert.match(persistenceHookSource, /export function useCharacterBuilderPersistence/, 'persistence hook should be exported');
   assert.match(persistenceHookSource, /readPersistedState/, 'persistence hook should own local hydration');
   assert.match(persistenceHookSource, /writePersistedPendingRuns/, 'persistence hook should own pending run persistence');


### PR DESCRIPTION
## Summary\n- move Character Builder reference upload and library selection into a focused hook\n- keep reference image construction, slot updates, and auth-required handling out of the workspace component\n- extend the architecture contract for the new reference asset hook\n\n## Verification\n- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/character-builder-workspace-architecture.test.ts\n- ./node_modules/.bin/tsc --noEmit --pretty false\n- npm --prefix frontend run lint\n- npm run lint:exposure