### PR TITLE
Split upscale preview controls

### DIFF
--- a/frontend/src/components/tools/UpscaleWorkspace.tsx
+++ b/frontend/src/components/tools/UpscaleWorkspace.tsx
@@ -3,7 +3,7 @@
 /* eslint-disable @next/next/no-img-element */
 
 import Link from 'next/link';
-import { useEffect, useMemo, useRef, useState, type PointerEvent } from 'react';
+import { useMemo, useState, type PointerEvent } from 'react';
 import {
   ArrowLeft,
   ArrowRight,
@@ -49,6 +49,8 @@ import type {
 } from '@/types/tools-upscale';
 import type { GroupSummary } from '@/types/groups';
 import type { Job } from '@/types/jobs';
+import { Label, SegmentButton } from './upscale/_components/upscale-workspace-controls';
+import { UpscaleHeroSummaryCard } from './upscale/_components/UpscaleHeroSummaryCard';
 import { DEFAULT_UPSCALE_COPY } from './upscale/_lib/upscale-workspace-copy';
 import {
   clampComparePosition,
@@ -66,6 +68,7 @@ import {
 } from './upscale/_lib/upscale-workspace-helpers';
 import { useUpscaleLibraryAssets } from './upscale/_hooks/useUpscaleLibraryAssets';
 import { useUpscalePricingPreview } from './upscale/_hooks/useUpscalePricingPreview';
+import { useUpscalePreviewScroller } from './upscale/_hooks/useUpscalePreviewScroller';
 import { useUpscaleRecentJobs } from './upscale/_hooks/useUpscaleRecentJobs';
 import { useUpscaleSourceMedia } from './upscale/_hooks/useUpscaleSourceMedia';
 import type {
@@ -75,37 +78,6 @@ import type {
   RecentUpscaleMedia,
   UploadedAsset,
 } from './upscale/_lib/upscale-workspace-types';
-
-function Label({ children }: { children: React.ReactNode }) {
-  return <span className="mb-1.5 block text-[10px] font-semibold uppercase tracking-[0.14em] text-text-muted">{children}</span>;
-}
-
-function SegmentButton({
-  active,
-  disabled,
-  children,
-  onClick,
-}: {
-  active: boolean;
-  disabled?: boolean;
-  children: React.ReactNode;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      disabled={disabled}
-      onClick={onClick}
-      className={`inline-flex min-h-[46px] items-center justify-center gap-2 rounded-input border px-3 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-60 ${
-        active
-          ? 'border-brand bg-brand text-on-brand shadow-card'
-          : 'border-border bg-surface text-text-secondary hover:border-border-hover hover:bg-surface-hover hover:text-text-primary'
-      }`}
-    >
-      {children}
-    </button>
-  );
-}
 
 export default function UpscaleWorkspace() {
   const { loading: authLoading, user } = useRequireAuth({ redirectIfLoggedOut: false });
@@ -149,7 +121,6 @@ export default function UpscaleWorkspace() {
   });
   const [activeRecentGroupId, setActiveRecentGroupId] = useState<string | null>(null);
   const [savingRecentGroupId, setSavingRecentGroupId] = useState<string | null>(null);
-  const previewScrollerRef = useRef<HTMLDivElement | null>(null);
 
   const engines = useMemo(() => listUpscaleToolEngines(mediaType), [mediaType]);
   const engine = useMemo(() => engines.find((entry) => entry.id === engineId) ?? engines[0], [engineId, engines]);
@@ -191,6 +162,13 @@ export default function UpscaleWorkspace() {
   const zoomCanvasWidth = activePreviewMode === 'source' ? sourceWidth : outputWidth;
   const zoomCanvasHeight = activePreviewMode === 'source' ? sourceHeight : outputHeight;
   const mediaTypeLabel = mediaType === 'video' ? 'Video' : 'Image';
+  const previewScrollerRef = useUpscalePreviewScroller({
+    activePreviewMode,
+    isPixelZoom,
+    previewZoom,
+    resultPreviewUrl,
+    sourcePreviewUrl,
+  });
   const { mutate, recentGroups } = useUpscaleRecentJobs({
     hasResult,
     mediaType,
@@ -218,21 +196,6 @@ export default function UpscaleWorkspace() {
     setUploading,
     source,
   });
-
-  useEffect(() => {
-    const scroller = previewScrollerRef.current;
-    if (!scroller) return undefined;
-    if (!isPixelZoom) {
-      scroller.scrollLeft = 0;
-      scroller.scrollTop = 0;
-      return undefined;
-    }
-    const frame = window.requestAnimationFrame(() => {
-      scroller.scrollLeft = Math.max(0, (scroller.scrollWidth - scroller.clientWidth) / 2);
-      scroller.scrollTop = Math.max(0, (scroller.scrollHeight - scroller.clientHeight) / 2);
-    });
-    return () => window.cancelAnimationFrame(frame);
-  }, [activePreviewMode, isPixelZoom, previewZoom, resultPreviewUrl, sourcePreviewUrl]);
 
   function changeMediaType(next: UpscaleMediaType) {
     setMediaType(next);
@@ -555,43 +518,18 @@ export default function UpscaleWorkspace() {
                   <p className="mt-3 max-w-2xl text-base leading-7 text-text-secondary">{copy.subtitle}</p>
                 </div>
 
-                <div className="rounded-[20px] border border-border bg-surface-glass-90 p-5 shadow-card backdrop-blur">
-                  <div className="flex items-center gap-3">
-                    <span className="inline-flex h-10 w-10 items-center justify-center rounded-[10px] bg-brand text-on-brand">
-                      <WandSparkles className="h-5 w-5" />
-                    </span>
-                    <div className="min-w-0 flex-1">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <p className="truncate text-base font-semibold text-text-primary">{engine?.label ?? 'Upscale engine'}</p>
-                        <span className="rounded-full border border-success-border bg-success-bg px-2.5 py-1 text-[11px] font-semibold text-success">
-                          Active
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div className="mt-5 grid grid-cols-4 gap-2 text-center">
-                    <div>
-                      <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-text-muted">Mode</p>
-                      <p className="mt-1 text-sm font-semibold text-text-primary">{mode === 'target' ? targetResolution : `${upscaleFactor}x`}</p>
-                    </div>
-                    <div>
-                      <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-text-muted">Type</p>
-                      <p className="mt-1 text-sm font-semibold text-text-primary">{mediaTypeLabel}</p>
-                    </div>
-                    <div>
-                      <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-text-muted">Format</p>
-                      <p className="mt-1 text-sm font-semibold text-text-primary">{outputFormat.toUpperCase()}</p>
-                    </div>
-                    <div>
-                      <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-text-muted">Price</p>
-                      <p className="mt-1 text-sm font-semibold text-text-primary">{priceLabel}</p>
-                    </div>
-                  </div>
-                  <Button className="mt-5 w-full rounded-[10px] bg-brand py-3 text-on-brand hover:bg-brand-hover" onClick={handleRun} disabled={!canRun}>
-                    {running ? <Loader2 className="h-4 w-4 animate-spin" /> : <WandSparkles className="h-4 w-4" />}
-                    {running ? copy.running : copy.run}
-                  </Button>
-                </div>
+                <UpscaleHeroSummaryCard
+                  canRun={canRun}
+                  engineLabel={engine?.label ?? 'Upscale engine'}
+                  mediaTypeLabel={mediaTypeLabel}
+                  modeLabel={mode === 'target' ? targetResolution : `${upscaleFactor}x`}
+                  onRun={handleRun}
+                  outputFormatLabel={outputFormat.toUpperCase()}
+                  priceLabel={priceLabel}
+                  runLabel={copy.run}
+                  running={running}
+                  runningLabel={copy.running}
+                />
               </div>
             </section>
 

--- a/frontend/src/components/tools/upscale/_components/UpscaleHeroSummaryCard.tsx
+++ b/frontend/src/components/tools/upscale/_components/UpscaleHeroSummaryCard.tsx
@@ -1,0 +1,66 @@
+import { Loader2, WandSparkles } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+
+export function UpscaleHeroSummaryCard({
+  canRun,
+  engineLabel,
+  mediaTypeLabel,
+  modeLabel,
+  onRun,
+  outputFormatLabel,
+  priceLabel,
+  runLabel,
+  running,
+  runningLabel,
+}: {
+  canRun: boolean;
+  engineLabel: string;
+  mediaTypeLabel: string;
+  modeLabel: string;
+  onRun: () => void;
+  outputFormatLabel: string;
+  priceLabel: string;
+  runLabel: string;
+  running: boolean;
+  runningLabel: string;
+}) {
+  return (
+    <div className="rounded-[20px] border border-border bg-surface-glass-90 p-5 shadow-card backdrop-blur">
+      <div className="flex items-center gap-3">
+        <span className="inline-flex h-10 w-10 items-center justify-center rounded-[10px] bg-brand text-on-brand">
+          <WandSparkles className="h-5 w-5" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="truncate text-base font-semibold text-text-primary">{engineLabel}</p>
+            <span className="rounded-full border border-success-border bg-success-bg px-2.5 py-1 text-[11px] font-semibold text-success">
+              Active
+            </span>
+          </div>
+        </div>
+      </div>
+      <div className="mt-5 grid grid-cols-4 gap-2 text-center">
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-text-muted">Mode</p>
+          <p className="mt-1 text-sm font-semibold text-text-primary">{modeLabel}</p>
+        </div>
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-text-muted">Type</p>
+          <p className="mt-1 text-sm font-semibold text-text-primary">{mediaTypeLabel}</p>
+        </div>
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-text-muted">Format</p>
+          <p className="mt-1 text-sm font-semibold text-text-primary">{outputFormatLabel}</p>
+        </div>
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-text-muted">Price</p>
+          <p className="mt-1 text-sm font-semibold text-text-primary">{priceLabel}</p>
+        </div>
+      </div>
+      <Button className="mt-5 w-full rounded-[10px] bg-brand py-3 text-on-brand hover:bg-brand-hover" onClick={onRun} disabled={!canRun}>
+        {running ? <Loader2 className="h-4 w-4 animate-spin" /> : <WandSparkles className="h-4 w-4" />}
+        {running ? runningLabel : runLabel}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/tools/upscale/_components/upscale-workspace-controls.tsx
+++ b/frontend/src/components/tools/upscale/_components/upscale-workspace-controls.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from 'react';
+
+export function Label({ children }: { children: ReactNode }) {
+  return <span className="mb-1.5 block text-[10px] font-semibold uppercase tracking-[0.14em] text-text-muted">{children}</span>;
+}
+
+export function SegmentButton({
+  active,
+  disabled,
+  children,
+  onClick,
+}: {
+  active: boolean;
+  disabled?: boolean;
+  children: ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className={`inline-flex min-h-[46px] items-center justify-center gap-2 rounded-input border px-3 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-60 ${
+        active
+          ? 'border-brand bg-brand text-on-brand shadow-card'
+          : 'border-border bg-surface text-text-secondary hover:border-border-hover hover:bg-surface-hover hover:text-text-primary'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/components/tools/upscale/_hooks/useUpscalePreviewScroller.ts
+++ b/frontend/src/components/tools/upscale/_hooks/useUpscalePreviewScroller.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react';
+import type { PreviewMode, PreviewZoom } from '../_lib/upscale-workspace-types';
+
+export function useUpscalePreviewScroller({
+  activePreviewMode,
+  isPixelZoom,
+  previewZoom,
+  resultPreviewUrl,
+  sourcePreviewUrl,
+}: {
+  activePreviewMode: PreviewMode;
+  isPixelZoom: boolean;
+  previewZoom: PreviewZoom;
+  resultPreviewUrl: string;
+  sourcePreviewUrl: string;
+}) {
+  const previewScrollerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const scroller = previewScrollerRef.current;
+    if (!scroller) return undefined;
+    if (!isPixelZoom) {
+      scroller.scrollLeft = 0;
+      scroller.scrollTop = 0;
+      return undefined;
+    }
+    const frame = window.requestAnimationFrame(() => {
+      scroller.scrollLeft = Math.max(0, (scroller.scrollWidth - scroller.clientWidth) / 2);
+      scroller.scrollTop = Math.max(0, (scroller.scrollHeight - scroller.clientHeight) / 2);
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [activePreviewMode, isPixelZoom, previewZoom, resultPreviewUrl, sourcePreviewUrl]);
+
+  return previewScrollerRef;
+}

--- a/tests/upscale-workspace-architecture.test.ts
+++ b/tests/upscale-workspace-architecture.test.ts
@@ -10,8 +10,11 @@ const typesPath = join(root, 'frontend/src/components/tools/upscale/_lib/upscale
 const helpersPath = join(root, 'frontend/src/components/tools/upscale/_lib/upscale-workspace-helpers.ts');
 const libraryHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscaleLibraryAssets.ts');
 const pricingHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscalePricingPreview.ts');
+const previewScrollerHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscalePreviewScroller.ts');
 const recentJobsHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscaleRecentJobs.ts');
 const sourceMediaHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscaleSourceMedia.ts');
+const controlsPath = join(root, 'frontend/src/components/tools/upscale/_components/upscale-workspace-controls.tsx');
+const heroSummaryCardPath = join(root, 'frontend/src/components/tools/upscale/_components/UpscaleHeroSummaryCard.tsx');
 
 const workspaceSource = readFileSync(workspacePath, 'utf8');
 
@@ -21,16 +24,22 @@ test('upscale workspace delegates copy, local types, and helper logic', () => {
   assert.ok(existsSync(helpersPath), 'upscale workspace helper logic should live in a colocated helper module');
   assert.ok(existsSync(libraryHookPath), 'upscale library asset loading should live in a colocated hook');
   assert.ok(existsSync(pricingHookPath), 'upscale pricing preview should live in a colocated hook');
+  assert.ok(existsSync(previewScrollerHookPath), 'upscale preview scroller should live in a colocated hook');
   assert.ok(existsSync(recentJobsHookPath), 'upscale recent jobs orchestration should live in a colocated hook');
   assert.ok(existsSync(sourceMediaHookPath), 'upscale source media orchestration should live in a colocated hook');
+  assert.ok(existsSync(controlsPath), 'upscale workspace controls should live in colocated components');
+  assert.ok(existsSync(heroSummaryCardPath), 'upscale hero summary should live in a colocated component');
 
   assert.match(workspaceSource, /from '\.\/upscale\/_lib\/upscale-workspace-copy'/, 'workspace should import upscale copy');
   assert.match(workspaceSource, /from '\.\/upscale\/_lib\/upscale-workspace-types'/, 'workspace should import upscale local types');
   assert.match(workspaceSource, /from '\.\/upscale\/_lib\/upscale-workspace-helpers'/, 'workspace should import upscale helpers');
   assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscaleLibraryAssets'/, 'workspace should import library hook');
   assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscalePricingPreview'/, 'workspace should import pricing hook');
+  assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscalePreviewScroller'/, 'workspace should import preview scroller hook');
   assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscaleRecentJobs'/, 'workspace should import recent jobs hook');
   assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscaleSourceMedia'/, 'workspace should import source media hook');
+  assert.match(workspaceSource, /from '\.\/upscale\/_components\/upscale-workspace-controls'/, 'workspace should import workspace controls');
+  assert.match(workspaceSource, /from '\.\/upscale\/_components\/UpscaleHeroSummaryCard'/, 'workspace should import hero summary card');
 });
 
 test('upscale workspace does not regain extracted ownership', () => {
@@ -51,9 +60,14 @@ test('upscale workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /mediaTypeFromMime/, 'source media MIME detection belongs in useUpscaleSourceMedia');
   assert.doesNotMatch(workspaceSource, /new window\.Image/, 'source image dimension hydration belongs in useUpscaleSourceMedia');
   assert.doesNotMatch(workspaceSource, /function selectLibraryAsset\(/, 'library source selection belongs in useUpscaleSourceMedia');
+  assert.doesNotMatch(workspaceSource, /function Label\(/, 'workspace labels belong in upscale workspace controls');
+  assert.doesNotMatch(workspaceSource, /function SegmentButton\(/, 'workspace segment buttons belong in upscale workspace controls');
+  assert.doesNotMatch(workspaceSource, /requestAnimationFrame/, 'preview centering belongs in useUpscalePreviewScroller');
+  assert.doesNotMatch(workspaceSource, /scrollLeft/, 'preview scroll position belongs in useUpscalePreviewScroller');
+  assert.doesNotMatch(workspaceSource, /rounded-\[20px\] border border-border bg-surface-glass-90/, 'hero summary card belongs in UpscaleHeroSummaryCard');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 1060, `UpscaleWorkspace should stay below 1060 lines after source media hook extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 1000, `UpscaleWorkspace should stay below 1000 lines after preview control extraction, got ${lineCount}`);
 });
 
 test('upscale helper modules expose the expected workspace contract', () => {
@@ -62,8 +76,11 @@ test('upscale helper modules expose the expected workspace contract', () => {
   const helpersSource = readFileSync(helpersPath, 'utf8');
   const libraryHookSource = readFileSync(libraryHookPath, 'utf8');
   const pricingHookSource = readFileSync(pricingHookPath, 'utf8');
+  const previewScrollerHookSource = readFileSync(previewScrollerHookPath, 'utf8');
   const recentJobsHookSource = readFileSync(recentJobsHookPath, 'utf8');
   const sourceMediaHookSource = readFileSync(sourceMediaHookPath, 'utf8');
+  const controlsSource = readFileSync(controlsPath, 'utf8');
+  const heroSummaryCardSource = readFileSync(heroSummaryCardPath, 'utf8');
 
   assert.match(copySource, /export const DEFAULT_UPSCALE_COPY =/, 'copy module should export default copy');
 
@@ -99,6 +116,9 @@ test('upscale helper modules expose the expected workspace contract', () => {
   assert.match(pricingHookSource, /buildUpscalePricingPreview/, 'pricing hook should build the preview');
   assert.match(pricingHookSource, /readVideoPricingMetadata/, 'pricing hook should load video metadata');
   assert.match(pricingHookSource, /BillingProductResponse/, 'pricing hook should parse billing products');
+  assert.match(previewScrollerHookSource, /export function useUpscalePreviewScroller/, 'preview scroller hook should be exported');
+  assert.match(previewScrollerHookSource, /requestAnimationFrame/, 'preview scroller hook should center zoomed previews');
+  assert.match(previewScrollerHookSource, /scrollLeft/, 'preview scroller hook should own horizontal scroll positioning');
   assert.match(recentJobsHookSource, /export function useUpscaleRecentJobs/, 'recent jobs hook should be exported');
   assert.match(recentJobsHookSource, /useInfiniteJobs\(12, \{ surface: 'upscale' \}\)/, 'recent jobs hook should own the upscale feed');
   assert.match(recentJobsHookSource, /getJobStatus/, 'recent jobs hook should poll pending jobs');
@@ -107,4 +127,8 @@ test('upscale helper modules expose the expected workspace contract', () => {
   assert.match(sourceMediaHookSource, /uploadSourceFile/, 'source media hook should own source uploads');
   assert.match(sourceMediaHookSource, /mediaTypeFromMime/, 'source media hook should own MIME detection');
   assert.match(sourceMediaHookSource, /new window\.Image/, 'source media hook should hydrate image dimensions');
+  assert.match(controlsSource, /export function Label/, 'workspace label component should be exported');
+  assert.match(controlsSource, /export function SegmentButton/, 'workspace segment button should be exported');
+  assert.match(heroSummaryCardSource, /export function UpscaleHeroSummaryCard/, 'hero summary card should be exported');
+  assert.match(heroSummaryCardSource, /WandSparkles/, 'hero summary card should own its action icon');
 });


### PR DESCRIPTION
## Summary
- Move Upscale workspace Label/SegmentButton controls into colocated components
- Move preview zoom scroll-centering into a dedicated hook
- Extract the hero summary card and tighten the Upscale architecture contract

## Checks
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/upscale-workspace-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- git diff --check -- touched files
- npm --prefix frontend run lint
- npm run lint:exposure