### PR TITLE
Split login auth surface

### DIFF
--- a/frontend/app/(core)/login/_components/LoginAuthSurface.tsx
+++ b/frontend/app/(core)/login/_components/LoginAuthSurface.tsx
@@ -1,0 +1,377 @@
+'use client';
+
+import type { FormEvent, Ref } from 'react';
+import clsx from 'clsx';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import type { AuthCopy, AuthMode } from '../_lib/login-copy';
+import { formatTemplate } from '../_lib/login-helpers';
+
+type SignupSuggestion = { email: string; password: string };
+
+type LoginAuthSurfaceProps = {
+  authCopy: AuthCopy;
+  mode: AuthMode;
+  effectiveMode: Exclude<AuthMode, 'reset'>;
+  email: string;
+  password: string;
+  confirm: string;
+  status: string | null;
+  statusTone: 'info' | 'success';
+  error: string | null;
+  signupSuggestion: SignupSuggestion | null;
+  isGoogleOAuthStarting: boolean;
+  acceptTerms: boolean;
+  termsError: boolean;
+  ageConfirmed: boolean;
+  marketingOptIn: boolean;
+  legalMinAge: number;
+  emailRef: Ref<HTMLInputElement>;
+  passwordRef: Ref<HTMLInputElement>;
+  onBack: () => void;
+  onModeChange: (mode: AuthMode) => void;
+  onGoogleSignIn: () => void | Promise<void>;
+  onSignInSubmit: (event: FormEvent<HTMLFormElement>) => void | Promise<void>;
+  onSignUpSubmit: (event: FormEvent<HTMLFormElement>) => void | Promise<void>;
+  onResetSubmit: (event: FormEvent<HTMLFormElement>) => void | Promise<void>;
+  onEmailChange: (value: string) => void;
+  onPasswordChange: (value: string) => void;
+  onConfirmChange: (value: string) => void;
+  onSyncInputState: () => void;
+  onAcceptTermsChange: (checked: boolean) => void;
+  onAgeConfirmedChange: (checked: boolean) => void;
+  onMarketingOptInChange: (checked: boolean) => void;
+  onAcceptSignupSuggestion: () => void;
+  onClearSignupSuggestion: () => void;
+};
+
+function GoogleIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M19.6 10.2301C19.6 9.55008 19.54 8.90008 19.43 8.28008H10V12.0401H15.42C15.18 13.2901 14.5 14.3301 13.46 15.0301V17.5401H16.7C18.64 15.7401 19.6 13.2101 19.6 10.2301Z" fill="#4285F4" />
+      <path d="M10 20.0001C12.7 20.0001 14.97 19.1001 16.7 17.5401L13.46 15.0301C12.53 15.6501 11.37 16.0301 10 16.0301C7.39502 16.0301 5.19502 14.2201 4.40502 11.8201H1.06006V14.4101C2.78006 17.6401 6.11006 20.0001 10 20.0001Z" fill="#34A853" />
+      <path d="M4.405 11.8201C4.205 11.2001 4.09 10.5401 4.09 9.86008C4.09 9.18008 4.205 8.52008 4.405 7.90008V5.31006H1.06C0.38 6.68006 0 8.24008 0 9.86008C0 11.4801 0.38 13.0401 1.06 14.4101L4.405 11.8201Z" fill="#FBBC05" />
+      <path d="M10 3.98005C11.57 3.98005 12.97 4.52005 14.07 5.56005L16.78 2.85005C14.97 1.16005 12.7 0.200043 10 0.200043C6.11006 0.200043 2.78006 2.56005 1.06006 5.79005L4.40506 8.38005C5.19506 5.98005 7.39506 3.98005 10 3.98005Z" fill="#EA4335" />
+    </svg>
+  );
+}
+
+export function LoginAuthSurface({
+  authCopy,
+  mode,
+  effectiveMode,
+  email,
+  password,
+  confirm,
+  status,
+  statusTone,
+  error,
+  signupSuggestion,
+  isGoogleOAuthStarting,
+  acceptTerms,
+  termsError,
+  ageConfirmed,
+  marketingOptIn,
+  legalMinAge,
+  emailRef,
+  passwordRef,
+  onBack,
+  onModeChange,
+  onGoogleSignIn,
+  onSignInSubmit,
+  onSignUpSubmit,
+  onResetSubmit,
+  onEmailChange,
+  onPasswordChange,
+  onConfirmChange,
+  onSyncInputState,
+  onAcceptTermsChange,
+  onAgeConfirmedChange,
+  onMarketingOptInChange,
+  onAcceptSignupSuggestion,
+  onClearSignupSuggestion,
+}: LoginAuthSurfaceProps) {
+  const renderTermsStatement = () => (
+    <span className={clsx(termsError && 'text-state-warning')}>
+      {authCopy.terms.prefix}
+      <a href="/legal/terms" target="_blank" rel="noopener noreferrer" className="text-brand underline">
+        {authCopy.terms.termsLabel}
+      </a>
+      {authCopy.terms.infix}
+      <a href="/legal/privacy" target="_blank" rel="noopener noreferrer" className="text-brand underline">
+        {authCopy.terms.privacyLabel}
+      </a>
+      {authCopy.terms.suffix}
+    </span>
+  );
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-bg p-6">
+      <div className="mb-6 w-full max-w-md">
+        <Button type="button" onClick={onBack} variant="ghost" size="sm" className="gap-2">
+          <span aria-hidden>←</span>
+          <span>{authCopy.back}</span>
+        </Button>
+      </div>
+      <div className="w-full max-w-md stack-gap-lg rounded-card border border-border bg-surface p-6 shadow-card">
+        <header className="stack-gap">
+          <div>
+            <h1 className="text-lg font-semibold text-text-primary">
+              {mode === 'signup'
+                ? authCopy.modes.signup.title
+                : mode === 'reset'
+                  ? authCopy.modes.reset.title
+                  : authCopy.modes.signin.title}
+            </h1>
+            <p className="text-sm text-text-secondary">
+              {mode === 'signup'
+                ? authCopy.modes.signup.description
+                : mode === 'reset'
+                  ? authCopy.modes.reset.description
+                  : authCopy.modes.signin.description}
+            </p>
+          </div>
+
+          <div className="flex items-center gap-2 rounded-pill bg-bg p-1 text-sm font-medium">
+            <Button
+              type="button"
+              variant={effectiveMode === 'signin' ? 'primary' : 'ghost'}
+              size="sm"
+              onClick={() => onModeChange('signin')}
+              className={clsx(
+                'flex-1 rounded-pill px-3 py-2',
+                effectiveMode === 'signin' ? 'shadow-card' : 'hover:bg-surface'
+              )}
+            >
+              {authCopy.tabs.signin}
+            </Button>
+            <Button
+              type="button"
+              variant={effectiveMode === 'signup' ? 'primary' : 'ghost'}
+              size="sm"
+              onClick={() => onModeChange('signup')}
+              className={clsx(
+                'flex-1 rounded-pill px-3 py-2',
+                effectiveMode === 'signup' ? 'shadow-card' : 'hover:bg-surface'
+              )}
+            >
+              {authCopy.tabs.signup}
+            </Button>
+          </div>
+        </header>
+
+        {mode !== 'reset' ? (
+          <>
+            <Button
+              type="button"
+              onClick={onGoogleSignIn}
+              variant="outline"
+              disabled={isGoogleOAuthStarting}
+              aria-busy={isGoogleOAuthStarting}
+              className="w-full justify-center gap-2 font-medium"
+            >
+              <span aria-hidden className="inline-flex h-5 w-5 items-center justify-center">
+                <GoogleIcon />
+              </span>
+              Continue with Google
+            </Button>
+            <div className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-text-muted">
+              <span className="h-px flex-1 bg-border" aria-hidden />
+              <span>{authCopy.divider}</span>
+              <span className="h-px flex-1 bg-border" aria-hidden />
+            </div>
+            <form onSubmit={mode === 'signin' ? onSignInSubmit : onSignUpSubmit} className="stack-gap-sm">
+              <label className="block text-sm">
+                <span className="mb-1 block text-text-secondary">{authCopy.fields.email}</span>
+                <Input
+                  type="email"
+                  required
+                  ref={emailRef}
+                  name="email"
+                  value={email}
+                  onChange={(e) => onEmailChange(e.target.value)}
+                  onFocus={onSyncInputState}
+                  className="mt-2"
+                  placeholder={authCopy.placeholders.email}
+                  autoComplete="email"
+                />
+              </label>
+              <label className="block text-sm">
+                <span className="mb-1 block text-text-secondary">{authCopy.fields.password}</span>
+                <Input
+                  type="password"
+                  required
+                  ref={passwordRef}
+                  name="password"
+                  value={password}
+                  onChange={(e) => onPasswordChange(e.target.value)}
+                  onFocus={onSyncInputState}
+                  className="mt-2"
+                  placeholder={mode === 'signup' ? authCopy.placeholders.passwordNew : authCopy.placeholders.password}
+                  autoComplete={mode === 'signup' ? 'new-password' : 'current-password'}
+                />
+              </label>
+              {mode === 'signup' && (
+                <label className="block text-sm">
+                  <span className="mb-1 block text-text-secondary">{authCopy.fields.confirmPassword}</span>
+                  <Input
+                    type="password"
+                    required
+                    value={confirm}
+                    onChange={(e) => onConfirmChange(e.target.value)}
+                    className="mt-2"
+                    placeholder={authCopy.placeholders.passwordNew}
+                    autoComplete="new-password"
+                  />
+                </label>
+              )}
+              {mode === 'signup' && (
+                <div className="stack-gap-sm rounded-card bg-bg p-3 text-sm text-text-secondary">
+                  <label className="flex items-start gap-2">
+                    <input
+                      type="checkbox"
+                      checked={acceptTerms}
+                      onChange={(event) => onAcceptTermsChange(event.target.checked)}
+                      className={clsx(
+                        'mt-1 h-4 w-4 rounded border-border text-brand focus:ring-ring',
+                        termsError && 'border-state-warning text-state-warning focus:ring-state-warning'
+                      )}
+                      required
+                    />
+                    <span className={clsx(termsError && 'text-state-warning')}>
+                      {renderTermsStatement()}
+                    </span>
+                  </label>
+                  {termsError ? (
+                    <p className="pl-6 text-xs text-state-warning">{authCopy.terms.error}</p>
+                  ) : null}
+                  <label className="flex items-start gap-2">
+                    <input
+                      type="checkbox"
+                      checked={ageConfirmed}
+                      onChange={(event) => onAgeConfirmedChange(event.target.checked)}
+                      className="mt-1 h-4 w-4 rounded border-border text-brand focus:ring-ring"
+                      required
+                    />
+                    <span>{formatTemplate(authCopy.terms.age, { age: String(legalMinAge) })}</span>
+                  </label>
+                  <label className="flex items-start gap-2">
+                    <input
+                      type="checkbox"
+                      checked={marketingOptIn}
+                      onChange={(event) => onMarketingOptInChange(event.target.checked)}
+                      className="mt-1 h-4 w-4 rounded border-border text-brand focus:ring-ring"
+                    />
+                    <span>{authCopy.terms.marketing}</span>
+                  </label>
+                </div>
+              )}
+
+              <Button
+                type="submit"
+                variant={mode === 'signup' ? 'primary' : 'outline'}
+                className="w-full"
+              >
+                {mode === 'signin' ? authCopy.actions.signin : authCopy.actions.signup}
+              </Button>
+            </form>
+
+            {mode === 'signin' ? (
+              <div className="flex flex-col gap-2 text-xs">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onModeChange('reset')}
+                  className="self-start text-brand hover:text-brandHover"
+                >
+                  {authCopy.forgotPassword}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onModeChange('signup')}
+                  className="self-start text-brand hover:text-brandHover"
+                >
+                  {authCopy.links.newAccount}
+                </Button>
+              </div>
+            ) : (
+              <Button type="button" variant="ghost" size="sm" onClick={() => onModeChange('signin')}>
+                {authCopy.links.haveAccount}
+              </Button>
+            )}
+          </>
+        ) : (
+          <form onSubmit={onResetSubmit} className="stack-gap-sm">
+            <label className="block text-sm">
+              <span className="mb-1 block text-text-secondary">{authCopy.fields.email}</span>
+              <Input
+                type="email"
+                required
+                ref={emailRef}
+                name="email"
+                value={email}
+                onChange={(e) => onEmailChange(e.target.value)}
+                onFocus={onSyncInputState}
+                className="mt-2"
+                placeholder="you@domain.com"
+                autoComplete="email"
+              />
+            </label>
+            <div className="flex justify-between text-xs">
+              <Button type="button" variant="ghost" size="sm" onClick={() => onModeChange('signin')}>
+                {authCopy.links.backToSignIn}
+              </Button>
+            </div>
+            <Button type="submit" variant="outline" className="w-full">
+              {authCopy.actions.reset}
+            </Button>
+          </form>
+        )}
+
+        {status && (
+          <div
+            className={clsx(
+              'rounded-card border px-3 py-3 text-sm font-medium',
+              statusTone === 'success'
+                ? 'border-brand bg-surface-2 text-brand'
+                : 'border-border bg-bg text-text-secondary'
+            )}
+          >
+            {status}
+          </div>
+        )}
+        {mode === 'signin' && signupSuggestion && (
+          <div className="rounded-card border border-dashed border-border bg-surface-glass-75 px-3 py-3 text-xs text-text-secondary">
+            <p className="text-sm font-semibold text-text-primary">New here?</p>
+            <p className="mt-1">
+              {formatTemplate(authCopy.signupSuggestion.body, { email: signupSuggestion.email })}
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <Button type="button" size="sm" onClick={onAcceptSignupSuggestion}>
+                {authCopy.signupSuggestion.accept}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={onClearSignupSuggestion}
+              >
+                {authCopy.signupSuggestion.decline}
+              </Button>
+            </div>
+          </div>
+        )}
+        {error && <p className="text-xs text-state-warning">{error}</p>}
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/(core)/login/_lib/login-copy.ts
+++ b/frontend/app/(core)/login/_lib/login-copy.ts
@@ -11,5 +11,6 @@ export const AUTH_COPY = {
 } as const;
 
 export type Locale = keyof typeof AUTH_COPY;
+export type AuthCopy = (typeof AUTH_COPY)[Locale];
 
 export const LOCALE_OPTIONS: Locale[] = ['en', 'fr', 'es'];

--- a/frontend/app/(core)/login/page.tsx
+++ b/frontend/app/(core)/login/page.tsx
@@ -14,10 +14,8 @@ import {
   readBrowserSession,
 } from '@/lib/supabase-auth-cleanup';
 import { canonicalizeBrowserAuthOrigin } from '@/lib/siteOrigin';
+import { LoginAuthSurface } from './_components/LoginAuthSurface';
 import { startOAuthCookieRedirectFallback } from './_lib/oauth-cookie-fallback';
-import clsx from 'clsx';
-import { Button } from '@/components/ui/Button';
-import { Input } from '@/components/ui/Input';
 import { AUTH_COPY, type AuthMode, type Locale } from './_lib/login-copy';
 import {
   buildAuthCallbackRedirect,
@@ -25,7 +23,6 @@ import {
   consumePendingGoogleLogin,
   DEFAULT_NEXT_PATH,
   detectLocale,
-  formatTemplate,
   getBrowserAuthRedirectOrigin,
   markPendingGoogleLogin,
   sanitizeNextPath,
@@ -523,6 +520,20 @@ export default function LoginPage() {
     setSignupSuggestion(null);
   }, [signupSuggestion, setMode, setConfirm, setStatusTone, setStatus]);
 
+  const handleClearSignupSuggestion = useCallback(() => {
+    setSignupSuggestion(null);
+  }, []);
+
+  const handleAcceptTermsChange = useCallback((checked: boolean) => {
+    setAcceptTerms(checked);
+    if (checked) {
+      setTermsError(false);
+      setError((prev) =>
+        prev === 'You must accept the Terms of Service and Privacy Policy to continue.' ? null : prev
+      );
+    }
+  }, []);
+
   async function submitSignupConsents(userId: string) {
     try {
       const res = await fetch('/api/legal/consents', {
@@ -730,7 +741,7 @@ export default function LoginPage() {
     };
   }, [completeAuthenticatedRedirect, nextPath, nextPathReady]);
 
-  const effectiveMode: AuthMode = mode === 'reset' ? 'signin' : mode;
+  const effectiveMode: Exclude<AuthMode, 'reset'> = mode === 'reset' ? 'signin' : mode;
 
   const handleBack = useCallback(() => {
     if (typeof window === 'undefined') {
@@ -749,301 +760,41 @@ export default function LoginPage() {
     setLocale(detected);
   }, []);
 
-  const renderTermsStatement = () => (
-    <span className={clsx(termsError && 'text-state-warning')}>
-      {authCopy.terms.prefix}
-      <a href="/legal/terms" target="_blank" rel="noopener noreferrer" className="text-brand underline">
-        {authCopy.terms.termsLabel}
-      </a>
-      {authCopy.terms.infix}
-      <a href="/legal/privacy" target="_blank" rel="noopener noreferrer" className="text-brand underline">
-        {authCopy.terms.privacyLabel}
-      </a>
-      {authCopy.terms.suffix}
-    </span>
-  );
-
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-bg p-6">
-      <div className="mb-6 w-full max-w-md">
-        <Button type="button" onClick={handleBack} variant="ghost" size="sm" className="gap-2">
-          <span aria-hidden>←</span>
-          <span>{authCopy.back}</span>
-        </Button>
-      </div>
-      <div className="w-full max-w-md stack-gap-lg rounded-card border border-border bg-surface p-6 shadow-card">
-        <header className="stack-gap">
-          <div>
-            <h1 className="text-lg font-semibold text-text-primary">
-              {mode === 'signup'
-                ? authCopy.modes.signup.title
-                : mode === 'reset'
-                  ? authCopy.modes.reset.title
-                  : authCopy.modes.signin.title}
-            </h1>
-            <p className="text-sm text-text-secondary">
-              {mode === 'signup'
-                ? authCopy.modes.signup.description
-                : mode === 'reset'
-                  ? authCopy.modes.reset.description
-                  : authCopy.modes.signin.description}
-            </p>
-          </div>
-
-          <div className="flex items-center gap-2 rounded-pill bg-bg p-1 text-sm font-medium">
-            <Button
-              type="button"
-              variant={effectiveMode === 'signin' ? 'primary' : 'ghost'}
-              size="sm"
-              onClick={() => setMode('signin')}
-              className={clsx(
-                'flex-1 rounded-pill px-3 py-2',
-                effectiveMode === 'signin' ? 'shadow-card' : 'hover:bg-surface'
-              )}
-            >
-              {authCopy.tabs.signin}
-            </Button>
-            <Button
-              type="button"
-              variant={effectiveMode === 'signup' ? 'primary' : 'ghost'}
-              size="sm"
-              onClick={() => setMode('signup')}
-              className={clsx(
-                'flex-1 rounded-pill px-3 py-2',
-                effectiveMode === 'signup' ? 'shadow-card' : 'hover:bg-surface'
-              )}
-            >
-              {authCopy.tabs.signup}
-            </Button>
-          </div>
-        </header>
-
-        {mode !== 'reset' ? (
-          <>
-            <Button
-              type="button"
-              onClick={signInWithGoogle}
-              variant="outline"
-              disabled={isGoogleOAuthStarting}
-              aria-busy={isGoogleOAuthStarting}
-              className="w-full justify-center gap-2 font-medium"
-            >
-              <span aria-hidden className="inline-flex h-5 w-5 items-center justify-center">
-                <svg
-                  width="20"
-                  height="20"
-                  viewBox="0 0 20 20"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path d="M19.6 10.2301C19.6 9.55008 19.54 8.90008 19.43 8.28008H10V12.0401H15.42C15.18 13.2901 14.5 14.3301 13.46 15.0301V17.5401H16.7C18.64 15.7401 19.6 13.2101 19.6 10.2301Z" fill="#4285F4" />
-                  <path d="M10 20.0001C12.7 20.0001 14.97 19.1001 16.7 17.5401L13.46 15.0301C12.53 15.6501 11.37 16.0301 10 16.0301C7.39502 16.0301 5.19502 14.2201 4.40502 11.8201H1.06006V14.4101C2.78006 17.6401 6.11006 20.0001 10 20.0001Z" fill="#34A853" />
-                  <path d="M4.405 11.8201C4.205 11.2001 4.09 10.5401 4.09 9.86008C4.09 9.18008 4.205 8.52008 4.405 7.90008V5.31006H1.06C0.38 6.68006 0 8.24008 0 9.86008C0 11.4801 0.38 13.0401 1.06 14.4101L4.405 11.8201Z" fill="#FBBC05" />
-                  <path d="M10 3.98005C11.57 3.98005 12.97 4.52005 14.07 5.56005L16.78 2.85005C14.97 1.16005 12.7 0.200043 10 0.200043C6.11006 0.200043 2.78006 2.56005 1.06006 5.79005L4.40506 8.38005C5.19506 5.98005 7.39506 3.98005 10 3.98005Z" fill="#EA4335" />
-                </svg>
-              </span>
-              Continue with Google
-            </Button>
-            <div className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-text-muted">
-              <span className="h-px flex-1 bg-border" aria-hidden />
-              <span>{authCopy.divider}</span>
-              <span className="h-px flex-1 bg-border" aria-hidden />
-            </div>
-            <form onSubmit={mode === 'signin' ? signInWithPassword : signUpWithPassword} className="stack-gap-sm">
-              <label className="block text-sm">
-                <span className="mb-1 block text-text-secondary">{authCopy.fields.email}</span>
-                <Input
-                  type="email"
-                  required
-                  ref={emailRef}
-                  name="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  onFocus={syncInputState}
-                  className="mt-2"
-                  placeholder={authCopy.placeholders.email}
-                  autoComplete="email"
-                />
-              </label>
-              <label className="block text-sm">
-                <span className="mb-1 block text-text-secondary">{authCopy.fields.password}</span>
-                <Input
-                  type="password"
-                  required
-                  ref={passwordRef}
-                  name="password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  onFocus={syncInputState}
-                  className="mt-2"
-                  placeholder={mode === 'signup' ? authCopy.placeholders.passwordNew : authCopy.placeholders.password}
-                  autoComplete={mode === 'signup' ? 'new-password' : 'current-password'}
-                />
-              </label>
-              {mode === 'signup' && (
-                <label className="block text-sm">
-                  <span className="mb-1 block text-text-secondary">{authCopy.fields.confirmPassword}</span>
-                  <Input
-                    type="password"
-                    required
-                    value={confirm}
-                    onChange={(e) => setConfirm(e.target.value)}
-                    className="mt-2"
-                    placeholder={authCopy.placeholders.passwordNew}
-                    autoComplete="new-password"
-                  />
-                </label>
-              )}
-              {mode === 'signup' && (
-                <div className="stack-gap-sm rounded-card bg-bg p-3 text-sm text-text-secondary">
-                  <label className="flex items-start gap-2">
-                    <input
-                      type="checkbox"
-                      checked={acceptTerms}
-                      onChange={(event) => {
-                        const checked = event.target.checked;
-                        setAcceptTerms(checked);
-                        if (checked) {
-                          setTermsError(false);
-                          setError((prev) =>
-                            prev === 'You must accept the Terms of Service and Privacy Policy to continue.' ? null : prev
-                          );
-                        }
-                      }}
-                      className={clsx(
-                        'mt-1 h-4 w-4 rounded border-border text-brand focus:ring-ring',
-                        termsError && 'border-state-warning text-state-warning focus:ring-state-warning'
-                      )}
-                      required
-                    />
-                  <span className={clsx(termsError && 'text-state-warning')}>
-                      {renderTermsStatement()}
-                    </span>
-                  </label>
-                  {termsError ? (
-                    <p className="pl-6 text-xs text-state-warning">{authCopy.terms.error}</p>
-                  ) : null}
-                  <label className="flex items-start gap-2">
-                    <input
-                      type="checkbox"
-                      checked={ageConfirmed}
-                      onChange={(event) => setAgeConfirmed(event.target.checked)}
-                      className="mt-1 h-4 w-4 rounded border-border text-brand focus:ring-ring"
-                      required
-                    />
-                    <span>{formatTemplate(authCopy.terms.age, { age: String(LEGAL_MIN_AGE) })}</span>
-                  </label>
-                  <label className="flex items-start gap-2">
-                    <input
-                      type="checkbox"
-                      checked={marketingOptIn}
-                      onChange={(event) => setMarketingOptIn(event.target.checked)}
-                      className="mt-1 h-4 w-4 rounded border-border text-brand focus:ring-ring"
-                    />
-                    <span>{authCopy.terms.marketing}</span>
-                  </label>
-                </div>
-              )}
-
-              <Button
-                type="submit"
-                variant={mode === 'signup' ? 'primary' : 'outline'}
-                className="w-full"
-              >
-                {mode === 'signin' ? authCopy.actions.signin : authCopy.actions.signup}
-              </Button>
-            </form>
-
-            {mode === 'signin' ? (
-              <div className="flex flex-col gap-2 text-xs">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setMode('reset')}
-                  className="self-start text-brand hover:text-brandHover"
-                >
-                  {authCopy.forgotPassword}
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setMode('signup')}
-                  className="self-start text-brand hover:text-brandHover"
-                >
-                  {authCopy.links.newAccount}
-                </Button>
-              </div>
-            ) : (
-              <Button type="button" variant="ghost" size="sm" onClick={() => setMode('signin')}>
-                {authCopy.links.haveAccount}
-              </Button>
-            )}
-          </>
-        ) : (
-          <form onSubmit={sendReset} className="stack-gap-sm">
-            <label className="block text-sm">
-              <span className="mb-1 block text-text-secondary">{authCopy.fields.email}</span>
-              <Input
-                type="email"
-                required
-                ref={emailRef}
-                name="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                onFocus={syncInputState}
-                className="mt-2"
-                placeholder="you@domain.com"
-                autoComplete="email"
-              />
-            </label>
-            <div className="flex justify-between text-xs">
-              <Button type="button" variant="ghost" size="sm" onClick={() => setMode('signin')}>
-                {authCopy.links.backToSignIn}
-              </Button>
-            </div>
-            <Button type="submit" variant="outline" className="w-full">
-              {authCopy.actions.reset}
-            </Button>
-          </form>
-        )}
-
-        {status && (
-          <div
-            className={clsx(
-              'rounded-card border px-3 py-3 text-sm font-medium',
-              statusTone === 'success'
-                ? 'border-brand bg-surface-2 text-brand'
-                : 'border-border bg-bg text-text-secondary'
-            )}
-          >
-            {status}
-          </div>
-        )}
-        {mode === 'signin' && signupSuggestion && (
-          <div className="rounded-card border border-dashed border-border bg-surface-glass-75 px-3 py-3 text-xs text-text-secondary">
-            <p className="text-sm font-semibold text-text-primary">New here?</p>
-            <p className="mt-1">
-              {formatTemplate(authCopy.signupSuggestion.body, { email: signupSuggestion.email })}
-            </p>
-            <div className="mt-3 flex flex-wrap gap-2">
-              <Button type="button" size="sm" onClick={handleAcceptSignupSuggestion}>
-                {authCopy.signupSuggestion.accept}
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => setSignupSuggestion(null)}
-              >
-                {authCopy.signupSuggestion.decline}
-              </Button>
-            </div>
-          </div>
-        )}
-        {error && <p className="text-xs text-state-warning">{error}</p>}
-      </div>
-    </main>
+    <LoginAuthSurface
+      authCopy={authCopy}
+      mode={mode}
+      effectiveMode={effectiveMode}
+      email={email}
+      password={password}
+      confirm={confirm}
+      status={status}
+      statusTone={statusTone}
+      error={error}
+      signupSuggestion={signupSuggestion}
+      isGoogleOAuthStarting={isGoogleOAuthStarting}
+      acceptTerms={acceptTerms}
+      termsError={termsError}
+      ageConfirmed={ageConfirmed}
+      marketingOptIn={marketingOptIn}
+      legalMinAge={LEGAL_MIN_AGE}
+      emailRef={emailRef}
+      passwordRef={passwordRef}
+      onBack={handleBack}
+      onModeChange={setMode}
+      onGoogleSignIn={signInWithGoogle}
+      onSignInSubmit={signInWithPassword}
+      onSignUpSubmit={signUpWithPassword}
+      onResetSubmit={sendReset}
+      onEmailChange={setEmail}
+      onPasswordChange={setPassword}
+      onConfirmChange={setConfirm}
+      onSyncInputState={syncInputState}
+      onAcceptTermsChange={handleAcceptTermsChange}
+      onAgeConfirmedChange={setAgeConfirmed}
+      onMarketingOptInChange={setMarketingOptIn}
+      onAcceptSignupSuggestion={handleAcceptSignupSuggestion}
+      onClearSignupSuggestion={handleClearSignupSuggestion}
+    />
   );
 }

--- a/tests/login-page-architecture.test.ts
+++ b/tests/login-page-architecture.test.ts
@@ -7,12 +7,14 @@ const root = process.cwd();
 const pagePath = join(root, 'frontend/app/(core)/login/page.tsx');
 const copyPath = join(root, 'frontend/app/(core)/login/_lib/login-copy.ts');
 const helpersPath = join(root, 'frontend/app/(core)/login/_lib/login-helpers.ts');
+const authSurfacePath = join(root, 'frontend/app/(core)/login/_components/LoginAuthSurface.tsx');
 
 const pageSource = readFileSync(pagePath, 'utf8');
 
 test('login page delegates localized copy and browser helpers to route-local modules', () => {
   assert.ok(existsSync(copyPath), 'login localized copy should stay in a route-local copy module');
   assert.ok(existsSync(helpersPath), 'login browser helpers should stay in a route-local helper module');
+  assert.ok(existsSync(authSurfacePath), 'login form UI should stay in a route-local component module');
 
   assert.match(
     pageSource,
@@ -23,6 +25,11 @@ test('login page delegates localized copy and browser helpers to route-local mod
     pageSource,
     /from '\.\/_lib\/login-helpers'/,
     'login page should import auth path and OAuth helpers from the route-local helper module'
+  );
+  assert.match(
+    pageSource,
+    /from '\.\/_components\/LoginAuthSurface'/,
+    'login page should render the route-local auth surface component'
   );
 });
 
@@ -36,16 +43,22 @@ test('login page does not regain auth copy or browser helper ownership', () => {
   );
 
   const lineCount = pageSource.split('\n').length;
-  assert.ok(lineCount <= 1060, `login page should stay below 1060 lines after helper extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 820, `login page should stay below 820 lines after UI extraction, got ${lineCount}`);
+  assert.doesNotMatch(pageSource, /<main className=/, 'login page should not own the full form surface JSX');
 });
 
 test('login helper modules expose the expected route contract', () => {
   const copySource = readFileSync(copyPath, 'utf8');
   const helpersSource = readFileSync(helpersPath, 'utf8');
+  const authSurfaceSource = readFileSync(authSurfacePath, 'utf8');
 
   assert.match(copySource, /export const AUTH_COPY =/, 'copy module should export the auth copy dictionary');
   assert.match(copySource, /export type AuthMode =/, 'copy module should export the auth mode type');
   assert.match(copySource, /export type Locale =/, 'copy module should export the locale type derived from auth copy');
+  assert.match(copySource, /export type AuthCopy =/, 'copy module should export the auth copy shape for UI props');
+  assert.match(authSurfaceSource, /export function LoginAuthSurface/, 'auth surface component should export the login form shell');
+  assert.match(authSurfaceSource, /function GoogleIcon\(/, 'auth surface component should own the inline Google icon');
+  assert.match(authSurfaceSource, /formatTemplate\(authCopy\.terms\.age/, 'auth surface component should own localized legal text rendering');
 
   for (const helperName of [
     'detectLocale',


### PR DESCRIPTION
## Summary
- moved the login form/shell JSX into `LoginAuthSurface`
- kept `page.tsx` focused on auth orchestration, OAuth recovery, storage, redirects, and submit handlers
- exported `AuthCopy` for typed route-local UI props and tightened login architecture tests

## Checks
- `pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/login-page-architecture.test.ts tests/login-hydration-contract.test.ts tests/login-oauth-cookie-fallback.test.ts tests/supabase-auth-refresh-scope.test.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false` from `frontend/`
- `git diff --check -- frontend/app/(core)/login/page.tsx frontend/app/(core)/login/_components/LoginAuthSurface.tsx frontend/app/(core)/login/_lib/login-copy.ts tests/login-page-architecture.test.ts`
- `npm --prefix frontend run lint`
- `npm run lint:exposure`
