### PR TITLE
Split character builder page shell

### DIFF
--- a/frontend/src/components/tools/CharacterBuilderWorkspace.tsx
+++ b/frontend/src/components/tools/CharacterBuilderWorkspace.tsx
@@ -12,8 +12,6 @@ import {
   ArrowLeft,
   Upload,
 } from 'lucide-react';
-import { HeaderBar } from '@/components/HeaderBar';
-import { AppSidebar } from '@/components/AppSidebar';
 import { MediaLightbox, type MediaLightboxEntry } from '@/components/MediaLightbox';
 import { Button, ButtonLink } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
@@ -53,6 +51,12 @@ import {
   StyleChoiceCard,
   type BuildLookSectionKey,
 } from './character-builder/_components/character-builder-workspace-components';
+import {
+  CharacterBuilderAuthGateModal,
+  CharacterBuilderDisabledState,
+  CharacterBuilderLoadingSkeleton,
+  CharacterBuilderPageFrame,
+} from './character-builder/_components/character-builder-page-shell';
 import { useCharacterBuilderHistoricalResults } from './character-builder/_hooks/useCharacterBuilderHistoricalResults';
 import { useCharacterBuilderJobSnapshotLoader } from './character-builder/_hooks/useCharacterBuilderJobSnapshotLoader';
 import { useCharacterBuilderGenerationRunner } from './character-builder/_hooks/useCharacterBuilderGenerationRunner';
@@ -405,54 +409,41 @@ export default function CharacterBuilderPage() {
   }
 
   if (authLoading || !hydrated) {
-    return (
-      <div className="flex min-h-screen flex-col bg-bg">
-        <HeaderBar />
-        <div className="flex flex-1 min-w-0 flex-col xl:flex-row">
-          <div className="hidden xl:block">
-            <AppSidebar />
-          </div>
-          <main className="flex-1 min-w-0 overflow-y-auto p-5 pb-80 lg:p-7 lg:pb-40 xl:pb-64">
-            <div className="space-y-4 animate-pulse">
-              <div className="h-40 rounded-card border border-border bg-surface" />
-              <div className="grid gap-4 xl:grid-cols-[minmax(0,1.4fr)_360px]">
-                <div className="h-[720px] rounded-card border border-border bg-surface" />
-                <div className="h-[560px] rounded-card border border-border bg-surface" />
-              </div>
-            </div>
-          </main>
-        </div>
-      </div>
-    );
+    return <CharacterBuilderLoadingSkeleton />;
   }
 
   if (!FEATURES.workflows.toolsSection) {
-    return (
-      <div className="flex min-h-screen flex-col bg-bg">
-        <HeaderBar />
-        <div className="flex flex-1 min-w-0 flex-col xl:flex-row">
-          <div className="hidden xl:block">
-            <AppSidebar />
-          </div>
-          <main className="flex-1 min-w-0 overflow-y-auto p-5 pb-80 lg:p-7 lg:pb-40 xl:pb-64">
-            <Card className="border border-border p-6">
-              <h1 className="text-2xl font-semibold text-text-primary">{copy.disabledTitle}</h1>
-              <p className="mt-2 text-sm text-text-secondary">{copy.disabledBody}</p>
-            </Card>
-          </main>
-        </div>
-      </div>
-    );
+    return <CharacterBuilderDisabledState title={copy.disabledTitle} body={copy.disabledBody} />;
   }
 
   return (
-    <div className="flex min-h-screen flex-col bg-bg">
-      <HeaderBar />
-      <div className="flex flex-1 min-w-0 flex-col xl:flex-row">
-        <div className="hidden xl:block">
-          <AppSidebar />
-        </div>
-        <main className="flex-1 min-w-0 overflow-y-auto p-5 pb-80 lg:p-7 lg:pb-40 xl:pb-64">
+    <CharacterBuilderPageFrame
+      overlays={
+        <>
+          {lightboxEntry ? (
+            <MediaLightbox
+              title={copy.top.resultsTitle}
+              subtitle={lightboxEntry.engineLabel ?? undefined}
+              prompt={lightboxEntry.prompt ?? null}
+              entries={[lightboxEntry]}
+              onClose={() => setLightboxEntry(null)}
+            />
+          ) : null}
+          <CharacterReferenceLibraryModal
+            open={libraryModalRole !== null}
+            onClose={() => setLibraryModalRole(null)}
+            onSelect={handleLibrarySelect}
+            copy={copy}
+          />
+          <CharacterBuilderAuthGateModal
+            open={authModalOpen}
+            copy={copy}
+            loginRedirectTarget={loginRedirectTarget}
+            onClose={() => setAuthModalOpen(false)}
+          />
+        </>
+      }
+    >
           <div className="mx-auto w-full max-w-[1500px] space-y-6">
             <div>
               <ButtonLink
@@ -1139,59 +1130,6 @@ export default function CharacterBuilderPage() {
               </div>
             </div>
           </div>
-        </main>
-      </div>
-      {lightboxEntry ? (
-        <MediaLightbox
-          title={copy.top.resultsTitle}
-          subtitle={lightboxEntry.engineLabel ?? undefined}
-          prompt={lightboxEntry.prompt ?? null}
-          entries={[lightboxEntry]}
-          onClose={() => setLightboxEntry(null)}
-        />
-      ) : null}
-      <CharacterReferenceLibraryModal
-        open={libraryModalRole !== null}
-        onClose={() => setLibraryModalRole(null)}
-        onSelect={handleLibrarySelect}
-        copy={copy}
-      />
-      {authModalOpen ? (
-        <div className="fixed inset-0 z-[10050] flex items-center justify-center bg-surface-on-media-dark-60 px-3 py-6 sm:px-6">
-          <div className="absolute inset-0" role="presentation" onClick={() => setAuthModalOpen(false)} />
-          <div className="relative z-10 w-full max-w-md rounded-modal border border-border bg-surface p-6 shadow-float">
-            <div className="flex items-start justify-between gap-4">
-              <div className="flex-1">
-                <h2 className="text-base font-semibold text-text-primary">{copy.authGate.title}</h2>
-                <p className="mt-2 text-sm text-text-secondary">{copy.authGate.body}</p>
-              </div>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => setAuthModalOpen(false)}
-                className="rounded-full border-hairline bg-surface-glass-80 px-3 py-1.5 text-sm text-text-muted hover:bg-surface-2"
-                aria-label={copy.authGate.close}
-              >
-                {copy.authGate.close}
-              </Button>
-            </div>
-            <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
-              <ButtonLink href={`/login?next=${encodeURIComponent(loginRedirectTarget)}`} size="sm" className="px-4">
-                {copy.authGate.primary}
-              </ButtonLink>
-              <ButtonLink
-                href={`/login?mode=signin&next=${encodeURIComponent(loginRedirectTarget)}`}
-                variant="outline"
-                size="sm"
-                className="px-4"
-              >
-                {copy.authGate.secondary}
-              </ButtonLink>
-            </div>
-          </div>
-        </div>
-      ) : null}
-    </div>
+    </CharacterBuilderPageFrame>
   );
 }

--- a/frontend/src/components/tools/character-builder/_components/character-builder-page-shell.tsx
+++ b/frontend/src/components/tools/character-builder/_components/character-builder-page-shell.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { AppSidebar } from '@/components/AppSidebar';
+import { HeaderBar } from '@/components/HeaderBar';
+import { Button } from '@/components/ui/Button';
+import { ButtonLink } from '@/components/ui/Button';
+import { Card } from '@/components/ui/Card';
+import type { CharacterCopy } from '../_lib/character-builder-copy';
+
+export function CharacterBuilderPageFrame({
+  children,
+  overlays,
+}: {
+  children: ReactNode;
+  overlays?: ReactNode;
+}) {
+  return (
+    <div className="flex min-h-screen flex-col bg-bg">
+      <HeaderBar />
+      <div className="flex flex-1 min-w-0 flex-col xl:flex-row">
+        <div className="hidden xl:block">
+          <AppSidebar />
+        </div>
+        <main className="flex-1 min-w-0 overflow-y-auto p-5 pb-80 lg:p-7 lg:pb-40 xl:pb-64">
+          {children}
+        </main>
+      </div>
+      {overlays}
+    </div>
+  );
+}
+
+export function CharacterBuilderLoadingSkeleton() {
+  return (
+    <CharacterBuilderPageFrame>
+      <div className="space-y-4 animate-pulse">
+        <div className="h-40 rounded-card border border-border bg-surface" />
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1.4fr)_360px]">
+          <div className="h-[720px] rounded-card border border-border bg-surface" />
+          <div className="h-[560px] rounded-card border border-border bg-surface" />
+        </div>
+      </div>
+    </CharacterBuilderPageFrame>
+  );
+}
+
+export function CharacterBuilderDisabledState({ title, body }: { title: string; body: string }) {
+  return (
+    <CharacterBuilderPageFrame>
+      <Card className="border border-border p-6">
+        <h1 className="text-2xl font-semibold text-text-primary">{title}</h1>
+        <p className="mt-2 text-sm text-text-secondary">{body}</p>
+      </Card>
+    </CharacterBuilderPageFrame>
+  );
+}
+
+export function CharacterBuilderAuthGateModal({
+  open,
+  copy,
+  loginRedirectTarget,
+  onClose,
+}: {
+  open: boolean;
+  copy: CharacterCopy;
+  loginRedirectTarget: string;
+  onClose: () => void;
+}) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[10050] flex items-center justify-center bg-surface-on-media-dark-60 px-3 py-6 sm:px-6">
+      <div className="absolute inset-0" role="presentation" onClick={onClose} />
+      <div className="relative z-10 w-full max-w-md rounded-modal border border-border bg-surface p-6 shadow-float">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1">
+            <h2 className="text-base font-semibold text-text-primary">{copy.authGate.title}</h2>
+            <p className="mt-2 text-sm text-text-secondary">{copy.authGate.body}</p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onClose}
+            className="rounded-full border-hairline bg-surface-glass-80 px-3 py-1.5 text-sm text-text-muted hover:bg-surface-2"
+            aria-label={copy.authGate.close}
+          >
+            {copy.authGate.close}
+          </Button>
+        </div>
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
+          <ButtonLink href={`/login?next=${encodeURIComponent(loginRedirectTarget)}`} size="sm" className="px-4">
+            {copy.authGate.primary}
+          </ButtonLink>
+          <ButtonLink
+            href={`/login?mode=signin&next=${encodeURIComponent(loginRedirectTarget)}`}
+            variant="outline"
+            size="sm"
+            className="px-4"
+          >
+            {copy.authGate.secondary}
+          </ButtonLink>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tests/character-builder-workspace-architecture.test.ts
+++ b/tests/character-builder-workspace-architecture.test.ts
@@ -15,6 +15,7 @@ const formControlsPath = join(root, 'frontend/src/components/tools/character-bui
 const referenceLibraryPath = join(root, 'frontend/src/components/tools/character-builder/_components/character-builder-reference-library.tsx');
 const resultCardsPath = join(root, 'frontend/src/components/tools/character-builder/_components/character-builder-result-cards.tsx');
 const resultsGalleryPath = join(root, 'frontend/src/components/tools/character-builder/_components/character-builder-results-gallery.tsx');
+const pageShellPath = join(root, 'frontend/src/components/tools/character-builder/_components/character-builder-page-shell.tsx');
 const optionsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderOptions.ts');
 const historicalResultsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderHistoricalResults.ts');
 const pendingRunsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderPendingRunsSync.ts');
@@ -38,6 +39,7 @@ test('character builder workspace delegates copy, local types, and helper logic'
   assert.ok(existsSync(referenceLibraryPath), 'reference library components should live in a focused component module');
   assert.ok(existsSync(resultCardsPath), 'result card components should live in a focused component module');
   assert.ok(existsSync(resultsGalleryPath), 'result gallery composition should live in a focused component module');
+  assert.ok(existsSync(pageShellPath), 'page shell and auth modal chrome should live in a focused component module');
   assert.ok(existsSync(optionsHookPath), 'localized option derivation should live in a focused hook');
   assert.ok(existsSync(historicalResultsHookPath), 'historical result derivation should live in a focused hook');
   assert.ok(existsSync(pendingRunsHookPath), 'pending run polling should live in a focused hook');
@@ -49,6 +51,7 @@ test('character builder workspace delegates copy, local types, and helper logic'
   assert.ok(existsSync(persistenceHookPath), 'local persistence should live in a focused hook');
 
   assert.match(workspaceSource, /from '\.\/character-builder\/_components\/character-builder-workspace-components'/, 'workspace should import UI components');
+  assert.match(workspaceSource, /from '\.\/character-builder\/_components\/character-builder-page-shell'/, 'workspace should import page shell components');
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderOptions'/, 'workspace should import localized options hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderHistoricalResults'/, 'workspace should import historical results hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderPendingRunsSync'/, 'workspace should import pending run sync hook');
@@ -94,12 +97,15 @@ test('character builder workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /new IntersectionObserver/, 'result infinite scroll observer belongs in useCharacterBuilderResultsInfiniteScroll');
   assert.doesNotMatch(workspaceSource, /scrollContainer\.addEventListener/, 'result scroll listener belongs in useCharacterBuilderResultsInfiniteScroll');
   assert.doesNotMatch(workspaceSource, /<ResultCard/, 'result card composition belongs in CharacterBuilderResultsGallery');
+  assert.doesNotMatch(workspaceSource, /<HeaderBar/, 'page chrome belongs in CharacterBuilderPageFrame');
+  assert.doesNotMatch(workspaceSource, /<AppSidebar/, 'page sidebar chrome belongs in CharacterBuilderPageFrame');
+  assert.doesNotMatch(workspaceSource, /fixed inset-0 z-\[10050\]/, 'auth gate modal UI belongs in CharacterBuilderAuthGateModal');
   assert.doesNotMatch(workspaceSource, /readPersistedState\(\)/, 'local hydration belongs in useCharacterBuilderPersistence');
   assert.doesNotMatch(workspaceSource, /writePersistedPendingRuns/, 'pending run persistence belongs in useCharacterBuilderPersistence');
   assert.doesNotMatch(workspaceSource, /visitorSanitizedRef/, 'visitor cleanup tracking belongs in useCharacterBuilderPersistence');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 1210, `CharacterBuilderWorkspace should stay below 1210 lines after result extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 1145, `CharacterBuilderWorkspace should stay below 1145 lines after shell extraction, got ${lineCount}`);
 });
 
 test('character builder helper modules expose the expected workspace contract', () => {
@@ -113,6 +119,7 @@ test('character builder helper modules expose the expected workspace contract', 
   const referenceLibrarySource = readFileSync(referenceLibraryPath, 'utf8');
   const resultCardsSource = readFileSync(resultCardsPath, 'utf8');
   const resultsGallerySource = readFileSync(resultsGalleryPath, 'utf8');
+  const pageShellSource = readFileSync(pageShellPath, 'utf8');
   const optionsHookSource = readFileSync(optionsHookPath, 'utf8');
   const historicalResultsHookSource = readFileSync(historicalResultsHookPath, 'utf8');
   const pendingRunsHookSource = readFileSync(pendingRunsHookPath, 'utf8');
@@ -222,6 +229,10 @@ test('character builder helper modules expose the expected workspace contract', 
   assert.match(resultsGallerySource, /export function CharacterBuilderResultsGallery/, 'results gallery should be exported');
   assert.match(resultsGallerySource, /<ResultCard/, 'results gallery should compose result cards');
   assert.match(resultsGallerySource, /triggerAppDownload/, 'results gallery should own downloads');
+  assert.match(pageShellSource, /export function CharacterBuilderPageFrame/, 'page shell should export the workspace frame');
+  assert.match(pageShellSource, /export function CharacterBuilderLoadingSkeleton/, 'page shell should export the loading skeleton');
+  assert.match(pageShellSource, /export function CharacterBuilderDisabledState/, 'page shell should export the disabled state');
+  assert.match(pageShellSource, /export function CharacterBuilderAuthGateModal/, 'page shell should export the auth gate modal');
 
   assert.match(optionsHookSource, /export function useCharacterBuilderOptions/, 'options hook should be exported');
   assert.match(optionsHookSource, /getAvailableCharacterFormatOptions/, 'options hook should own format option derivation');


### PR DESCRIPTION
## Summary
- extracted Character Builder page chrome, loading skeleton, disabled state, and auth gate modal into `character-builder-page-shell.tsx`
- kept `CharacterBuilderWorkspace.tsx` focused on builder state, hooks, and section composition
- tightened the character builder architecture contract around the new shell boundary

## Checks
- `pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/character-builder-workspace-architecture.test.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false` from `frontend/`
- `git diff --check -- frontend/src/components/tools/CharacterBuilderWorkspace.tsx frontend/src/components/tools/character-builder/_components/character-builder-page-shell.tsx tests/character-builder-workspace-architecture.test.ts`
- `npm --prefix frontend run lint`
- `npm run lint:exposure`
