### PR TITLE
Split image generation executor helpers

### DIFF
--- a/frontend/src/server/images/execute-image-generation.ts
+++ b/frontend/src/server/images/execute-image-generation.ts
@@ -2,7 +2,6 @@ import { ApiError, ValidationError } from '@fal-ai/client';
 import { randomUUID } from 'crypto';
 import { listFalEngines } from '@/config/falEngines';
 import type {
-  CharacterReferenceSelection,
   ImageGenerationMode,
   ImageGenerationRequest,
   ImageGenerationResponse,
@@ -62,6 +61,12 @@ import {
   parseRequestId,
   sanitizeCharacterReferences,
 } from './image-provider-payload';
+import {
+  buildReceiptSnapshot,
+  recordRefundReceipt,
+  type PendingReceipt,
+} from './image-generation-receipts';
+import { buildDefaultSettingsSnapshot } from './image-generation-settings-snapshot';
 
 export { buildResponseFromExistingJob } from './existing-image-job-response';
 export { ImageGenerationExecutionError } from './image-generation-error';
@@ -69,20 +74,6 @@ export { ImageGenerationExecutionError } from './image-generation-error';
 const DISPLAY_CURRENCY = 'USD';
 const DISPLAY_CURRENCY_LOWER: Currency = 'usd';
 const SIGNED_REFERENCE_URL_TTL_SECONDS = 60 * 60;
-type PendingReceipt = {
-  userId: string;
-  amountCents: number;
-  currency: string;
-  description: string;
-  jobId: string;
-  surface: JobSurface;
-  billingProductKey: BillingProductKey | null;
-  snapshot: unknown;
-  applicationFeeCents: number | null;
-  vendorAccountId: string | null;
-  stripePaymentIntentId?: string | null;
-  stripeChargeId?: string | null;
-};
 
 type ExecuteImageGenerationOptions = {
   userId: string;
@@ -118,137 +109,6 @@ function normalizeMode(value: unknown, fallback: ImageGenerationMode = 't2i'): I
   if (value === 'generate') return 't2i';
   if (value === 'edit') return 'i2i';
   return fallback;
-}
-
-function buildReceiptSnapshot(pricing: PricingSnapshot): Record<string, unknown> {
-  const snapshot: Record<string, unknown> = {
-    totalCents: pricing.totalCents,
-    currency: pricing.currency,
-  };
-
-  const discountCandidate = (pricing as {
-    discount?: { amountCents?: number; percentApplied?: number; label?: string };
-  }).discount;
-  if (discountCandidate && typeof discountCandidate.amountCents === 'number' && discountCandidate.amountCents > 0) {
-    snapshot.discount = {
-      amountCents: discountCandidate.amountCents,
-      percentApplied: discountCandidate.percentApplied ?? null,
-      label: discountCandidate.label ?? null,
-    };
-  }
-
-  const taxesCandidate = (pricing as { taxes?: Array<{ amountCents?: number; label?: string }> }).taxes;
-  if (Array.isArray(taxesCandidate)) {
-    const taxes = taxesCandidate
-      .filter((tax) => tax && typeof tax.amountCents === 'number' && tax.amountCents > 0)
-      .map((tax) => ({
-        amountCents: tax.amountCents!,
-        label: tax.label ?? null,
-      }));
-    if (taxes.length) {
-      snapshot.taxes = taxes;
-    }
-  }
-
-  return snapshot;
-}
-
-async function recordRefundReceipt(receipt: PendingReceipt, label: string, priceOnly: boolean) {
-  try {
-    await query(
-      `INSERT INTO app_receipts (
-         user_id,
-         type,
-         amount_cents,
-         currency,
-         description,
-         job_id,
-         surface,
-         billing_product_key,
-         pricing_snapshot,
-         application_fee_cents,
-         vendor_account_id,
-         stripe_payment_intent_id,
-         stripe_charge_id,
-         platform_revenue_cents,
-         destination_acct
-       )
-       VALUES ($1,'refund',$2,$3,$4,$5,$6,$7,$8::jsonb,$9,$10,$11,$12,$13,$14)
-       ON CONFLICT DO NOTHING`,
-      [
-        receipt.userId,
-        receipt.amountCents,
-        receipt.currency,
-        label,
-        receipt.jobId,
-        receipt.surface,
-        receipt.billingProductKey,
-        JSON.stringify(receipt.snapshot),
-        priceOnly ? null : 0,
-        priceOnly ? null : receipt.vendorAccountId,
-        receipt.stripePaymentIntentId ?? null,
-        receipt.stripeChargeId ?? null,
-        priceOnly ? null : 0,
-        priceOnly ? null : receipt.vendorAccountId,
-      ]
-    );
-  } catch (error) {
-    console.warn('[images] failed to record refund receipt', error);
-  }
-}
-
-function buildDefaultSettingsSnapshot(args: {
-  surface: JobSurface;
-  engineEntry: ImageEngineEntry;
-  mode: ImageGenerationMode;
-  prompt: string;
-  numImages: number;
-  resolvedAspectRatio: string | null;
-  resolution: string;
-  customImageSize: GptImage2ImageSize | null;
-  normalizedSeed: number | null;
-  outputFormat: string | null;
-  quality: string | null;
-  maskUrl: string | null;
-  enableWebSearch: boolean;
-  thinkingLevel: string | null;
-  limitGenerations: boolean;
-  imageUrls: string[];
-  characterReferences: CharacterReferenceSelection[];
-  membershipTier?: string;
-  visibility: 'public' | 'private';
-  indexable: boolean;
-}): unknown {
-  return {
-    schemaVersion: 1,
-    surface: args.surface,
-    engineId: args.engineEntry.id,
-    engineLabel: args.engineEntry.marketingName,
-    inputMode: args.mode,
-    prompt: args.prompt,
-    core: {
-      numImages: args.numImages,
-      aspectRatio: args.resolvedAspectRatio ?? null,
-      resolution: args.resolution,
-      customImageSize: args.customImageSize,
-      seed: args.normalizedSeed,
-      outputFormat: args.outputFormat,
-      quality: args.quality,
-      maskUrl: args.maskUrl,
-      enableWebSearch: args.enableWebSearch,
-      thinkingLevel: args.thinkingLevel,
-      limitGenerations: args.limitGenerations,
-    },
-    refs: {
-      imageUrls: args.imageUrls,
-      characterReferences: args.characterReferences,
-    },
-    meta: {
-      memberTier: args.membershipTier ?? null,
-      visibility: args.visibility,
-      indexable: args.indexable,
-    },
-  };
 }
 
 function fail(

--- a/frontend/src/server/images/image-generation-receipts.ts
+++ b/frontend/src/server/images/image-generation-receipts.ts
@@ -1,0 +1,95 @@
+import { query } from '@/lib/db';
+import type { BillingProductKey, JobSurface } from '@/types/billing';
+import type { PricingSnapshot } from '@/types/engines';
+
+export type PendingReceipt = {
+  userId: string;
+  amountCents: number;
+  currency: string;
+  description: string;
+  jobId: string;
+  surface: JobSurface;
+  billingProductKey: BillingProductKey | null;
+  snapshot: unknown;
+  applicationFeeCents: number | null;
+  vendorAccountId: string | null;
+  stripePaymentIntentId?: string | null;
+  stripeChargeId?: string | null;
+};
+
+export function buildReceiptSnapshot(pricing: PricingSnapshot): Record<string, unknown> {
+  const snapshot: Record<string, unknown> = {
+    totalCents: pricing.totalCents,
+    currency: pricing.currency,
+  };
+
+  const discountCandidate = (pricing as {
+    discount?: { amountCents?: number; percentApplied?: number; label?: string };
+  }).discount;
+  if (discountCandidate && typeof discountCandidate.amountCents === 'number' && discountCandidate.amountCents > 0) {
+    snapshot.discount = {
+      amountCents: discountCandidate.amountCents,
+      percentApplied: discountCandidate.percentApplied ?? null,
+      label: discountCandidate.label ?? null,
+    };
+  }
+
+  const taxesCandidate = (pricing as { taxes?: Array<{ amountCents?: number; label?: string }> }).taxes;
+  if (Array.isArray(taxesCandidate)) {
+    const taxes = taxesCandidate
+      .filter((tax) => tax && typeof tax.amountCents === 'number' && tax.amountCents > 0)
+      .map((tax) => ({
+        amountCents: tax.amountCents!,
+        label: tax.label ?? null,
+      }));
+    if (taxes.length) {
+      snapshot.taxes = taxes;
+    }
+  }
+
+  return snapshot;
+}
+
+export async function recordRefundReceipt(receipt: PendingReceipt, label: string, priceOnly: boolean) {
+  try {
+    await query(
+      `INSERT INTO app_receipts (
+         user_id,
+         type,
+         amount_cents,
+         currency,
+         description,
+         job_id,
+         surface,
+         billing_product_key,
+         pricing_snapshot,
+         application_fee_cents,
+         vendor_account_id,
+         stripe_payment_intent_id,
+         stripe_charge_id,
+         platform_revenue_cents,
+         destination_acct
+       )
+       VALUES ($1,'refund',$2,$3,$4,$5,$6,$7,$8::jsonb,$9,$10,$11,$12,$13,$14)
+       ON CONFLICT DO NOTHING`,
+      [
+        receipt.userId,
+        receipt.amountCents,
+        receipt.currency,
+        label,
+        receipt.jobId,
+        receipt.surface,
+        receipt.billingProductKey,
+        JSON.stringify(receipt.snapshot),
+        priceOnly ? null : 0,
+        priceOnly ? null : receipt.vendorAccountId,
+        receipt.stripePaymentIntentId ?? null,
+        receipt.stripeChargeId ?? null,
+        priceOnly ? null : 0,
+        priceOnly ? null : receipt.vendorAccountId,
+      ]
+    );
+  } catch (error) {
+    console.warn('[images] failed to record refund receipt', error);
+  }
+}

--- a/frontend/src/server/images/image-generation-settings-snapshot.ts
+++ b/frontend/src/server/images/image-generation-settings-snapshot.ts
@@ -1,0 +1,61 @@
+import type {
+  CharacterReferenceSelection,
+  ImageGenerationMode,
+} from '@/types/image-generation';
+import type { FalEngineEntry } from '@/config/falEngines';
+import type { JobSurface } from '@/types/billing';
+import type { GptImage2ImageSize } from '@/lib/image/gptImage2';
+
+export function buildDefaultSettingsSnapshot(args: {
+  surface: JobSurface;
+  engineEntry: FalEngineEntry;
+  mode: ImageGenerationMode;
+  prompt: string;
+  numImages: number;
+  resolvedAspectRatio: string | null;
+  resolution: string;
+  customImageSize: GptImage2ImageSize | null;
+  normalizedSeed: number | null;
+  outputFormat: string | null;
+  quality: string | null;
+  maskUrl: string | null;
+  enableWebSearch: boolean;
+  thinkingLevel: string | null;
+  limitGenerations: boolean;
+  imageUrls: string[];
+  characterReferences: CharacterReferenceSelection[];
+  membershipTier?: string;
+  visibility: 'public' | 'private';
+  indexable: boolean;
+}): unknown {
+  return {
+    schemaVersion: 1,
+    surface: args.surface,
+    engineId: args.engineEntry.id,
+    engineLabel: args.engineEntry.marketingName,
+    inputMode: args.mode,
+    prompt: args.prompt,
+    core: {
+      numImages: args.numImages,
+      aspectRatio: args.resolvedAspectRatio ?? null,
+      resolution: args.resolution,
+      customImageSize: args.customImageSize,
+      seed: args.normalizedSeed,
+      outputFormat: args.outputFormat,
+      quality: args.quality,
+      maskUrl: args.maskUrl,
+      enableWebSearch: args.enableWebSearch,
+      thinkingLevel: args.thinkingLevel,
+      limitGenerations: args.limitGenerations,
+    },
+    refs: {
+      imageUrls: args.imageUrls,
+      characterReferences: args.characterReferences,
+    },
+    meta: {
+      memberTier: args.membershipTier ?? null,
+      visibility: args.visibility,
+      indexable: args.indexable,
+    },
+  };
+}

--- a/tests/image-generation-server-architecture.test.ts
+++ b/tests/image-generation-server-architecture.test.ts
@@ -10,6 +10,8 @@ const referenceNormalizationPath = join(root, 'frontend/src/server/images/image-
 const initialJobPath = join(root, 'frontend/src/server/images/image-initial-job.ts');
 const errorPath = join(root, 'frontend/src/server/images/image-generation-error.ts');
 const providerPayloadPath = join(root, 'frontend/src/server/images/image-provider-payload.ts');
+const receiptsPath = join(root, 'frontend/src/server/images/image-generation-receipts.ts');
+const settingsSnapshotPath = join(root, 'frontend/src/server/images/image-generation-settings-snapshot.ts');
 
 const executorSource = readFileSync(executorPath, 'utf8');
 const existingJobResponseSource = readFileSync(existingJobResponsePath, 'utf8');
@@ -17,6 +19,8 @@ const referenceNormalizationSource = readFileSync(referenceNormalizationPath, 'u
 const initialJobSource = readFileSync(initialJobPath, 'utf8');
 const errorSource = readFileSync(errorPath, 'utf8');
 const providerPayloadSource = readFileSync(providerPayloadPath, 'utf8');
+const receiptsSource = readFileSync(receiptsPath, 'utf8');
+const settingsSnapshotSource = readFileSync(settingsSnapshotPath, 'utf8');
 
 test('image generation executor delegates focused server helpers', () => {
   assert.ok(existsSync(existingJobResponsePath), 'existing image job response helpers should live in a focused module');
@@ -24,11 +28,15 @@ test('image generation executor delegates focused server helpers', () => {
   assert.ok(existsSync(initialJobPath), 'atomic initial image job creation should live in a focused module');
   assert.ok(existsSync(errorPath), 'image generation execution error should live in a focused module');
   assert.ok(existsSync(providerPayloadPath), 'provider payload parsing should live in a focused module');
+  assert.ok(existsSync(receiptsPath), 'image generation receipt helpers should live in a focused module');
+  assert.ok(existsSync(settingsSnapshotPath), 'image settings snapshot helpers should live in a focused module');
   assert.match(executorSource, /from '\.\/existing-image-job-response'/);
   assert.match(executorSource, /from '\.\/image-reference-normalization'/);
   assert.match(executorSource, /from '\.\/image-initial-job'/);
   assert.match(executorSource, /from '\.\/image-generation-error'/);
   assert.match(executorSource, /from '\.\/image-provider-payload'/);
+  assert.match(executorSource, /from '\.\/image-generation-receipts'/);
+  assert.match(executorSource, /from '\.\/image-generation-settings-snapshot'/);
   assert.match(executorSource, /export \{ buildResponseFromExistingJob \} from '\.\/existing-image-job-response'/);
   assert.match(executorSource, /export \{ ImageGenerationExecutionError \} from '\.\/image-generation-error'/);
 });
@@ -49,9 +57,12 @@ test('image generation executor does not regain extracted server ownership', () 
   assert.doesNotMatch(executorSource, /function buildCharacterReferencePrompt\(/, 'character reference prompt building belongs in image-provider-payload.ts');
   assert.doesNotMatch(executorSource, /function extractImages\(/, 'provider image extraction belongs in image-provider-payload.ts');
   assert.doesNotMatch(executorSource, /function parseRequestId\(/, 'provider request id parsing belongs in image-provider-payload.ts');
+  assert.doesNotMatch(executorSource, /function buildReceiptSnapshot\(/, 'receipt snapshots belong in image-generation-receipts.ts');
+  assert.doesNotMatch(executorSource, /async function recordRefundReceipt\(/, 'refund receipt writes belong in image-generation-receipts.ts');
+  assert.doesNotMatch(executorSource, /function buildDefaultSettingsSnapshot\(/, 'default settings snapshots belong in image-generation-settings-snapshot.ts');
 
   const lineCount = executorSource.split('\n').length;
-  assert.ok(lineCount <= 1110, `image generation executor should stay below 1110 lines after provider payload extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 970, `image generation executor should stay below 970 lines after receipt and settings extraction, got ${lineCount}`);
 });
 
 test('existing image job response module exposes the expected contract', () => {
@@ -75,4 +86,8 @@ test('existing image job response module exposes the expected contract', () => {
   assert.match(providerPayloadSource, /export function buildCharacterReferencePrompt/);
   assert.match(providerPayloadSource, /export function extractImages/);
   assert.match(providerPayloadSource, /export function parseRequestId/);
+  assert.match(receiptsSource, /export type PendingReceipt/);
+  assert.match(receiptsSource, /export function buildReceiptSnapshot/);
+  assert.match(receiptsSource, /export async function recordRefundReceipt/);
+  assert.match(settingsSnapshotSource, /export function buildDefaultSettingsSnapshot/);
 });


### PR DESCRIPTION
## Summary
- move image receipt snapshot and refund receipt writes into a focused server helper
- move default image settings snapshot construction into a focused helper
- tighten the image generation server architecture contract around the extracted responsibilities

## Checks
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/image-generation-server-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false
- git diff --check -- frontend/src/server/images/execute-image-generation.ts frontend/src/server/images/image-generation-receipts.ts frontend/src/server/images/image-generation-settings-snapshot.ts tests/image-generation-server-architecture.test.ts
- npm --prefix frontend run lint
- npm run lint:exposure