### PR TITLE
[codex] Split image provider payload helpers

### DIFF
--- a/frontend/src/server/images/execute-image-generation.ts
+++ b/frontend/src/server/images/execute-image-generation.ts
@@ -3,7 +3,6 @@ import { randomUUID } from 'crypto';
 import { listFalEngines } from '@/config/falEngines';
 import type {
   CharacterReferenceSelection,
-  GeneratedImage,
   ImageGenerationMode,
   ImageGenerationRequest,
   ImageGenerationResponse,
@@ -57,6 +56,12 @@ import {
 } from './image-reference-normalization';
 import { ImageGenerationExecutionError } from './image-generation-error';
 import { createAtomicInitialImageJob, PLACEHOLDER_THUMB } from './image-initial-job';
+import {
+  buildCharacterReferencePrompt,
+  extractImages,
+  parseRequestId,
+  sanitizeCharacterReferences,
+} from './image-provider-payload';
 
 export { buildResponseFromExistingJob } from './existing-image-job-response';
 export { ImageGenerationExecutionError } from './image-generation-error';
@@ -113,121 +118,6 @@ function normalizeMode(value: unknown, fallback: ImageGenerationMode = 't2i'): I
   if (value === 'generate') return 't2i';
   if (value === 'edit') return 'i2i';
   return fallback;
-}
-
-function normalizeUrl(value: string): string {
-  const trimmed = value.trim();
-  if (!trimmed) return trimmed;
-  if (/^https?:\/\//i.test(trimmed)) return trimmed;
-  return `https://fal.media/files/${trimmed.replace(/^\.?\/+/, '')}`;
-}
-
-function sanitizeCharacterReferences(value: unknown): CharacterReferenceSelection[] {
-  if (!Array.isArray(value)) return [];
-
-  return value.reduce<CharacterReferenceSelection[]>((acc, entry) => {
-    if (!entry || typeof entry !== 'object') return acc;
-    const record = entry as Record<string, unknown>;
-    const id = typeof record.id === 'string' ? record.id.trim() : '';
-    const jobId = typeof record.jobId === 'string' ? record.jobId.trim() : '';
-    const imageUrl = typeof record.imageUrl === 'string' ? record.imageUrl.trim() : '';
-    if (!id || !jobId || !/^https?:\/\//i.test(imageUrl)) return acc;
-
-    acc.push({
-      id,
-      jobId,
-      imageUrl,
-      thumbUrl:
-        typeof record.thumbUrl === 'string' && /^https?:\/\//i.test(record.thumbUrl.trim())
-          ? record.thumbUrl.trim()
-          : null,
-      prompt: typeof record.prompt === 'string' && record.prompt.trim().length ? record.prompt.trim() : null,
-      createdAt: typeof record.createdAt === 'string' && record.createdAt.trim().length ? record.createdAt.trim() : null,
-      engineLabel:
-        typeof record.engineLabel === 'string' && record.engineLabel.trim().length ? record.engineLabel.trim() : null,
-      outputMode:
-        record.outputMode === 'portrait-reference' || record.outputMode === 'character-sheet'
-          ? record.outputMode
-          : null,
-      action:
-        record.action === 'generate' || record.action === 'full-body-fix' || record.action === 'lighting-variant'
-          ? record.action
-          : null,
-    });
-    return acc;
-  }, []);
-}
-
-function buildCharacterReferencePrompt(prompt: string, characterReferences: CharacterReferenceSelection[]): string {
-  if (!characterReferences.length) return prompt;
-
-  const instruction =
-    characterReferences.length === 1
-      ? 'Use the selected character reference as the primary identity anchor. Preserve face, hairstyle, body proportions, and distinctive character cues unless the prompt explicitly requests a change.'
-      : 'Treat the selected character references as distinct character identities. Preserve each separately, match cast order to selection order, and do not merge identities. If the user prompt implies fewer characters than selected, prioritize them in selection order.';
-
-  return `${prompt}\n\nCharacter reference instructions:\n${instruction}`;
-}
-
-function extractImages(payload: unknown): GeneratedImage[] {
-  const roots: unknown[] = [];
-  if (payload && typeof payload === 'object') {
-    const record = payload as Record<string, unknown>;
-    roots.push(record);
-    if (record.output && typeof record.output === 'object') roots.push(record.output);
-    if (record.response && typeof record.response === 'object') roots.push(record.response);
-    if (record.data && typeof record.data === 'object') roots.push(record.data);
-  }
-
-  for (const root of roots) {
-    if (!root || typeof root !== 'object') continue;
-    const imagesCandidate = (root as { images?: unknown }).images;
-    if (!Array.isArray(imagesCandidate)) continue;
-
-    const mapped = imagesCandidate.reduce<GeneratedImage[]>((acc, entry) => {
-      if (!entry || typeof entry !== 'object') return acc;
-      const record = entry as Record<string, unknown>;
-      const urlRaw = typeof record.url === 'string' ? record.url : null;
-      if (!urlRaw) return acc;
-
-      acc.push({
-        url: normalizeUrl(urlRaw),
-        width: typeof record.width === 'number' ? record.width : null,
-        height: typeof record.height === 'number' ? record.height : null,
-        mimeType:
-          typeof record.content_type === 'string'
-            ? record.content_type
-            : typeof record.mimetype === 'string'
-              ? record.mimetype
-              : null,
-      });
-      return acc;
-    }, []);
-
-    if (mapped.length) {
-      return mapped;
-    }
-  }
-
-  return [];
-}
-
-function parseRequestId(payload: unknown): string | undefined {
-  if (!payload || typeof payload !== 'object') return undefined;
-  const record = payload as Record<string, unknown>;
-  if (typeof record.request_id === 'string') return record.request_id;
-  if (typeof record.id === 'string') return record.id;
-  if (record.response && typeof record.response === 'object') {
-    const responseRecord = record.response as Record<string, unknown>;
-    if (typeof responseRecord.request_id === 'string') return responseRecord.request_id;
-    if (typeof responseRecord.id === 'string') return responseRecord.id;
-  }
-  if (record.output && typeof record.output === 'object') {
-    const outputRecord = record.output as Record<string, unknown>;
-    if (typeof outputRecord.request_id === 'string') return outputRecord.request_id;
-    if (typeof outputRecord.id === 'string') return outputRecord.id;
-  }
-  return undefined;
 }
 
 function buildReceiptSnapshot(pricing: PricingSnapshot): Record<string, unknown> {

--- a/frontend/src/server/images/image-provider-payload.ts
+++ b/frontend/src/server/images/image-provider-payload.ts
@@ -1,0 +1,119 @@
+import type {
+  CharacterReferenceSelection,
+  GeneratedImage,
+} from '@/types/image-generation';
+
+export function normalizeProviderImageUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return trimmed;
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  return `https://fal.media/files/${trimmed.replace(/^\.?\/+/, '')}`;
+}
+
+export function sanitizeCharacterReferences(value: unknown): CharacterReferenceSelection[] {
+  if (!Array.isArray(value)) return [];
+
+  return value.reduce<CharacterReferenceSelection[]>((acc, entry) => {
+    if (!entry || typeof entry !== 'object') return acc;
+    const record = entry as Record<string, unknown>;
+    const id = typeof record.id === 'string' ? record.id.trim() : '';
+    const jobId = typeof record.jobId === 'string' ? record.jobId.trim() : '';
+    const imageUrl = typeof record.imageUrl === 'string' ? record.imageUrl.trim() : '';
+    if (!id || !jobId || !/^https?:\/\//i.test(imageUrl)) return acc;
+
+    acc.push({
+      id,
+      jobId,
+      imageUrl,
+      thumbUrl:
+        typeof record.thumbUrl === 'string' && /^https?:\/\//i.test(record.thumbUrl.trim())
+          ? record.thumbUrl.trim()
+          : null,
+      prompt: typeof record.prompt === 'string' && record.prompt.trim().length ? record.prompt.trim() : null,
+      createdAt: typeof record.createdAt === 'string' && record.createdAt.trim().length ? record.createdAt.trim() : null,
+      engineLabel:
+        typeof record.engineLabel === 'string' && record.engineLabel.trim().length ? record.engineLabel.trim() : null,
+      outputMode:
+        record.outputMode === 'portrait-reference' || record.outputMode === 'character-sheet'
+          ? record.outputMode
+          : null,
+      action:
+        record.action === 'generate' || record.action === 'full-body-fix' || record.action === 'lighting-variant'
+          ? record.action
+          : null,
+    });
+    return acc;
+  }, []);
+}
+
+export function buildCharacterReferencePrompt(prompt: string, characterReferences: CharacterReferenceSelection[]): string {
+  if (!characterReferences.length) return prompt;
+
+  const instruction =
+    characterReferences.length === 1
+      ? 'Use the selected character reference as the primary identity anchor. Preserve face, hairstyle, body proportions, and distinctive character cues unless the prompt explicitly requests a change.'
+      : 'Treat the selected character references as distinct character identities. Preserve each separately, match cast order to selection order, and do not merge identities. If the user prompt implies fewer characters than selected, prioritize them in selection order.';
+
+  return `${prompt}\n\nCharacter reference instructions:\n${instruction}`;
+}
+
+export function extractImages(payload: unknown): GeneratedImage[] {
+  const roots: unknown[] = [];
+  if (payload && typeof payload === 'object') {
+    const record = payload as Record<string, unknown>;
+    roots.push(record);
+    if (record.output && typeof record.output === 'object') roots.push(record.output);
+    if (record.response && typeof record.response === 'object') roots.push(record.response);
+    if (record.data && typeof record.data === 'object') roots.push(record.data);
+  }
+
+  for (const root of roots) {
+    if (!root || typeof root !== 'object') continue;
+    const imagesCandidate = (root as { images?: unknown }).images;
+    if (!Array.isArray(imagesCandidate)) continue;
+
+    const mapped = imagesCandidate.reduce<GeneratedImage[]>((acc, entry) => {
+      if (!entry || typeof entry !== 'object') return acc;
+      const record = entry as Record<string, unknown>;
+      const urlRaw = typeof record.url === 'string' ? record.url : null;
+      if (!urlRaw) return acc;
+
+      acc.push({
+        url: normalizeProviderImageUrl(urlRaw),
+        width: typeof record.width === 'number' ? record.width : null,
+        height: typeof record.height === 'number' ? record.height : null,
+        mimeType:
+          typeof record.content_type === 'string'
+            ? record.content_type
+            : typeof record.mimetype === 'string'
+              ? record.mimetype
+              : null,
+      });
+      return acc;
+    }, []);
+
+    if (mapped.length) {
+      return mapped;
+    }
+  }
+
+  return [];
+}
+
+export function parseRequestId(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== 'object') return undefined;
+  const record = payload as Record<string, unknown>;
+  if (typeof record.request_id === 'string') return record.request_id;
+  if (typeof record.id === 'string') return record.id;
+  if (record.response && typeof record.response === 'object') {
+    const responseRecord = record.response as Record<string, unknown>;
+    if (typeof responseRecord.request_id === 'string') return responseRecord.request_id;
+    if (typeof responseRecord.id === 'string') return responseRecord.id;
+  }
+  if (record.output && typeof record.output === 'object') {
+    const outputRecord = record.output as Record<string, unknown>;
+    if (typeof outputRecord.request_id === 'string') return outputRecord.request_id;
+    if (typeof outputRecord.id === 'string') return outputRecord.id;
+  }
+  return undefined;
+}

--- a/tests/image-generation-server-architecture.test.ts
+++ b/tests/image-generation-server-architecture.test.ts
@@ -9,22 +9,26 @@ const existingJobResponsePath = join(root, 'frontend/src/server/images/existing-
 const referenceNormalizationPath = join(root, 'frontend/src/server/images/image-reference-normalization.ts');
 const initialJobPath = join(root, 'frontend/src/server/images/image-initial-job.ts');
 const errorPath = join(root, 'frontend/src/server/images/image-generation-error.ts');
+const providerPayloadPath = join(root, 'frontend/src/server/images/image-provider-payload.ts');
 
 const executorSource = readFileSync(executorPath, 'utf8');
 const existingJobResponseSource = readFileSync(existingJobResponsePath, 'utf8');
 const referenceNormalizationSource = readFileSync(referenceNormalizationPath, 'utf8');
 const initialJobSource = readFileSync(initialJobPath, 'utf8');
 const errorSource = readFileSync(errorPath, 'utf8');
+const providerPayloadSource = readFileSync(providerPayloadPath, 'utf8');
 
 test('image generation executor delegates focused server helpers', () => {
   assert.ok(existsSync(existingJobResponsePath), 'existing image job response helpers should live in a focused module');
   assert.ok(existsSync(referenceNormalizationPath), 'image reference normalization should live in a focused module');
   assert.ok(existsSync(initialJobPath), 'atomic initial image job creation should live in a focused module');
   assert.ok(existsSync(errorPath), 'image generation execution error should live in a focused module');
+  assert.ok(existsSync(providerPayloadPath), 'provider payload parsing should live in a focused module');
   assert.match(executorSource, /from '\.\/existing-image-job-response'/);
   assert.match(executorSource, /from '\.\/image-reference-normalization'/);
   assert.match(executorSource, /from '\.\/image-initial-job'/);
   assert.match(executorSource, /from '\.\/image-generation-error'/);
+  assert.match(executorSource, /from '\.\/image-provider-payload'/);
   assert.match(executorSource, /export \{ buildResponseFromExistingJob \} from '\.\/existing-image-job-response'/);
   assert.match(executorSource, /export \{ ImageGenerationExecutionError \} from '\.\/image-generation-error'/);
 });
@@ -40,9 +44,14 @@ test('image generation executor does not regain extracted server ownership', () 
   assert.doesNotMatch(executorSource, /reserveWalletChargeInExecutor/, 'wallet reservation belongs in image-initial-job.ts');
   assert.doesNotMatch(executorSource, /async function insertProvisionalImageJob\(/, 'provisional job insert belongs in image-initial-job.ts');
   assert.doesNotMatch(executorSource, /export class ImageGenerationExecutionError/, 'execution error contract belongs in image-generation-error.ts');
+  assert.doesNotMatch(executorSource, /function normalizeUrl\(/, 'provider URL normalization belongs in image-provider-payload.ts');
+  assert.doesNotMatch(executorSource, /function sanitizeCharacterReferences\(/, 'character reference sanitizing belongs in image-provider-payload.ts');
+  assert.doesNotMatch(executorSource, /function buildCharacterReferencePrompt\(/, 'character reference prompt building belongs in image-provider-payload.ts');
+  assert.doesNotMatch(executorSource, /function extractImages\(/, 'provider image extraction belongs in image-provider-payload.ts');
+  assert.doesNotMatch(executorSource, /function parseRequestId\(/, 'provider request id parsing belongs in image-provider-payload.ts');
 
   const lineCount = executorSource.split('\n').length;
-  assert.ok(lineCount <= 1220, `image generation executor should stay below 1220 lines after initial job extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 1110, `image generation executor should stay below 1110 lines after provider payload extraction, got ${lineCount}`);
 });
 
 test('existing image job response module exposes the expected contract', () => {
@@ -61,4 +70,9 @@ test('existing image job response module exposes the expected contract', () => {
   assert.match(initialJobSource, /withDbTransaction/);
   assert.match(initialJobSource, /reserveWalletChargeInExecutor/);
   assert.match(errorSource, /export class ImageGenerationExecutionError/);
+  assert.match(providerPayloadSource, /export function normalizeProviderImageUrl/);
+  assert.match(providerPayloadSource, /export function sanitizeCharacterReferences/);
+  assert.match(providerPayloadSource, /export function buildCharacterReferencePrompt/);
+  assert.match(providerPayloadSource, /export function extractImages/);
+  assert.match(providerPayloadSource, /export function parseRequestId/);
 });


### PR DESCRIPTION
Summary
- move provider payload image extraction/request id parsing into a focused server helper
- keep character reference sanitizing and prompt instructions out of the image executor
- extend the architecture contract so the executor stays below 1110 lines

Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/image-generation-server-architecture.test.ts tests/image-generation-atomic.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- git diff --check -- frontend/src/server/images/execute-image-generation.ts frontend/src/server/images/image-provider-payload.ts tests/image-generation-server-architecture.test.ts
- npm --prefix frontend run lint
- npm run lint:exposure