### PR TITLE
[codex] Split admin metrics shared helpers

### DIFF
--- a/frontend/server/admin-metrics.ts
+++ b/frontend/server/admin-metrics.ts
@@ -1,331 +1,54 @@
-import { isDatabaseConfigured, query } from '@/lib/db';
+import { isDatabaseConfigured } from '@/lib/db';
 import { ensureBillingSchema } from '@/lib/schema';
 import { getServiceNoticeSetting } from '@/server/app-settings';
 import type {
   AdminHealthSnapshot,
   AdminMetricsComparison,
   AdminMetrics,
-  AmountSeriesPoint,
   BehaviorMetrics,
   EngineHealthStat,
   EngineUsage,
   FunnelMetrics,
   HealthMetrics,
-  MetricsRange,
-  MetricsRangeLabel,
-  MonthlyAmountPoint,
-  MonthlyPoint,
-  TimeSeriesPoint,
-  WhaleUser,
 } from '@/lib/admin/types';
+import {
+  ENGINE_USAGE_WINDOW_DAYS,
+  HEALTH_WINDOW_HOURS,
+  PENDING_STALE_MINUTES,
+  buildEmptyMetrics,
+  buildRange,
+  coerceNumber,
+  completedCondition,
+  fillAmountSeries,
+  fillDailySeries,
+  mapAmountRows,
+  mapCountRows,
+  mapEngineUsage,
+  refundedFailedCondition,
+  resolveRange,
+  safeQuery,
+  toISO,
+  unresolvedFailedCondition,
+  type AdminMetricsOptions,
+  type AmountRow,
+  type BehaviorRow,
+  type CountRow,
+  type CountValueRow,
+  type DurationRow,
+  type EngineAggRow,
+  type FailedEngineRow,
+  type FunnelRow,
+  type HealthRow,
+  type ReturningRow,
+  type SummaryRow,
+  type WhaleRow,
+} from '@/server/admin-metrics/admin-metrics-helpers';
 export type { AdminMetrics, MetricsRangeLabel } from '@/lib/admin/types';
-
-type AdminMetricsOptions = {
-  excludeUserIds?: string[];
-};
-
-type CountRow = {
-  bucket: Date | string;
-  count: number | string | null;
-};
-
-type AmountRow = CountRow & {
-  amount_cents: number | string | null;
-};
-
-type SummaryRow = {
-  total: number | string | null;
-};
-
-type EngineAggRow = {
-  engine_id: string | null;
-  engine_label: string | null;
-  render_count: number | string | null;
-  user_count: number | string | null;
-  amount_cents: number | string | null;
-};
-
-type FunnelRow = {
-  total_topup_users: number | string | null;
-  converted_within_30d: number | string | null;
-};
-
-type DurationRow = {
-  avg_days: number | string | null;
-};
-
-type BehaviorRow = {
-  avg_renders: number | string | null;
-  median_renders: number | string | null;
-};
-
-type ReturningRow = {
-  returning_count: number | string | null;
-};
-
-type CountValueRow = {
-  count: number | string | null;
-};
-
-type WhaleRow = {
-  user_id: string;
-  lifetime_topup_cents: number | string | null;
-  lifetime_charge_cents: number | string | null;
-  render_count: number | string | null;
-  first_seen_at: Date | string | null;
-  last_active_at: Date | string | null;
-};
-
-type HealthRow = {
-  failed_count: number | string | null;
-  total_count: number | string | null;
-};
-
-type FailedEngineRow = {
-  engine_id: string | null;
-  engine_label: string | null;
-  failed_count: number | string | null;
-  total_count: number | string | null;
-};
-
-const RANGE_DAYS: Record<MetricsRangeLabel, number> = {
-  '24h': 1,
-  '7d': 7,
-  '30d': 30,
-  '90d': 90,
-};
-
-const HEALTH_WINDOW_HOURS = 24;
-const PENDING_STALE_MINUTES = 15;
-const ENGINE_USAGE_WINDOW_DAYS = 30;
-
-function unresolvedFailedCondition(alias: string): string {
-  return `(
-    LOWER(COALESCE(${alias}.status, '')) IN ('failed', 'error', 'errored', 'cancelled', 'canceled', 'aborted')
-    AND COALESCE(${alias}.payment_status, '') NOT ILIKE '%refunded%'
-    AND NOT EXISTS (
-      SELECT 1
-      FROM app_receipts refund_receipts
-      WHERE refund_receipts.job_id = ${alias}.job_id
-        AND refund_receipts.type = 'refund'
-    )
-  )`;
-}
-
-function refundedFailedCondition(alias: string): string {
-  return `(
-    LOWER(COALESCE(${alias}.status, '')) IN ('failed', 'error', 'errored', 'cancelled', 'canceled', 'aborted')
-    AND (
-      COALESCE(${alias}.payment_status, '') ILIKE '%refunded%'
-      OR EXISTS (
-        SELECT 1
-        FROM app_receipts refund_receipts
-        WHERE refund_receipts.job_id = ${alias}.job_id
-          AND refund_receipts.type = 'refund'
-      )
-    )
-  )`;
-}
-
-function completedCondition(alias: string): string {
-  return `LOWER(COALESCE(${alias}.status, '')) IN ('completed', 'success', 'succeeded', 'finished')`;
-}
-
-export const METRIC_RANGE_OPTIONS: MetricsRangeLabel[] = ['24h', '7d', '30d', '90d'];
-export const DEFAULT_METRIC_RANGE: MetricsRangeLabel = '30d';
-
-export function normalizeMetricsRange(candidate?: string | null): MetricsRangeLabel {
-  if (!candidate) {
-    return DEFAULT_METRIC_RANGE;
-  }
-  const normalized = candidate.trim().toLowerCase();
-  if (normalized === '24h' || normalized.startsWith('24') || normalized === '1d') {
-    return '24h';
-  }
-  if (normalized.startsWith('7')) {
-    return '7d';
-  }
-  if (normalized.startsWith('9')) {
-    return '90d';
-  }
-  if (normalized.startsWith('30')) {
-    return '30d';
-  }
-  return DEFAULT_METRIC_RANGE;
-}
-
-function resolveRange(candidate?: string | null): MetricsRange {
-  const label = normalizeMetricsRange(candidate);
-  const days = RANGE_DAYS[label];
-  return buildRange(days, label);
-}
-
-function buildRange(days: number, label: MetricsRangeLabel): MetricsRange {
-  const now = new Date();
-  const todayStart = startOfUtcDay(now);
-  const rangeStart = new Date(todayStart);
-  rangeStart.setUTCDate(rangeStart.getUTCDate() - (days - 1));
-  return {
-    label,
-    days,
-    from: rangeStart.toISOString(),
-    to: now.toISOString(),
-  };
-}
-
-function startOfUtcDay(date: Date): Date {
-  const copy = new Date(date);
-  copy.setUTCHours(0, 0, 0, 0);
-  return copy;
-}
-
-function buildDailyBuckets(range: MetricsRange): string[] {
-  const buckets: string[] = [];
-  const todayStart = startOfUtcDay(new Date());
-  const start = new Date(todayStart);
-  start.setUTCDate(start.getUTCDate() - (range.days - 1));
-  for (let i = 0; i < range.days; i += 1) {
-    const current = new Date(start);
-    current.setUTCDate(start.getUTCDate() + i);
-    buckets.push(current.toISOString());
-  }
-  return buckets;
-}
-
-function toISO(value: Date | string): string {
-  if (value instanceof Date) {
-    return value.toISOString();
-  }
-  return new Date(value).toISOString();
-}
-
-function coerceNumber(value: number | string | null | undefined): number {
-  if (typeof value === 'number') return value;
-  if (typeof value === 'string') {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : 0;
-  }
-  return 0;
-}
-
-async function safeQuery<T>(sql: string, params?: ReadonlyArray<unknown>): Promise<T[]> {
-  try {
-    return await query<T>(sql, params);
-  } catch (error) {
-    console.warn('[admin-metrics] query failed', {
-      sql,
-      error: error instanceof Error ? error.message : error,
-    });
-    return [];
-  }
-}
-
-function mapCountRows(rows: CountRow[]): TimeSeriesPoint[] {
-  return rows
-    .map((row) => ({
-      date: toISO(row.bucket),
-      value: coerceNumber(row.count),
-    }))
-    .sort((a, b) => a.date.localeCompare(b.date));
-}
-
-function mapAmountRows(rows: AmountRow[]): AmountSeriesPoint[] {
-  return rows
-    .map((row) => ({
-      date: toISO(row.bucket),
-      count: coerceNumber(row.count),
-      amountCents: coerceNumber(row.amount_cents),
-    }))
-    .sort((a, b) => a.date.localeCompare(b.date));
-}
-
-function fillDailySeries(points: TimeSeriesPoint[], range: MetricsRange): TimeSeriesPoint[] {
-  if (range.days === 1) {
-    return [
-      {
-        date: range.to,
-        value: points.reduce((sum, point) => sum + point.value, 0),
-      },
-    ];
-  }
-
-  const buckets = buildDailyBuckets(range);
-  const map = new Map(points.map((point) => [point.date.slice(0, 10), point.value]));
-  return buckets.map((iso) => {
-    const key = iso.slice(0, 10);
-    return {
-      date: iso,
-      value: map.get(key) ?? 0,
-    };
-  });
-}
-
-function fillAmountSeries(points: AmountSeriesPoint[], range: MetricsRange): AmountSeriesPoint[] {
-  if (range.days === 1) {
-    return [
-      {
-        date: range.to,
-        count: points.reduce((sum, point) => sum + point.count, 0),
-        amountCents: points.reduce((sum, point) => sum + point.amountCents, 0),
-      },
-    ];
-  }
-
-  const buckets = buildDailyBuckets(range);
-  const map = new Map(points.map((point) => [point.date.slice(0, 10), point]));
-  return buckets.map((iso) => {
-    const key = iso.slice(0, 10);
-    const entry = map.get(key);
-    if (entry) {
-      return { date: iso, count: entry.count, amountCents: entry.amountCents };
-    }
-    return { date: iso, count: 0, amountCents: 0 };
-  });
-}
-
-function buildEmptyMetrics(range: MetricsRange): AdminMetrics {
-  return {
-    totals: {
-      totalAccounts: 0,
-      payingAccounts: 0,
-      activeAccounts30d: 0,
-      allTimeTopUpsUsd: 0,
-      allTimeRenderChargesUsd: 0,
-    },
-    range,
-    timeseries: {
-      signupsDaily: fillDailySeries([], range),
-      activeAccountsDaily: fillDailySeries([], range),
-      topupsDaily: fillAmountSeries([], range),
-      chargesDaily: fillAmountSeries([], range),
-    },
-    monthly: {
-      signupsMonthly: [],
-      topupsMonthly: [],
-      chargesMonthly: [],
-    },
-    engines: [],
-    funnels: {
-      signupToTopUpConversion: 0,
-      totalTopupUsers: 0,
-      topUpToRenderConversion30d: 0,
-      convertedWithin30dUsers: 0,
-      avgTimeSignupToFirstTopUpDays: null,
-      avgTimeTopUpToFirstRenderDays: null,
-    },
-    behavior: {
-      avgRendersPerPayingUser30d: 0,
-      medianRendersPerPayingUser30d: 0,
-      returningUsers7d: 0,
-      whalesTop10: [],
-    },
-    health: {
-      failedRenders30d: 0,
-      failedRendersRate30d: 0,
-      failedByEngine30d: [],
-    },
-  };
-}
+export {
+  DEFAULT_METRIC_RANGE,
+  METRIC_RANGE_OPTIONS,
+  normalizeMetricsRange,
+} from '@/server/admin-metrics/admin-metrics-helpers';
 
 async function loadEngineUsageRows(excludedUserIds?: string[]): Promise<EngineAggRow[]> {
   const filteredUserIds = (excludedUserIds ?? []).map((userId) => userId.trim()).filter(Boolean);
@@ -367,30 +90,6 @@ async function loadEngineUsageRows(excludedUserIds?: string[]): Promise<EngineAg
     `,
     params
   );
-}
-
-function mapEngineUsage(rows: EngineAggRow[]): EngineUsage[] {
-  const renderTotal = rows.reduce((sum, row) => sum + coerceNumber(row.render_count), 0);
-  const revenueTotalCents = rows.reduce((sum, row) => sum + coerceNumber(row.amount_cents), 0);
-
-  return rows.map((row) => {
-    const renderCount = coerceNumber(row.render_count);
-    const distinctUsers = coerceNumber(row.user_count);
-    const amountCents = coerceNumber(row.amount_cents);
-    const amountUsd = amountCents / 100;
-    const engineId = row.engine_id ?? 'unknown';
-    const engineLabel = row.engine_label ?? engineId;
-    return {
-      engineId,
-      engineLabel,
-      rendersCount30d: renderCount,
-      rendersAmount30dUsd: amountUsd,
-      distinctUsers30d: distinctUsers,
-      shareOfTotalRenders30d: renderTotal ? renderCount / renderTotal : 0,
-      shareOfTotalRevenue30d: revenueTotalCents ? amountCents / revenueTotalCents : 0,
-      avgSpendPerUser30d: distinctUsers ? amountUsd / distinctUsers : 0,
-    };
-  });
 }
 
 export async function fetchAdminMetrics(

--- a/frontend/server/admin-metrics/admin-metrics-helpers.ts
+++ b/frontend/server/admin-metrics/admin-metrics-helpers.ts
@@ -1,0 +1,339 @@
+import { query } from '@/lib/db';
+import type {
+  AdminMetrics,
+  AmountSeriesPoint,
+  EngineUsage,
+  MetricsRange,
+  MetricsRangeLabel,
+  TimeSeriesPoint,
+} from '@/lib/admin/types';
+
+export type AdminMetricsOptions = {
+  excludeUserIds?: string[];
+};
+
+export type CountRow = {
+  bucket: Date | string;
+  count: number | string | null;
+};
+
+export type AmountRow = CountRow & {
+  amount_cents: number | string | null;
+};
+
+export type SummaryRow = {
+  total: number | string | null;
+};
+
+export type EngineAggRow = {
+  engine_id: string | null;
+  engine_label: string | null;
+  render_count: number | string | null;
+  user_count: number | string | null;
+  amount_cents: number | string | null;
+};
+
+export type FunnelRow = {
+  total_topup_users: number | string | null;
+  converted_within_30d: number | string | null;
+};
+
+export type DurationRow = {
+  avg_days: number | string | null;
+};
+
+export type BehaviorRow = {
+  avg_renders: number | string | null;
+  median_renders: number | string | null;
+};
+
+export type ReturningRow = {
+  returning_count: number | string | null;
+};
+
+export type CountValueRow = {
+  count: number | string | null;
+};
+
+export type WhaleRow = {
+  user_id: string;
+  lifetime_topup_cents: number | string | null;
+  lifetime_charge_cents: number | string | null;
+  render_count: number | string | null;
+  first_seen_at: Date | string | null;
+  last_active_at: Date | string | null;
+};
+
+export type HealthRow = {
+  failed_count: number | string | null;
+  total_count: number | string | null;
+};
+
+export type FailedEngineRow = {
+  engine_id: string | null;
+  engine_label: string | null;
+  failed_count: number | string | null;
+  total_count: number | string | null;
+};
+
+const RANGE_DAYS: Record<MetricsRangeLabel, number> = {
+  '24h': 1,
+  '7d': 7,
+  '30d': 30,
+  '90d': 90,
+};
+
+export const HEALTH_WINDOW_HOURS = 24;
+export const PENDING_STALE_MINUTES = 15;
+export const ENGINE_USAGE_WINDOW_DAYS = 30;
+export const METRIC_RANGE_OPTIONS: MetricsRangeLabel[] = ['24h', '7d', '30d', '90d'];
+export const DEFAULT_METRIC_RANGE: MetricsRangeLabel = '30d';
+
+export function unresolvedFailedCondition(alias: string): string {
+  return `(
+    LOWER(COALESCE(${alias}.status, '')) IN ('failed', 'error', 'errored', 'cancelled', 'canceled', 'aborted')
+    AND COALESCE(${alias}.payment_status, '') NOT ILIKE '%refunded%'
+    AND NOT EXISTS (
+      SELECT 1
+      FROM app_receipts refund_receipts
+      WHERE refund_receipts.job_id = ${alias}.job_id
+        AND refund_receipts.type = 'refund'
+    )
+  )`;
+}
+
+export function refundedFailedCondition(alias: string): string {
+  return `(
+    LOWER(COALESCE(${alias}.status, '')) IN ('failed', 'error', 'errored', 'cancelled', 'canceled', 'aborted')
+    AND (
+      COALESCE(${alias}.payment_status, '') ILIKE '%refunded%'
+      OR EXISTS (
+        SELECT 1
+        FROM app_receipts refund_receipts
+        WHERE refund_receipts.job_id = ${alias}.job_id
+          AND refund_receipts.type = 'refund'
+      )
+    )
+  )`;
+}
+
+export function completedCondition(alias: string): string {
+  return `LOWER(COALESCE(${alias}.status, '')) IN ('completed', 'success', 'succeeded', 'finished')`;
+}
+
+export function normalizeMetricsRange(candidate?: string | null): MetricsRangeLabel {
+  if (!candidate) {
+    return DEFAULT_METRIC_RANGE;
+  }
+  const normalized = candidate.trim().toLowerCase();
+  if (normalized === '24h' || normalized.startsWith('24') || normalized === '1d') {
+    return '24h';
+  }
+  if (normalized.startsWith('7')) {
+    return '7d';
+  }
+  if (normalized.startsWith('9')) {
+    return '90d';
+  }
+  if (normalized.startsWith('30')) {
+    return '30d';
+  }
+  return DEFAULT_METRIC_RANGE;
+}
+
+export function resolveRange(candidate?: string | null): MetricsRange {
+  const label = normalizeMetricsRange(candidate);
+  const days = RANGE_DAYS[label];
+  return buildRange(days, label);
+}
+
+export function buildRange(days: number, label: MetricsRangeLabel): MetricsRange {
+  const now = new Date();
+  const todayStart = startOfUtcDay(now);
+  const rangeStart = new Date(todayStart);
+  rangeStart.setUTCDate(rangeStart.getUTCDate() - (days - 1));
+  return {
+    label,
+    days,
+    from: rangeStart.toISOString(),
+    to: now.toISOString(),
+  };
+}
+
+function startOfUtcDay(date: Date): Date {
+  const copy = new Date(date);
+  copy.setUTCHours(0, 0, 0, 0);
+  return copy;
+}
+
+function buildDailyBuckets(range: MetricsRange): string[] {
+  const buckets: string[] = [];
+  const todayStart = startOfUtcDay(new Date());
+  const start = new Date(todayStart);
+  start.setUTCDate(start.getUTCDate() - (range.days - 1));
+  for (let i = 0; i < range.days; i += 1) {
+    const current = new Date(start);
+    current.setUTCDate(start.getUTCDate() + i);
+    buckets.push(current.toISOString());
+  }
+  return buckets;
+}
+
+export function toISO(value: Date | string): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  return new Date(value).toISOString();
+}
+
+export function coerceNumber(value: number | string | null | undefined): number {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+export async function safeQuery<T>(sql: string, params?: ReadonlyArray<unknown>): Promise<T[]> {
+  try {
+    return await query<T>(sql, params);
+  } catch (error) {
+    console.warn('[admin-metrics] query failed', {
+      sql,
+      error: error instanceof Error ? error.message : error,
+    });
+    return [];
+  }
+}
+
+export function mapCountRows(rows: CountRow[]): TimeSeriesPoint[] {
+  return rows
+    .map((row) => ({
+      date: toISO(row.bucket),
+      value: coerceNumber(row.count),
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+export function mapAmountRows(rows: AmountRow[]): AmountSeriesPoint[] {
+  return rows
+    .map((row) => ({
+      date: toISO(row.bucket),
+      count: coerceNumber(row.count),
+      amountCents: coerceNumber(row.amount_cents),
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+export function fillDailySeries(points: TimeSeriesPoint[], range: MetricsRange): TimeSeriesPoint[] {
+  if (range.days === 1) {
+    return [
+      {
+        date: range.to,
+        value: points.reduce((sum, point) => sum + point.value, 0),
+      },
+    ];
+  }
+
+  const buckets = buildDailyBuckets(range);
+  const map = new Map(points.map((point) => [point.date.slice(0, 10), point.value]));
+  return buckets.map((iso) => {
+    const key = iso.slice(0, 10);
+    return {
+      date: iso,
+      value: map.get(key) ?? 0,
+    };
+  });
+}
+
+export function fillAmountSeries(points: AmountSeriesPoint[], range: MetricsRange): AmountSeriesPoint[] {
+  if (range.days === 1) {
+    return [
+      {
+        date: range.to,
+        count: points.reduce((sum, point) => sum + point.count, 0),
+        amountCents: points.reduce((sum, point) => sum + point.amountCents, 0),
+      },
+    ];
+  }
+
+  const buckets = buildDailyBuckets(range);
+  const map = new Map(points.map((point) => [point.date.slice(0, 10), point]));
+  return buckets.map((iso) => {
+    const key = iso.slice(0, 10);
+    const entry = map.get(key);
+    if (entry) {
+      return { date: iso, count: entry.count, amountCents: entry.amountCents };
+    }
+    return { date: iso, count: 0, amountCents: 0 };
+  });
+}
+
+export function buildEmptyMetrics(range: MetricsRange): AdminMetrics {
+  return {
+    totals: {
+      totalAccounts: 0,
+      payingAccounts: 0,
+      activeAccounts30d: 0,
+      allTimeTopUpsUsd: 0,
+      allTimeRenderChargesUsd: 0,
+    },
+    range,
+    timeseries: {
+      signupsDaily: fillDailySeries([], range),
+      activeAccountsDaily: fillDailySeries([], range),
+      topupsDaily: fillAmountSeries([], range),
+      chargesDaily: fillAmountSeries([], range),
+    },
+    monthly: {
+      signupsMonthly: [],
+      topupsMonthly: [],
+      chargesMonthly: [],
+    },
+    engines: [],
+    funnels: {
+      signupToTopUpConversion: 0,
+      totalTopupUsers: 0,
+      topUpToRenderConversion30d: 0,
+      convertedWithin30dUsers: 0,
+      avgTimeSignupToFirstTopUpDays: null,
+      avgTimeTopUpToFirstRenderDays: null,
+    },
+    behavior: {
+      avgRendersPerPayingUser30d: 0,
+      medianRendersPerPayingUser30d: 0,
+      returningUsers7d: 0,
+      whalesTop10: [],
+    },
+    health: {
+      failedRenders30d: 0,
+      failedRendersRate30d: 0,
+      failedByEngine30d: [],
+    },
+  };
+}
+
+export function mapEngineUsage(rows: EngineAggRow[]): EngineUsage[] {
+  const renderTotal = rows.reduce((sum, row) => sum + coerceNumber(row.render_count), 0);
+  const revenueTotalCents = rows.reduce((sum, row) => sum + coerceNumber(row.amount_cents), 0);
+
+  return rows.map((row) => {
+    const renderCount = coerceNumber(row.render_count);
+    const distinctUsers = coerceNumber(row.user_count);
+    const amountCents = coerceNumber(row.amount_cents);
+    const amountUsd = amountCents / 100;
+    const engineId = row.engine_id ?? 'unknown';
+    const engineLabel = row.engine_label ?? engineId;
+    return {
+      engineId,
+      engineLabel,
+      rendersCount30d: renderCount,
+      rendersAmount30dUsd: amountUsd,
+      distinctUsers30d: distinctUsers,
+      shareOfTotalRenders30d: renderTotal ? renderCount / renderTotal : 0,
+      shareOfTotalRevenue30d: revenueTotalCents ? amountCents / revenueTotalCents : 0,
+      avgSpendPerUser30d: distinctUsers ? amountUsd / distinctUsers : 0,
+    };
+  });
+}

--- a/tests/admin-metrics-server-architecture.test.ts
+++ b/tests/admin-metrics-server-architecture.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const root = process.cwd();
+const metricsPath = join(root, 'frontend/server/admin-metrics.ts');
+const helpersPath = join(root, 'frontend/server/admin-metrics/admin-metrics-helpers.ts');
+
+const metricsSource = readFileSync(metricsPath, 'utf8');
+const helpersSource = readFileSync(helpersPath, 'utf8');
+
+test('admin metrics delegates shared row helpers and range logic', () => {
+  assert.ok(existsSync(helpersPath), 'admin metrics helpers should live in a focused server module');
+  assert.match(metricsSource, /from '@\/server\/admin-metrics\/admin-metrics-helpers'/);
+  assert.match(metricsSource, /fetchAdminMetrics\(/);
+  assert.match(metricsSource, /fetchAdminMetricsComparison\(/);
+  assert.match(metricsSource, /fetchAdminHealth\(/);
+});
+
+test('admin metrics fetcher does not regain shared helper ownership', () => {
+  for (const pattern of [
+    /type CountRow =/,
+    /type AmountRow =/,
+    /function unresolvedFailedCondition\(/,
+    /function refundedFailedCondition\(/,
+    /function completedCondition\(/,
+    /function normalizeMetricsRange\(/,
+    /function buildRange\(/,
+    /function coerceNumber\(/,
+    /async function safeQuery\(/,
+    /function mapCountRows\(/,
+    /function mapAmountRows\(/,
+    /function fillDailySeries\(/,
+    /function fillAmountSeries\(/,
+    /function buildEmptyMetrics\(/,
+    /function mapEngineUsage\(/,
+  ]) {
+    assert.doesNotMatch(metricsSource, pattern);
+  }
+
+  const lineCount = metricsSource.split('\n').length;
+  assert.ok(lineCount <= 820, `admin-metrics.ts should stay below 820 lines after helper extraction, got ${lineCount}`);
+});
+
+test('admin metrics helper module exposes the expected contract', () => {
+  for (const exportName of [
+    'AdminMetricsOptions',
+    'CountRow',
+    'AmountRow',
+    'EngineAggRow',
+    'FailedEngineRow',
+    'HEALTH_WINDOW_HOURS',
+    'PENDING_STALE_MINUTES',
+    'ENGINE_USAGE_WINDOW_DAYS',
+    'METRIC_RANGE_OPTIONS',
+    'DEFAULT_METRIC_RANGE',
+    'unresolvedFailedCondition',
+    'refundedFailedCondition',
+    'completedCondition',
+    'normalizeMetricsRange',
+    'resolveRange',
+    'buildRange',
+    'toISO',
+    'coerceNumber',
+    'safeQuery',
+    'mapCountRows',
+    'mapAmountRows',
+    'fillDailySeries',
+    'fillAmountSeries',
+    'buildEmptyMetrics',
+    'mapEngineUsage',
+  ]) {
+    assert.match(helpersSource, new RegExp(`export (type |const |function |async function )${exportName}`));
+  }
+});


### PR DESCRIPTION
Summary
- move admin metrics row contracts, range helpers, SQL status predicates, safeQuery, series filling, and engine usage mapping into admin-metrics-helpers
- keep admin-metrics.ts focused on fetch orchestration
- re-export existing range helpers from admin-metrics for current callers
- add an architecture contract for the server metrics boundary

Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/admin-metrics-server-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- git diff --check -- touched admin metrics paths
- npm --prefix frontend run lint
- npm run lint:exposure