### PR TITLE
[codex] Split character builder result responsibilities

### DIFF
--- a/frontend/src/components/tools/CharacterBuilderWorkspace.tsx
+++ b/frontend/src/components/tools/CharacterBuilderWorkspace.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx';
 import Link from 'next/link';
 import { usePathname, useSearchParams } from 'next/navigation';
 import useSWR from 'swr';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import {
   ArrowLeft,
   Upload,
@@ -19,7 +19,6 @@ import { Button, ButtonLink } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
 import { Input, Textarea } from '@/components/ui/Input';
 import { authFetch } from '@/lib/authFetch';
-import { suggestDownloadFilename, triggerAppDownload } from '@/lib/download';
 import { useI18n } from '@/lib/i18n/I18nProvider';
 import {
   AUTO_TRAIT_KEYS,
@@ -28,12 +27,9 @@ import {
   normalizeCharacterFormatMode,
   normalizeTraitsForSourceMode,
 } from '@/lib/character-builder';
-import { saveImageToLibrary } from '@/lib/api';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { FEATURES } from '@/content/feature-flags';
 import type {
-  CharacterBuilderResult,
-  CharacterBuilderSettingsSnapshot,
   CharacterBuilderState,
   CharacterBuilderTraitSource,
   CharacterBuilderTraits,
@@ -42,18 +38,16 @@ import type {
 import {
   BuildLookCarouselCard,
   CharacterBuilderStickyDock,
+  CharacterBuilderResultsGallery,
   CharacterReferenceLibraryModal,
   CompactSelectField,
-  EmptyResultsRail,
   GENDER_CARD_META,
   HairEditorPanel,
   IconChoiceCard,
   MultiToggleGroup,
   OutputPreviewCard,
-  PendingResultCard,
   REALISM_CARD_META,
   ReferenceSlot,
-  ResultCard,
   SectionTitle,
   SegmentedControl,
   StyleChoiceCard,
@@ -66,6 +60,8 @@ import { useCharacterBuilderOptions } from './character-builder/_hooks/useCharac
 import { useCharacterBuilderPersistence } from './character-builder/_hooks/useCharacterBuilderPersistence';
 import { useCharacterBuilderPendingRunsSync } from './character-builder/_hooks/useCharacterBuilderPendingRunsSync';
 import { useCharacterBuilderReferenceAssets } from './character-builder/_hooks/useCharacterBuilderReferenceAssets';
+import { useCharacterBuilderResultActions } from './character-builder/_hooks/useCharacterBuilderResultActions';
+import { useCharacterBuilderResultsInfiniteScroll } from './character-builder/_hooks/useCharacterBuilderResultsInfiniteScroll';
 import { DEFAULT_CHARACTER_COPY, type CharacterCopy } from './character-builder/_lib/character-builder-copy';
 import {
   buildResetCharacterBuilderState,
@@ -73,24 +69,19 @@ import {
   findChoiceLabel,
   getCharacterBillingProductKey,
   getFlattenedResults,
-  getFormatDisplayLabel,
   getHairSummary,
   getOutfitSummary,
   getRefByRole,
-  getResultActionLabel,
   hasCustomOutfitSettings,
   hasCustomHairSettings,
   INITIAL_LOADING_REQUEST_COUNTS,
-  isAuthRequiredError,
   normalizeTag,
-  parseCharacterBuilderSnapshot,
   removeReferenceImage,
   serializeResettableCharacterBuilderState,
   summarizeCustomText,
 } from './character-builder/_lib/character-builder-helpers';
 import type {
   BillingProductResponse,
-  HistoricalCharacterGalleryItem,
   LoadingRequestCounts,
   LoadingRequestKey,
   PendingCharacterRun,
@@ -114,7 +105,6 @@ export default function CharacterBuilderPage() {
   const [mustRemainDraft, setMustRemainDraft] = useState('');
   const [loadingActions, setLoadingActions] = useState<LoadingRequestCounts>(INITIAL_LOADING_REQUEST_COUNTS);
   const [pendingRuns, setPendingRuns] = useState<PendingCharacterRun[]>([]);
-  const [savingResultId, setSavingResultId] = useState<string | null>(null);
   const [lightboxEntry, setLightboxEntry] = useState<MediaLightboxEntry | null>(null);
   const [authModalOpen, setAuthModalOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -122,8 +112,6 @@ export default function CharacterBuilderPage() {
   const [hydrated, setHydrated] = useState(false);
   const identityFileRef = useRef<HTMLInputElement | null>(null);
   const styleFileRef = useRef<HTMLInputElement | null>(null);
-  const resultsScrollContainerRef = useRef<HTMLDivElement | null>(null);
-  const resultsSentinelRef = useRef<HTMLDivElement | null>(null);
   const loginRedirectTarget = useMemo(() => {
     const base = pathname || '/app/tools/character-builder';
     const search = searchParams?.toString();
@@ -132,6 +120,23 @@ export default function CharacterBuilderPage() {
   const openAuthGate = useCallback(() => {
     setAuthModalOpen(true);
   }, []);
+  const {
+    applySettingsSnapshot,
+    handleDuplicateHistoricalSettings,
+    handleSaveHistoricalResult,
+    handleSaveResult,
+    savingResultId,
+    setSavingResultId,
+  } = useCharacterBuilderResultActions({
+    copy,
+    openAuthGate,
+    setAdvancedOpen,
+    setError,
+    setShowStyleReferenceSlot,
+    setState,
+    setStatusMessage,
+    user,
+  });
 
   const {
     genderOptions,
@@ -164,6 +169,14 @@ export default function CharacterBuilderPage() {
     loadMoreHistoricalResults,
     mutateHistoricalJobs,
   } = useCharacterBuilderHistoricalResults(flattenedResults);
+  const {
+    resultsScrollContainerRef,
+    resultsSentinelRef,
+  } = useCharacterBuilderResultsInfiniteScroll({
+    hasMore: historicalHasMore,
+    loadMoreResults: loadMoreHistoricalResults,
+    resultsLength: historicalResults.length,
+  });
   const identityReference = getRefByRole(state.referenceImages, 'identity');
   const styleReference = getRefByRole(state.referenceImages, 'style');
   const hasIdentityReference = Boolean(identityReference);
@@ -272,52 +285,6 @@ export default function CharacterBuilderPage() {
       : null;
   const isActionLoading = (key: LoadingRequestKey): boolean => (loadingActions[key] ?? 0) > 0;
 
-  useEffect(() => {
-    const sentinel = resultsSentinelRef.current;
-    if (!sentinel || !historicalHasMore) return;
-
-    let previousY = 0;
-    let previousRatio = 0;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (
-            entry.isIntersecting &&
-            (entry.boundingClientRect.y > previousY || entry.intersectionRatio > previousRatio)
-          ) {
-            loadMoreHistoricalResults();
-          }
-          previousY = entry.boundingClientRect.y;
-          previousRatio = entry.intersectionRatio;
-        });
-      },
-      {
-        root: resultsScrollContainerRef.current,
-        threshold: 0.2,
-      }
-    );
-
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [historicalHasMore, historicalResults.length, loadMoreHistoricalResults]);
-
-  useEffect(() => {
-    const scrollContainer = resultsScrollContainerRef.current;
-    if (!scrollContainer || !historicalHasMore) return undefined;
-
-    const maybeLoadMore = () => {
-      const remainingScroll = scrollContainer.scrollHeight - scrollContainer.scrollTop - scrollContainer.clientHeight;
-      if (remainingScroll <= 320) {
-        loadMoreHistoricalResults();
-      }
-    };
-
-    maybeLoadMore();
-    scrollContainer.addEventListener('scroll', maybeLoadMore, { passive: true });
-    return () => scrollContainer.removeEventListener('scroll', maybeLoadMore);
-  }, [historicalHasMore, historicalResults.length, loadMoreHistoricalResults]);
-
   function updateTrait<K extends keyof Pick<
     CharacterBuilderTraits,
     | 'genderPresentation'
@@ -401,286 +368,40 @@ export default function CharacterBuilderPage() {
     }));
   }
 
-  function applySettingsSnapshot(snapshot: CharacterBuilderSettingsSnapshot, selectedId?: string) {
+  const handleSelectResult = useCallback((resultId: string) => {
     setState((previous) => ({
       ...previous,
-      sourceMode: snapshot.builder.sourceMode,
-      referenceImages: snapshot.builder.referenceImages,
-      traits: snapshot.builder.traits,
-      outputMode: snapshot.builder.outputMode,
-      consistencyMode: snapshot.builder.consistencyMode,
-      referenceStrength: snapshot.builder.referenceStrength,
-      qualityMode: snapshot.builder.qualityMode,
-      formatMode: normalizeCharacterFormatMode(snapshot.builder.formatMode, snapshot.builder.qualityMode),
-      outputOptions: snapshot.builder.outputOptions,
-      advancedNotes: snapshot.builder.advancedNotes,
-      mustRemainVisible: snapshot.builder.mustRemainVisible,
-      selectedResultId: selectedId ?? previous.selectedResultId,
+      selectedResultId: resultId,
     }));
-    setAdvancedOpen(Boolean(snapshot.builder.advancedNotes));
-    setStatusMessage(copy.duplicateDone);
-  }
-
-  async function handleSaveResult(result: CharacterBuilderResult) {
-    if (!user) {
-      openAuthGate();
-      return;
-    }
-    setSavingResultId(result.id);
-    setError(null);
-    setStatusMessage(null);
-    try {
-      await saveImageToLibrary({
-        url: result.url,
-        jobId: result.jobId,
-        label: copy.generatePanel.portraitTitle,
-        source: 'character',
-      });
-      setStatusMessage(copy.savedToLibrary);
-    } catch (saveError) {
-      if (isAuthRequiredError(saveError)) {
-        openAuthGate();
-        return;
-      }
-      setError(saveError instanceof Error ? saveError.message : copy.saveToLibraryFailed);
-    } finally {
-      setSavingResultId(null);
-    }
-  }
-
-  async function handleSaveHistoricalResult(item: HistoricalCharacterGalleryItem) {
-    if (!user) {
-      openAuthGate();
-      return;
-    }
-    setSavingResultId(item.id);
-    setError(null);
-    setStatusMessage(null);
-    try {
-      await saveImageToLibrary({
-        url: item.imageUrl,
-        jobId: item.jobId,
-        label: copy.generatePanel.portraitTitle,
-        source: 'character',
-      });
-      setStatusMessage(copy.savedToLibrary);
-    } catch (saveError) {
-      if (isAuthRequiredError(saveError)) {
-        openAuthGate();
-        return;
-      }
-      setError(saveError instanceof Error ? saveError.message : copy.saveToLibraryFailed);
-    } finally {
-      setSavingResultId(null);
-    }
-  }
-
-  async function handleDuplicateHistoricalSettings(item: HistoricalCharacterGalleryItem) {
-    if (!user) {
-      openAuthGate();
-      return;
-    }
-    setError(null);
-    setStatusMessage(null);
-    try {
-      const response = await authFetch(`/api/jobs/${encodeURIComponent(item.jobId)}`);
-      const payload = (await response.json().catch(() => null)) as
-        | { ok?: boolean; settingsSnapshot?: unknown; error?: string }
-        | null;
-      if (!response.ok || !payload?.ok || !payload.settingsSnapshot) {
-        throw new Error(payload?.error ?? copy.runFailed);
-      }
-      const snapshotState = parseCharacterBuilderSnapshot(payload.settingsSnapshot);
-      if (!snapshotState) {
-        throw new Error(copy.missingRun);
-      }
-      setState((previous) => ({
-        ...previous,
-        ...snapshotState,
-        selectedResultId: item.id,
-      }));
-      setAdvancedOpen(Boolean(snapshotState.advancedNotes));
-      setShowStyleReferenceSlot(Boolean(snapshotState.referenceImages?.some((image) => image.role === 'style')));
-      setStatusMessage(copy.duplicateDone);
-    } catch (duplicateError) {
-      if (isAuthRequiredError(duplicateError)) {
-        openAuthGate();
-        return;
-      }
-      setError(duplicateError instanceof Error ? duplicateError.message : copy.runFailed);
-    }
-  }
+  }, []);
 
   function renderResultsGallery(variant: 'desktop' | 'mobile') {
-    if (!hasResults) {
-      return variant === 'desktop' ? <EmptyResultsRail copy={copy} /> : null;
-    }
-    const itemClassName = variant === 'desktop' ? '' : 'min-w-[280px] shrink-0 snap-start';
-    const items = (
-      <>
-        {pendingRuns.map((pendingRun) => {
-          const pendingOutputLabel =
-            findChoiceLabel(outputModeLabelOptions, pendingRun.outputMode) ?? copy.generatePanel.portraitTitle;
-          const pendingQualityLabel =
-            findChoiceLabel(qualityLabelOptions, pendingRun.qualityMode) ?? copy.options.quality.draft.label;
-          const pendingFormatLabel = getFormatDisplayLabel(copy, pendingRun.formatMode, pendingRun.qualityMode);
-          const subtitle = `${pendingOutputLabel} · ${pendingQualityLabel} · ${pendingFormatLabel}`;
-          const badge = pendingRun.generateCount === 4 ? '4x' : null;
-          return (
-            <div key={pendingRun.id} className={itemClassName}>
-              <PendingResultCard
-                title={getResultActionLabel(copy, pendingRun.action)}
-                subtitle={subtitle}
-                badge={badge}
-                copy={copy}
-              />
-            </div>
-          );
-        })}
-        {flattenedResults.map((result) => {
-          const run = state.runs.find((entry) => entry.id === result.runId);
-          const resultOutputLabel =
-            findChoiceLabel(outputModeLabelOptions, result.outputMode) ?? copy.generatePanel.portraitTitle;
-          const resultQualityLabel =
-            findChoiceLabel(qualityLabelOptions, result.qualityMode) ?? copy.options.quality.draft.label;
-          const resultFormatLabel = getFormatDisplayLabel(copy, run?.formatMode ?? 'standard', result.qualityMode);
-          const subtitle = `${resultOutputLabel} · ${resultQualityLabel} · ${resultFormatLabel}`;
-          const badge = run && run.results.length > 1 ? `${run.results.length}x` : null;
-
-          return (
-            <div key={result.id} className={itemClassName}>
-              <ResultCard
-                result={result}
-                selected={state.selectedResultId === result.id}
-                title={getResultActionLabel(copy, result.action)}
-                subtitle={subtitle}
-                badge={badge}
-                saving={savingResultId === result.id}
-                onOpen={() => {
-                  setState((previous) => ({
-                    ...previous,
-                    selectedResultId: result.id,
-                  }));
-                  setLightboxEntry({
-                    id: result.id,
-                    label: getResultActionLabel(copy, result.action),
-                    thumbUrl: result.url,
-                    mediaType: 'image',
-                    status: 'completed',
-                    engineLabel: result.engineLabel,
-                    createdAt: result.createdAt,
-                    jobId: result.jobId,
-                    prompt: run?.settingsSnapshot?.prompt ?? null,
-                  });
-                }}
-                onSelect={() =>
-                  setState((previous) => ({
-                    ...previous,
-                    selectedResultId: result.id,
-                  }))
-                }
-                onDownload={() =>
-                  triggerAppDownload(
-                    result.url,
-                    suggestDownloadFilename(result.url, `character-reference-${result.id.replace(/[^a-z0-9]+/gi, '-')}`)
-                  )
-                }
-                onSave={() => void handleSaveResult(result)}
-                onDuplicateSettings={() => {
-                  if (run?.settingsSnapshot) {
-                    applySettingsSnapshot(run.settingsSnapshot, result.id);
-                  }
-                }}
-                copy={copy}
-              />
-            </div>
-          );
-        })}
-        {historicalResults.map((item) => {
-          const createdLabel = (() => {
-            try {
-              return new Intl.DateTimeFormat(undefined, { dateStyle: 'short', timeStyle: 'short' }).format(new Date(item.createdAt));
-            } catch {
-              return item.createdAt;
-            }
-          })();
-
-          return (
-            <div key={item.id} className={itemClassName}>
-              <ResultCard
-                result={{
-                  id: item.id,
-                  runId: item.jobId,
-                  jobId: item.jobId,
-                  url: item.imageUrl,
-                  thumbUrl: item.thumbUrl,
-                  engineId: '',
-                  engineLabel: item.engineLabel,
-                  action: 'generate',
-                  outputMode: 'portrait-reference',
-                  qualityMode: state.qualityMode,
-                  createdAt: item.createdAt,
-                }}
-                selected={state.selectedResultId === item.id}
-                title={copy.resultCard.referenceOutput}
-                subtitle={`${item.engineLabel} · ${createdLabel}`}
-                saving={savingResultId === item.id}
-                onOpen={() => {
-                  setState((previous) => ({
-                    ...previous,
-                    selectedResultId: item.id,
-                  }));
-                  setLightboxEntry({
-                    id: item.id,
-                    label: copy.resultCard.referenceOutput,
-                    thumbUrl: item.imageUrl,
-                    mediaType: 'image',
-                    status: 'completed',
-                    engineLabel: item.engineLabel,
-                    createdAt: item.createdAt,
-                    jobId: item.jobId,
-                    prompt: item.prompt,
-                  });
-                }}
-                onSelect={() =>
-                  setState((previous) => ({
-                    ...previous,
-                    selectedResultId: item.id,
-                  }))
-                }
-                onDownload={() =>
-                  triggerAppDownload(
-                    item.imageUrl,
-                    suggestDownloadFilename(item.imageUrl, `character-reference-${item.id.replace(/[^a-z0-9]+/gi, '-')}`)
-                  )
-                }
-                onSave={() => void handleSaveHistoricalResult(item)}
-                onDuplicateSettings={() => void handleDuplicateHistoricalSettings(item)}
-                copy={copy}
-              />
-            </div>
-          );
-        })}
-      </>
+    return (
+      <CharacterBuilderResultsGallery
+        copy={copy}
+        flattenedResults={flattenedResults}
+        historicalHasMore={historicalHasMore}
+        historicalIsFetchingMore={historicalIsFetchingMore}
+        historicalJobsLoading={historicalJobsLoading}
+        historicalResults={historicalResults}
+        outputModeLabelOptions={outputModeLabelOptions}
+        pendingRuns={pendingRuns}
+        qualityLabelOptions={qualityLabelOptions}
+        qualityMode={state.qualityMode}
+        resultsScrollContainerRef={resultsScrollContainerRef}
+        resultsSentinelRef={resultsSentinelRef}
+        runs={state.runs}
+        savingResultId={savingResultId}
+        selectedResultId={state.selectedResultId}
+        variant={variant}
+        onDuplicateHistoricalSettings={(item) => void handleDuplicateHistoricalSettings(item)}
+        onDuplicateSettings={applySettingsSnapshot}
+        onOpenLightbox={setLightboxEntry}
+        onSaveHistoricalResult={(item) => void handleSaveHistoricalResult(item)}
+        onSaveResult={(result) => void handleSaveResult(result)}
+        onSelectResult={handleSelectResult}
+      />
     );
-
-    if (variant === 'desktop') {
-      return (
-        <div className="relative flex-1 min-h-0">
-          <div ref={resultsScrollContainerRef} className="scrollbar-rail h-full overflow-y-auto space-y-3 pr-4 pt-1">
-            {items}
-            {historicalHasMore ? <div ref={resultsSentinelRef} className="h-6" /> : null}
-            {historicalIsFetchingMore || historicalJobsLoading ? (
-              <div className="flex justify-center py-3 text-xs font-medium text-text-secondary">
-                {copy.resultCard.pending}
-              </div>
-            ) : null}
-          </div>
-        </div>
-      );
-    }
-
-    return <div className="-mx-1 flex gap-3 overflow-x-auto px-1 pb-1">{items}</div>;
   }
 
   if (authLoading || !hydrated) {

--- a/frontend/src/components/tools/character-builder/_components/character-builder-results-gallery.tsx
+++ b/frontend/src/components/tools/character-builder/_components/character-builder-results-gallery.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import type { RefObject } from 'react';
+import type { MediaLightboxEntry } from '@/components/MediaLightbox';
+import { suggestDownloadFilename, triggerAppDownload } from '@/lib/download';
+import type {
+  CharacterBuilderResult,
+  CharacterBuilderRun,
+  CharacterBuilderSettingsSnapshot,
+  CharacterBuilderState,
+} from '@/types/character-builder';
+import type { CharacterCopy } from '../_lib/character-builder-copy';
+import {
+  findChoiceLabel,
+  getFormatDisplayLabel,
+  getResultActionLabel,
+} from '../_lib/character-builder-helpers';
+import type {
+  ChoiceOption,
+  HistoricalCharacterGalleryItem,
+  PendingCharacterRun,
+} from '../_lib/character-builder-types';
+import {
+  EmptyResultsRail,
+  PendingResultCard,
+  ResultCard,
+} from './character-builder-result-cards';
+
+interface CharacterBuilderResultsGalleryProps {
+  copy: CharacterCopy;
+  flattenedResults: CharacterBuilderResult[];
+  historicalHasMore: boolean;
+  historicalIsFetchingMore: boolean;
+  historicalJobsLoading: boolean;
+  historicalResults: HistoricalCharacterGalleryItem[];
+  outputModeLabelOptions: ChoiceOption[];
+  pendingRuns: PendingCharacterRun[];
+  qualityLabelOptions: ChoiceOption[];
+  qualityMode: CharacterBuilderState['qualityMode'];
+  resultsScrollContainerRef: RefObject<HTMLDivElement>;
+  resultsSentinelRef: RefObject<HTMLDivElement>;
+  runs: CharacterBuilderRun[];
+  savingResultId: string | null;
+  selectedResultId: string | null;
+  variant: 'desktop' | 'mobile';
+  onDuplicateHistoricalSettings: (item: HistoricalCharacterGalleryItem) => void;
+  onDuplicateSettings: (snapshot: CharacterBuilderSettingsSnapshot, selectedId: string) => void;
+  onOpenLightbox: (entry: MediaLightboxEntry) => void;
+  onSaveHistoricalResult: (item: HistoricalCharacterGalleryItem) => void;
+  onSaveResult: (result: CharacterBuilderResult) => void;
+  onSelectResult: (resultId: string) => void;
+}
+
+export function CharacterBuilderResultsGallery({
+  copy,
+  flattenedResults,
+  historicalHasMore,
+  historicalIsFetchingMore,
+  historicalJobsLoading,
+  historicalResults,
+  outputModeLabelOptions,
+  pendingRuns,
+  qualityLabelOptions,
+  qualityMode,
+  resultsScrollContainerRef,
+  resultsSentinelRef,
+  runs,
+  savingResultId,
+  selectedResultId,
+  variant,
+  onDuplicateHistoricalSettings,
+  onDuplicateSettings,
+  onOpenLightbox,
+  onSaveHistoricalResult,
+  onSaveResult,
+  onSelectResult,
+}: CharacterBuilderResultsGalleryProps) {
+  const hasResults = flattenedResults.length > 0 || pendingRuns.length > 0 || historicalResults.length > 0;
+  if (!hasResults) {
+    return variant === 'desktop' ? <EmptyResultsRail copy={copy} /> : null;
+  }
+
+  const itemClassName = variant === 'desktop' ? '' : 'min-w-[280px] shrink-0 snap-start';
+  const items = (
+    <>
+      {pendingRuns.map((pendingRun) => {
+        const pendingOutputLabel =
+          findChoiceLabel(outputModeLabelOptions, pendingRun.outputMode) ?? copy.generatePanel.portraitTitle;
+        const pendingQualityLabel =
+          findChoiceLabel(qualityLabelOptions, pendingRun.qualityMode) ?? copy.options.quality.draft.label;
+        const pendingFormatLabel = getFormatDisplayLabel(copy, pendingRun.formatMode, pendingRun.qualityMode);
+        const subtitle = `${pendingOutputLabel} · ${pendingQualityLabel} · ${pendingFormatLabel}`;
+        const badge = pendingRun.generateCount === 4 ? '4x' : null;
+        return (
+          <div key={pendingRun.id} className={itemClassName}>
+            <PendingResultCard
+              title={getResultActionLabel(copy, pendingRun.action)}
+              subtitle={subtitle}
+              badge={badge}
+              copy={copy}
+            />
+          </div>
+        );
+      })}
+      {flattenedResults.map((result) => {
+        const run = runs.find((entry) => entry.id === result.runId);
+        const resultOutputLabel =
+          findChoiceLabel(outputModeLabelOptions, result.outputMode) ?? copy.generatePanel.portraitTitle;
+        const resultQualityLabel =
+          findChoiceLabel(qualityLabelOptions, result.qualityMode) ?? copy.options.quality.draft.label;
+        const resultFormatLabel = getFormatDisplayLabel(copy, run?.formatMode ?? 'standard', result.qualityMode);
+        const subtitle = `${resultOutputLabel} · ${resultQualityLabel} · ${resultFormatLabel}`;
+        const badge = run && run.results.length > 1 ? `${run.results.length}x` : null;
+        const title = getResultActionLabel(copy, result.action);
+
+        return (
+          <div key={result.id} className={itemClassName}>
+            <ResultCard
+              result={result}
+              selected={selectedResultId === result.id}
+              title={title}
+              subtitle={subtitle}
+              badge={badge}
+              saving={savingResultId === result.id}
+              onOpen={() => {
+                onSelectResult(result.id);
+                onOpenLightbox({
+                  id: result.id,
+                  label: title,
+                  thumbUrl: result.url,
+                  mediaType: 'image',
+                  status: 'completed',
+                  engineLabel: result.engineLabel,
+                  createdAt: result.createdAt,
+                  jobId: result.jobId,
+                  prompt: run?.settingsSnapshot?.prompt ?? null,
+                });
+              }}
+              onSelect={() => onSelectResult(result.id)}
+              onDownload={() =>
+                triggerAppDownload(
+                  result.url,
+                  suggestDownloadFilename(result.url, `character-reference-${result.id.replace(/[^a-z0-9]+/gi, '-')}`)
+                )
+              }
+              onSave={() => onSaveResult(result)}
+              onDuplicateSettings={() => {
+                if (run?.settingsSnapshot) {
+                  onDuplicateSettings(run.settingsSnapshot, result.id);
+                }
+              }}
+              copy={copy}
+            />
+          </div>
+        );
+      })}
+      {historicalResults.map((item) => {
+        const createdLabel = formatHistoricalCreatedAt(item.createdAt);
+
+        return (
+          <div key={item.id} className={itemClassName}>
+            <ResultCard
+              result={{
+                id: item.id,
+                runId: item.jobId,
+                jobId: item.jobId,
+                url: item.imageUrl,
+                thumbUrl: item.thumbUrl,
+                engineId: '',
+                engineLabel: item.engineLabel,
+                action: 'generate',
+                outputMode: 'portrait-reference',
+                qualityMode,
+                createdAt: item.createdAt,
+              }}
+              selected={selectedResultId === item.id}
+              title={copy.resultCard.referenceOutput}
+              subtitle={`${item.engineLabel} · ${createdLabel}`}
+              saving={savingResultId === item.id}
+              onOpen={() => {
+                onSelectResult(item.id);
+                onOpenLightbox({
+                  id: item.id,
+                  label: copy.resultCard.referenceOutput,
+                  thumbUrl: item.imageUrl,
+                  mediaType: 'image',
+                  status: 'completed',
+                  engineLabel: item.engineLabel,
+                  createdAt: item.createdAt,
+                  jobId: item.jobId,
+                  prompt: item.prompt,
+                });
+              }}
+              onSelect={() => onSelectResult(item.id)}
+              onDownload={() =>
+                triggerAppDownload(
+                  item.imageUrl,
+                  suggestDownloadFilename(item.imageUrl, `character-reference-${item.id.replace(/[^a-z0-9]+/gi, '-')}`)
+                )
+              }
+              onSave={() => onSaveHistoricalResult(item)}
+              onDuplicateSettings={() => onDuplicateHistoricalSettings(item)}
+              copy={copy}
+            />
+          </div>
+        );
+      })}
+    </>
+  );
+
+  if (variant === 'desktop') {
+    return (
+      <div className="relative flex-1 min-h-0">
+        <div ref={resultsScrollContainerRef} className="scrollbar-rail h-full overflow-y-auto space-y-3 pr-4 pt-1">
+          {items}
+          {historicalHasMore ? <div ref={resultsSentinelRef} className="h-6" /> : null}
+          {historicalIsFetchingMore || historicalJobsLoading ? (
+            <div className="flex justify-center py-3 text-xs font-medium text-text-secondary">
+              {copy.resultCard.pending}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
+  return <div className="-mx-1 flex gap-3 overflow-x-auto px-1 pb-1">{items}</div>;
+}
+
+function formatHistoricalCreatedAt(createdAt: string): string {
+  try {
+    return new Intl.DateTimeFormat(undefined, { dateStyle: 'short', timeStyle: 'short' }).format(new Date(createdAt));
+  } catch {
+    return createdAt;
+  }
+}

--- a/frontend/src/components/tools/character-builder/_components/character-builder-workspace-components.tsx
+++ b/frontend/src/components/tools/character-builder/_components/character-builder-workspace-components.tsx
@@ -27,3 +27,4 @@ export {
   PendingResultCard,
   ResultCard,
 } from './character-builder-result-cards';
+export { CharacterBuilderResultsGallery } from './character-builder-results-gallery';

--- a/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderResultActions.ts
+++ b/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderResultActions.ts
@@ -1,0 +1,197 @@
+import { useCallback, useState, type Dispatch, type SetStateAction } from 'react';
+import { saveImageToLibrary } from '@/lib/api';
+import { authFetch } from '@/lib/authFetch';
+import { normalizeCharacterFormatMode } from '@/lib/character-builder';
+import type {
+  CharacterBuilderResult,
+  CharacterBuilderSettingsSnapshot,
+  CharacterBuilderState,
+} from '@/types/character-builder';
+import type { CharacterCopy } from '../_lib/character-builder-copy';
+import {
+  isAuthRequiredError,
+  parseCharacterBuilderSnapshot,
+} from '../_lib/character-builder-helpers';
+import type { HistoricalCharacterGalleryItem } from '../_lib/character-builder-types';
+
+interface UseCharacterBuilderResultActionsOptions {
+  copy: CharacterCopy;
+  openAuthGate: () => void;
+  setAdvancedOpen: Dispatch<SetStateAction<boolean>>;
+  setError: Dispatch<SetStateAction<string | null>>;
+  setShowStyleReferenceSlot: Dispatch<SetStateAction<boolean>>;
+  setState: Dispatch<SetStateAction<CharacterBuilderState>>;
+  setStatusMessage: Dispatch<SetStateAction<string | null>>;
+  user: unknown;
+}
+
+export function useCharacterBuilderResultActions({
+  copy,
+  openAuthGate,
+  setAdvancedOpen,
+  setError,
+  setShowStyleReferenceSlot,
+  setState,
+  setStatusMessage,
+  user,
+}: UseCharacterBuilderResultActionsOptions) {
+  const [savingResultId, setSavingResultId] = useState<string | null>(null);
+
+  const applySettingsSnapshot = useCallback(
+    (snapshot: CharacterBuilderSettingsSnapshot, selectedId?: string) => {
+      setState((previous) => ({
+        ...previous,
+        sourceMode: snapshot.builder.sourceMode,
+        referenceImages: snapshot.builder.referenceImages,
+        traits: snapshot.builder.traits,
+        outputMode: snapshot.builder.outputMode,
+        consistencyMode: snapshot.builder.consistencyMode,
+        referenceStrength: snapshot.builder.referenceStrength,
+        qualityMode: snapshot.builder.qualityMode,
+        formatMode: normalizeCharacterFormatMode(snapshot.builder.formatMode, snapshot.builder.qualityMode),
+        outputOptions: snapshot.builder.outputOptions,
+        advancedNotes: snapshot.builder.advancedNotes,
+        mustRemainVisible: snapshot.builder.mustRemainVisible,
+        selectedResultId: selectedId ?? previous.selectedResultId,
+      }));
+      setAdvancedOpen(Boolean(snapshot.builder.advancedNotes));
+      setStatusMessage(copy.duplicateDone);
+    },
+    [copy.duplicateDone, setAdvancedOpen, setState, setStatusMessage]
+  );
+
+  const handleSaveResult = useCallback(
+    async (result: CharacterBuilderResult) => {
+      if (!user) {
+        openAuthGate();
+        return;
+      }
+      setSavingResultId(result.id);
+      setError(null);
+      setStatusMessage(null);
+      try {
+        await saveImageToLibrary({
+          url: result.url,
+          jobId: result.jobId,
+          label: copy.generatePanel.portraitTitle,
+          source: 'character',
+        });
+        setStatusMessage(copy.savedToLibrary);
+      } catch (saveError) {
+        if (isAuthRequiredError(saveError)) {
+          openAuthGate();
+          return;
+        }
+        setError(saveError instanceof Error ? saveError.message : copy.saveToLibraryFailed);
+      } finally {
+        setSavingResultId(null);
+      }
+    },
+    [
+      copy.generatePanel.portraitTitle,
+      copy.savedToLibrary,
+      copy.saveToLibraryFailed,
+      openAuthGate,
+      setError,
+      setStatusMessage,
+      user,
+    ]
+  );
+
+  const handleSaveHistoricalResult = useCallback(
+    async (item: HistoricalCharacterGalleryItem) => {
+      if (!user) {
+        openAuthGate();
+        return;
+      }
+      setSavingResultId(item.id);
+      setError(null);
+      setStatusMessage(null);
+      try {
+        await saveImageToLibrary({
+          url: item.imageUrl,
+          jobId: item.jobId,
+          label: copy.generatePanel.portraitTitle,
+          source: 'character',
+        });
+        setStatusMessage(copy.savedToLibrary);
+      } catch (saveError) {
+        if (isAuthRequiredError(saveError)) {
+          openAuthGate();
+          return;
+        }
+        setError(saveError instanceof Error ? saveError.message : copy.saveToLibraryFailed);
+      } finally {
+        setSavingResultId(null);
+      }
+    },
+    [
+      copy.generatePanel.portraitTitle,
+      copy.savedToLibrary,
+      copy.saveToLibraryFailed,
+      openAuthGate,
+      setError,
+      setStatusMessage,
+      user,
+    ]
+  );
+
+  const handleDuplicateHistoricalSettings = useCallback(
+    async (item: HistoricalCharacterGalleryItem) => {
+      if (!user) {
+        openAuthGate();
+        return;
+      }
+      setError(null);
+      setStatusMessage(null);
+      try {
+        const response = await authFetch(`/api/jobs/${encodeURIComponent(item.jobId)}`);
+        const payload = (await response.json().catch(() => null)) as
+          | { ok?: boolean; settingsSnapshot?: unknown; error?: string }
+          | null;
+        if (!response.ok || !payload?.ok || !payload.settingsSnapshot) {
+          throw new Error(payload?.error ?? copy.runFailed);
+        }
+        const snapshotState = parseCharacterBuilderSnapshot(payload.settingsSnapshot);
+        if (!snapshotState) {
+          throw new Error(copy.missingRun);
+        }
+        setState((previous) => ({
+          ...previous,
+          ...snapshotState,
+          selectedResultId: item.id,
+        }));
+        setAdvancedOpen(Boolean(snapshotState.advancedNotes));
+        setShowStyleReferenceSlot(Boolean(snapshotState.referenceImages?.some((image) => image.role === 'style')));
+        setStatusMessage(copy.duplicateDone);
+      } catch (duplicateError) {
+        if (isAuthRequiredError(duplicateError)) {
+          openAuthGate();
+          return;
+        }
+        setError(duplicateError instanceof Error ? duplicateError.message : copy.runFailed);
+      }
+    },
+    [
+      copy.duplicateDone,
+      copy.missingRun,
+      copy.runFailed,
+      openAuthGate,
+      setAdvancedOpen,
+      setError,
+      setShowStyleReferenceSlot,
+      setState,
+      setStatusMessage,
+      user,
+    ]
+  );
+
+  return {
+    applySettingsSnapshot,
+    handleDuplicateHistoricalSettings,
+    handleSaveHistoricalResult,
+    handleSaveResult,
+    savingResultId,
+    setSavingResultId,
+  };
+}

--- a/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderResultsInfiniteScroll.ts
+++ b/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderResultsInfiniteScroll.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef } from 'react';
+
+interface UseCharacterBuilderResultsInfiniteScrollOptions {
+  hasMore: boolean;
+  resultsLength: number;
+  loadMoreResults: () => void;
+}
+
+export function useCharacterBuilderResultsInfiniteScroll({
+  hasMore,
+  resultsLength,
+  loadMoreResults,
+}: UseCharacterBuilderResultsInfiniteScrollOptions) {
+  const resultsScrollContainerRef = useRef<HTMLDivElement>(null!);
+  const resultsSentinelRef = useRef<HTMLDivElement>(null!);
+
+  useEffect(() => {
+    const sentinel = resultsSentinelRef.current;
+    if (!sentinel || !hasMore) return;
+
+    let previousY = 0;
+    let previousRatio = 0;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (
+            entry.isIntersecting &&
+            (entry.boundingClientRect.y > previousY || entry.intersectionRatio > previousRatio)
+          ) {
+            loadMoreResults();
+          }
+          previousY = entry.boundingClientRect.y;
+          previousRatio = entry.intersectionRatio;
+        });
+      },
+      {
+        root: resultsScrollContainerRef.current,
+        threshold: 0.2,
+      }
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, resultsLength, loadMoreResults]);
+
+  useEffect(() => {
+    const scrollContainer = resultsScrollContainerRef.current;
+    if (!scrollContainer || !hasMore) return undefined;
+
+    const maybeLoadMore = () => {
+      const remainingScroll = scrollContainer.scrollHeight - scrollContainer.scrollTop - scrollContainer.clientHeight;
+      if (remainingScroll <= 320) {
+        loadMoreResults();
+      }
+    };
+
+    maybeLoadMore();
+    scrollContainer.addEventListener('scroll', maybeLoadMore, { passive: true });
+    return () => scrollContainer.removeEventListener('scroll', maybeLoadMore);
+  }, [hasMore, resultsLength, loadMoreResults]);
+
+  return {
+    resultsScrollContainerRef,
+    resultsSentinelRef,
+  };
+}

--- a/tests/character-builder-workspace-architecture.test.ts
+++ b/tests/character-builder-workspace-architecture.test.ts
@@ -14,12 +14,15 @@ const generateDockPath = join(root, 'frontend/src/components/tools/character-bui
 const formControlsPath = join(root, 'frontend/src/components/tools/character-builder/_components/character-builder-form-controls.tsx');
 const referenceLibraryPath = join(root, 'frontend/src/components/tools/character-builder/_components/character-builder-reference-library.tsx');
 const resultCardsPath = join(root, 'frontend/src/components/tools/character-builder/_components/character-builder-result-cards.tsx');
+const resultsGalleryPath = join(root, 'frontend/src/components/tools/character-builder/_components/character-builder-results-gallery.tsx');
 const optionsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderOptions.ts');
 const historicalResultsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderHistoricalResults.ts');
 const pendingRunsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderPendingRunsSync.ts');
 const jobSnapshotHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderJobSnapshotLoader.ts');
 const generationRunnerHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderGenerationRunner.ts');
 const referenceAssetsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderReferenceAssets.ts');
+const resultActionsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderResultActions.ts');
+const resultsInfiniteScrollHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderResultsInfiniteScroll.ts');
 const persistenceHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderPersistence.ts');
 
 const workspaceSource = readFileSync(workspacePath, 'utf8');
@@ -34,12 +37,15 @@ test('character builder workspace delegates copy, local types, and helper logic'
   assert.ok(existsSync(formControlsPath), 'form controls should live in a focused component module');
   assert.ok(existsSync(referenceLibraryPath), 'reference library components should live in a focused component module');
   assert.ok(existsSync(resultCardsPath), 'result card components should live in a focused component module');
+  assert.ok(existsSync(resultsGalleryPath), 'result gallery composition should live in a focused component module');
   assert.ok(existsSync(optionsHookPath), 'localized option derivation should live in a focused hook');
   assert.ok(existsSync(historicalResultsHookPath), 'historical result derivation should live in a focused hook');
   assert.ok(existsSync(pendingRunsHookPath), 'pending run polling should live in a focused hook');
   assert.ok(existsSync(jobSnapshotHookPath), 'job snapshot loading should live in a focused hook');
   assert.ok(existsSync(generationRunnerHookPath), 'generation submission should live in a focused hook');
   assert.ok(existsSync(referenceAssetsHookPath), 'reference asset upload and library selection should live in a focused hook');
+  assert.ok(existsSync(resultActionsHookPath), 'result actions should live in a focused hook');
+  assert.ok(existsSync(resultsInfiniteScrollHookPath), 'result infinite scroll should live in a focused hook');
   assert.ok(existsSync(persistenceHookPath), 'local persistence should live in a focused hook');
 
   assert.match(workspaceSource, /from '\.\/character-builder\/_components\/character-builder-workspace-components'/, 'workspace should import UI components');
@@ -49,6 +55,8 @@ test('character builder workspace delegates copy, local types, and helper logic'
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderJobSnapshotLoader'/, 'workspace should import job snapshot loader hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderGenerationRunner'/, 'workspace should import generation runner hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderReferenceAssets'/, 'workspace should import reference asset hook');
+  assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderResultActions'/, 'workspace should import result actions hook');
+  assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderResultsInfiniteScroll'/, 'workspace should import result infinite scroll hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderPersistence'/, 'workspace should import persistence hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_lib\/character-builder-copy'/, 'workspace should import character copy');
   assert.match(workspaceSource, /from '\.\/character-builder\/_lib\/character-builder-types'/, 'workspace should import local types');
@@ -76,12 +84,22 @@ test('character builder workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /async function handleUpload\(/, 'reference upload handling belongs in useCharacterBuilderReferenceAssets');
   assert.doesNotMatch(workspaceSource, /function handleLibrarySelect\(/, 'reference library selection belongs in useCharacterBuilderReferenceAssets');
   assert.doesNotMatch(workspaceSource, /buildReferenceImage/, 'reference image construction belongs in useCharacterBuilderReferenceAssets');
+  assert.doesNotMatch(workspaceSource, /async function handleSaveResult\(/, 'result save actions belong in useCharacterBuilderResultActions');
+  assert.doesNotMatch(workspaceSource, /async function handleSaveHistoricalResult\(/, 'historical save actions belong in useCharacterBuilderResultActions');
+  assert.doesNotMatch(workspaceSource, /async function handleDuplicateHistoricalSettings\(/, 'historical duplicate actions belong in useCharacterBuilderResultActions');
+  assert.doesNotMatch(workspaceSource, /function applySettingsSnapshot\(/, 'result snapshot application belongs in useCharacterBuilderResultActions');
+  assert.doesNotMatch(workspaceSource, /saveImageToLibrary/, 'result library saving belongs in useCharacterBuilderResultActions');
+  assert.doesNotMatch(workspaceSource, /parseCharacterBuilderSnapshot/, 'historical snapshot parsing belongs in useCharacterBuilderResultActions');
+  assert.doesNotMatch(workspaceSource, /triggerAppDownload/, 'result downloads belong in CharacterBuilderResultsGallery');
+  assert.doesNotMatch(workspaceSource, /new IntersectionObserver/, 'result infinite scroll observer belongs in useCharacterBuilderResultsInfiniteScroll');
+  assert.doesNotMatch(workspaceSource, /scrollContainer\.addEventListener/, 'result scroll listener belongs in useCharacterBuilderResultsInfiniteScroll');
+  assert.doesNotMatch(workspaceSource, /<ResultCard/, 'result card composition belongs in CharacterBuilderResultsGallery');
   assert.doesNotMatch(workspaceSource, /readPersistedState\(\)/, 'local hydration belongs in useCharacterBuilderPersistence');
   assert.doesNotMatch(workspaceSource, /writePersistedPendingRuns/, 'pending run persistence belongs in useCharacterBuilderPersistence');
   assert.doesNotMatch(workspaceSource, /visitorSanitizedRef/, 'visitor cleanup tracking belongs in useCharacterBuilderPersistence');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 1485, `CharacterBuilderWorkspace should stay below 1485 lines after reference asset hook extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 1210, `CharacterBuilderWorkspace should stay below 1210 lines after result extraction, got ${lineCount}`);
 });
 
 test('character builder helper modules expose the expected workspace contract', () => {
@@ -94,12 +112,15 @@ test('character builder helper modules expose the expected workspace contract', 
   const formControlsSource = readFileSync(formControlsPath, 'utf8');
   const referenceLibrarySource = readFileSync(referenceLibraryPath, 'utf8');
   const resultCardsSource = readFileSync(resultCardsPath, 'utf8');
+  const resultsGallerySource = readFileSync(resultsGalleryPath, 'utf8');
   const optionsHookSource = readFileSync(optionsHookPath, 'utf8');
   const historicalResultsHookSource = readFileSync(historicalResultsHookPath, 'utf8');
   const pendingRunsHookSource = readFileSync(pendingRunsHookPath, 'utf8');
   const jobSnapshotHookSource = readFileSync(jobSnapshotHookPath, 'utf8');
   const generationRunnerHookSource = readFileSync(generationRunnerHookPath, 'utf8');
   const referenceAssetsHookSource = readFileSync(referenceAssetsHookPath, 'utf8');
+  const resultActionsHookSource = readFileSync(resultActionsHookPath, 'utf8');
+  const resultsInfiniteScrollHookSource = readFileSync(resultsInfiniteScrollHookPath, 'utf8');
   const persistenceHookSource = readFileSync(persistenceHookPath, 'utf8');
 
   assert.match(copySource, /export const DEFAULT_CHARACTER_COPY =/, 'copy module should export default copy');
@@ -148,6 +169,7 @@ test('character builder helper modules expose the expected workspace contract', 
     './character-builder-form-controls',
     './character-builder-reference-library',
     './character-builder-result-cards',
+    './character-builder-results-gallery',
   ]) {
     assert.match(componentsSource, new RegExp(`from '${moduleName}'`), `component barrel should re-export ${moduleName}`);
   }
@@ -156,6 +178,7 @@ test('character builder helper modules expose the expected workspace contract', 
   assert.doesNotMatch(componentsSource, /export function HairEditorPanel\(/, 'form controls should not be implemented in the barrel');
   assert.doesNotMatch(componentsSource, /export function CharacterReferenceLibraryModal\(/, 'library modal should not be implemented in the barrel');
   assert.doesNotMatch(componentsSource, /export function ResultCard\(/, 'result cards should not be implemented in the barrel');
+  assert.doesNotMatch(componentsSource, /export function CharacterBuilderResultsGallery\(/, 'result gallery should not be implemented in the barrel');
 
   for (const exportName of [
     'VisualChoiceCard',
@@ -196,6 +219,10 @@ test('character builder helper modules expose the expected workspace contract', 
     assert.match(resultCardsSource, new RegExp(`export function ${exportName}`), `${exportName} should be exported`);
   }
 
+  assert.match(resultsGallerySource, /export function CharacterBuilderResultsGallery/, 'results gallery should be exported');
+  assert.match(resultsGallerySource, /<ResultCard/, 'results gallery should compose result cards');
+  assert.match(resultsGallerySource, /triggerAppDownload/, 'results gallery should own downloads');
+
   assert.match(optionsHookSource, /export function useCharacterBuilderOptions/, 'options hook should be exported');
   assert.match(optionsHookSource, /getAvailableCharacterFormatOptions/, 'options hook should own format option derivation');
   assert.match(historicalResultsHookSource, /export function useCharacterBuilderHistoricalResults/, 'historical results hook should be exported');
@@ -212,6 +239,12 @@ test('character builder helper modules expose the expected workspace contract', 
   assert.match(referenceAssetsHookSource, /uploadImage/, 'reference asset hook should own uploads');
   assert.match(referenceAssetsHookSource, /buildReferenceImage/, 'reference asset hook should build uploaded references');
   assert.match(referenceAssetsHookSource, /updateReferenceImage/, 'reference asset hook should update reference slots');
+  assert.match(resultActionsHookSource, /export function useCharacterBuilderResultActions/, 'result actions hook should be exported');
+  assert.match(resultActionsHookSource, /saveImageToLibrary/, 'result actions hook should own library saves');
+  assert.match(resultActionsHookSource, /parseCharacterBuilderSnapshot/, 'result actions hook should own historical snapshot parsing');
+  assert.match(resultsInfiniteScrollHookSource, /export function useCharacterBuilderResultsInfiniteScroll/, 'results scroll hook should be exported');
+  assert.match(resultsInfiniteScrollHookSource, /new IntersectionObserver/, 'results scroll hook should own the observer');
+  assert.match(resultsInfiniteScrollHookSource, /scrollContainer\.addEventListener/, 'results scroll hook should own scroll fallback loading');
   assert.match(persistenceHookSource, /export function useCharacterBuilderPersistence/, 'persistence hook should be exported');
   assert.match(persistenceHookSource, /readPersistedState/, 'persistence hook should own local hydration');
   assert.match(persistenceHookSource, /writePersistedPendingRuns/, 'persistence hook should own pending run persistence');


### PR DESCRIPTION
Summary
- move result gallery rendering into a dedicated CharacterBuilderResultsGallery component
- move save/duplicate result actions into useCharacterBuilderResultActions
- move result infinite-scroll refs/effects into useCharacterBuilderResultsInfiniteScroll
- lower the CharacterBuilderWorkspace architecture budget to 1210 lines

Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/character-builder-workspace-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- git diff --check -- touched character-builder paths
- npm --prefix frontend run lint
- npm run lint:exposure