### PR TITLE
Split audio workspace sections

### DIFF
--- a/frontend/app/(core)/(workspace)/app/audio/AudioWorkspace.tsx
+++ b/frontend/app/(core)/(workspace)/app/audio/AudioWorkspace.tsx
@@ -5,26 +5,21 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import {
   AudioLines,
-  CheckCircle2,
   ChevronDown,
   Clock3,
-  Coins,
-  FileVideo,
   Gauge,
   Languages,
   Mic2,
   Play,
   SlidersHorizontal,
   Sparkles,
-  Upload,
-  Video,
 } from 'lucide-react';
 
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { authFetch } from '@/lib/authFetch';
 import { useI18n } from '@/lib/i18n/I18nProvider';
 import type { Job } from '@/types/jobs';
-import { Button, ButtonLink } from '@/components/ui/Button';
+import { ButtonLink } from '@/components/ui/Button';
 import { Textarea } from '@/components/ui/Input';
 import { UIIcon } from '@/components/ui/UIIcon';
 import {
@@ -57,7 +52,10 @@ import {
   type AudioVoiceProfile,
 } from '@/lib/audio-generation';
 import AudioLatestRendersRail from './AudioLatestRendersRail';
+import { AudioGenerationDock } from './_components/audio-generation-dock';
 import { AudioGeneratedVideoPickerModal } from './_components/audio-generated-video-picker';
+import { AudioSourceVideoSection } from './_components/audio-source-video-section';
+import { AudioVoiceSection } from './_components/audio-voice-section';
 import { AudioModePicker, AudioSelectControl, ToggleRow } from './_components/audio-workspace-controls';
 import { useAudioActiveJobPolling } from './_hooks/useAudioActiveJobPolling';
 import { useAudioGenerationRunner } from './_hooks/useAudioGenerationRunner';
@@ -605,6 +603,12 @@ export default function AudioWorkspace() {
             duration: estimatedDurationSec ? formatAudioDurationLabel(estimatedDurationSec) : '-',
           })
         : copy.pricing.missingOptions;
+  const activeProgress =
+    activeJob?.status === 'running' || activeJob?.status === 'pending'
+      ? activeJob.progress
+      : null;
+  const dockDurationLabel = estimatedDurationSec ? formatAudioDurationLabel(estimatedDurationSec) : '-';
+  const dockPriceLabel = quote ? formatCurrency(quote.totalCents, quote.currency, locale) : '-';
 
   if (authLoading) {
     return <div className="flex-1" />;
@@ -664,71 +668,16 @@ export default function AudioWorkspace() {
             </section>
 
             {(sourceVideoRequired || sourceVideo) ? (
-              <section className="rounded-[12px] border border-hairline bg-surface p-4 shadow-card">
-                <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-                  <div className="flex min-w-0 items-start gap-3">
-                    <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[9px] bg-brand-soft text-brand">
-                      <UIIcon icon={FileVideo} size={22} />
-                    </span>
-                    <div className="min-w-0">
-                      <h2 className="text-sm font-semibold text-text-primary">{copy.source.title}</h2>
-                      <p className="mt-1 text-sm text-text-secondary">
-                        {sourceVideoRequired ? copy.source.required : copy.source.optional}
-                      </p>
-                      {sourceVideo ? (
-                        <p className="mt-2 truncate text-sm font-semibold text-text-primary">
-                          {sourceVideo.label}
-                          <span className="ml-2 text-xs font-medium text-text-muted">
-                            {sourceVideo.durationSec ? formatAudioDurationLabel(sourceVideo.durationSec) : copy.source.durationPending}
-                          </span>
-                        </p>
-                      ) : null}
-                    </div>
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      disabled={isUploadingSource}
-                      onClick={() => sourceInputRef.current?.click()}
-                    >
-                      <UIIcon icon={Upload} size={16} />
-                      {isUploadingSource ? copy.source.uploading : copy.source.upload}
-                    </Button>
-                    <Button type="button" variant="outline" size="sm" onClick={() => setGeneratedPickerOpen(true)}>
-                      <UIIcon icon={Video} size={16} />
-                      {copy.source.useGenerated}
-                    </Button>
-                    {sourceVideo ? (
-                      <Button type="button" variant="ghost" size="sm" onClick={handleClearSourceVideo}>
-                        {copy.source.clear}
-                      </Button>
-                    ) : null}
-                  </div>
-                </div>
-                <input
-                  ref={sourceInputRef}
-                  type="file"
-                  accept="video/*"
-                  className="sr-only"
-                  onChange={(event) => {
-                    void handleSourceFileSelect(event.target.files);
-                  }}
-                />
-                {sourceVideo ? (
-                  <div className="mt-3 flex items-center gap-3 rounded-[10px] border border-hairline bg-bg px-3 py-2">
-                    <div className="h-12 w-20 overflow-hidden rounded-[8px] border border-hairline bg-surface">
-                      <video src={sourceVideo.url} poster={sourceVideo.thumbUrl ?? undefined} className="h-full w-full object-cover" muted playsInline preload="metadata" />
-                    </div>
-                    <p className="min-w-0 flex-1 truncate text-xs text-text-secondary">
-                      {sourceVideo.aspectRatio ? `${sourceVideo.aspectRatio} · ` : ''}
-                      {sourceVideo.durationSec ? formatAudioDurationLabel(sourceVideo.durationSec) : copy.source.durationPending}
-                    </p>
-                    <CheckCircle2 className="h-5 w-5 text-success" aria-hidden />
-                  </div>
-                ) : null}
-              </section>
+              <AudioSourceVideoSection
+                copy={copy}
+                inputRef={sourceInputRef}
+                isUploading={isUploadingSource}
+                onClear={handleClearSourceVideo}
+                onFileSelect={handleSourceFileSelect}
+                onOpenGeneratedPicker={() => setGeneratedPickerOpen(true)}
+                required={sourceVideoRequired}
+                sourceVideo={sourceVideo}
+              />
             ) : null}
 
             <section className="rounded-[12px] border border-hairline bg-surface shadow-card">
@@ -761,61 +710,14 @@ export default function AudioWorkspace() {
 
             <section className="grid gap-4 lg:grid-cols-2">
               {showVoiceFields ? (
-                <div className="rounded-[12px] border border-hairline bg-surface p-4 shadow-card">
-                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                    <div>
-                      <p className="text-base font-semibold text-text-primary">{copy.controls.voice}</p>
-                      <p className="mt-1 text-sm text-text-secondary">{copy.controls.selectedVoice}</p>
-                    </div>
-                    <Button type="button" variant="outline" size="sm">
-                      {copy.controls.chooseVoice}
-                    </Button>
-                  </div>
-                  <div className="mt-4 grid gap-3 sm:grid-cols-2">
-                    <div className="flex items-center gap-3 rounded-[10px] border border-hairline bg-bg px-3 py-3">
-                        <span className="flex h-8 w-8 items-center justify-center rounded-full bg-brand-soft text-brand">
-                          <UIIcon icon={Play} size={16} />
-                        </span>
-                      <span className="min-w-0 flex-1 truncate text-sm text-text-secondary">{copy.controls.selectedVoice}</span>
-                        <AudioLines className="h-4 w-4 text-brand" aria-hidden />
-                      </div>
-                    <div className="rounded-[10px] border border-hairline bg-bg px-3 py-3">
-                      <div className="flex items-start justify-between gap-2">
-                        <div className="min-w-0">
-                          <p className="text-sm font-semibold text-text-primary">{copy.controls.voiceSample}</p>
-                          <p className="mt-1 truncate text-xs text-text-secondary">
-                            {voiceSample ? voiceSample.name : copy.controls.uploadVoiceSampleHint}
-                          </p>
-                        </div>
-                        {voiceSample ? (
-                          <Button type="button" variant="ghost" size="sm" onClick={() => setVoiceSample(null)}>
-                            {copy.source.clear}
-                          </Button>
-                        ) : null}
-                      </div>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="mt-3 w-full justify-center"
-                        disabled={isUploadingVoice}
-                        onClick={() => voiceInputRef.current?.click()}
-                      >
-                        <UIIcon icon={Upload} size={16} />
-                        {isUploadingVoice ? copy.source.uploading : copy.controls.uploadVoiceSample}
-                      </Button>
-                      <input
-                        ref={voiceInputRef}
-                        type="file"
-                        accept="audio/*"
-                        className="sr-only"
-                        onChange={(event) => {
-                          void handleVoiceFileSelect(event.target.files);
-                        }}
-                      />
-                    </div>
-                  </div>
-                </div>
+                <AudioVoiceSection
+                  copy={copy}
+                  inputRef={voiceInputRef}
+                  isUploading={isUploadingVoice}
+                  onClear={() => setVoiceSample(null)}
+                  onFileSelect={handleVoiceFileSelect}
+                  voiceSample={voiceSample}
+                />
               ) : null}
 
               <div className="rounded-[12px] border border-hairline bg-surface p-4 shadow-card lg:col-span-2">
@@ -950,58 +852,16 @@ export default function AudioWorkspace() {
             </div>
           </div>
 
-          <div className="fixed bottom-0 left-0 right-0 z-[80] border-t border-hairline bg-bg px-4 py-3 shadow-[0_-18px_44px_rgba(15,23,42,0.08)] md:left-[188px] lg:px-7 xl:right-[332px]">
-            <div className="mx-auto flex w-full max-w-[980px] flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <div className="flex flex-wrap items-center gap-2">
-                <div className="flex min-w-[132px] items-center gap-2 rounded-[9px] border border-hairline bg-surface px-3 py-2">
-                  <span className="flex h-8 w-8 items-center justify-center rounded-[8px] bg-bg text-text-secondary">
-                      <UIIcon icon={Clock3} size={19} />
-                    </span>
-                    <div>
-                      <p className="text-xs text-text-muted">{copy.pricing.durationEyebrow}</p>
-                    <p className="text-sm font-semibold text-text-primary">
-                      ~ {estimatedDurationSec ? formatAudioDurationLabel(estimatedDurationSec) : '-'}
-                    </p>
-                    </div>
-                  </div>
-                <div className="flex min-w-[132px] items-center gap-2 rounded-[9px] border border-hairline bg-surface px-3 py-2">
-                  <span className="flex h-8 w-8 items-center justify-center rounded-[8px] bg-bg text-text-secondary">
-                      <UIIcon icon={Coins} size={19} />
-                    </span>
-                    <div>
-                      <p className="text-xs text-text-muted">{copy.pricing.eyebrow}</p>
-                    <p className="text-sm font-semibold text-text-primary">
-                        {quote ? formatCurrency(quote.totalCents, quote.currency, locale) : '-'}
-                      </p>
-                    </div>
-                  </div>
-                {activeJob?.status === 'running' || activeJob?.status === 'pending' ? (
-                  <div className="rounded-[9px] border border-brand/25 bg-brand-soft px-3 py-2 text-sm font-semibold text-brand">
-                    {activeJob.progress}%
-                  </div>
-                ) : null}
-                </div>
-
-              <div className="flex flex-col gap-2 sm:min-w-[360px] sm:flex-row sm:items-center sm:justify-end">
-                <p className="text-sm text-text-secondary sm:text-right">{generationHint}</p>
-                <div className="flex w-full shrink-0 sm:w-auto">
-                  <Button
-                    type="button"
-                    size="lg"
-                    onClick={handleGenerate}
-                    disabled={!canGenerate}
-                    className="min-w-0 flex-1 rounded-r-none sm:min-w-[210px]"
-                  >
-                      <UIIcon icon={AudioLines} size={18} />
-                      {isGenerating ? copy.pricing.generating : copy.pricing.generate}
-                    </Button>
-                    <Button type="button" size="lg" disabled={!canGenerate} className="rounded-l-none border-l border-white/25 px-3">
-                      <ChevronDown className="h-4 w-4" aria-hidden />
-                    </Button>
-                  </div>
-                </div>
-              </div>
-          </div>
+          <AudioGenerationDock
+            activeProgress={activeProgress}
+            canGenerate={canGenerate}
+            copy={copy}
+            durationLabel={dockDurationLabel}
+            generationHint={generationHint}
+            isGenerating={isGenerating}
+            onGenerate={handleGenerate}
+            priceLabel={dockPriceLabel}
+          />
         </main>
       </div>
 

--- a/frontend/app/(core)/(workspace)/app/audio/_components/audio-generation-dock.tsx
+++ b/frontend/app/(core)/(workspace)/app/audio/_components/audio-generation-dock.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { AudioLines, ChevronDown, Clock3, Coins } from 'lucide-react';
+
+import { Button } from '@/components/ui/Button';
+import { UIIcon } from '@/components/ui/UIIcon';
+import type { AudioWorkspaceCopy } from '../copy';
+
+export function AudioGenerationDock({
+  activeProgress,
+  canGenerate,
+  copy,
+  durationLabel,
+  generationHint,
+  isGenerating,
+  onGenerate,
+  priceLabel,
+}: {
+  activeProgress: number | null;
+  canGenerate: boolean;
+  copy: AudioWorkspaceCopy;
+  durationLabel: string;
+  generationHint: string;
+  isGenerating: boolean;
+  onGenerate: () => void;
+  priceLabel: string;
+}) {
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-[80] border-t border-hairline bg-bg px-4 py-3 shadow-[0_-18px_44px_rgba(15,23,42,0.08)] md:left-[188px] lg:px-7 xl:right-[332px]">
+      <div className="mx-auto flex w-full max-w-[980px] flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex min-w-[132px] items-center gap-2 rounded-[9px] border border-hairline bg-surface px-3 py-2">
+            <span className="flex h-8 w-8 items-center justify-center rounded-[8px] bg-bg text-text-secondary">
+              <UIIcon icon={Clock3} size={19} />
+            </span>
+            <div>
+              <p className="text-xs text-text-muted">{copy.pricing.durationEyebrow}</p>
+              <p className="text-sm font-semibold text-text-primary">~ {durationLabel}</p>
+            </div>
+          </div>
+          <div className="flex min-w-[132px] items-center gap-2 rounded-[9px] border border-hairline bg-surface px-3 py-2">
+            <span className="flex h-8 w-8 items-center justify-center rounded-[8px] bg-bg text-text-secondary">
+              <UIIcon icon={Coins} size={19} />
+            </span>
+            <div>
+              <p className="text-xs text-text-muted">{copy.pricing.eyebrow}</p>
+              <p className="text-sm font-semibold text-text-primary">{priceLabel}</p>
+            </div>
+          </div>
+          {activeProgress == null ? null : (
+            <div className="rounded-[9px] border border-brand/25 bg-brand-soft px-3 py-2 text-sm font-semibold text-brand">
+              {activeProgress}%
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-2 sm:min-w-[360px] sm:flex-row sm:items-center sm:justify-end">
+          <p className="text-sm text-text-secondary sm:text-right">{generationHint}</p>
+          <div className="flex w-full shrink-0 sm:w-auto">
+            <Button
+              type="button"
+              size="lg"
+              onClick={onGenerate}
+              disabled={!canGenerate}
+              className="min-w-0 flex-1 rounded-r-none sm:min-w-[210px]"
+            >
+              <UIIcon icon={AudioLines} size={18} />
+              {isGenerating ? copy.pricing.generating : copy.pricing.generate}
+            </Button>
+            <Button type="button" size="lg" disabled={!canGenerate} className="rounded-l-none border-l border-white/25 px-3">
+              <ChevronDown className="h-4 w-4" aria-hidden />
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/(core)/(workspace)/app/audio/_components/audio-source-video-section.tsx
+++ b/frontend/app/(core)/(workspace)/app/audio/_components/audio-source-video-section.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import type { RefObject } from 'react';
+import { CheckCircle2, FileVideo, Upload, Video } from 'lucide-react';
+
+import { Button } from '@/components/ui/Button';
+import { UIIcon } from '@/components/ui/UIIcon';
+import { formatAudioDurationLabel } from '@/lib/audio-generation';
+import type { SourceVideoState } from '../_lib/audio-workspace-types';
+import type { AudioWorkspaceCopy } from '../copy';
+
+export function AudioSourceVideoSection({
+  copy,
+  inputRef,
+  isUploading,
+  onClear,
+  onFileSelect,
+  onOpenGeneratedPicker,
+  required,
+  sourceVideo,
+}: {
+  copy: AudioWorkspaceCopy;
+  inputRef: RefObject<HTMLInputElement>;
+  isUploading: boolean;
+  onClear: () => void;
+  onFileSelect: (fileList: FileList | null) => void | Promise<void>;
+  onOpenGeneratedPicker: () => void;
+  required: boolean;
+  sourceVideo: SourceVideoState | null;
+}) {
+  return (
+    <section className="rounded-[12px] border border-hairline bg-surface p-4 shadow-card">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex min-w-0 items-start gap-3">
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[9px] bg-brand-soft text-brand">
+            <UIIcon icon={FileVideo} size={22} />
+          </span>
+          <div className="min-w-0">
+            <h2 className="text-sm font-semibold text-text-primary">{copy.source.title}</h2>
+            <p className="mt-1 text-sm text-text-secondary">
+              {required ? copy.source.required : copy.source.optional}
+            </p>
+            {sourceVideo ? (
+              <p className="mt-2 truncate text-sm font-semibold text-text-primary">
+                {sourceVideo.label}
+                <span className="ml-2 text-xs font-medium text-text-muted">
+                  {sourceVideo.durationSec ? formatAudioDurationLabel(sourceVideo.durationSec) : copy.source.durationPending}
+                </span>
+              </p>
+            ) : null}
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={isUploading}
+            onClick={() => inputRef.current?.click()}
+          >
+            <UIIcon icon={Upload} size={16} />
+            {isUploading ? copy.source.uploading : copy.source.upload}
+          </Button>
+          <Button type="button" variant="outline" size="sm" onClick={onOpenGeneratedPicker}>
+            <UIIcon icon={Video} size={16} />
+            {copy.source.useGenerated}
+          </Button>
+          {sourceVideo ? (
+            <Button type="button" variant="ghost" size="sm" onClick={onClear}>
+              {copy.source.clear}
+            </Button>
+          ) : null}
+        </div>
+      </div>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="video/*"
+        className="sr-only"
+        onChange={(event) => {
+          void onFileSelect(event.target.files);
+        }}
+      />
+      {sourceVideo ? (
+        <div className="mt-3 flex items-center gap-3 rounded-[10px] border border-hairline bg-bg px-3 py-2">
+          <div className="h-12 w-20 overflow-hidden rounded-[8px] border border-hairline bg-surface">
+            <video src={sourceVideo.url} poster={sourceVideo.thumbUrl ?? undefined} className="h-full w-full object-cover" muted playsInline preload="metadata" />
+          </div>
+          <p className="min-w-0 flex-1 truncate text-xs text-text-secondary">
+            {sourceVideo.aspectRatio ? `${sourceVideo.aspectRatio} · ` : ''}
+            {sourceVideo.durationSec ? formatAudioDurationLabel(sourceVideo.durationSec) : copy.source.durationPending}
+          </p>
+          <CheckCircle2 className="h-5 w-5 text-success" aria-hidden />
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/app/(core)/(workspace)/app/audio/_components/audio-voice-section.tsx
+++ b/frontend/app/(core)/(workspace)/app/audio/_components/audio-voice-section.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import type { RefObject } from 'react';
+import { AudioLines, Play, Upload } from 'lucide-react';
+
+import { Button } from '@/components/ui/Button';
+import { UIIcon } from '@/components/ui/UIIcon';
+import type { AudioWorkspaceCopy } from '../copy';
+
+export function AudioVoiceSection({
+  copy,
+  inputRef,
+  isUploading,
+  onClear,
+  onFileSelect,
+  voiceSample,
+}: {
+  copy: AudioWorkspaceCopy;
+  inputRef: RefObject<HTMLInputElement>;
+  isUploading: boolean;
+  onClear: () => void;
+  onFileSelect: (fileList: FileList | null) => void | Promise<void>;
+  voiceSample: { url: string; name: string } | null;
+}) {
+  return (
+    <div className="rounded-[12px] border border-hairline bg-surface p-4 shadow-card">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-base font-semibold text-text-primary">{copy.controls.voice}</p>
+          <p className="mt-1 text-sm text-text-secondary">{copy.controls.selectedVoice}</p>
+        </div>
+        <Button type="button" variant="outline" size="sm">
+          {copy.controls.chooseVoice}
+        </Button>
+      </div>
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        <div className="flex items-center gap-3 rounded-[10px] border border-hairline bg-bg px-3 py-3">
+          <span className="flex h-8 w-8 items-center justify-center rounded-full bg-brand-soft text-brand">
+            <UIIcon icon={Play} size={16} />
+          </span>
+          <span className="min-w-0 flex-1 truncate text-sm text-text-secondary">{copy.controls.selectedVoice}</span>
+          <AudioLines className="h-4 w-4 text-brand" aria-hidden />
+        </div>
+        <div className="rounded-[10px] border border-hairline bg-bg px-3 py-3">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-text-primary">{copy.controls.voiceSample}</p>
+              <p className="mt-1 truncate text-xs text-text-secondary">
+                {voiceSample ? voiceSample.name : copy.controls.uploadVoiceSampleHint}
+              </p>
+            </div>
+            {voiceSample ? (
+              <Button type="button" variant="ghost" size="sm" onClick={onClear}>
+                {copy.source.clear}
+              </Button>
+            ) : null}
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="mt-3 w-full justify-center"
+            disabled={isUploading}
+            onClick={() => inputRef.current?.click()}
+          >
+            <UIIcon icon={Upload} size={16} />
+            {isUploading ? copy.source.uploading : copy.controls.uploadVoiceSample}
+          </Button>
+          <input
+            ref={inputRef}
+            type="file"
+            accept="audio/*"
+            className="sr-only"
+            onChange={(event) => {
+              void onFileSelect(event.target.files);
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tests/audio-workspace-architecture.test.ts
+++ b/tests/audio-workspace-architecture.test.ts
@@ -8,6 +8,9 @@ const audioDir = join(root, 'frontend/app/(core)/(workspace)/app/audio');
 const workspacePath = join(audioDir, 'AudioWorkspace.tsx');
 const controlsPath = join(audioDir, '_components/audio-workspace-controls.tsx');
 const generatedPickerPath = join(audioDir, '_components/audio-generated-video-picker.tsx');
+const sourceVideoSectionPath = join(audioDir, '_components/audio-source-video-section.tsx');
+const generationDockPath = join(audioDir, '_components/audio-generation-dock.tsx');
+const voiceSectionPath = join(audioDir, '_components/audio-voice-section.tsx');
 const helpersPath = join(audioDir, '_lib/audio-workspace-helpers.ts');
 const typesPath = join(audioDir, '_lib/audio-workspace-types.ts');
 const activeJobHookPath = join(audioDir, '_hooks/useAudioActiveJobPolling.ts');
@@ -19,6 +22,9 @@ const workspaceSource = readFileSync(workspacePath, 'utf8');
 test('audio workspace delegates local controls, helpers, and contracts', () => {
   assert.ok(existsSync(controlsPath), 'audio control components should live in a route-local component module');
   assert.ok(existsSync(generatedPickerPath), 'generated video picker should live in a route-local component module');
+  assert.ok(existsSync(sourceVideoSectionPath), 'source video section should live in a route-local component module');
+  assert.ok(existsSync(generationDockPath), 'generation dock should live in a route-local component module');
+  assert.ok(existsSync(voiceSectionPath), 'voice section should live in a route-local component module');
   assert.ok(existsSync(helpersPath), 'audio browser/API helpers should live in a route-local helper module');
   assert.ok(existsSync(typesPath), 'audio local contracts should live in a route-local type module');
   assert.ok(existsSync(activeJobHookPath), 'active audio job polling should live in a route-local hook');
@@ -27,6 +33,9 @@ test('audio workspace delegates local controls, helpers, and contracts', () => {
 
   assert.match(workspaceSource, /from '\.\/_components\/audio-workspace-controls'/);
   assert.match(workspaceSource, /from '\.\/_components\/audio-generated-video-picker'/);
+  assert.match(workspaceSource, /from '\.\/_components\/audio-source-video-section'/);
+  assert.match(workspaceSource, /from '\.\/_components\/audio-generation-dock'/);
+  assert.match(workspaceSource, /from '\.\/_components\/audio-voice-section'/);
   assert.match(workspaceSource, /from '\.\/_hooks\/useAudioActiveJobPolling'/);
   assert.match(workspaceSource, /from '\.\/_hooks\/useAudioGeneratedVideos'/);
   assert.match(workspaceSource, /from '\.\/_hooks\/useAudioGenerationRunner'/);
@@ -44,18 +53,24 @@ test('audio workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /function AudioSelectControl\(/, 'audio controls belong in _components/audio-workspace-controls.tsx');
   assert.doesNotMatch(workspaceSource, /generated-source-skeleton/, 'generated video picker UI belongs in _components/audio-generated-video-picker.tsx');
   assert.doesNotMatch(workspaceSource, /copy\.picker\.audioBadge/, 'generated video picker card UI belongs in _components/audio-generated-video-picker.tsx');
+  assert.doesNotMatch(workspaceSource, /copy\.source\.useGenerated/, 'source video section UI belongs in _components/audio-source-video-section.tsx');
+  assert.doesNotMatch(workspaceSource, /fixed bottom-0 left-0 right-0/, 'generation dock UI belongs in _components/audio-generation-dock.tsx');
+  assert.doesNotMatch(workspaceSource, /copy\.controls\.uploadVoiceSampleHint/, 'voice section UI belongs in _components/audio-voice-section.tsx');
   assert.doesNotMatch(workspaceSource, /getJobStatus/, 'active job polling belongs in useAudioActiveJobPolling');
   assert.doesNotMatch(workspaceSource, /surface=video&limit=60/, 'generated video loading belongs in useAudioGeneratedVideos');
   assert.doesNotMatch(workspaceSource, /runAudioGenerate/, 'audio generation submission belongs in useAudioGenerationRunner');
   assert.doesNotMatch(workspaceSource, /resolveUiErrorMessage\(error, copy\.messages\.generationFailed/, 'generation failure mapping belongs in useAudioGenerationRunner');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 1030, `AudioWorkspace should stay below 1030 lines after generation runner extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 890, `AudioWorkspace should stay below 890 lines after section extraction, got ${lineCount}`);
 });
 
 test('audio helper modules expose the expected workspace contract', () => {
   const controlsSource = readFileSync(controlsPath, 'utf8');
   const generatedPickerSource = readFileSync(generatedPickerPath, 'utf8');
+  const sourceVideoSectionSource = readFileSync(sourceVideoSectionPath, 'utf8');
+  const generationDockSource = readFileSync(generationDockPath, 'utf8');
+  const voiceSectionSource = readFileSync(voiceSectionPath, 'utf8');
   const helpersSource = readFileSync(helpersPath, 'utf8');
   const typesSource = readFileSync(typesPath, 'utf8');
   const activeJobHookSource = readFileSync(activeJobHookPath, 'utf8');
@@ -75,6 +90,12 @@ test('audio helper modules expose the expected workspace contract', () => {
     /export function AudioGeneratedVideoPickerModal/,
     'AudioGeneratedVideoPickerModal should be exported'
   );
+  assert.match(sourceVideoSectionSource, /export function AudioSourceVideoSection/, 'AudioSourceVideoSection should be exported');
+  assert.match(sourceVideoSectionSource, /copy\.source\.useGenerated/, 'source video section should own generated picker trigger copy');
+  assert.match(generationDockSource, /export function AudioGenerationDock/, 'AudioGenerationDock should be exported');
+  assert.match(generationDockSource, /fixed bottom-0 left-0 right-0/, 'generation dock should own fixed dock layout');
+  assert.match(voiceSectionSource, /export function AudioVoiceSection/, 'AudioVoiceSection should be exported');
+  assert.match(voiceSectionSource, /copy\.controls\.uploadVoiceSampleHint/, 'voice section should own voice sample copy');
   assert.match(activeJobHookSource, /export function useAudioActiveJobPolling/, 'active job polling hook should be exported');
   assert.match(activeJobHookSource, /getJobStatus/, 'active job polling hook should poll job status');
   assert.match(generatedVideosHookSource, /export function useAudioGeneratedVideos/, 'generated videos hook should be exported');


### PR DESCRIPTION
## Summary
- Move source video selection UI into a route-local component
- Move voice sample UI into a route-local component
- Move the fixed generation dock into a route-local component and tighten the audio architecture contract

## Checks
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/audio-workspace-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- git diff --check -- touched files
- npm --prefix frontend run lint
- npm run lint:exposure