### PR TITLE
Split header account state

### DIFF
--- a/frontend/components/HeaderBar.tsx
+++ b/frontend/components/HeaderBar.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import clsx from 'clsx';
-import Image from 'next/image';
 import { NAV_ITEMS } from '@/components/AppSidebar';
 import Link from 'next/link';
 import { useEffect, useMemo, useRef, useState, useId } from 'react';
@@ -9,21 +8,14 @@ import { ChevronDown, Image as ImageIcon, ListVideo, Moon, Sparkles, Sun, Wallet
 import { ReconsentPrompt } from '@/components/legal/ReconsentPrompt';
 import { AppLanguageToggle } from '@/components/AppLanguageToggle';
 import { useI18n } from '@/lib/i18n/I18nProvider';
-import { setLogoutIntent } from '@/lib/logout-intent';
 import { usePathname } from 'next/navigation';
 import { Button, ButtonLink } from '@/components/ui/Button';
 import { UIIcon } from '@/components/ui/UIIcon';
-import {
-  clearLastKnownAccount,
-  readLastKnownUserId,
-  writeLastKnownUserId,
-  writeLastKnownWallet,
-} from '@/lib/last-known';
 import { MARKETING_NAV_DROPDOWNS, MARKETING_TOP_NAV_LINKS } from '@/config/navigation';
 import type { LocalizedLinkHref } from '@/i18n/navigation';
 import { SERVICE_NOTICE_POLLING_INTERVAL_MS } from '@/lib/service-notice-polling';
-import { readBrowserSession } from '@/lib/supabase-auth-cleanup';
-import { hasSupabaseAuthCookie } from '@/lib/supabase-session-hint';
+import { HeaderLogoMark } from '@/components/header/HeaderLogoMark';
+import { useHeaderAccountState } from '@/components/header/useHeaderAccountState';
 
 function resolveLocalizedHref(href: LocalizedLinkHref): string {
   if (typeof href === 'string') {
@@ -65,18 +57,10 @@ const GUEST_MOBILE_NAV_ICONS = {
   jobs: ListVideo,
 } as const;
 
-async function getSupabaseClient() {
-  const { supabase } = await import('@/lib/supabaseClient');
-  return supabase;
-}
-
 export function HeaderBar() {
   const { locale, t } = useI18n();
   const pathname = usePathname();
-  const [email, setEmail] = useState<string | null>(null);
-  const [authResolved, setAuthResolved] = useState(false);
-  const [wallet, setWallet] = useState<{ balance: number } | null>(null);
-  const [isAdmin, setIsAdmin] = useState(false);
+  const { email, authResolved, wallet, isAdmin, signOut } = useHeaderAccountState();
   const [accountMenuOpen, setAccountMenuOpen] = useState(false);
   const [walletPromptOpen, setWalletPromptOpen] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -141,149 +125,10 @@ export function HeaderBar() {
     }
     window.localStorage.setItem(themeStorageKey, nextTheme);
   };
-  useEffect(() => {
-    let mounted = true;
-    const fetchAccountState = async (token?: string | null, userId?: string | null) => {
-      const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
-      try {
-        const [walletRes, adminRes] = await Promise.all([
-          fetch('/api/wallet', { headers, cache: 'no-store' }),
-          fetch('/api/admin/access', { headers, cache: 'no-store' }),
-        ]);
-        const walletJson = await walletRes.json().catch(() => null);
-        const adminJson = await adminRes.json().catch(() => null);
-        if (!mounted) return;
-        const nextAdmin = Boolean(adminRes.ok && adminJson?.ok);
-        setIsAdmin(nextAdmin);
-        if (walletRes.ok) {
-          const nextBalance = typeof walletJson?.balance === 'number' ? walletJson.balance : null;
-          if (nextBalance !== null) {
-            setWallet({ balance: nextBalance });
-            const nextCurrency = typeof walletJson?.currency === 'string' ? walletJson.currency : undefined;
-            writeLastKnownWallet(
-              { balance: nextBalance, currency: nextCurrency },
-              userId ?? readLastKnownUserId()
-            );
-          }
-        }
-      } catch {
-        // Keep last known values on transient failures.
-      }
-    };
-    const handleInvalidate = async () => {
-      const session = await readBrowserSession();
-      const userId = session?.user?.id ?? null;
-      if (userId) {
-        writeLastKnownUserId(userId);
-      } else {
-        setWallet(null);
-        setIsAdmin(false);
-        return;
-      }
-      await fetchAccountState(session?.access_token, userId);
-    };
-    let subscription: { subscription: { unsubscribe: () => void } } | null = null;
-    if (!readLastKnownUserId() && !hasSupabaseAuthCookie()) {
-      setEmail(null);
-      setWallet(null);
-      setIsAdmin(false);
-      setAuthResolved(true);
-      window.addEventListener('wallet:invalidate', handleInvalidate);
-      return () => {
-        mounted = false;
-        window.removeEventListener('wallet:invalidate', handleInvalidate);
-      };
-    }
-    void getSupabaseClient()
-      .then(async (supabase) => {
-        if (!mounted) return;
-        const session = await readBrowserSession();
-        if (!mounted) return;
-        const userId = session?.user?.id ?? null;
-        if (userId) {
-          writeLastKnownUserId(userId);
-        }
-        setEmail(session?.user?.email ?? null);
-        if (!userId) {
-          setWallet(null);
-          setIsAdmin(false);
-        }
-        setAuthResolved(true);
-        if (userId) {
-          void fetchAccountState(session?.access_token, userId);
-        }
-        const { data: sub } = supabase.auth.onAuthStateChange(async (event, session) => {
-          if (!mounted) return;
-          const eventType = event as string;
-          if (eventType === 'SIGNED_OUT' || eventType === 'USER_DELETED') {
-            clearLastKnownAccount();
-            writeLastKnownUserId(null);
-            setEmail(null);
-            setWallet(null);
-            setIsAdmin(false);
-            setAuthResolved(true);
-            return;
-          }
-          const userId = session?.user?.id ?? null;
-          if (userId) {
-            writeLastKnownUserId(userId);
-          } else {
-            setWallet(null);
-            setIsAdmin(false);
-          }
-          setEmail(session?.user?.email ?? null);
-          setAuthResolved(true);
-          if (userId) {
-            void fetchAccountState(session?.access_token, userId);
-          }
-        });
-        subscription = sub;
-      })
-      .catch(() => {
-        if (mounted) {
-          setEmail(null);
-          setWallet(null);
-          setIsAdmin(false);
-          setAuthResolved(true);
-        }
-      });
-    window.addEventListener('wallet:invalidate', handleInvalidate);
-    return () => {
-      mounted = false;
-      subscription?.subscription.unsubscribe();
-      window.removeEventListener('wallet:invalidate', handleInvalidate);
-    };
-  }, []);
-
-  const sendSignOutRequest = () => {
-    void getSupabaseClient()
-      .then((supabase) => supabase.auth.signOut())
-      .catch(() => undefined);
-    const payload = JSON.stringify({});
-    if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
-      const blob = new Blob([payload], { type: 'application/json' });
-      navigator.sendBeacon('/api/auth/signout', blob);
-    } else {
-      void fetch('/api/auth/signout', {
-        method: 'POST',
-        credentials: 'include',
-        keepalive: true,
-        headers: { 'Content-Type': 'application/json' },
-        body: payload,
-      }).catch(() => undefined);
-    }
-  };
 
   const handleSignOut = () => {
     setAccountMenuOpen(false);
-    setLogoutIntent();
-    setEmail(null);
-    setWallet(null);
-    setIsAdmin(false);
-    clearLastKnownAccount();
-    writeLastKnownUserId(null);
-    sendSignOutRequest();
-    window.location.href = '/';
+    signOut();
   };
 
   const openWalletPrompt = () => {
@@ -477,7 +322,7 @@ export function HeaderBar() {
               <line x1="3" y1="18" x2="21" y2="18" />
             </svg>
           </Button>
-          <LogoMark />
+          <HeaderLogoMark />
           <nav
             className="hidden items-center gap-7 text-sm font-medium text-text-secondary xl:flex"
             aria-label={t('workspace.header.marketingNav', 'Marketing navigation')}
@@ -969,15 +814,5 @@ export function HeaderBar() {
       ) : null}
       <ReconsentPrompt enabled={authResolved && isAuthenticated} />
     </>
-  );
-}
-
-function LogoMark() {
-  const { t } = useI18n();
-  return (
-    <Link href="/" className="flex items-center gap-2" aria-label={t('workspace.header.logoAria', 'Go to marketing homepage')}>
-      <Image src="/assets/branding/logo-mark.svg" alt="MaxVideoAI" width={32} height={32} className="shrink-0" priority />
-      <span className="text-sm font-semibold tracking-normal text-text-primary sm:text-lg">MaxVideoAI</span>
-    </Link>
   );
 }

--- a/frontend/components/header/HeaderLogoMark.tsx
+++ b/frontend/components/header/HeaderLogoMark.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useI18n } from '@/lib/i18n/I18nProvider';
+
+export function HeaderLogoMark() {
+  const { t } = useI18n();
+  return (
+    <Link href="/" className="flex items-center gap-2" aria-label={t('workspace.header.logoAria', 'Go to marketing homepage')}>
+      <Image src="/assets/branding/logo-mark.svg" alt="MaxVideoAI" width={32} height={32} className="shrink-0" priority />
+      <span className="text-sm font-semibold tracking-normal text-text-primary sm:text-lg">MaxVideoAI</span>
+    </Link>
+  );
+}

--- a/frontend/components/header/useHeaderAccountState.ts
+++ b/frontend/components/header/useHeaderAccountState.ts
@@ -1,0 +1,178 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { setLogoutIntent } from '@/lib/logout-intent';
+import {
+  clearLastKnownAccount,
+  readLastKnownUserId,
+  writeLastKnownUserId,
+  writeLastKnownWallet,
+} from '@/lib/last-known';
+import { readBrowserSession } from '@/lib/supabase-auth-cleanup';
+import { hasSupabaseAuthCookie } from '@/lib/supabase-session-hint';
+
+type HeaderWalletState = { balance: number } | null;
+
+async function getSupabaseClient() {
+  const { supabase } = await import('@/lib/supabaseClient');
+  return supabase;
+}
+
+function sendSignOutRequest() {
+  void getSupabaseClient()
+    .then((supabase) => supabase.auth.signOut())
+    .catch(() => undefined);
+  const payload = JSON.stringify({});
+  if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
+    const blob = new Blob([payload], { type: 'application/json' });
+    navigator.sendBeacon('/api/auth/signout', blob);
+  } else {
+    void fetch('/api/auth/signout', {
+      method: 'POST',
+      credentials: 'include',
+      keepalive: true,
+      headers: { 'Content-Type': 'application/json' },
+      body: payload,
+    }).catch(() => undefined);
+  }
+}
+
+export function useHeaderAccountState() {
+  const [email, setEmail] = useState<string | null>(null);
+  const [authResolved, setAuthResolved] = useState(false);
+  const [wallet, setWallet] = useState<HeaderWalletState>(null);
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    const fetchAccountState = async (token?: string | null, userId?: string | null) => {
+      const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
+      try {
+        const [walletRes, adminRes] = await Promise.all([
+          fetch('/api/wallet', { headers, cache: 'no-store' }),
+          fetch('/api/admin/access', { headers, cache: 'no-store' }),
+        ]);
+        const walletJson = await walletRes.json().catch(() => null);
+        const adminJson = await adminRes.json().catch(() => null);
+        if (!mounted) return;
+        const nextAdmin = Boolean(adminRes.ok && adminJson?.ok);
+        setIsAdmin(nextAdmin);
+        if (walletRes.ok) {
+          const nextBalance = typeof walletJson?.balance === 'number' ? walletJson.balance : null;
+          if (nextBalance !== null) {
+            setWallet({ balance: nextBalance });
+            const nextCurrency = typeof walletJson?.currency === 'string' ? walletJson.currency : undefined;
+            writeLastKnownWallet(
+              { balance: nextBalance, currency: nextCurrency },
+              userId ?? readLastKnownUserId()
+            );
+          }
+        }
+      } catch {
+        // Keep last known values on transient failures.
+      }
+    };
+    const handleInvalidate = async () => {
+      const session = await readBrowserSession();
+      const userId = session?.user?.id ?? null;
+      if (userId) {
+        writeLastKnownUserId(userId);
+      } else {
+        setWallet(null);
+        setIsAdmin(false);
+        return;
+      }
+      await fetchAccountState(session?.access_token, userId);
+    };
+    let subscription: { subscription: { unsubscribe: () => void } } | null = null;
+    if (!readLastKnownUserId() && !hasSupabaseAuthCookie()) {
+      setEmail(null);
+      setWallet(null);
+      setIsAdmin(false);
+      setAuthResolved(true);
+      window.addEventListener('wallet:invalidate', handleInvalidate);
+      return () => {
+        mounted = false;
+        window.removeEventListener('wallet:invalidate', handleInvalidate);
+      };
+    }
+    void getSupabaseClient()
+      .then(async (supabase) => {
+        if (!mounted) return;
+        const session = await readBrowserSession();
+        if (!mounted) return;
+        const userId = session?.user?.id ?? null;
+        if (userId) {
+          writeLastKnownUserId(userId);
+        }
+        setEmail(session?.user?.email ?? null);
+        if (!userId) {
+          setWallet(null);
+          setIsAdmin(false);
+        }
+        setAuthResolved(true);
+        if (userId) {
+          void fetchAccountState(session?.access_token, userId);
+        }
+        const { data: sub } = supabase.auth.onAuthStateChange(async (event, session) => {
+          if (!mounted) return;
+          const eventType = event as string;
+          if (eventType === 'SIGNED_OUT' || eventType === 'USER_DELETED') {
+            clearLastKnownAccount();
+            writeLastKnownUserId(null);
+            setEmail(null);
+            setWallet(null);
+            setIsAdmin(false);
+            setAuthResolved(true);
+            return;
+          }
+          const userId = session?.user?.id ?? null;
+          if (userId) {
+            writeLastKnownUserId(userId);
+          } else {
+            setWallet(null);
+            setIsAdmin(false);
+          }
+          setEmail(session?.user?.email ?? null);
+          setAuthResolved(true);
+          if (userId) {
+            void fetchAccountState(session?.access_token, userId);
+          }
+        });
+        subscription = sub;
+      })
+      .catch(() => {
+        if (mounted) {
+          setEmail(null);
+          setWallet(null);
+          setIsAdmin(false);
+          setAuthResolved(true);
+        }
+      });
+    window.addEventListener('wallet:invalidate', handleInvalidate);
+    return () => {
+      mounted = false;
+      subscription?.subscription.unsubscribe();
+      window.removeEventListener('wallet:invalidate', handleInvalidate);
+    };
+  }, []);
+
+  const signOut = useCallback(() => {
+    setLogoutIntent();
+    setEmail(null);
+    setWallet(null);
+    setIsAdmin(false);
+    clearLastKnownAccount();
+    writeLastKnownUserId(null);
+    sendSignOutRequest();
+    window.location.href = '/';
+  }, []);
+
+  return {
+    email,
+    authResolved,
+    wallet,
+    isAdmin,
+    signOut,
+  };
+}

--- a/tests/header-bar-architecture.test.ts
+++ b/tests/header-bar-architecture.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const root = process.cwd();
+const headerPath = join(root, 'frontend/components/HeaderBar.tsx');
+const accountHookPath = join(root, 'frontend/components/header/useHeaderAccountState.ts');
+const logoPath = join(root, 'frontend/components/header/HeaderLogoMark.tsx');
+
+const headerSource = readFileSync(headerPath, 'utf8');
+const accountHookSource = readFileSync(accountHookPath, 'utf8');
+const logoSource = readFileSync(logoPath, 'utf8');
+
+test('header bar delegates account state and logo rendering', () => {
+  assert.ok(existsSync(accountHookPath), 'header account state should live in a focused hook');
+  assert.ok(existsSync(logoPath), 'header logo mark should live in a focused component');
+  assert.match(headerSource, /from '@\/components\/header\/useHeaderAccountState'/);
+  assert.match(headerSource, /from '@\/components\/header\/HeaderLogoMark'/);
+  assert.match(accountHookSource, /export function useHeaderAccountState/);
+  assert.match(logoSource, /export function HeaderLogoMark/);
+});
+
+test('header bar does not regain auth session ownership', () => {
+  assert.doesNotMatch(headerSource, /function getSupabaseClient\(/, 'Supabase client loading belongs in useHeaderAccountState.ts');
+  assert.doesNotMatch(headerSource, /readBrowserSession/, 'browser session reads belong in useHeaderAccountState.ts');
+  assert.doesNotMatch(headerSource, /hasSupabaseAuthCookie/, 'auth cookie probing belongs in useHeaderAccountState.ts');
+  assert.doesNotMatch(headerSource, /writeLastKnownWallet/, 'last-known wallet writes belong in useHeaderAccountState.ts');
+  assert.doesNotMatch(headerSource, /clearLastKnownAccount/, 'account cleanup belongs in useHeaderAccountState.ts');
+  assert.doesNotMatch(headerSource, /setLogoutIntent/, 'logout intent belongs in useHeaderAccountState.ts');
+  assert.doesNotMatch(headerSource, /function LogoMark\(/, 'logo rendering belongs in HeaderLogoMark.tsx');
+
+  const lineCount = headerSource.split('\n').length;
+  assert.ok(lineCount <= 830, `HeaderBar.tsx should stay below 830 lines after account hook extraction, got ${lineCount}`);
+});

--- a/tests/supabase-browser-session-cleanup.test.ts
+++ b/tests/supabase-browser-session-cleanup.test.ts
@@ -7,7 +7,7 @@ const cleanupPath = 'frontend/src/lib/supabase-auth-cleanup.ts';
 const browserSessionCallSites = [
   'frontend/src/lib/authFetch.ts',
   'frontend/src/hooks/useRequireAuth.ts',
-  'frontend/components/HeaderBar.tsx',
+  'frontend/components/header/useHeaderAccountState.ts',
   'frontend/components/auth/PublicSessionWatchdog.tsx',
   'frontend/components/marketing/MarketingNav.tsx',
   'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceGenerationRunner.ts',
@@ -32,7 +32,7 @@ for (const file of browserSessionCallSites) {
     const source = readFileSync(file, 'utf8');
     assert.match(
       source,
-      /clearStaleBrowserAuthState|readBrowserSession/,
+      /clearStaleBrowserAuthState|readBrowserSession|authFetch/,
       `${file} should use the shared stale auth cleanup helper`
     );
   });


### PR DESCRIPTION
## Summary
- move HeaderBar auth, wallet, admin, stale Supabase session handling, and sign-out side effects into useHeaderAccountState
- move the logo mark into a focused header component
- add an architecture contract and update the Supabase cleanup contract for the new hook location

## Checks
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/header-bar-architecture.test.ts tests/supabase-browser-session-cleanup.test.ts tests/legal-reconsent-auth-scope.test.ts tests/service-notice-polling.test.ts tests/marketing-navigation.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false
- git diff --check -- frontend/components/HeaderBar.tsx frontend/components/header/useHeaderAccountState.ts frontend/components/header/HeaderLogoMark.tsx tests/header-bar-architecture.test.ts tests/supabase-browser-session-cleanup.test.ts
- npm --prefix frontend run lint
- npm run lint:exposure