### PR TITLE
Split admin playlists sidebar

### DIFF
--- a/frontend/components/admin/PlaylistsManager.tsx
+++ b/frontend/components/admin/PlaylistsManager.tsx
@@ -15,11 +15,9 @@ import {
 import clsx from 'clsx';
 import { Button } from '@/components/ui/Button';
 import { authFetch } from '@/lib/authFetch';
-import { MissingFamilyCard } from '@/components/admin/playlists/MissingFamilyCard';
-import { PlaylistRailCard } from '@/components/admin/playlists/PlaylistRailCard';
+import { PlaylistsSidebar } from '@/components/admin/playlists/PlaylistsSidebar';
 import { StatusPill } from '@/components/admin/playlists/PlaylistStatusPill';
 import {
-  GROUP_LABELS,
   buildFamilyHelpers,
   buildHelperFallbackLabel,
   buildPlaylistUpdateFromItems,
@@ -671,144 +669,21 @@ export function PlaylistsManager({
       ) : null}
 
       <div className="grid gap-6 xl:grid-cols-[360px_minmax(0,1fr)]">
-        <aside className="space-y-6">
-          {groupedPlaylists.runtime.length ? (
-            <section className="space-y-3">
-              <div className="flex items-center justify-between gap-3">
-                <h2 className="text-xs font-semibold uppercase tracking-micro text-text-muted">{GROUP_LABELS.runtime}</h2>
-                <span className="text-xs text-text-muted">{groupedPlaylists.runtime.length}</span>
-              </div>
-              <div className="space-y-2">
-                {groupedPlaylists.runtime.map((playlist) => (
-                  <PlaylistRailCard
-                    key={playlist.id}
-                    playlist={playlist}
-                    isActive={playlist.id === selectedId}
-                    onSelect={handleSelectPlaylist}
-                  />
-                ))}
-              </div>
-            </section>
-          ) : null}
-
-          <section className="space-y-3">
-            <div className="flex items-center justify-between gap-3">
-              <button
-                type="button"
-                onClick={() => setShowFamilyCollections((current) => !current)}
-                className="flex min-w-0 items-center gap-2 text-left"
-              >
-                <svg
-                  viewBox="0 0 20 20"
-                  aria-hidden="true"
-                  className={clsx('h-4 w-4 text-text-muted transition-transform', showFamilyCollections ? 'rotate-90' : 'rotate-0')}
-                >
-                  <path
-                    d="M7.5 5.5 12 10l-4.5 4.5"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="1.8"
-                  />
-                </svg>
-                <h2 className="text-xs font-semibold uppercase tracking-micro text-text-muted">{GROUP_LABELS.family}</h2>
-              </button>
-              <div className="flex items-center gap-2 text-xs text-text-muted">
-                {emptyFamilyCount ? <span>{emptyFamilyCount} empty</span> : null}
-                <span>{familyHelpers.length}</span>
-              </div>
-            </div>
-            {showFamilyCollections ? (
-              <div className="space-y-2">
-                {familyHelpers.map((helper) => {
-                  const playlist = helper.playlistId
-                    ? groupedPlaylists.family.find((entry) => entry.id === helper.playlistId) ?? null
-                    : null;
-                  if (playlist) {
-                    return (
-                      <PlaylistRailCard
-                        key={playlist.id}
-                        playlist={playlist}
-                        isActive={playlist.id === selectedId}
-                        onSelect={handleSelectPlaylist}
-                      />
-                    );
-                  }
-                  return (
-                    <MissingFamilyCard
-                      key={helper.familyId}
-                      helper={helper}
-                      onCreate={handleCreateMissingFamilyPlaylists}
-                      onSeed={handleSeedFamilyPlaylist}
-                      pending={isPending}
-                    />
-                  );
-                })}
-              </div>
-            ) : null}
-          </section>
-
-          {groupedPlaylists.model.length ? (
-            <section className="space-y-3">
-              <div className="flex items-center justify-between gap-3">
-                <button
-                  type="button"
-                  onClick={() => setShowModelCollections((current) => !current)}
-                  className="flex min-w-0 items-center gap-2 text-left"
-                >
-                  <svg
-                    viewBox="0 0 20 20"
-                    aria-hidden="true"
-                    className={clsx('h-4 w-4 text-text-muted transition-transform', showModelCollections ? 'rotate-90' : 'rotate-0')}
-                  >
-                    <path
-                      d="M7.5 5.5 12 10l-4.5 4.5"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="1.8"
-                    />
-                  </svg>
-                  <h2 className="text-xs font-semibold uppercase tracking-micro text-text-muted">{GROUP_LABELS.model}</h2>
-                </button>
-                <span className="text-xs text-text-muted">{groupedPlaylists.model.length}</span>
-              </div>
-              {showModelCollections ? (
-                <div className="space-y-2">
-                  {groupedPlaylists.model.map((playlist) => (
-                    <PlaylistRailCard
-                      key={playlist.id}
-                      playlist={playlist}
-                      isActive={playlist.id === selectedId}
-                      onSelect={handleSelectPlaylist}
-                    />
-                  ))}
-                </div>
-              ) : null}
-            </section>
-          ) : null}
-
-          {showDraftCollections && groupedPlaylists.draft.length ? (
-            <section className="space-y-3">
-              <div className="flex items-center justify-between gap-3">
-                <h2 className="text-xs font-semibold uppercase tracking-micro text-text-muted">{GROUP_LABELS.draft}</h2>
-                <span className="text-xs text-text-muted">{groupedPlaylists.draft.length}</span>
-              </div>
-              <div className="space-y-2">
-                {groupedPlaylists.draft.map((playlist) => (
-                  <PlaylistRailCard
-                    key={playlist.id}
-                    playlist={playlist}
-                    isActive={playlist.id === selectedId}
-                    onSelect={handleSelectPlaylist}
-                  />
-                ))}
-              </div>
-            </section>
-          ) : null}
-        </aside>
+        <PlaylistsSidebar
+          emptyFamilyCount={emptyFamilyCount}
+          familyHelpers={familyHelpers}
+          groupedPlaylists={groupedPlaylists}
+          onCreateMissingFamilyPlaylists={handleCreateMissingFamilyPlaylists}
+          onSeedFamilyPlaylist={handleSeedFamilyPlaylist}
+          onSelectPlaylist={handleSelectPlaylist}
+          onToggleFamilyCollections={() => setShowFamilyCollections((current) => !current)}
+          onToggleModelCollections={() => setShowModelCollections((current) => !current)}
+          pending={isPending}
+          selectedId={selectedId}
+          showDraftCollections={showDraftCollections}
+          showFamilyCollections={showFamilyCollections}
+          showModelCollections={showModelCollections}
+        />
 
         <section className="space-y-6">
           {selectedPlaylist ? (

--- a/frontend/components/admin/playlists/PlaylistsSidebar.tsx
+++ b/frontend/components/admin/playlists/PlaylistsSidebar.tsx
@@ -1,0 +1,174 @@
+import clsx from 'clsx';
+import { GROUP_LABELS } from './playlist-helpers';
+import type { EditablePlaylist, FamilyPlaylistHelperCard } from './playlist-types';
+import { MissingFamilyCard } from './MissingFamilyCard';
+import { PlaylistRailCard } from './PlaylistRailCard';
+
+export function PlaylistsSidebar({
+  emptyFamilyCount,
+  familyHelpers,
+  groupedPlaylists,
+  onCreateMissingFamilyPlaylists,
+  onSeedFamilyPlaylist,
+  onSelectPlaylist,
+  onToggleFamilyCollections,
+  onToggleModelCollections,
+  pending,
+  selectedId,
+  showDraftCollections,
+  showFamilyCollections,
+  showModelCollections,
+}: {
+  emptyFamilyCount: number;
+  familyHelpers: FamilyPlaylistHelperCard[];
+  groupedPlaylists: {
+    runtime: EditablePlaylist[];
+    family: EditablePlaylist[];
+    model: EditablePlaylist[];
+    draft: EditablePlaylist[];
+  };
+  onCreateMissingFamilyPlaylists: (familyId?: string | null) => void;
+  onSeedFamilyPlaylist: (familyId: string) => void;
+  onSelectPlaylist: (playlistId: string) => void;
+  onToggleFamilyCollections: () => void;
+  onToggleModelCollections: () => void;
+  pending: boolean;
+  selectedId: string | null;
+  showDraftCollections: boolean;
+  showFamilyCollections: boolean;
+  showModelCollections: boolean;
+}) {
+  return (
+    <aside className="space-y-6">
+      {groupedPlaylists.runtime.length ? (
+        <section className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-xs font-semibold uppercase tracking-micro text-text-muted">{GROUP_LABELS.runtime}</h2>
+            <span className="text-xs text-text-muted">{groupedPlaylists.runtime.length}</span>
+          </div>
+          <div className="space-y-2">
+            {groupedPlaylists.runtime.map((playlist) => (
+              <PlaylistRailCard
+                key={playlist.id}
+                playlist={playlist}
+                isActive={playlist.id === selectedId}
+                onSelect={onSelectPlaylist}
+              />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      <section className="space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <button
+            type="button"
+            onClick={onToggleFamilyCollections}
+            className="flex min-w-0 items-center gap-2 text-left"
+          >
+            <DisclosureIcon open={showFamilyCollections} />
+            <h2 className="text-xs font-semibold uppercase tracking-micro text-text-muted">{GROUP_LABELS.family}</h2>
+          </button>
+          <div className="flex items-center gap-2 text-xs text-text-muted">
+            {emptyFamilyCount ? <span>{emptyFamilyCount} empty</span> : null}
+            <span>{familyHelpers.length}</span>
+          </div>
+        </div>
+        {showFamilyCollections ? (
+          <div className="space-y-2">
+            {familyHelpers.map((helper) => {
+              const playlist = helper.playlistId
+                ? groupedPlaylists.family.find((entry) => entry.id === helper.playlistId) ?? null
+                : null;
+              if (playlist) {
+                return (
+                  <PlaylistRailCard
+                    key={playlist.id}
+                    playlist={playlist}
+                    isActive={playlist.id === selectedId}
+                    onSelect={onSelectPlaylist}
+                  />
+                );
+              }
+              return (
+                <MissingFamilyCard
+                  key={helper.familyId}
+                  helper={helper}
+                  onCreate={(familyId) => onCreateMissingFamilyPlaylists(familyId)}
+                  onSeed={onSeedFamilyPlaylist}
+                  pending={pending}
+                />
+              );
+            })}
+          </div>
+        ) : null}
+      </section>
+
+      {groupedPlaylists.model.length ? (
+        <section className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <button
+              type="button"
+              onClick={onToggleModelCollections}
+              className="flex min-w-0 items-center gap-2 text-left"
+            >
+              <DisclosureIcon open={showModelCollections} />
+              <h2 className="text-xs font-semibold uppercase tracking-micro text-text-muted">{GROUP_LABELS.model}</h2>
+            </button>
+            <span className="text-xs text-text-muted">{groupedPlaylists.model.length}</span>
+          </div>
+          {showModelCollections ? (
+            <div className="space-y-2">
+              {groupedPlaylists.model.map((playlist) => (
+                <PlaylistRailCard
+                  key={playlist.id}
+                  playlist={playlist}
+                  isActive={playlist.id === selectedId}
+                  onSelect={onSelectPlaylist}
+                />
+              ))}
+            </div>
+          ) : null}
+        </section>
+      ) : null}
+
+      {showDraftCollections && groupedPlaylists.draft.length ? (
+        <section className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-xs font-semibold uppercase tracking-micro text-text-muted">{GROUP_LABELS.draft}</h2>
+            <span className="text-xs text-text-muted">{groupedPlaylists.draft.length}</span>
+          </div>
+          <div className="space-y-2">
+            {groupedPlaylists.draft.map((playlist) => (
+              <PlaylistRailCard
+                key={playlist.id}
+                playlist={playlist}
+                isActive={playlist.id === selectedId}
+                onSelect={onSelectPlaylist}
+              />
+            ))}
+          </div>
+        </section>
+      ) : null}
+    </aside>
+  );
+}
+
+function DisclosureIcon({ open }: { open: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      aria-hidden="true"
+      className={clsx('h-4 w-4 text-text-muted transition-transform', open ? 'rotate-90' : 'rotate-0')}
+    >
+      <path
+        d="M7.5 5.5 12 10l-4.5 4.5"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.8"
+      />
+    </svg>
+  );
+}

--- a/tests/admin-playlists-architecture.test.ts
+++ b/tests/admin-playlists-architecture.test.ts
@@ -11,21 +11,21 @@ const helpersPath = join(playlistsDir, 'playlist-helpers.ts');
 const statusPillPath = join(playlistsDir, 'PlaylistStatusPill.tsx');
 const railCardPath = join(playlistsDir, 'PlaylistRailCard.tsx');
 const missingFamilyCardPath = join(playlistsDir, 'MissingFamilyCard.tsx');
+const sidebarPath = join(playlistsDir, 'PlaylistsSidebar.tsx');
 
 const managerSource = readFileSync(managerPath, 'utf8');
 const helpersSource = readFileSync(helpersPath, 'utf8');
 const typesSource = readFileSync(typesPath, 'utf8');
 
 test('admin playlists manager delegates contracts, helper logic, and card UI', () => {
-  for (const file of [typesPath, helpersPath, statusPillPath, railCardPath, missingFamilyCardPath]) {
+  for (const file of [typesPath, helpersPath, statusPillPath, railCardPath, missingFamilyCardPath, sidebarPath]) {
     assert.ok(existsSync(file), `${file} should exist`);
   }
 
   assert.match(managerSource, /from '@\/components\/admin\/playlists\/playlist-types'/);
   assert.match(managerSource, /from '@\/components\/admin\/playlists\/playlist-helpers'/);
   assert.match(managerSource, /from '@\/components\/admin\/playlists\/PlaylistStatusPill'/);
-  assert.match(managerSource, /from '@\/components\/admin\/playlists\/PlaylistRailCard'/);
-  assert.match(managerSource, /from '@\/components\/admin\/playlists\/MissingFamilyCard'/);
+  assert.match(managerSource, /from '@\/components\/admin\/playlists\/PlaylistsSidebar'/);
 });
 
 test('admin playlists manager does not regain extracted ownership', () => {
@@ -34,15 +34,23 @@ test('admin playlists manager does not regain extracted ownership', () => {
   assert.doesNotMatch(managerSource, /getExampleFamilyIds/, 'model family catalog access belongs in playlist-helpers.ts');
   assert.doesNotMatch(managerSource, /function PlaylistRailCard\(/, 'rail card UI belongs in PlaylistRailCard.tsx');
   assert.doesNotMatch(managerSource, /function MissingFamilyCard\(/, 'missing family helper UI belongs in MissingFamilyCard.tsx');
+  assert.doesNotMatch(managerSource, /GROUP_LABELS\.runtime/, 'playlist rail grouping belongs in PlaylistsSidebar.tsx');
+  assert.doesNotMatch(managerSource, /showModelCollections \? \(/, 'model rail disclosure belongs in PlaylistsSidebar.tsx');
 
   const lineCount = managerSource.split('\n').length;
-  assert.ok(lineCount <= 1100, `PlaylistsManager should stay below 1100 lines after playlist module extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 960, `PlaylistsManager should stay below 960 lines after sidebar extraction, got ${lineCount}`);
 });
 
 test('admin playlist helper modules expose the expected contract', () => {
+  const sidebarSource = readFileSync(sidebarPath, 'utf8');
+
   for (const typeName of ['PlaylistSummary', 'PlaylistItemRecord', 'PlaylistsManagerProps', 'EditablePlaylist', 'FamilyPlaylistHelperCard']) {
     assert.match(typesSource, new RegExp(`export type ${typeName}\\b`), `${typeName} should be exported`);
   }
+
+  assert.match(sidebarSource, /export function PlaylistsSidebar/, 'PlaylistsSidebar should be exported');
+  assert.match(sidebarSource, /GROUP_LABELS\.runtime/, 'PlaylistsSidebar should own rail grouping labels');
+  assert.match(sidebarSource, /MissingFamilyCard/, 'PlaylistsSidebar should compose missing family cards');
 
   for (const exportName of [
     'GROUP_LABELS',


### PR DESCRIPTION
## Summary
- Move the admin playlists rail into PlaylistsSidebar
- Keep PlaylistsManager focused on state, mutations, and selected playlist detail
- Tighten the admin playlists architecture contract and line budget

## Checks
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/admin-playlists-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- git diff --check -- touched files
- npm --prefix frontend run lint
- npm run lint:exposure