### PR TITLE
Split compare page metadata

### DIFF
--- a/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-metadata.ts
+++ b/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-metadata.ts
@@ -1,0 +1,117 @@
+import type { Metadata } from 'next';
+import { isPublishedComparisonSlug } from '@/lib/compare-hub/data';
+import { resolveDictionary } from '@/lib/i18n/server';
+import { buildSeoMetadata } from '@/lib/seo/metadata';
+import type { ComparePageCopy } from './compare-page-copy';
+import { buildSpecValues } from './compare-page-helpers';
+import {
+  formatEngineMetaName,
+  formatEngineName,
+  formatTemplate,
+  getCanonicalCompareSlug,
+  isPending,
+  loadEngineKeySpecs,
+  replaceCriteriaCount,
+  resolveEngines,
+} from './compare-page-helpers';
+import { getComparePageOverride } from './compare-page-overrides';
+import type { Params } from './compare-page-types';
+
+export async function buildComparePageMetadata(props: {
+  params: Promise<Params>;
+  searchParams?: Promise<{ order?: string }>;
+}): Promise<Metadata> {
+  const searchParams = await props.searchParams;
+  const params = await props.params;
+  const locale = params.locale ?? 'en';
+  const { dictionary } = await resolveDictionary({ locale });
+  const compareCopy = (dictionary.comparePage ?? {}) as ComparePageCopy;
+  const slug = params.slug;
+  const canonicalInfo = getCanonicalCompareSlug(slug);
+  const canonicalSlug = canonicalInfo?.canonicalSlug ?? slug;
+  const pageOverride = getComparePageOverride(locale, canonicalSlug);
+  const metaOverride = {
+    ...(compareCopy.meta?.slugOverrides?.[canonicalSlug] ?? {}),
+    ...(pageOverride?.meta ?? {}),
+  };
+  const resolved = canonicalInfo ? resolveEngines(canonicalInfo.canonicalSlug) : null;
+  const pairHasNativeAudio = Boolean(resolved?.left.engine?.audio) || Boolean(resolved?.right.engine?.audio);
+  const criteriaCount = pairHasNativeAudio ? 11 : 10;
+  const titleTemplate =
+    metaOverride.title ?? compareCopy.meta?.title ?? '{left} vs {right} — Side-by-Side Specs, Pricing & Prompt Test | MaxVideoAI';
+  const titleFallback =
+    compareCopy.meta?.titleFallback ??
+    'Compare AI video engines — Side-by-Side Specs, Pricing & Prompt Test | MaxVideoAI';
+  const descriptionTemplate = replaceCriteriaCount(
+    metaOverride.description ??
+      compareCopy.meta?.description ??
+      `Compare {left} vs {right} on MaxVideoAI with identical prompts, key specs, and a scorecard across ${criteriaCount} criteria.`,
+    criteriaCount
+  );
+  const descriptionFallback =
+    compareCopy.meta?.descriptionFallback ?? 'Side-by-side comparison of AI video engines with MaxVideoAI metrics and guidance.';
+  const title = resolved
+    ? formatTemplate(titleTemplate, {
+        left: formatEngineMetaName(resolved.left),
+        right: formatEngineMetaName(resolved.right),
+      })
+    : titleFallback;
+  const description = resolved
+    ? formatTemplate(descriptionTemplate, {
+        left: formatEngineName(resolved.left),
+        right: formatEngineName(resolved.right),
+      })
+    : descriptionFallback;
+
+  let robots: Metadata['robots'] | undefined;
+  if (!isPublishedComparisonSlug(canonicalSlug)) {
+    robots = { index: false, follow: true };
+  }
+  if (resolved) {
+    const keySpecs = await loadEngineKeySpecs();
+    const leftKeySpecs = keySpecs.get(resolved.left.modelSlug)?.keySpecs ?? undefined;
+    const rightKeySpecs = keySpecs.get(resolved.right.modelSlug)?.keySpecs ?? undefined;
+    const leftSpecs = buildSpecValues(resolved.left, leftKeySpecs);
+    const rightSpecs = buildSpecValues(resolved.right, rightKeySpecs);
+    const rows = [
+      leftSpecs.textToVideo,
+      rightSpecs.textToVideo,
+      leftSpecs.imageToVideo,
+      rightSpecs.imageToVideo,
+      leftSpecs.videoToVideo,
+      rightSpecs.videoToVideo,
+      leftSpecs.firstLastFrame,
+      rightSpecs.firstLastFrame,
+      leftSpecs.referenceImageStyle,
+      rightSpecs.referenceImageStyle,
+      leftSpecs.referenceVideo,
+      rightSpecs.referenceVideo,
+      leftSpecs.maxResolution,
+      rightSpecs.maxResolution,
+      leftSpecs.maxDuration,
+      rightSpecs.maxDuration,
+      leftSpecs.aspectRatios,
+      rightSpecs.aspectRatios,
+      leftSpecs.fpsOptions,
+      rightSpecs.fpsOptions,
+      leftSpecs.outputFormats,
+      rightSpecs.outputFormats,
+    ];
+    const pendingCount = rows.filter((value) => isPending(value)).length;
+    const pendingRatio = rows.length ? pendingCount / rows.length : 0;
+    if (pendingRatio >= 0.35) {
+      robots = { index: false, follow: true };
+    }
+  }
+  if (typeof searchParams?.order === 'string' && searchParams.order.trim()) {
+    robots = { index: false, follow: true };
+  }
+
+  return buildSeoMetadata({
+    locale,
+    title,
+    description,
+    englishPath: `/ai-video-engines/${canonicalSlug}`,
+    robots,
+  });
+}

--- a/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/page.tsx
+++ b/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/page.tsx
@@ -5,7 +5,6 @@ import { ArrowLeft, Trophy } from 'lucide-react';
 import { Link } from '@/i18n/navigation';
 import { localePathnames, locales } from '@/i18n/locales';
 import { resolveDictionary } from '@/lib/i18n/server';
-import { buildSeoMetadata } from '@/lib/seo/metadata';
 import { buildMetadataUrls } from '@/lib/metadataUrls';
 import { isDatabaseConfigured } from '@/lib/db';
 import { getCompareShowdowns, type CompareShowdown } from '@/config/compare-showdowns';
@@ -37,6 +36,7 @@ import type {
 import type { ComparePageCopy } from './_lib/compare-page-copy';
 import { getComparePageOverride } from './_lib/compare-page-overrides';
 import { buildCompareFaqItems, buildCompareFaqJsonLd } from './_lib/compare-page-faq';
+import { buildComparePageMetadata } from './_lib/compare-page-metadata';
 import {
   buildCompareSummaryRows,
   buildComparisonMetrics,
@@ -51,7 +51,6 @@ import {
   computeOverall,
   computePairScores,
   computePricingScore,
-  formatEngineMetaName,
   formatEngineName,
   formatEngineShortName,
   formatSpeedChip,
@@ -97,100 +96,7 @@ export async function generateMetadata(
     searchParams?: Promise<{ order?: string }>;
   }
 ): Promise<Metadata> {
-  const searchParams = await props.searchParams;
-  const params = await props.params;
-  const locale = params.locale ?? 'en';
-  const { dictionary } = await resolveDictionary({ locale });
-  const compareCopy = (dictionary.comparePage ?? {}) as ComparePageCopy;
-  const slug = params.slug;
-  const canonicalInfo = getCanonicalCompareSlug(slug);
-  const canonicalSlug = canonicalInfo?.canonicalSlug ?? slug;
-  const pageOverride = getComparePageOverride(locale, canonicalSlug);
-  const metaOverride = {
-    ...(compareCopy.meta?.slugOverrides?.[canonicalSlug] ?? {}),
-    ...(pageOverride?.meta ?? {}),
-  };
-  const resolved = canonicalInfo ? resolveEngines(canonicalInfo.canonicalSlug) : null;
-  const pairHasNativeAudio = Boolean(resolved?.left.engine?.audio) || Boolean(resolved?.right.engine?.audio);
-  const criteriaCount = pairHasNativeAudio ? 11 : 10;
-  const titleTemplate =
-    metaOverride.title ?? compareCopy.meta?.title ?? '{left} vs {right} — Side-by-Side Specs, Pricing & Prompt Test | MaxVideoAI';
-  const titleFallback =
-    compareCopy.meta?.titleFallback ??
-    'Compare AI video engines — Side-by-Side Specs, Pricing & Prompt Test | MaxVideoAI';
-  const descriptionTemplate = replaceCriteriaCount(
-    metaOverride.description ??
-      compareCopy.meta?.description ??
-      `Compare {left} vs {right} on MaxVideoAI with identical prompts, key specs, and a scorecard across ${criteriaCount} criteria.`,
-    criteriaCount
-  );
-  const descriptionFallback =
-    compareCopy.meta?.descriptionFallback ?? 'Side-by-side comparison of AI video engines with MaxVideoAI metrics and guidance.';
-  const title = resolved
-    ? formatTemplate(titleTemplate, {
-        left: formatEngineMetaName(resolved.left),
-        right: formatEngineMetaName(resolved.right),
-      })
-    : titleFallback;
-  const description = resolved
-    ? formatTemplate(descriptionTemplate, {
-        left: formatEngineName(resolved.left),
-        right: formatEngineName(resolved.right),
-      })
-    : descriptionFallback;
-
-  let robots: Metadata['robots'] | undefined;
-  if (!isPublishedComparisonSlug(canonicalSlug)) {
-    robots = { index: false, follow: true };
-  }
-  if (resolved) {
-    const keySpecs = await loadEngineKeySpecs();
-    const leftKeySpecs = keySpecs.get(resolved.left.modelSlug)?.keySpecs ?? undefined;
-    const rightKeySpecs = keySpecs.get(resolved.right.modelSlug)?.keySpecs ?? undefined;
-    const leftSpecs = buildSpecValues(resolved.left, leftKeySpecs);
-    const rightSpecs = buildSpecValues(resolved.right, rightKeySpecs);
-    const rows = [
-      leftSpecs.textToVideo,
-      rightSpecs.textToVideo,
-      leftSpecs.imageToVideo,
-      rightSpecs.imageToVideo,
-      leftSpecs.videoToVideo,
-      rightSpecs.videoToVideo,
-      leftSpecs.firstLastFrame,
-      rightSpecs.firstLastFrame,
-      leftSpecs.referenceImageStyle,
-      rightSpecs.referenceImageStyle,
-      leftSpecs.referenceVideo,
-      rightSpecs.referenceVideo,
-      leftSpecs.maxResolution,
-      rightSpecs.maxResolution,
-      leftSpecs.maxDuration,
-      rightSpecs.maxDuration,
-      leftSpecs.aspectRatios,
-      rightSpecs.aspectRatios,
-      leftSpecs.fpsOptions,
-      rightSpecs.fpsOptions,
-      leftSpecs.outputFormats,
-      rightSpecs.outputFormats,
-    ];
-    const pendingCount = rows.filter((value) => isPending(value)).length;
-    const pendingRatio = rows.length ? pendingCount / rows.length : 0;
-    if (pendingRatio >= 0.35) {
-      robots = { index: false, follow: true };
-    }
-  }
-  if (typeof searchParams?.order === 'string' && searchParams.order.trim()) {
-    robots = { index: false, follow: true };
-  }
-
-  const meta = buildSeoMetadata({
-    locale,
-    title,
-    description,
-    englishPath: `/ai-video-engines/${canonicalSlug}`,
-    robots,
-  });
-  return meta;
+  return buildComparePageMetadata(props);
 }
 
 export default async function CompareDetailPage(

--- a/tests/compare-page-architecture.test.ts
+++ b/tests/compare-page-architecture.test.ts
@@ -16,6 +16,10 @@ const faqSource = readFileSync(
   'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-faq.ts',
   'utf8'
 );
+const metadataSource = readFileSync(
+  'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-metadata.ts',
+  'utf8'
+);
 const scorecardSource = readFileSync(
   'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-scorecard.ts',
   'utf8'
@@ -28,10 +32,11 @@ const generateCardSource = readFileSync(
 test('comparison detail page delegates copy, helper, and media responsibilities', () => {
   const lineCount = pageSource.split('\n').length;
 
-  assert.ok(lineCount < 1300, `comparison page should stay under 1300 lines after split, got ${lineCount}`);
+  assert.ok(lineCount <= 1100, `comparison page should stay under 1100 lines after metadata split, got ${lineCount}`);
   assert.ok(pageSource.includes("from './_lib/compare-page-helpers'"));
   assert.ok(pageSource.includes("from './_lib/compare-page-overrides'"));
   assert.ok(pageSource.includes("from './_lib/compare-page-faq'"));
+  assert.ok(pageSource.includes("from './_lib/compare-page-metadata'"));
   assert.ok(pageSource.includes("from './_lib/compare-page-scorecard'"));
   assert.ok(pageSource.includes("from './_components/CompareGenerateCard'"));
   assert.ok(pageSource.includes("from './_components/CompareShowdownMedia'"));
@@ -40,6 +45,7 @@ test('comparison detail page delegates copy, helper, and media responsibilities'
   assert.doesNotMatch(pageSource, /type ComparePageCopy =/);
   assert.doesNotMatch(pageSource, /const generatedFaqItems =/);
   assert.doesNotMatch(pageSource, /const comparisonMetrics = \[/);
+  assert.doesNotMatch(pageSource, /buildSeoMetadata/);
 });
 
 test('comparison detail helpers own routing, pricing, specs, and localized overrides', () => {
@@ -56,5 +62,7 @@ test('comparison detail split helpers own FAQ, scorecard, and generate card resp
   assert.match(scorecardSource, /export function buildComparisonMetrics/);
   assert.match(scorecardSource, /export function buildCompareSummaryRows/);
   assert.match(scorecardSource, /export function deriveCompareStrengths/);
+  assert.match(metadataSource, /export async function buildComparePageMetadata/);
+  assert.match(metadataSource, /buildSeoMetadata/);
   assert.match(generateCardSource, /export function CompareGenerateCard/);
 });


### PR DESCRIPTION
## Summary
- move compare detail generateMetadata logic into a focused route-local metadata helper
- keep the page route focused on params, redirects, data assembly, and rendering
- tighten the compare page architecture contract around the metadata split

## Checks
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/compare-page-architecture.test.ts tests/nofollow.test.ts tests/seedance-prelaunch.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false
- git diff --check -- frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/page.tsx frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-metadata.ts tests/compare-page-architecture.test.ts
- npm --prefix frontend run lint
- npm run lint:exposure