### PR TITLE
[codex] Split moderation table parts

### DIFF
--- a/frontend/components/admin/ModerationTable.tsx
+++ b/frontend/components/admin/ModerationTable.tsx
@@ -3,20 +3,33 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import clsx from 'clsx';
-import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react';
 import { VideoThumbnailEditor } from '@/components/admin/VideoThumbnailEditor.client';
+import { ModerationPlaylistControls } from '@/components/admin/moderation/ModerationPlaylistControls';
+import {
+  BUCKET_OPTIONS,
+  SURFACE_OPTIONS,
+  PublicationPill,
+  StatePill,
+  compareChronologically,
+  formatDate,
+  getPublicationLabel,
+  isFailedVideo,
+  matchesBucket,
+  resolvePublicationState,
+} from '@/components/admin/moderation/moderation-table-utils';
 import { Button, ButtonLink } from '@/components/ui/Button';
 import { authFetch } from '@/lib/authFetch';
 import { isPlaceholderMediaUrl, normalizeMediaUrl } from '@/lib/media';
 
-type PlaylistOption = {
+export type PlaylistOption = {
   id: string;
   name: string;
   slug: string;
   usageTargets?: string[];
 };
 
-type PlaylistTag = {
+export type PlaylistTag = {
   id: string;
   name: string;
 };
@@ -58,102 +71,6 @@ type ModerationTableProps = {
 };
 
 type ModerationViewMode = 'wall' | 'table';
-
-const FAILURE_STATES = new Set(['failed', 'error', 'errored', 'cancelled', 'canceled', 'aborted']);
-const BUCKET_OPTIONS: Array<{ id: ModerationBucket; label: string; helper: string }> = [
-  { id: 'not-published', label: 'Not published', helper: 'Anything not yet published on the site' },
-  { id: 'published', label: 'Published', helper: 'Live on site and eligible for public surfaces' },
-  { id: 'all', label: 'All', helper: 'Everything in the editorial publication queue' },
-];
-const SURFACE_OPTIONS: Array<{ id: ModerationSurface; label: string }> = [
-  { id: 'video', label: 'Video' },
-  { id: 'image', label: 'Image' },
-  { id: 'audio', label: 'Audio' },
-  { id: 'character', label: 'Character' },
-  { id: 'angle', label: 'Angle' },
-];
-
-function compareChronologically(a: Pick<ModerationVideo, 'createdAt' | 'id'>, b: Pick<ModerationVideo, 'createdAt' | 'id'>) {
-  const aTime = Number.isNaN(Date.parse(a.createdAt)) ? 0 : Date.parse(a.createdAt);
-  const bTime = Number.isNaN(Date.parse(b.createdAt)) ? 0 : Date.parse(b.createdAt);
-  if (aTime !== bTime) {
-    return bTime - aTime;
-  }
-  return b.id.localeCompare(a.id);
-}
-
-function formatDate(value?: string | null) {
-  if (!value) return 'Unknown';
-  try {
-    return new Intl.DateTimeFormat('en-US', {
-      dateStyle: 'short',
-      timeStyle: 'medium',
-    }).format(new Date(value));
-  } catch {
-    return value;
-  }
-}
-
-function isFailedVideo(video: Pick<ModerationVideo, 'status'>) {
-  const normalized = video.status?.trim().toLowerCase() ?? '';
-  return FAILURE_STATES.has(normalized);
-}
-
-function resolvePublicationState(video: Pick<ModerationVideo, 'visibility' | 'indexable'>): PublicationState {
-  if (video.visibility === 'public' && video.indexable) {
-    return 'published';
-  }
-  if (video.visibility === 'private' && !video.indexable) {
-    return 'private';
-  }
-  return 'legacy-mismatch';
-}
-
-function getPublicationLabel(video: Pick<ModerationVideo, 'visibility' | 'isPublishedOnSite'>) {
-  if (video.isPublishedOnSite) return 'Published';
-  if (video.visibility === 'private') return 'Private';
-  return 'Not published';
-}
-
-function matchesBucket(video: Pick<ModerationVideo, 'status' | 'visibility' | 'isPublishedOnSite'>, bucket: ModerationBucket) {
-  if (isFailedVideo(video)) return false;
-  if (bucket === 'all') return true;
-  if (bucket === 'published') return video.isPublishedOnSite;
-  return !video.isPublishedOnSite;
-}
-
-function PublicationPill({ state }: { state: PublicationState }) {
-  const className =
-    state === 'published'
-      ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700'
-      : 'border-warning-border/60 bg-warning-bg/20 text-warning';
-
-  const label =
-    state === 'published'
-      ? 'Published'
-      : state === 'private'
-        ? 'Private'
-        : 'Not published';
-
-  return <span className={`inline-flex rounded-full border px-2 py-1 text-[11px] font-semibold ${className}`}>{label}</span>;
-}
-
-function StatePill({
-  children,
-  tone = 'neutral',
-}: {
-  children: ReactNode;
-  tone?: 'ok' | 'warn' | 'neutral';
-}) {
-  const className =
-    tone === 'ok'
-      ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700'
-      : tone === 'warn'
-        ? 'border-warning-border/60 bg-warning-bg/20 text-warning'
-        : 'border-border bg-bg text-text-secondary';
-
-  return <span className={`inline-flex rounded-full border px-2 py-1 text-[11px] font-semibold ${className}`}>{children}</span>;
-}
 
 export function ModerationTable({
   videos,
@@ -525,79 +442,25 @@ export function ModerationTable({
       const compact = options?.compact ?? false;
       const emphasizeAssigned = options?.emphasizeAssigned ?? false;
       const enabled = options?.enabled ?? true;
-      if (!enabled) return null;
       const assignedPlaylists = playlistAssignments[video.id] ?? [];
       const playlistState = playlistStatus[video.id];
-      const isAssigningPlaylist = Boolean(playlistState?.loading);
-      const playlistMessage = playlistState?.message ?? null;
-      const playlistErrorMessage = playlistState?.error ?? null;
 
       return (
-        <div className="space-y-2 text-xs">
-          {assignedPlaylists.length ? (
-            <div className={clsx('flex flex-wrap gap-2', emphasizeAssigned && 'gap-1.5')}>
-              {assignedPlaylists.map((playlist) => (
-                <Button
-                  key={`${video.id}-${playlist.id}`}
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  onClick={() => handleRemoveFromPlaylist(video, playlist.id)}
-                  disabled={isAssigningPlaylist}
-                  className={clsx(
-                    'min-h-0 h-auto gap-1 rounded-pill px-2 py-1 text-[11px]',
-                    emphasizeAssigned
-                      ? 'border-success-border bg-success-bg font-semibold text-success hover:border-error-border hover:text-error'
-                      : 'border-border bg-bg text-text-secondary hover:border-error-border hover:text-error'
-                  )}
-                >
-                  {playlist.name}
-                  <span aria-hidden>×</span>
-                  <span className="sr-only">Remove from {playlist.name}</span>
-                </Button>
-              ))}
-            </div>
-          ) : compact ? (
-            <p className="text-[11px] text-text-muted">No playlist yet</p>
-          ) : (
-            <p className="text-xs text-text-muted">No playlist assignment yet.</p>
-          )}
-          {compact ? null : (
-            <label className="block text-[11px] font-semibold uppercase tracking-micro text-text-muted">Add to playlist</label>
-          )}
-          <select
-            className={clsx(
-              'w-full rounded-input border border-hairline bg-bg text-xs text-text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-              compact ? 'px-2 py-1.5' : 'px-2 py-2'
-            )}
-            defaultValue=""
-            disabled={playlistsLoading || !playlists.length || isAssigningPlaylist}
-            onChange={(event) => {
-              const playlistId = event.target.value;
-              if (!playlistId) return;
-              void handleAssignToPlaylist(video, playlistId);
-              event.target.value = '';
-            }}
-          >
-            <option value="">
-              {playlistsLoading ? 'Loading playlists…' : playlists.length ? 'Select playlist' : 'No playlists'}
-            </option>
-            {orderedPlaylists.map((playlist) => {
-              const disabled = assignedPlaylists.some((entry) => entry.id === playlist.id);
-              return (
-                <option key={playlist.id} value={playlist.id} disabled={disabled}>
-                  {playlist.usageTargets?.length ? '★ ' : ''}
-                  {playlist.name}
-                </option>
-              );
-            })}
-          </select>
-          {playlistMessage ? <p className="text-[11px] text-success">{playlistMessage}</p> : null}
-          {playlistErrorMessage ? <p className="text-[11px] text-error">{playlistErrorMessage}</p> : null}
-        </div>
+        <ModerationPlaylistControls
+          assignedPlaylists={assignedPlaylists}
+          compact={compact}
+          emphasizeAssigned={emphasizeAssigned}
+          enabled={enabled}
+          isLoadingPlaylists={playlistsLoading}
+          onAssign={(targetVideo, playlistId) => void handleAssignToPlaylist(targetVideo, playlistId)}
+          onRemove={(targetVideo, playlistId) => void handleRemoveFromPlaylist(targetVideo, playlistId)}
+          orderedPlaylists={orderedPlaylists}
+          playlistState={playlistState}
+          video={video}
+        />
       );
     },
-    [handleAssignToPlaylist, handleRemoveFromPlaylist, orderedPlaylists, playlistAssignments, playlistStatus, playlists.length, playlistsLoading]
+    [handleAssignToPlaylist, handleRemoveFromPlaylist, orderedPlaylists, playlistAssignments, playlistStatus, playlistsLoading]
   );
 
   const renderModerationActions = useCallback(

--- a/frontend/components/admin/moderation/ModerationPlaylistControls.tsx
+++ b/frontend/components/admin/moderation/ModerationPlaylistControls.tsx
@@ -1,0 +1,108 @@
+import clsx from 'clsx';
+import { Button } from '@/components/ui/Button';
+import type {
+  ModerationVideo,
+  PlaylistOption,
+  PlaylistTag,
+} from '@/components/admin/ModerationTable';
+
+type PlaylistState = {
+  loading: boolean;
+  message: string | null;
+  error: string | null;
+};
+
+export function ModerationPlaylistControls({
+  assignedPlaylists,
+  compact = false,
+  emphasizeAssigned = false,
+  enabled = true,
+  isLoadingPlaylists,
+  onAssign,
+  onRemove,
+  orderedPlaylists,
+  playlistState,
+  video,
+}: {
+  assignedPlaylists: PlaylistTag[];
+  compact?: boolean;
+  emphasizeAssigned?: boolean;
+  enabled?: boolean;
+  isLoadingPlaylists: boolean;
+  onAssign: (video: ModerationVideo, playlistId: string) => void;
+  onRemove: (video: ModerationVideo, playlistId: string) => void;
+  orderedPlaylists: PlaylistOption[];
+  playlistState?: PlaylistState;
+  video: ModerationVideo;
+}) {
+  if (!enabled) return null;
+
+  const isAssigningPlaylist = Boolean(playlistState?.loading);
+  const playlistMessage = playlistState?.message ?? null;
+  const playlistErrorMessage = playlistState?.error ?? null;
+
+  return (
+    <div className="space-y-2 text-xs">
+      {assignedPlaylists.length ? (
+        <div className={clsx('flex flex-wrap gap-2', emphasizeAssigned && 'gap-1.5')}>
+          {assignedPlaylists.map((playlist) => (
+            <Button
+              key={`${video.id}-${playlist.id}`}
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => onRemove(video, playlist.id)}
+              disabled={isAssigningPlaylist}
+              className={clsx(
+                'min-h-0 h-auto gap-1 rounded-pill px-2 py-1 text-[11px]',
+                emphasizeAssigned
+                  ? 'border-success-border bg-success-bg font-semibold text-success hover:border-error-border hover:text-error'
+                  : 'border-border bg-bg text-text-secondary hover:border-error-border hover:text-error'
+              )}
+            >
+              {playlist.name}
+              <span aria-hidden>×</span>
+              <span className="sr-only">Remove from {playlist.name}</span>
+            </Button>
+          ))}
+        </div>
+      ) : compact ? (
+        <p className="text-[11px] text-text-muted">No playlist yet</p>
+      ) : (
+        <p className="text-xs text-text-muted">No playlist assignment yet.</p>
+      )}
+      {compact ? null : (
+        <label className="block text-[11px] font-semibold uppercase tracking-micro text-text-muted">Add to playlist</label>
+      )}
+      <select
+        className={clsx(
+          'w-full rounded-input border border-hairline bg-bg text-xs text-text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          compact ? 'px-2 py-1.5' : 'px-2 py-2'
+        )}
+        defaultValue=""
+        disabled={isLoadingPlaylists || !orderedPlaylists.length || isAssigningPlaylist}
+        onChange={(event) => {
+          const playlistId = event.target.value;
+          if (!playlistId) return;
+          onAssign(video, playlistId);
+          event.target.value = '';
+        }}
+      >
+        <option value="">
+          {isLoadingPlaylists ? 'Loading playlists…' : orderedPlaylists.length ? 'Select playlist' : 'No playlists'}
+        </option>
+        {orderedPlaylists.map((playlist) => {
+          const disabled = assignedPlaylists.some((entry) => entry.id === playlist.id);
+          return (
+            <option key={playlist.id} value={playlist.id} disabled={disabled}>
+              {playlist.usageTargets?.length ? '★ ' : ''}
+              {playlist.name}
+            </option>
+          );
+        })}
+      </select>
+      {playlistMessage ? <p className="text-[11px] text-success">{playlistMessage}</p> : null}
+      {playlistErrorMessage ? <p className="text-[11px] text-error">{playlistErrorMessage}</p> : null}
+    </div>
+  );
+}

--- a/frontend/components/admin/moderation/moderation-table-utils.tsx
+++ b/frontend/components/admin/moderation/moderation-table-utils.tsx
@@ -1,0 +1,111 @@
+import type { ReactNode } from 'react';
+import type {
+  ModerationBucket,
+  ModerationSurface,
+  ModerationVideo,
+  PublicationState,
+} from '@/components/admin/ModerationTable';
+
+const FAILURE_STATES = new Set(['failed', 'error', 'errored', 'cancelled', 'canceled', 'aborted']);
+
+export const BUCKET_OPTIONS: Array<{ id: ModerationBucket; label: string; helper: string }> = [
+  { id: 'not-published', label: 'Not published', helper: 'Anything not yet published on the site' },
+  { id: 'published', label: 'Published', helper: 'Live on site and eligible for public surfaces' },
+  { id: 'all', label: 'All', helper: 'Everything in the editorial publication queue' },
+];
+
+export const SURFACE_OPTIONS: Array<{ id: ModerationSurface; label: string }> = [
+  { id: 'video', label: 'Video' },
+  { id: 'image', label: 'Image' },
+  { id: 'audio', label: 'Audio' },
+  { id: 'character', label: 'Character' },
+  { id: 'angle', label: 'Angle' },
+];
+
+export function compareChronologically(
+  a: Pick<ModerationVideo, 'createdAt' | 'id'>,
+  b: Pick<ModerationVideo, 'createdAt' | 'id'>
+) {
+  const aTime = Number.isNaN(Date.parse(a.createdAt)) ? 0 : Date.parse(a.createdAt);
+  const bTime = Number.isNaN(Date.parse(b.createdAt)) ? 0 : Date.parse(b.createdAt);
+  if (aTime !== bTime) {
+    return bTime - aTime;
+  }
+  return b.id.localeCompare(a.id);
+}
+
+export function formatDate(value?: string | null) {
+  if (!value) return 'Unknown';
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      dateStyle: 'short',
+      timeStyle: 'medium',
+    }).format(new Date(value));
+  } catch {
+    return value;
+  }
+}
+
+export function isFailedVideo(video: Pick<ModerationVideo, 'status'>) {
+  const normalized = video.status?.trim().toLowerCase() ?? '';
+  return FAILURE_STATES.has(normalized);
+}
+
+export function resolvePublicationState(video: Pick<ModerationVideo, 'visibility' | 'indexable'>): PublicationState {
+  if (video.visibility === 'public' && video.indexable) {
+    return 'published';
+  }
+  if (video.visibility === 'private' && !video.indexable) {
+    return 'private';
+  }
+  return 'legacy-mismatch';
+}
+
+export function getPublicationLabel(video: Pick<ModerationVideo, 'visibility' | 'isPublishedOnSite'>) {
+  if (video.isPublishedOnSite) return 'Published';
+  if (video.visibility === 'private') return 'Private';
+  return 'Not published';
+}
+
+export function matchesBucket(
+  video: Pick<ModerationVideo, 'status' | 'visibility' | 'isPublishedOnSite'>,
+  bucket: ModerationBucket
+) {
+  if (isFailedVideo(video)) return false;
+  if (bucket === 'all') return true;
+  if (bucket === 'published') return video.isPublishedOnSite;
+  return !video.isPublishedOnSite;
+}
+
+export function PublicationPill({ state }: { state: PublicationState }) {
+  const className =
+    state === 'published'
+      ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700'
+      : 'border-warning-border/60 bg-warning-bg/20 text-warning';
+
+  const label =
+    state === 'published'
+      ? 'Published'
+      : state === 'private'
+        ? 'Private'
+        : 'Not published';
+
+  return <span className={`inline-flex rounded-full border px-2 py-1 text-[11px] font-semibold ${className}`}>{label}</span>;
+}
+
+export function StatePill({
+  children,
+  tone = 'neutral',
+}: {
+  children: ReactNode;
+  tone?: 'ok' | 'warn' | 'neutral';
+}) {
+  const className =
+    tone === 'ok'
+      ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700'
+      : tone === 'warn'
+        ? 'border-warning-border/60 bg-warning-bg/20 text-warning'
+        : 'border-border bg-bg text-text-secondary';
+
+  return <span className={`inline-flex rounded-full border px-2 py-1 text-[11px] font-semibold ${className}`}>{children}</span>;
+}

--- a/tests/moderation-table-architecture.test.ts
+++ b/tests/moderation-table-architecture.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const root = process.cwd();
+const tablePath = join(root, 'frontend/components/admin/ModerationTable.tsx');
+const utilsPath = join(root, 'frontend/components/admin/moderation/moderation-table-utils.tsx');
+const playlistControlsPath = join(root, 'frontend/components/admin/moderation/ModerationPlaylistControls.tsx');
+
+const tableSource = readFileSync(tablePath, 'utf8');
+const utilsSource = readFileSync(utilsPath, 'utf8');
+const playlistControlsSource = readFileSync(playlistControlsPath, 'utf8');
+
+test('moderation table delegates helper pills and playlist controls', () => {
+  assert.ok(existsSync(tablePath), 'moderation table should exist');
+  assert.ok(existsSync(utilsPath), 'moderation helper/pill module should exist');
+  assert.ok(existsSync(playlistControlsPath), 'moderation playlist controls should exist');
+  assert.match(tableSource, /from '@\/components\/admin\/moderation\/moderation-table-utils'/);
+  assert.match(tableSource, /from '@\/components\/admin\/moderation\/ModerationPlaylistControls'/);
+});
+
+test('moderation table does not regain extracted ownership', () => {
+  for (const pattern of [
+    /const FAILURE_STATES =/,
+    /const BUCKET_OPTIONS:/,
+    /const SURFACE_OPTIONS:/,
+    /function compareChronologically\(/,
+    /function formatDate\(/,
+    /function isFailedVideo\(/,
+    /function resolvePublicationState\(/,
+    /function getPublicationLabel\(/,
+    /function matchesBucket\(/,
+    /function PublicationPill\(/,
+    /function StatePill\(/,
+    /<select[\s\S]*Select playlist/,
+  ]) {
+    assert.doesNotMatch(tableSource, pattern);
+  }
+
+  const lineCount = tableSource.split('\n').length;
+  assert.ok(lineCount <= 985, `ModerationTable should stay below 985 lines after helper extraction, got ${lineCount}`);
+});
+
+test('moderation helper modules expose the expected contract', () => {
+  for (const exportName of [
+    'BUCKET_OPTIONS',
+    'SURFACE_OPTIONS',
+    'compareChronologically',
+    'formatDate',
+    'isFailedVideo',
+    'resolvePublicationState',
+    'getPublicationLabel',
+    'matchesBucket',
+    'PublicationPill',
+    'StatePill',
+  ]) {
+    assert.match(utilsSource, new RegExp(`export (const |function )${exportName}`));
+  }
+
+  assert.match(playlistControlsSource, /export function ModerationPlaylistControls/);
+  assert.match(playlistControlsSource, /Select playlist/);
+  assert.match(playlistControlsSource, /onAssign/);
+  assert.match(playlistControlsSource, /onRemove/);
+});


### PR DESCRIPTION
Summary
- move publication helper functions, bucket/surface options, and pills into moderation-table-utils
- move playlist assignment UI into ModerationPlaylistControls
- keep ModerationTable focused on queue state, loading, mutations, and layout orchestration
- add a moderation table architecture contract with a 985-line budget

Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/moderation-table-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- git diff --check -- touched moderation paths
- npm --prefix frontend run lint
- npm run lint:exposure