### PR TITLE
Split compare detail route sections

### DIFF
--- a/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_components/CompareDetailContent.tsx
+++ b/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_components/CompareDetailContent.tsx
@@ -1,0 +1,697 @@
+import type { CSSProperties } from 'react';
+import clsx from 'clsx';
+import { ArrowLeft, Trophy } from 'lucide-react';
+import type { AppLocale } from '@/i18n/locales';
+import { Link } from '@/i18n/navigation';
+import { DeferredSourcePrompt } from '@/components/i18n/DeferredSourcePrompt.client';
+import type { SelectOption } from '@/components/ui/SelectMenu';
+import type { CompareShowdown } from '@/config/compare-showdowns';
+import { getImageAlt } from '@/lib/image-alt';
+import { CompareEngineSelector } from '../CompareEngineSelector.client';
+import { CompareScoreboard } from '../CompareScoreboard.client';
+import { CopyPromptButton } from '../CopyPromptButton.client';
+import type { CompareDetailLabels, ComparePageCopy } from '../_lib/compare-page-copy';
+import type { CompareFaqItem } from '../_lib/compare-page-faq';
+import type { ComparePageOverride } from '../_lib/compare-page-overrides';
+import type { CompareMetric, CompareSummaryRow } from '../_lib/compare-page-scorecard';
+import {
+  deriveCompareStrengths,
+  formatWinnerSummaryValue,
+  resolveSummaryLabelClass,
+  resolveSummaryMarker,
+} from '../_lib/compare-page-scorecard';
+import type { EngineAccent } from '../_lib/compare-page-helpers';
+import {
+  buildGenerateHref,
+  formatEngineName,
+  formatEngineShortName,
+  formatTemplate,
+  isPending,
+  localizeBestFor,
+  replaceCriteriaCount,
+  stripAudioReferencesForSilentPair,
+} from '../_lib/compare-page-helpers';
+import type { EngineCatalogEntry, ShowdownSide } from '../_lib/compare-page-types';
+import type { CompareSpecRow } from '../_lib/compare-page-spec-rows';
+import { CompareGenerateCard } from './CompareGenerateCard';
+import { renderShowdownMedia } from './CompareShowdownMedia';
+import { renderSpecValue } from './CompareSpecValue';
+
+export type CompareShowdownSlot = CompareShowdown & { left: ShowdownSide; right: ShowdownSide };
+
+type RelatedComparisonLink = {
+  href: { pathname: string; params: { slug: string } };
+  label: string;
+};
+
+type CompareDetailContentProps = {
+  activeLocale: AppLocale;
+  breadcrumbJsonLd: unknown;
+  compareCopy: ComparePageCopy;
+  compareHubHref: string;
+  comparisonMetrics: CompareMetric[];
+  criteriaCount: number;
+  exposeSourcePrompt: boolean;
+  faqItems: CompareFaqItem[];
+  faqJsonLd: unknown;
+  generateWithLabel: string;
+  heroIntroTemplate: string;
+  labels: CompareDetailLabels;
+  left: EngineCatalogEntry;
+  leftAccent: EngineAccent;
+  leftCanGenerate: boolean;
+  leftIsPrelaunch: boolean;
+  leftOverall: number | null;
+  leftScoreStyle: CSSProperties;
+  localizedPromptNote: string;
+  pageOverride?: ComparePageOverride | null;
+  pairHasNativeAudio: boolean;
+  prelaunchNotice: { title: string; body: string } | null;
+  relatedLinks: RelatedComparisonLink[];
+  resolvedLeftOptions: SelectOption[];
+  resolvedRightOptions: SelectOption[];
+  right: EngineCatalogEntry;
+  rightAccent: EngineAccent;
+  rightCanGenerate: boolean;
+  rightIsPrelaunch: boolean;
+  rightOverall: number | null;
+  rightScoreStyle: CSSProperties;
+  scorecardCriteriaLabel: string;
+  scorecardProvisionalNote: string | null;
+  showdownActionHint: string;
+  showdownActionLabel: string;
+  showdownSlots: CompareShowdownSlot[];
+  showdownSubtitle: string;
+  slug: string;
+  specRows: CompareSpecRow[];
+  summaryRows: CompareSummaryRow[];
+  webPageJsonLd: unknown;
+  winnerSummaryHeading: string;
+};
+
+export function CompareDetailContent({
+  activeLocale,
+  breadcrumbJsonLd,
+  compareCopy,
+  compareHubHref,
+  comparisonMetrics,
+  criteriaCount,
+  exposeSourcePrompt,
+  faqItems,
+  faqJsonLd,
+  generateWithLabel,
+  heroIntroTemplate,
+  labels,
+  left,
+  leftAccent,
+  leftCanGenerate,
+  leftIsPrelaunch,
+  leftOverall,
+  leftScoreStyle,
+  localizedPromptNote,
+  pageOverride,
+  pairHasNativeAudio,
+  prelaunchNotice,
+  relatedLinks,
+  resolvedLeftOptions,
+  resolvedRightOptions,
+  right,
+  rightAccent,
+  rightCanGenerate,
+  rightIsPrelaunch,
+  rightOverall,
+  rightScoreStyle,
+  scorecardCriteriaLabel,
+  scorecardProvisionalNote,
+  showdownActionHint,
+  showdownActionLabel,
+  showdownSlots,
+  showdownSubtitle,
+  slug,
+  specRows,
+  summaryRows,
+  webPageJsonLd,
+  winnerSummaryHeading,
+}: CompareDetailContentProps) {
+  return (
+    <div className="relative isolate overflow-hidden">
+      <div
+        className="pointer-events-none absolute right-0 top-24 -z-10 h-[760px] w-[46vw] opacity-70 dark:opacity-30"
+        style={{
+          backgroundImage:
+            'radial-gradient(circle at center, color-mix(in srgb, var(--brand) 30%, transparent) 1px, transparent 1px)',
+          backgroundSize: '16px 16px',
+          maskImage: 'linear-gradient(90deg, transparent, black 24%, black 74%, transparent)',
+        }}
+        aria-hidden
+      />
+      <div className="container-page max-w-[1040px] section">
+        <div className="space-y-4 sm:space-y-5">
+        <div className="text-sm text-text-muted">
+          <Link href={compareHubHref} className="inline-flex items-center gap-2 font-semibold text-brand hover:text-brandHover">
+            <ArrowLeft className="h-4 w-4" aria-hidden />
+            {compareCopy.hero?.back ?? 'Back to comparisons'}
+          </Link>
+        </div>
+        <header className="mx-auto max-w-[760px] py-6 text-center sm:py-8">
+          <p className="text-xs font-semibold uppercase tracking-micro text-text-muted">
+            {compareCopy.hero?.kicker ?? 'Compare engines'}
+          </p>
+          <h1 className="mt-3 text-[34px] font-semibold leading-[1.08] tracking-normal text-text-primary sm:text-[46px]">
+            {formatEngineName(left)} vs {formatEngineName(right)}
+          </h1>
+          <p className="mt-4 text-sm leading-6 text-text-secondary">
+            {formatTemplate(
+              heroIntroTemplate,
+              { left: formatEngineName(left), right: formatEngineName(right) }
+            )}
+          </p>
+          {prelaunchNotice ? (
+            <div className="mx-auto mt-4 max-w-3xl rounded-2xl border border-amber-300/70 bg-amber-50 px-4 py-3 text-left shadow-sm">
+              <p className="text-xs font-semibold uppercase tracking-micro text-amber-900">{prelaunchNotice.title}</p>
+              <p className="mt-1 text-sm text-amber-950">{prelaunchNotice.body}</p>
+            </div>
+          ) : null}
+        </header>
+
+        <section className="mx-auto max-w-[940px]">
+          <div className="relative grid gap-4 md:grid-cols-2">
+            <article className="relative flex overflow-visible rounded-[16px] border border-hairline bg-surface p-6 shadow-card">
+              <div className="flex w-full flex-col items-center gap-5 sm:flex-row-reverse">
+                <div
+                  className="relative isolate grid h-[96px] w-[96px] shrink-0 place-items-center rounded-full p-[3px]"
+                  style={leftScoreStyle}
+                >
+                  <span
+                    className="pointer-events-none absolute -inset-5 -z-10 rounded-full opacity-75 blur-2xl"
+                    style={{ background: 'color-mix(in srgb, var(--compare-accent) 45%, transparent)' }}
+                    aria-hidden
+                  />
+                  <div className="grid h-full w-full place-items-center rounded-full border border-white/80 bg-surface text-center shadow-[inset_0_1px_0_rgba(255,255,255,0.9)] dark:border-white/10 dark:bg-surface-2">
+                    <div className="leading-none">
+                      <span className="text-[28px] font-semibold tracking-normal text-text-primary">
+                        {leftOverall != null ? leftOverall.toFixed(1) : '-'}
+                      </span>
+                      <span className="ml-0.5 align-super text-[10px] font-semibold text-text-muted">/10</span>
+                      <span className="mt-1 block text-[8px] font-semibold uppercase tracking-[0.22em] text-text-muted">
+                        Score
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div className="flex min-w-0 flex-1 flex-col items-center gap-3 text-center">
+                  <h2 className="text-2xl font-semibold tracking-normal text-text-primary">
+                    {formatEngineName(left)}
+                  </h2>
+                  <CompareEngineSelector
+                    options={resolvedLeftOptions}
+                    value={left.modelSlug}
+                    otherValue={right.modelSlug}
+                    side="left"
+                  />
+                  {(() => {
+                    const bestFor = localizeBestFor(left.bestFor, activeLocale);
+                    const derived = deriveCompareStrengths(comparisonMetrics, 'left').join(', ');
+                    const strengths = bestFor && !isPending(bestFor) ? bestFor : derived;
+                    return strengths ? (
+                      <p className="max-w-[280px] text-xs leading-5 text-text-secondary">
+                        <span className="font-semibold text-text-primary">
+                          {compareCopy.scorecard?.strengthsLabel ?? 'Strengths'}:
+                        </span>{' '}
+                        {strengths}
+                      </p>
+                    ) : null;
+                  })()}
+                </div>
+              </div>
+            </article>
+
+            <article className="relative flex overflow-visible rounded-[16px] border border-hairline bg-surface p-6 shadow-card">
+              <div className="flex w-full flex-col items-center gap-5 sm:flex-row">
+                <div
+                  className="relative isolate grid h-[96px] w-[96px] shrink-0 place-items-center rounded-full p-[3px]"
+                  style={rightScoreStyle}
+                >
+                  <span
+                    className="pointer-events-none absolute -inset-5 -z-10 rounded-full opacity-75 blur-2xl"
+                    style={{ background: 'color-mix(in srgb, var(--compare-accent) 45%, transparent)' }}
+                    aria-hidden
+                  />
+                  <div className="grid h-full w-full place-items-center rounded-full border border-white/80 bg-surface text-center shadow-[inset_0_1px_0_rgba(255,255,255,0.9)] dark:border-white/10 dark:bg-surface-2">
+                    <div className="leading-none">
+                      <span className="text-[28px] font-semibold tracking-normal text-text-primary">
+                        {rightOverall != null ? rightOverall.toFixed(1) : '-'}
+                      </span>
+                      <span className="ml-0.5 align-super text-[10px] font-semibold text-text-muted">/10</span>
+                      <span className="mt-1 block text-[8px] font-semibold uppercase tracking-[0.22em] text-text-muted">
+                        Score
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div className="flex min-w-0 flex-1 flex-col items-center gap-3 text-center">
+                  <h2 className="text-2xl font-semibold tracking-normal text-text-primary">
+                    {formatEngineName(right)}
+                  </h2>
+                  <CompareEngineSelector
+                    options={resolvedRightOptions}
+                    value={right.modelSlug}
+                    otherValue={left.modelSlug}
+                    side="right"
+                  />
+                  {(() => {
+                    const bestFor = localizeBestFor(right.bestFor, activeLocale);
+                    const derived = deriveCompareStrengths(comparisonMetrics, 'right').join(', ');
+                    const strengths = bestFor && !isPending(bestFor) ? bestFor : derived;
+                    return strengths ? (
+                      <p className="max-w-[280px] text-xs leading-5 text-text-secondary">
+                        <span className="font-semibold text-text-primary">
+                          {compareCopy.scorecard?.strengthsLabel ?? 'Strengths'}:
+                        </span>{' '}
+                        {strengths}
+                      </p>
+                    ) : null;
+                  })()}
+                </div>
+              </div>
+            </article>
+
+            <div className="pointer-events-none absolute left-1/2 top-1/2 z-20 hidden -translate-x-1/2 -translate-y-1/2 md:flex">
+              <div className="flex h-11 w-11 items-center justify-center rounded-full border-4 border-bg bg-brand text-[11px] font-semibold uppercase tracking-micro text-on-brand shadow-[0_16px_34px_rgba(46,99,216,0.28)]">
+                VS
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-4 rounded-[16px] border border-hairline bg-surface p-4 shadow-card sm:p-8">
+            <div className="text-center">
+              <h2 className="text-xl font-semibold text-text-primary">
+                {compareCopy.scorecard?.title ?? 'Scorecard (Side-by-Side)'}
+              </h2>
+              <p className="mt-1 text-sm text-text-secondary">
+                {replaceCriteriaCount(
+                  compareCopy.scorecard?.subtitle ??
+                    `Scores reflect quality and control on MaxVideoAI across ${criteriaCount} criteria.`,
+                  criteriaCount
+                )}
+              </p>
+              {scorecardProvisionalNote ? (
+                <p className="mt-2 text-xs font-semibold text-text-muted">{scorecardProvisionalNote}</p>
+              ) : null}
+            </div>
+            <div className="mt-6 hidden items-center gap-3 text-[11px] font-semibold uppercase tracking-micro sm:grid sm:grid-cols-[minmax(0,1.6fr)_minmax(190px,1fr)_minmax(0,1.6fr)] sm:gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(210px,1fr)_minmax(0,2fr)]">
+              <span className="text-center text-brand">
+                {formatEngineName(left)}
+              </span>
+              <span className="text-center text-text-muted">{scorecardCriteriaLabel}</span>
+              <span className="text-center text-brand">
+                {formatEngineName(right)}
+              </span>
+            </div>
+            <CompareScoreboard
+              metrics={comparisonMetrics}
+              className="mt-4"
+              naLabel={labels.na}
+              pendingLabel={labels.pending}
+            />
+
+            <div className="mx-auto mt-7 w-full">
+              <div className="relative overflow-hidden rounded-[18px] border border-[#cfe0ff] bg-[#eef5ff] px-5 pb-5 pt-5 text-center shadow-[0_16px_34px_rgba(46,99,216,0.10),inset_0_1px_0_rgba(255,255,255,0.9)] dark:border-white/10 dark:bg-[#172338] dark:shadow-[0_16px_34px_rgba(0,0,0,0.24)]">
+                <div
+                  className="pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,#eaf2ff_0%,#f7fbff_58%,#ffffff_100%)] dark:bg-[linear-gradient(180deg,rgba(46,99,216,0.22)_0%,rgba(18,26,37,0.94)_58%,rgba(18,26,37,0.98)_100%)]"
+                  aria-hidden
+                />
+                <div
+                  className="pointer-events-none absolute left-1/2 top-0 h-28 w-[340px] -translate-x-1/2 rounded-full bg-white/80 blur-2xl dark:bg-white/10"
+                  aria-hidden
+                />
+                <div
+                  className="pointer-events-none absolute inset-x-10 top-0 h-px bg-gradient-to-r from-transparent via-white to-transparent dark:via-white/30"
+                  aria-hidden
+                />
+                <div className="relative z-10 flex items-center justify-center gap-3">
+                  <span className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/80 bg-white text-brand shadow-[0_12px_26px_rgba(46,99,216,0.14),inset_0_1px_0_rgba(255,255,255,0.95)] dark:border-white/10 dark:bg-white/8 dark:text-white">
+                    <Trophy className="h-5 w-5" aria-hidden />
+                  </span>
+                  <h3 className="text-lg font-semibold text-text-primary">
+                    {winnerSummaryHeading}
+                  </h3>
+                </div>
+                <div className="relative z-10 mt-4 grid gap-4">
+                  {summaryRows.slice(0, 1).map((row) => (
+                    <div
+                      key={row.id}
+                      className="flex flex-col items-center gap-2 text-center"
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className={clsx('h-2 w-2 opacity-90', resolveSummaryMarker(row.id, row.accent, leftAccent, rightAccent))} />
+                        <span className={clsx('text-[10px] font-semibold uppercase tracking-micro', resolveSummaryLabelClass(row.id))}>
+                          {row.label}
+                        </span>
+                      </div>
+                      <p className="max-w-[620px] text-sm leading-6 text-text-secondary">{formatWinnerSummaryValue(row)}</p>
+                    </div>
+                  ))}
+                  <div className="grid gap-3 border-t border-[#dbe7fb] pt-4 sm:grid-cols-2 sm:divide-x sm:divide-[#dbe7fb] dark:border-white/10 dark:sm:divide-white/10">
+                    {summaryRows.slice(1).map((row) => (
+                      <div
+                        key={row.id}
+                        className="flex flex-col items-center gap-2 px-3 text-center"
+                      >
+                        <div className="flex items-center gap-2">
+                          <span className={clsx('h-2 w-2 opacity-90', resolveSummaryMarker(row.id, row.accent, leftAccent, rightAccent))} />
+                          <span className={clsx('text-[10px] font-semibold uppercase tracking-micro', resolveSummaryLabelClass(row.id))}>
+                            {row.label}
+                          </span>
+                        </div>
+                        <p className="text-sm leading-5 text-text-secondary">{row.value}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+          </div>
+
+          <div className="mt-4 grid gap-4 sm:grid-cols-2">
+            <CompareGenerateCard
+              canGenerate={leftCanGenerate}
+              entry={left}
+              fullProfileLabel={compareCopy.scorecard?.fullProfile ?? 'Full engine profile'}
+              generateButtonLabel={formatTemplate(compareCopy.scorecard?.generateWith ?? 'Generate with {engine}', {
+                engine: formatEngineName(left),
+              })}
+              generateWithLabel={generateWithLabel}
+              side="left"
+            />
+            <CompareGenerateCard
+              canGenerate={rightCanGenerate}
+              entry={right}
+              fullProfileLabel={compareCopy.scorecard?.fullProfile ?? 'Full engine profile'}
+              generateButtonLabel={formatTemplate(compareCopy.scorecard?.generateWith ?? 'Generate with {engine}', {
+                engine: formatEngineName(right),
+              })}
+              generateWithLabel={generateWithLabel}
+              side="right"
+            />
+          </div>
+
+          <section className="mt-4 rounded-[16px] border border-hairline bg-surface p-6 shadow-card sm:p-8">
+              <h2 className="text-center text-2xl font-semibold text-text-primary">
+                {compareCopy.keySpecs?.title ?? 'Key Specs (Side-by-Side)'}
+              </h2>
+              <p className="mt-2 text-center text-sm text-text-secondary">
+                {stripAudioReferencesForSilentPair(
+                  compareCopy.keySpecs?.subtitle ??
+                    'Compare key AI video model specs side-by-side (pricing, inputs, resolution, duration, aspect ratios, audio, and core controls). This is a high-level snapshot — see the full engine profile for the complete feature set and prompt examples.',
+                  pairHasNativeAudio
+                )}
+              </p>
+
+              <div className="mt-4 rounded-card border border-hairline bg-surface shadow-card">
+                <div className="grid grid-cols-[minmax(90px,1fr)_minmax(80px,0.8fr)_minmax(90px,1fr)] gap-2 border-b border-hairline px-3 py-3 text-[10px] font-semibold uppercase tracking-micro text-text-muted min-[840px]:grid-cols-[minmax(200px,2fr)_minmax(220px,1fr)_minmax(200px,2fr)] min-[840px]:gap-4 min-[840px]:px-6 min-[840px]:py-4 min-[840px]:text-xs">
+                  <span className="text-left">{formatEngineName(left)}</span>
+                  <span className="text-center">{compareCopy.keySpecs?.keyLabel ?? 'Key spec'}</span>
+                  <span className="text-right">{formatEngineName(right)}</span>
+                </div>
+                <div className="divide-y divide-hairline">
+                  {specRows.map((row, index) => (
+                    <div
+                      key={row.label}
+                      className={clsx(
+                        'grid grid-cols-[minmax(90px,1fr)_minmax(80px,0.8fr)_minmax(90px,1fr)] gap-2 px-3 py-3 text-[11px] min-[840px]:grid-cols-[minmax(200px,2fr)_minmax(220px,1fr)_minmax(200px,2fr)] min-[840px]:gap-4 min-[840px]:px-6 min-[840px]:py-4 min-[840px]:text-sm',
+                        index % 2 === 1 && 'bg-surface-2'
+                      )}
+                    >
+                      <div className="rounded-md px-1 py-0.5 text-text-secondary sm:px-2 sm:py-1">
+                        {renderSpecValue(row.left, activeLocale, {
+                          pending: labels.pending,
+                          supported: labels.supported,
+                          notSupported: labels.notSupported,
+                        })}
+                        {'subline' in row && row.subline ? (
+                          <div className="mt-1 text-[10px] text-text-muted">{row.subline}</div>
+                        ) : null}
+                      </div>
+                      <span className="text-center text-text-primary">{row.label}</span>
+                      <div className="rounded-md px-1 py-0.5 text-right text-text-secondary sm:px-2 sm:py-1">
+                        {renderSpecValue(row.right, activeLocale, {
+                          pending: labels.pending,
+                          supported: labels.supported,
+                          notSupported: labels.notSupported,
+                        })}
+                        {'rightSubline' in row && row.rightSubline ? (
+                          <div className="mt-1 text-[10px] text-text-muted">{row.rightSubline}</div>
+                        ) : null}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {pageOverride?.topCards?.length ? (
+                <section className="mt-6 rounded-[24px] border border-hairline bg-surface-2/70 p-4 shadow-sm sm:p-5">
+                  <div className="grid gap-3 md:grid-cols-2">
+                    {pageOverride.topCards.map((card) => (
+                      <article
+                        key={card.title}
+                        className="rounded-[18px] border border-hairline bg-surface/90 px-4 py-3"
+                      >
+                        <p className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">
+                          {card.title}
+                        </p>
+                        <p className="mt-1.5 text-sm leading-6 text-text-secondary">{card.body}</p>
+                      </article>
+                    ))}
+                  </div>
+                </section>
+              ) : null}
+
+              {pageOverride?.primaryLinks?.length ? (
+                <section className="mt-4 rounded-[24px] border border-hairline bg-surface/90 px-4 py-4 shadow-sm sm:px-5">
+                  <h2 className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">
+                    {pageOverride.primaryLinksTitle ?? 'Recommended next steps'}
+                  </h2>
+                  <div className="mt-2 flex flex-wrap gap-x-4 gap-y-2 text-sm">
+                    {pageOverride.primaryLinks.map((item) => (
+                      <Link key={item.label} href={item.href} className="font-semibold text-brand hover:text-brandHover">
+                        {item.label}
+                      </Link>
+                    ))}
+                  </div>
+                </section>
+              ) : null}
+          </section>
+        </section>
+
+        
+
+        {showdownSlots.length ? (
+          <section className="stack-gap-sm">
+            <h2 className="text-2xl font-semibold text-text-primary">
+              {compareCopy.showdown?.title ?? 'Showdown (same prompt)'}
+            </h2>
+            <p className="text-sm text-text-secondary">
+              {showdownSubtitle}
+            </p>
+            <p className="text-xs text-text-muted">{compareCopy.showdown?.note ?? 'Showing up to 3 prompt pairs for clarity.'}</p>
+
+            <div className="stack-gap-lg">
+              {showdownSlots.map((entry) => {
+                const leftLabel = entry.left.label ?? formatEngineName(left);
+                const rightLabel = entry.right.label ?? formatEngineName(right);
+                const leftAlt = getImageAlt({
+                  kind: 'compareThumb',
+                  engine: leftLabel,
+                  compareEngine: rightLabel,
+                  label: `${entry.title} - ${leftLabel}`,
+                  locale: activeLocale,
+                });
+                const rightAlt = getImageAlt({
+                  kind: 'compareThumb',
+                  engine: rightLabel,
+                  compareEngine: leftLabel,
+                  label: `${entry.title} - ${rightLabel}`,
+                  locale: activeLocale,
+                });
+                return (
+                  <article
+                    key={`${slug}-showdown-${entry.id}`}
+                    className="rounded-card border border-hairline bg-surface p-6 shadow-card"
+                  >
+                    <div className="stack-gap-sm">
+                    <div>
+                      <h3 className="text-lg font-semibold text-text-primary">{entry.title}</h3>
+                      <p className="text-sm text-text-secondary">
+                        {labels.whatTests}: {entry.whatItTests}
+                      </p>
+                    </div>
+                    <div className="rounded-card border border-hairline bg-surface-2 p-3 text-sm text-text-secondary">
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="text-xs font-semibold uppercase tracking-micro text-text-muted">{labels.prompt}</span>
+                        {exposeSourcePrompt ? (
+                          <CopyPromptButton
+                            prompt={entry.prompt}
+                            copyLabel={compareCopy.labels?.copyPrompt ?? 'Copy prompt'}
+                            copiedLabel={compareCopy.labels?.copied ?? 'Copied'}
+                          />
+                        ) : null}
+                      </div>
+                      {exposeSourcePrompt ? (
+                        <DeferredSourcePrompt
+                          locale={activeLocale}
+                          prompt={entry.prompt}
+                          mode="details"
+                          className="mt-2"
+                          summaryClassName="cursor-pointer list-none text-xs font-semibold text-brand"
+                          promptClassName="mt-2 whitespace-pre-wrap text-text-primary"
+                          fallbackClassName="mt-2 text-sm text-text-secondary"
+                        />
+                      ) : (
+                        <p className="mt-2 text-sm text-text-secondary">{localizedPromptNote}</p>
+                      )}
+                    </div>
+                    <div className="grid grid-gap lg:grid-cols-2">
+                      {renderShowdownMedia(
+                        entry.left,
+                        formatEngineName(left),
+                        labels.placeholder,
+                        labels.placeholder,
+                        entry.aspectRatio,
+                        leftAlt
+                      )}
+                      {renderShowdownMedia(
+                        entry.right,
+                        formatEngineName(right),
+                        labels.placeholder,
+                        labels.placeholder,
+                        entry.aspectRatio,
+                        rightAlt
+                      )}
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2 text-sm text-text-secondary">
+                      <span className="text-xs font-semibold uppercase tracking-micro text-text-muted">{showdownActionLabel}</span>
+                      <Link
+                        href={buildGenerateHref(
+                          left.modelSlug,
+                          exposeSourcePrompt ? entry.prompt : null,
+                          entry.aspectRatio,
+                          entry.mode
+                        )}
+                        prefetch={false}
+                        className="rounded-full border border-hairline bg-surface px-3 py-1 text-xs font-semibold text-text-primary transition hover:bg-surface-2"
+                      >
+                        {leftIsPrelaunch
+                          ? labels.savePromptForLaunch
+                          : formatTemplate(compareCopy.scorecard?.generateWith ?? 'Generate with {engine}', {
+                              engine: formatEngineShortName(left),
+                            })}
+                      </Link>
+                      <Link
+                        href={buildGenerateHref(
+                          right.modelSlug,
+                          exposeSourcePrompt ? entry.prompt : null,
+                          entry.aspectRatio,
+                          entry.mode
+                        )}
+                        prefetch={false}
+                        className="rounded-full border border-hairline bg-surface px-3 py-1 text-xs font-semibold text-text-primary transition hover:bg-surface-2"
+                      >
+                        {rightIsPrelaunch
+                          ? labels.savePromptForLaunch
+                          : formatTemplate(compareCopy.scorecard?.generateWith ?? 'Generate with {engine}', {
+                              engine: formatEngineShortName(right),
+                            })}
+                      </Link>
+                      <span className="text-xs text-text-muted">{showdownActionHint}</span>
+                    </div>
+                  </div>
+                  </article>
+                );
+              })}
+            </div>
+            <p className="text-sm text-text-secondary">
+              {compareCopy.showdown?.footer ??
+                'This side-by-side AI video comparison uses identical prompts to highlight differences in motion, realism, human fidelity, and text legibility. For full specs, controls, and more prompt examples, open each engine profile.'}
+            </p>
+          </section>
+        ) : null}
+
+        {relatedLinks.length ? (
+          <section className="stack-gap-sm">
+            <h2 className="text-2xl font-semibold text-text-primary">
+              {compareCopy.related?.title ?? 'Related comparisons'}
+            </h2>
+            <p className="text-sm text-text-secondary">
+              {compareCopy.related?.subtitle ??
+                'Explore a few more popular side-by-side matchups.'}
+            </p>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {relatedLinks.map((item) => (
+                <Link
+                  key={item.href.params.slug}
+                  href={item.href}
+                  className="rounded-card border border-hairline bg-surface px-4 py-3 text-sm font-semibold text-text-primary transition hover:bg-surface-2"
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        <section className="stack-gap-sm">
+          <h2 className="text-2xl font-semibold text-text-primary">
+            {pageOverride?.faq?.title ?? compareCopy.faq?.title ?? 'FAQ'}
+          </h2>
+          <p className="text-sm text-text-secondary">
+            {formatTemplate(
+              pageOverride?.faq?.subtitle ??
+                compareCopy.faq?.subtitle ??
+                'Quick answers about {left} vs {right} on MaxVideoAI (pricing, modes, specs, and why results differ).',
+              { left: formatEngineName(left), right: formatEngineName(right) }
+            )}
+          </p>
+          <div className="stack-gap-sm">
+            {faqItems.map((item) => (
+              <details key={item.question} className="rounded-card border border-hairline bg-surface p-4">
+                <summary className="cursor-pointer text-sm font-semibold text-text-primary">
+                  {item.question}
+                </summary>
+                {Array.isArray(item.answer) ? (
+                  <ul className="mt-2 list-disc space-y-1 pl-4 text-sm text-text-secondary">
+                    {item.answer.map((line) => (
+                      <li key={line}>{line}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="mt-2 text-sm text-text-secondary">{item.answer}</p>
+                )}
+              </details>
+            ))}
+          </div>
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+          />
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+          />
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(webPageJsonLd) }}
+          />
+        </section>
+
+        <div className="text-sm text-text-muted">
+          <Link href={compareHubHref} className="font-semibold text-brand hover:text-brandHover">
+            {compareCopy.hero?.back ?? 'Back to comparisons'}
+          </Link>
+        </div>
+      </div>
+    </div>
+    </div>
+  );
+}

--- a/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-copy.ts
+++ b/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-copy.ts
@@ -97,3 +97,41 @@ export type ComparePageCopy = {
   metrics?: Record<string, { label?: string; tooltip?: string }>;
   breadcrumb?: { root?: string };
 };
+
+export type CompareDetailLabels = {
+  pending: string;
+  supported: string;
+  notSupported: string;
+  na: string;
+  prompt: string;
+  tryPrompt: string;
+  tryPromptPrelaunch: string;
+  opensGenerator: string;
+  opensGeneratorPrelaunch: string;
+  savePromptForLaunch: string;
+  whatTests: string;
+  placeholder: string;
+  expandPrompt: string;
+  collapsePrompt: string;
+};
+
+export function buildCompareDetailLabels(compareCopy: ComparePageCopy): CompareDetailLabels {
+  return {
+    pending: compareCopy.labels?.pending ?? 'Data pending',
+    supported: compareCopy.labels?.supported ?? 'Supported',
+    notSupported: compareCopy.labels?.notSupported ?? 'Not supported',
+    na: compareCopy.labels?.na ?? 'N/A',
+    prompt: compareCopy.labels?.prompt ?? 'Prompt',
+    tryPrompt: compareCopy.labels?.tryPrompt ?? 'Try this prompt:',
+    tryPromptPrelaunch: compareCopy.labels?.tryPromptPrelaunch ?? 'Prompt actions:',
+    opensGenerator: compareCopy.labels?.opensGenerator ?? 'Opens the generator pre-filled.',
+    opensGeneratorPrelaunch:
+      compareCopy.labels?.opensGeneratorPrelaunch ??
+      'Use these prompt links for planning; pre-launch engines unlock at launch.',
+    savePromptForLaunch: compareCopy.labels?.savePromptForLaunch ?? 'Save this prompt for launch',
+    whatTests: compareCopy.labels?.whatTests ?? 'What it tests',
+    placeholder: compareCopy.labels?.placeholder ?? '',
+    expandPrompt: compareCopy.labels?.expandPrompt ?? 'Show full prompt',
+    collapsePrompt: compareCopy.labels?.collapsePrompt ?? 'Hide full prompt',
+  };
+}

--- a/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-spec-rows.ts
+++ b/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-spec-rows.ts
@@ -1,0 +1,81 @@
+import type {
+  ComparePricingDisplay,
+  CompareSpecValues,
+  EngineCatalogEntry,
+} from './compare-page-types';
+import { formatSpeedChip, isPending } from './compare-page-helpers';
+
+export type CompareSpecRow = {
+  label: string;
+  left: string;
+  right: string;
+  subline?: string | null;
+  rightSubline?: string | null;
+};
+
+export function buildCompareSpecRows({
+  left,
+  right,
+  leftSpecs,
+  rightSpecs,
+  leftPricingDisplay,
+  rightPricingDisplay,
+  pairHasNativeAudio,
+  specLabels,
+}: {
+  left: EngineCatalogEntry;
+  right: EngineCatalogEntry;
+  leftSpecs: CompareSpecValues;
+  rightSpecs: CompareSpecValues;
+  leftPricingDisplay: ComparePricingDisplay;
+  rightPricingDisplay: ComparePricingDisplay;
+  pairHasNativeAudio: boolean;
+  specLabels: Record<string, string>;
+}): CompareSpecRow[] {
+  return [
+    {
+      label: specLabels.pricing ?? 'Pricing (MaxVideoAI)',
+      left: leftPricingDisplay.headline,
+      right: rightPricingDisplay.headline,
+      subline: leftPricingDisplay.subline,
+      rightSubline: rightPricingDisplay.subline,
+    },
+    { label: specLabels.textToVideo ?? 'Text-to-Video', left: leftSpecs.textToVideo, right: rightSpecs.textToVideo },
+    { label: specLabels.imageToVideo ?? 'Image-to-Video', left: leftSpecs.imageToVideo, right: rightSpecs.imageToVideo },
+    { label: specLabels.videoToVideo ?? 'Video-to-Video', left: leftSpecs.videoToVideo, right: rightSpecs.videoToVideo },
+    { label: specLabels.firstLastFrame ?? 'First/Last frame', left: leftSpecs.firstLastFrame, right: rightSpecs.firstLastFrame },
+    {
+      label: specLabels.referenceImageStyle ?? 'Reference image / style reference',
+      left: leftSpecs.referenceImageStyle,
+      right: rightSpecs.referenceImageStyle,
+    },
+    { label: specLabels.referenceVideo ?? 'Reference video', left: leftSpecs.referenceVideo, right: rightSpecs.referenceVideo },
+    { label: specLabels.maxResolution ?? 'Max resolution', left: leftSpecs.maxResolution, right: rightSpecs.maxResolution },
+    { label: specLabels.maxDuration ?? 'Max duration', left: leftSpecs.maxDuration, right: rightSpecs.maxDuration },
+    {
+      label: specLabels.avgRenderTime ?? 'Avg render time',
+      left: formatSpeedChip(left),
+      right: formatSpeedChip(right),
+    },
+    { label: specLabels.aspectRatios ?? 'Aspect ratios', left: leftSpecs.aspectRatios, right: rightSpecs.aspectRatios },
+    { label: specLabels.fpsOptions ?? 'FPS options', left: leftSpecs.fpsOptions, right: rightSpecs.fpsOptions },
+    { label: specLabels.outputFormats ?? 'Output format', left: leftSpecs.outputFormats, right: rightSpecs.outputFormats },
+    ...(pairHasNativeAudio
+      ? [
+          { label: specLabels.audioOutput ?? 'Audio output', left: leftSpecs.audioOutput, right: rightSpecs.audioOutput },
+          {
+            label: specLabels.nativeAudioGeneration ?? 'Native audio generation',
+            left: leftSpecs.nativeAudioGeneration,
+            right: rightSpecs.nativeAudioGeneration,
+          },
+          { label: specLabels.lipSync ?? 'Lip sync', left: leftSpecs.lipSync, right: rightSpecs.lipSync },
+        ]
+      : []),
+    {
+      label: specLabels.cameraMotionControls ?? 'Camera / motion controls',
+      left: leftSpecs.cameraMotionControls,
+      right: rightSpecs.cameraMotionControls,
+    },
+    { label: specLabels.watermark ?? 'Watermark', left: leftSpecs.watermark, right: rightSpecs.watermark },
+  ].filter((row) => !(isPending(row.left) && isPending(row.right)));
+}

--- a/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/page.tsx
+++ b/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/page.tsx
@@ -1,24 +1,14 @@
 import type { Metadata } from 'next';
 import { notFound, permanentRedirect, redirect } from 'next/navigation';
-import clsx from 'clsx';
-import { ArrowLeft, Trophy } from 'lucide-react';
-import { Link } from '@/i18n/navigation';
 import { localePathnames, locales } from '@/i18n/locales';
 import { resolveDictionary } from '@/lib/i18n/server';
 import { buildMetadataUrls } from '@/lib/metadataUrls';
 import { isDatabaseConfigured } from '@/lib/db';
-import { getCompareShowdowns, type CompareShowdown } from '@/config/compare-showdowns';
+import { getCompareShowdowns } from '@/config/compare-showdowns';
 import { isPublishedComparisonSlug } from '@/lib/compare-hub/data';
-import { DeferredSourcePrompt } from '@/components/i18n/DeferredSourcePrompt.client';
-import { CompareEngineSelector } from './CompareEngineSelector.client';
-import { CompareScoreboard } from './CompareScoreboard.client';
-import { CopyPromptButton } from './CopyPromptButton.client';
-import { CompareGenerateCard } from './_components/CompareGenerateCard';
-import { renderShowdownMedia } from './_components/CompareShowdownMedia';
-import { renderSpecValue } from './_components/CompareSpecValue';
 import { getLatestPublicVideoByPromptAndEngine, getPublicVideosByIds, type GalleryVideo } from '@/server/videos';
 import { fetchEngineAverageDurations } from '@/server/generate-metrics';
-import { getImageAlt } from '@/lib/image-alt';
+import { CompareDetailContent, type CompareShowdownSlot } from './_components/CompareDetailContent';
 import {
   COMPARE_SLUG_MAP,
   ENGINE_OPTIONS,
@@ -33,27 +23,21 @@ import type {
   ShowdownEntry,
   ShowdownSide,
 } from './_lib/compare-page-types';
-import type { ComparePageCopy } from './_lib/compare-page-copy';
+import { buildCompareDetailLabels, type ComparePageCopy } from './_lib/compare-page-copy';
 import { getComparePageOverride } from './_lib/compare-page-overrides';
 import { buildCompareFaqItems, buildCompareFaqJsonLd } from './_lib/compare-page-faq';
 import { buildComparePageMetadata } from './_lib/compare-page-metadata';
 import {
   buildCompareSummaryRows,
   buildComparisonMetrics,
-  deriveCompareStrengths,
-  formatWinnerSummaryValue,
-  resolveSummaryLabelClass,
-  resolveSummaryMarker,
 } from './_lib/compare-page-scorecard';
+import { buildCompareSpecRows } from './_lib/compare-page-spec-rows';
 import {
-  buildGenerateHref,
   buildSpecValues,
   computeOverall,
   computePairScores,
   computePricingScore,
   formatEngineName,
-  formatEngineShortName,
-  formatSpeedChip,
   formatTemplate,
   getCanonicalCompareSlug,
   getEngineAccent,
@@ -61,20 +45,17 @@ import {
   getPrelaunchCompareNotice,
   hydrateShowdowns,
   isEngineGeneratable,
-  isPending,
   isPrelaunchAvailability,
   LOCALIZED_SHOWDOWN_TESTS,
   LOCALIZED_SHOWDOWN_TITLES,
   loadEngineKeySpecs,
   loadEngineScores,
-  localizeBestFor,
   localizeMappedValue,
   replaceCriteriaCount,
   resolveEngines,
   resolveExcludedCompareRedirect,
   resolvePricingDisplay,
   reverseCompareSlug,
-  stripAudioReferencesForSilentPair,
 } from './_lib/compare-page-helpers';
 
 export const dynamicParams = true;
@@ -110,24 +91,7 @@ export default async function CompareDetailPage(
   const activeLocale = params.locale ?? 'en';
   const { dictionary } = await resolveDictionary({ locale: activeLocale });
   const compareCopy = (dictionary.comparePage ?? {}) as ComparePageCopy;
-  const labels = {
-    pending: compareCopy.labels?.pending ?? 'Data pending',
-    supported: compareCopy.labels?.supported ?? 'Supported',
-    notSupported: compareCopy.labels?.notSupported ?? 'Not supported',
-    na: compareCopy.labels?.na ?? 'N/A',
-    prompt: compareCopy.labels?.prompt ?? 'Prompt',
-    tryPrompt: compareCopy.labels?.tryPrompt ?? 'Try this prompt:',
-    tryPromptPrelaunch: compareCopy.labels?.tryPromptPrelaunch ?? 'Prompt actions:',
-    opensGenerator: compareCopy.labels?.opensGenerator ?? 'Opens the generator pre-filled.',
-    opensGeneratorPrelaunch:
-      compareCopy.labels?.opensGeneratorPrelaunch ??
-      'Use these prompt links for planning; pre-launch engines unlock at launch.',
-    savePromptForLaunch: compareCopy.labels?.savePromptForLaunch ?? 'Save this prompt for launch',
-    whatTests: compareCopy.labels?.whatTests ?? 'What it tests',
-    placeholder: compareCopy.labels?.placeholder ?? '',
-    expandPrompt: compareCopy.labels?.expandPrompt ?? 'Show full prompt',
-    collapsePrompt: compareCopy.labels?.collapsePrompt ?? 'Hide full prompt',
-  };
+  const labels = buildCompareDetailLabels(compareCopy);
   const slug = params.slug;
   const canonicalInfo = getCanonicalCompareSlug(slug);
   if (!canonicalInfo) {
@@ -318,7 +282,6 @@ export default async function CompareDetailPage(
       await Promise.all(lookupTasks);
     }
   }
-  type ShowdownSlot = CompareShowdown & { left: ShowdownSide; right: ShowdownSide };
   const showdownSlots = compareShowdowns.map((template, index) => {
     const entry = orderedShowdowns[index];
     const shouldSwapShowdownSides = showdownSourceSlug === canonicalSlug ? shouldSwapDisplayOrder : !shouldSwapDisplayOrder;
@@ -355,7 +318,7 @@ export default async function CompareDetailPage(
       left: leftSide,
       right: rightSide,
     };
-  }).filter(Boolean) as ShowdownSlot[];
+  }).filter(Boolean) as CompareShowdownSlot[];
   const leftAccent = getEngineAccent(left);
   const rightAccent = getEngineAccent(right);
   const leftIsPrelaunch = isPrelaunchAvailability(left);
@@ -370,52 +333,16 @@ export default async function CompareDetailPage(
   const resolvedLeftOptions = ENGINE_OPTIONS;
   const resolvedRightOptions = ENGINE_OPTIONS;
   const specLabels = compareCopy.specLabels ?? {};
-  const specRows = [
-    {
-      label: specLabels.pricing ?? 'Pricing (MaxVideoAI)',
-      left: leftPricingDisplay.headline,
-      right: rightPricingDisplay.headline,
-      subline: leftPricingDisplay.subline,
-      rightSubline: rightPricingDisplay.subline,
-    },
-    { label: specLabels.textToVideo ?? 'Text-to-Video', left: leftSpecs.textToVideo, right: rightSpecs.textToVideo },
-    { label: specLabels.imageToVideo ?? 'Image-to-Video', left: leftSpecs.imageToVideo, right: rightSpecs.imageToVideo },
-    { label: specLabels.videoToVideo ?? 'Video-to-Video', left: leftSpecs.videoToVideo, right: rightSpecs.videoToVideo },
-    { label: specLabels.firstLastFrame ?? 'First/Last frame', left: leftSpecs.firstLastFrame, right: rightSpecs.firstLastFrame },
-    {
-      label: specLabels.referenceImageStyle ?? 'Reference image / style reference',
-      left: leftSpecs.referenceImageStyle,
-      right: rightSpecs.referenceImageStyle,
-    },
-    { label: specLabels.referenceVideo ?? 'Reference video', left: leftSpecs.referenceVideo, right: rightSpecs.referenceVideo },
-    { label: specLabels.maxResolution ?? 'Max resolution', left: leftSpecs.maxResolution, right: rightSpecs.maxResolution },
-    { label: specLabels.maxDuration ?? 'Max duration', left: leftSpecs.maxDuration, right: rightSpecs.maxDuration },
-    {
-      label: specLabels.avgRenderTime ?? 'Avg render time',
-      left: formatSpeedChip(left),
-      right: formatSpeedChip(right),
-    },
-    { label: specLabels.aspectRatios ?? 'Aspect ratios', left: leftSpecs.aspectRatios, right: rightSpecs.aspectRatios },
-    { label: specLabels.fpsOptions ?? 'FPS options', left: leftSpecs.fpsOptions, right: rightSpecs.fpsOptions },
-    { label: specLabels.outputFormats ?? 'Output format', left: leftSpecs.outputFormats, right: rightSpecs.outputFormats },
-    ...(pairHasNativeAudio
-      ? [
-          { label: specLabels.audioOutput ?? 'Audio output', left: leftSpecs.audioOutput, right: rightSpecs.audioOutput },
-          {
-            label: specLabels.nativeAudioGeneration ?? 'Native audio generation',
-            left: leftSpecs.nativeAudioGeneration,
-            right: rightSpecs.nativeAudioGeneration,
-          },
-          { label: specLabels.lipSync ?? 'Lip sync', left: leftSpecs.lipSync, right: rightSpecs.lipSync },
-        ]
-      : []),
-    {
-      label: specLabels.cameraMotionControls ?? 'Camera / motion controls',
-      left: leftSpecs.cameraMotionControls,
-      right: rightSpecs.cameraMotionControls,
-    },
-    { label: specLabels.watermark ?? 'Watermark', left: leftSpecs.watermark, right: rightSpecs.watermark },
-  ].filter((row) => !(isPending(row.left) && isPending(row.right)));
+  const specRows = buildCompareSpecRows({
+    left,
+    right,
+    leftSpecs,
+    rightSpecs,
+    leftPricingDisplay,
+    rightPricingDisplay,
+    pairHasNativeAudio,
+    specLabels,
+  });
 
   const relatedSlugs = RELATED_COMPARISONS[canonicalSlug] ?? [];
   const relatedLinks = relatedSlugs
@@ -524,564 +451,49 @@ export default async function CompareDetailPage(
   }).trim();
 
   return (
-    <div className="relative isolate overflow-hidden">
-      <div
-        className="pointer-events-none absolute right-0 top-24 -z-10 h-[760px] w-[46vw] opacity-70 dark:opacity-30"
-        style={{
-          backgroundImage:
-            'radial-gradient(circle at center, color-mix(in srgb, var(--brand) 30%, transparent) 1px, transparent 1px)',
-          backgroundSize: '16px 16px',
-          maskImage: 'linear-gradient(90deg, transparent, black 24%, black 74%, transparent)',
-        }}
-        aria-hidden
-      />
-      <div className="container-page max-w-[1040px] section">
-        <div className="space-y-4 sm:space-y-5">
-        <div className="text-sm text-text-muted">
-          <Link href={compareHubHref} className="inline-flex items-center gap-2 font-semibold text-brand hover:text-brandHover">
-            <ArrowLeft className="h-4 w-4" aria-hidden />
-            {compareCopy.hero?.back ?? 'Back to comparisons'}
-          </Link>
-        </div>
-        <header className="mx-auto max-w-[760px] py-6 text-center sm:py-8">
-          <p className="text-xs font-semibold uppercase tracking-micro text-text-muted">
-            {compareCopy.hero?.kicker ?? 'Compare engines'}
-          </p>
-          <h1 className="mt-3 text-[34px] font-semibold leading-[1.08] tracking-normal text-text-primary sm:text-[46px]">
-            {formatEngineName(left)} vs {formatEngineName(right)}
-          </h1>
-          <p className="mt-4 text-sm leading-6 text-text-secondary">
-            {formatTemplate(
-              heroIntroTemplate,
-              { left: formatEngineName(left), right: formatEngineName(right) }
-            )}
-          </p>
-          {prelaunchNotice ? (
-            <div className="mx-auto mt-4 max-w-3xl rounded-2xl border border-amber-300/70 bg-amber-50 px-4 py-3 text-left shadow-sm">
-              <p className="text-xs font-semibold uppercase tracking-micro text-amber-900">{prelaunchNotice.title}</p>
-              <p className="mt-1 text-sm text-amber-950">{prelaunchNotice.body}</p>
-            </div>
-          ) : null}
-        </header>
-
-        <section className="mx-auto max-w-[940px]">
-          <div className="relative grid gap-4 md:grid-cols-2">
-            <article className="relative flex overflow-visible rounded-[16px] border border-hairline bg-surface p-6 shadow-card">
-              <div className="flex w-full flex-col items-center gap-5 sm:flex-row-reverse">
-                <div
-                  className="relative isolate grid h-[96px] w-[96px] shrink-0 place-items-center rounded-full p-[3px]"
-                  style={leftScoreStyle}
-                >
-                  <span
-                    className="pointer-events-none absolute -inset-5 -z-10 rounded-full opacity-75 blur-2xl"
-                    style={{ background: 'color-mix(in srgb, var(--compare-accent) 45%, transparent)' }}
-                    aria-hidden
-                  />
-                  <div className="grid h-full w-full place-items-center rounded-full border border-white/80 bg-surface text-center shadow-[inset_0_1px_0_rgba(255,255,255,0.9)] dark:border-white/10 dark:bg-surface-2">
-                    <div className="leading-none">
-                      <span className="text-[28px] font-semibold tracking-normal text-text-primary">
-                        {leftOverall != null ? leftOverall.toFixed(1) : '-'}
-                      </span>
-                      <span className="ml-0.5 align-super text-[10px] font-semibold text-text-muted">/10</span>
-                      <span className="mt-1 block text-[8px] font-semibold uppercase tracking-[0.22em] text-text-muted">
-                        Score
-                      </span>
-                    </div>
-                  </div>
-                </div>
-                <div className="flex min-w-0 flex-1 flex-col items-center gap-3 text-center">
-                  <h2 className="text-2xl font-semibold tracking-normal text-text-primary">
-                    {formatEngineName(left)}
-                  </h2>
-                  <CompareEngineSelector
-                    options={resolvedLeftOptions}
-                    value={left.modelSlug}
-                    otherValue={right.modelSlug}
-                    side="left"
-                  />
-                  {(() => {
-                    const bestFor = localizeBestFor(left.bestFor, activeLocale);
-                    const derived = deriveCompareStrengths(comparisonMetrics, 'left').join(', ');
-                    const strengths = bestFor && !isPending(bestFor) ? bestFor : derived;
-                    return strengths ? (
-                      <p className="max-w-[280px] text-xs leading-5 text-text-secondary">
-                        <span className="font-semibold text-text-primary">
-                          {compareCopy.scorecard?.strengthsLabel ?? 'Strengths'}:
-                        </span>{' '}
-                        {strengths}
-                      </p>
-                    ) : null;
-                  })()}
-                </div>
-              </div>
-            </article>
-
-            <article className="relative flex overflow-visible rounded-[16px] border border-hairline bg-surface p-6 shadow-card">
-              <div className="flex w-full flex-col items-center gap-5 sm:flex-row">
-                <div
-                  className="relative isolate grid h-[96px] w-[96px] shrink-0 place-items-center rounded-full p-[3px]"
-                  style={rightScoreStyle}
-                >
-                  <span
-                    className="pointer-events-none absolute -inset-5 -z-10 rounded-full opacity-75 blur-2xl"
-                    style={{ background: 'color-mix(in srgb, var(--compare-accent) 45%, transparent)' }}
-                    aria-hidden
-                  />
-                  <div className="grid h-full w-full place-items-center rounded-full border border-white/80 bg-surface text-center shadow-[inset_0_1px_0_rgba(255,255,255,0.9)] dark:border-white/10 dark:bg-surface-2">
-                    <div className="leading-none">
-                      <span className="text-[28px] font-semibold tracking-normal text-text-primary">
-                        {rightOverall != null ? rightOverall.toFixed(1) : '-'}
-                      </span>
-                      <span className="ml-0.5 align-super text-[10px] font-semibold text-text-muted">/10</span>
-                      <span className="mt-1 block text-[8px] font-semibold uppercase tracking-[0.22em] text-text-muted">
-                        Score
-                      </span>
-                    </div>
-                  </div>
-                </div>
-                <div className="flex min-w-0 flex-1 flex-col items-center gap-3 text-center">
-                  <h2 className="text-2xl font-semibold tracking-normal text-text-primary">
-                    {formatEngineName(right)}
-                  </h2>
-                  <CompareEngineSelector
-                    options={resolvedRightOptions}
-                    value={right.modelSlug}
-                    otherValue={left.modelSlug}
-                    side="right"
-                  />
-                  {(() => {
-                    const bestFor = localizeBestFor(right.bestFor, activeLocale);
-                    const derived = deriveCompareStrengths(comparisonMetrics, 'right').join(', ');
-                    const strengths = bestFor && !isPending(bestFor) ? bestFor : derived;
-                    return strengths ? (
-                      <p className="max-w-[280px] text-xs leading-5 text-text-secondary">
-                        <span className="font-semibold text-text-primary">
-                          {compareCopy.scorecard?.strengthsLabel ?? 'Strengths'}:
-                        </span>{' '}
-                        {strengths}
-                      </p>
-                    ) : null;
-                  })()}
-                </div>
-              </div>
-            </article>
-
-            <div className="pointer-events-none absolute left-1/2 top-1/2 z-20 hidden -translate-x-1/2 -translate-y-1/2 md:flex">
-              <div className="flex h-11 w-11 items-center justify-center rounded-full border-4 border-bg bg-brand text-[11px] font-semibold uppercase tracking-micro text-on-brand shadow-[0_16px_34px_rgba(46,99,216,0.28)]">
-                VS
-              </div>
-            </div>
-          </div>
-
-          <div className="mt-4 rounded-[16px] border border-hairline bg-surface p-4 shadow-card sm:p-8">
-            <div className="text-center">
-              <h2 className="text-xl font-semibold text-text-primary">
-                {compareCopy.scorecard?.title ?? 'Scorecard (Side-by-Side)'}
-              </h2>
-              <p className="mt-1 text-sm text-text-secondary">
-                {replaceCriteriaCount(
-                  compareCopy.scorecard?.subtitle ??
-                    `Scores reflect quality and control on MaxVideoAI across ${criteriaCount} criteria.`,
-                  criteriaCount
-                )}
-              </p>
-              {scorecardProvisionalNote ? (
-                <p className="mt-2 text-xs font-semibold text-text-muted">{scorecardProvisionalNote}</p>
-              ) : null}
-            </div>
-            <div className="mt-6 hidden items-center gap-3 text-[11px] font-semibold uppercase tracking-micro sm:grid sm:grid-cols-[minmax(0,1.6fr)_minmax(190px,1fr)_minmax(0,1.6fr)] sm:gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(210px,1fr)_minmax(0,2fr)]">
-              <span className="text-center text-brand">
-                {formatEngineName(left)}
-              </span>
-              <span className="text-center text-text-muted">{scorecardCriteriaLabel}</span>
-              <span className="text-center text-brand">
-                {formatEngineName(right)}
-              </span>
-            </div>
-            <CompareScoreboard
-              metrics={comparisonMetrics}
-              className="mt-4"
-              naLabel={labels.na}
-              pendingLabel={labels.pending}
-            />
-
-            <div className="mx-auto mt-7 w-full">
-              <div className="relative overflow-hidden rounded-[18px] border border-[#cfe0ff] bg-[#eef5ff] px-5 pb-5 pt-5 text-center shadow-[0_16px_34px_rgba(46,99,216,0.10),inset_0_1px_0_rgba(255,255,255,0.9)] dark:border-white/10 dark:bg-[#172338] dark:shadow-[0_16px_34px_rgba(0,0,0,0.24)]">
-                <div
-                  className="pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,#eaf2ff_0%,#f7fbff_58%,#ffffff_100%)] dark:bg-[linear-gradient(180deg,rgba(46,99,216,0.22)_0%,rgba(18,26,37,0.94)_58%,rgba(18,26,37,0.98)_100%)]"
-                  aria-hidden
-                />
-                <div
-                  className="pointer-events-none absolute left-1/2 top-0 h-28 w-[340px] -translate-x-1/2 rounded-full bg-white/80 blur-2xl dark:bg-white/10"
-                  aria-hidden
-                />
-                <div
-                  className="pointer-events-none absolute inset-x-10 top-0 h-px bg-gradient-to-r from-transparent via-white to-transparent dark:via-white/30"
-                  aria-hidden
-                />
-                <div className="relative z-10 flex items-center justify-center gap-3">
-                  <span className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/80 bg-white text-brand shadow-[0_12px_26px_rgba(46,99,216,0.14),inset_0_1px_0_rgba(255,255,255,0.95)] dark:border-white/10 dark:bg-white/8 dark:text-white">
-                    <Trophy className="h-5 w-5" aria-hidden />
-                  </span>
-                  <h3 className="text-lg font-semibold text-text-primary">
-                    {winnerSummaryHeading}
-                  </h3>
-                </div>
-                <div className="relative z-10 mt-4 grid gap-4">
-                  {summaryRows.slice(0, 1).map((row) => (
-                    <div
-                      key={row.id}
-                      className="flex flex-col items-center gap-2 text-center"
-                    >
-                      <div className="flex items-center gap-2">
-                        <span className={clsx('h-2 w-2 opacity-90', resolveSummaryMarker(row.id, row.accent, leftAccent, rightAccent))} />
-                        <span className={clsx('text-[10px] font-semibold uppercase tracking-micro', resolveSummaryLabelClass(row.id))}>
-                          {row.label}
-                        </span>
-                      </div>
-                      <p className="max-w-[620px] text-sm leading-6 text-text-secondary">{formatWinnerSummaryValue(row)}</p>
-                    </div>
-                  ))}
-                  <div className="grid gap-3 border-t border-[#dbe7fb] pt-4 sm:grid-cols-2 sm:divide-x sm:divide-[#dbe7fb] dark:border-white/10 dark:sm:divide-white/10">
-                    {summaryRows.slice(1).map((row) => (
-                      <div
-                        key={row.id}
-                        className="flex flex-col items-center gap-2 px-3 text-center"
-                      >
-                        <div className="flex items-center gap-2">
-                          <span className={clsx('h-2 w-2 opacity-90', resolveSummaryMarker(row.id, row.accent, leftAccent, rightAccent))} />
-                          <span className={clsx('text-[10px] font-semibold uppercase tracking-micro', resolveSummaryLabelClass(row.id))}>
-                            {row.label}
-                          </span>
-                        </div>
-                        <p className="text-sm leading-5 text-text-secondary">{row.value}</p>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            </div>
-
-          </div>
-
-          <div className="mt-4 grid gap-4 sm:grid-cols-2">
-            <CompareGenerateCard
-              canGenerate={leftCanGenerate}
-              entry={left}
-              fullProfileLabel={compareCopy.scorecard?.fullProfile ?? 'Full engine profile'}
-              generateButtonLabel={formatTemplate(compareCopy.scorecard?.generateWith ?? 'Generate with {engine}', {
-                engine: formatEngineName(left),
-              })}
-              generateWithLabel={generateWithLabel}
-              side="left"
-            />
-            <CompareGenerateCard
-              canGenerate={rightCanGenerate}
-              entry={right}
-              fullProfileLabel={compareCopy.scorecard?.fullProfile ?? 'Full engine profile'}
-              generateButtonLabel={formatTemplate(compareCopy.scorecard?.generateWith ?? 'Generate with {engine}', {
-                engine: formatEngineName(right),
-              })}
-              generateWithLabel={generateWithLabel}
-              side="right"
-            />
-          </div>
-
-          <section className="mt-4 rounded-[16px] border border-hairline bg-surface p-6 shadow-card sm:p-8">
-              <h2 className="text-center text-2xl font-semibold text-text-primary">
-                {compareCopy.keySpecs?.title ?? 'Key Specs (Side-by-Side)'}
-              </h2>
-              <p className="mt-2 text-center text-sm text-text-secondary">
-                {stripAudioReferencesForSilentPair(
-                  compareCopy.keySpecs?.subtitle ??
-                    'Compare key AI video model specs side-by-side (pricing, inputs, resolution, duration, aspect ratios, audio, and core controls). This is a high-level snapshot — see the full engine profile for the complete feature set and prompt examples.',
-                  pairHasNativeAudio
-                )}
-              </p>
-
-              <div className="mt-4 rounded-card border border-hairline bg-surface shadow-card">
-                <div className="grid grid-cols-[minmax(90px,1fr)_minmax(80px,0.8fr)_minmax(90px,1fr)] gap-2 border-b border-hairline px-3 py-3 text-[10px] font-semibold uppercase tracking-micro text-text-muted min-[840px]:grid-cols-[minmax(200px,2fr)_minmax(220px,1fr)_minmax(200px,2fr)] min-[840px]:gap-4 min-[840px]:px-6 min-[840px]:py-4 min-[840px]:text-xs">
-                  <span className="text-left">{formatEngineName(left)}</span>
-                  <span className="text-center">{compareCopy.keySpecs?.keyLabel ?? 'Key spec'}</span>
-                  <span className="text-right">{formatEngineName(right)}</span>
-                </div>
-                <div className="divide-y divide-hairline">
-                  {specRows.map((row, index) => (
-                    <div
-                      key={row.label}
-                      className={clsx(
-                        'grid grid-cols-[minmax(90px,1fr)_minmax(80px,0.8fr)_minmax(90px,1fr)] gap-2 px-3 py-3 text-[11px] min-[840px]:grid-cols-[minmax(200px,2fr)_minmax(220px,1fr)_minmax(200px,2fr)] min-[840px]:gap-4 min-[840px]:px-6 min-[840px]:py-4 min-[840px]:text-sm',
-                        index % 2 === 1 && 'bg-surface-2'
-                      )}
-                    >
-                      <div className="rounded-md px-1 py-0.5 text-text-secondary sm:px-2 sm:py-1">
-                        {renderSpecValue(row.left, activeLocale, {
-                          pending: labels.pending,
-                          supported: labels.supported,
-                          notSupported: labels.notSupported,
-                        })}
-                        {'subline' in row && row.subline ? (
-                          <div className="mt-1 text-[10px] text-text-muted">{row.subline}</div>
-                        ) : null}
-                      </div>
-                      <span className="text-center text-text-primary">{row.label}</span>
-                      <div className="rounded-md px-1 py-0.5 text-right text-text-secondary sm:px-2 sm:py-1">
-                        {renderSpecValue(row.right, activeLocale, {
-                          pending: labels.pending,
-                          supported: labels.supported,
-                          notSupported: labels.notSupported,
-                        })}
-                        {'rightSubline' in row && row.rightSubline ? (
-                          <div className="mt-1 text-[10px] text-text-muted">{row.rightSubline}</div>
-                        ) : null}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              {pageOverride?.topCards?.length ? (
-                <section className="mt-6 rounded-[24px] border border-hairline bg-surface-2/70 p-4 shadow-sm sm:p-5">
-                  <div className="grid gap-3 md:grid-cols-2">
-                    {pageOverride.topCards.map((card) => (
-                      <article
-                        key={card.title}
-                        className="rounded-[18px] border border-hairline bg-surface/90 px-4 py-3"
-                      >
-                        <p className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">
-                          {card.title}
-                        </p>
-                        <p className="mt-1.5 text-sm leading-6 text-text-secondary">{card.body}</p>
-                      </article>
-                    ))}
-                  </div>
-                </section>
-              ) : null}
-
-              {pageOverride?.primaryLinks?.length ? (
-                <section className="mt-4 rounded-[24px] border border-hairline bg-surface/90 px-4 py-4 shadow-sm sm:px-5">
-                  <h2 className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">
-                    {pageOverride.primaryLinksTitle ?? 'Recommended next steps'}
-                  </h2>
-                  <div className="mt-2 flex flex-wrap gap-x-4 gap-y-2 text-sm">
-                    {pageOverride.primaryLinks.map((item) => (
-                      <Link key={item.label} href={item.href} className="font-semibold text-brand hover:text-brandHover">
-                        {item.label}
-                      </Link>
-                    ))}
-                  </div>
-                </section>
-              ) : null}
-          </section>
-        </section>
-
-        
-
-        {showdownSlots.length ? (
-          <section className="stack-gap-sm">
-            <h2 className="text-2xl font-semibold text-text-primary">
-              {compareCopy.showdown?.title ?? 'Showdown (same prompt)'}
-            </h2>
-            <p className="text-sm text-text-secondary">
-              {showdownSubtitle}
-            </p>
-            <p className="text-xs text-text-muted">{compareCopy.showdown?.note ?? 'Showing up to 3 prompt pairs for clarity.'}</p>
-
-            <div className="stack-gap-lg">
-              {showdownSlots.map((entry) => {
-                const leftLabel = entry.left.label ?? formatEngineName(left);
-                const rightLabel = entry.right.label ?? formatEngineName(right);
-                const leftAlt = getImageAlt({
-                  kind: 'compareThumb',
-                  engine: leftLabel,
-                  compareEngine: rightLabel,
-                  label: `${entry.title} - ${leftLabel}`,
-                  locale: activeLocale,
-                });
-                const rightAlt = getImageAlt({
-                  kind: 'compareThumb',
-                  engine: rightLabel,
-                  compareEngine: leftLabel,
-                  label: `${entry.title} - ${rightLabel}`,
-                  locale: activeLocale,
-                });
-                return (
-                  <article
-                    key={`${slug}-showdown-${entry.id}`}
-                    className="rounded-card border border-hairline bg-surface p-6 shadow-card"
-                  >
-                    <div className="stack-gap-sm">
-                    <div>
-                      <h3 className="text-lg font-semibold text-text-primary">{entry.title}</h3>
-                      <p className="text-sm text-text-secondary">
-                        {labels.whatTests}: {entry.whatItTests}
-                      </p>
-                    </div>
-                    <div className="rounded-card border border-hairline bg-surface-2 p-3 text-sm text-text-secondary">
-                      <div className="flex items-center justify-between gap-2">
-                        <span className="text-xs font-semibold uppercase tracking-micro text-text-muted">{labels.prompt}</span>
-                        {exposeSourcePrompt ? (
-                          <CopyPromptButton
-                            prompt={entry.prompt}
-                            copyLabel={compareCopy.labels?.copyPrompt ?? 'Copy prompt'}
-                            copiedLabel={compareCopy.labels?.copied ?? 'Copied'}
-                          />
-                        ) : null}
-                      </div>
-                      {exposeSourcePrompt ? (
-                        <DeferredSourcePrompt
-                          locale={activeLocale}
-                          prompt={entry.prompt}
-                          mode="details"
-                          className="mt-2"
-                          summaryClassName="cursor-pointer list-none text-xs font-semibold text-brand"
-                          promptClassName="mt-2 whitespace-pre-wrap text-text-primary"
-                          fallbackClassName="mt-2 text-sm text-text-secondary"
-                        />
-                      ) : (
-                        <p className="mt-2 text-sm text-text-secondary">{localizedPromptNote}</p>
-                      )}
-                    </div>
-                    <div className="grid grid-gap lg:grid-cols-2">
-                      {renderShowdownMedia(
-                        entry.left,
-                        formatEngineName(left),
-                        labels.placeholder,
-                        labels.placeholder,
-                        entry.aspectRatio,
-                        leftAlt
-                      )}
-                      {renderShowdownMedia(
-                        entry.right,
-                        formatEngineName(right),
-                        labels.placeholder,
-                        labels.placeholder,
-                        entry.aspectRatio,
-                        rightAlt
-                      )}
-                    </div>
-                    <div className="flex flex-wrap items-center gap-2 text-sm text-text-secondary">
-                      <span className="text-xs font-semibold uppercase tracking-micro text-text-muted">{showdownActionLabel}</span>
-                      <Link
-                        href={buildGenerateHref(
-                          left.modelSlug,
-                          exposeSourcePrompt ? entry.prompt : null,
-                          entry.aspectRatio,
-                          entry.mode
-                        )}
-                        prefetch={false}
-                        className="rounded-full border border-hairline bg-surface px-3 py-1 text-xs font-semibold text-text-primary transition hover:bg-surface-2"
-                      >
-                        {leftIsPrelaunch
-                          ? labels.savePromptForLaunch
-                          : formatTemplate(compareCopy.scorecard?.generateWith ?? 'Generate with {engine}', {
-                              engine: formatEngineShortName(left),
-                            })}
-                      </Link>
-                      <Link
-                        href={buildGenerateHref(
-                          right.modelSlug,
-                          exposeSourcePrompt ? entry.prompt : null,
-                          entry.aspectRatio,
-                          entry.mode
-                        )}
-                        prefetch={false}
-                        className="rounded-full border border-hairline bg-surface px-3 py-1 text-xs font-semibold text-text-primary transition hover:bg-surface-2"
-                      >
-                        {rightIsPrelaunch
-                          ? labels.savePromptForLaunch
-                          : formatTemplate(compareCopy.scorecard?.generateWith ?? 'Generate with {engine}', {
-                              engine: formatEngineShortName(right),
-                            })}
-                      </Link>
-                      <span className="text-xs text-text-muted">{showdownActionHint}</span>
-                    </div>
-                  </div>
-                  </article>
-                );
-              })}
-            </div>
-            <p className="text-sm text-text-secondary">
-              {compareCopy.showdown?.footer ??
-                'This side-by-side AI video comparison uses identical prompts to highlight differences in motion, realism, human fidelity, and text legibility. For full specs, controls, and more prompt examples, open each engine profile.'}
-            </p>
-          </section>
-        ) : null}
-
-        {relatedLinks.length ? (
-          <section className="stack-gap-sm">
-            <h2 className="text-2xl font-semibold text-text-primary">
-              {compareCopy.related?.title ?? 'Related comparisons'}
-            </h2>
-            <p className="text-sm text-text-secondary">
-              {compareCopy.related?.subtitle ??
-                'Explore a few more popular side-by-side matchups.'}
-            </p>
-            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-              {relatedLinks.map((item) => (
-                <Link
-                  key={item.href.params.slug}
-                  href={item.href}
-                  className="rounded-card border border-hairline bg-surface px-4 py-3 text-sm font-semibold text-text-primary transition hover:bg-surface-2"
-                >
-                  {item.label}
-                </Link>
-              ))}
-            </div>
-          </section>
-        ) : null}
-
-        <section className="stack-gap-sm">
-          <h2 className="text-2xl font-semibold text-text-primary">
-            {pageOverride?.faq?.title ?? compareCopy.faq?.title ?? 'FAQ'}
-          </h2>
-          <p className="text-sm text-text-secondary">
-            {formatTemplate(
-              pageOverride?.faq?.subtitle ??
-                compareCopy.faq?.subtitle ??
-                'Quick answers about {left} vs {right} on MaxVideoAI (pricing, modes, specs, and why results differ).',
-              { left: formatEngineName(left), right: formatEngineName(right) }
-            )}
-          </p>
-          <div className="stack-gap-sm">
-            {faqItems.map((item) => (
-              <details key={item.question} className="rounded-card border border-hairline bg-surface p-4">
-                <summary className="cursor-pointer text-sm font-semibold text-text-primary">
-                  {item.question}
-                </summary>
-                {Array.isArray(item.answer) ? (
-                  <ul className="mt-2 list-disc space-y-1 pl-4 text-sm text-text-secondary">
-                    {item.answer.map((line) => (
-                      <li key={line}>{line}</li>
-                    ))}
-                  </ul>
-                ) : (
-                  <p className="mt-2 text-sm text-text-secondary">{item.answer}</p>
-                )}
-              </details>
-            ))}
-          </div>
-          <script
-            type="application/ld+json"
-            dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-          />
-          <script
-            type="application/ld+json"
-            dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
-          />
-          <script
-            type="application/ld+json"
-            dangerouslySetInnerHTML={{ __html: JSON.stringify(webPageJsonLd) }}
-          />
-        </section>
-
-        <div className="text-sm text-text-muted">
-          <Link href={compareHubHref} className="font-semibold text-brand hover:text-brandHover">
-            {compareCopy.hero?.back ?? 'Back to comparisons'}
-          </Link>
-        </div>
-      </div>
-    </div>
-    </div>
+    <CompareDetailContent
+      activeLocale={activeLocale}
+      breadcrumbJsonLd={breadcrumbJsonLd}
+      compareCopy={compareCopy}
+      compareHubHref={compareHubHref}
+      comparisonMetrics={comparisonMetrics}
+      criteriaCount={criteriaCount}
+      exposeSourcePrompt={exposeSourcePrompt}
+      faqItems={faqItems}
+      faqJsonLd={faqJsonLd}
+      generateWithLabel={generateWithLabel}
+      heroIntroTemplate={heroIntroTemplate}
+      labels={labels}
+      left={left}
+      leftAccent={leftAccent}
+      leftCanGenerate={leftCanGenerate}
+      leftIsPrelaunch={leftIsPrelaunch}
+      leftOverall={leftOverall}
+      leftScoreStyle={leftScoreStyle}
+      localizedPromptNote={localizedPromptNote}
+      pageOverride={pageOverride}
+      pairHasNativeAudio={pairHasNativeAudio}
+      prelaunchNotice={prelaunchNotice}
+      relatedLinks={relatedLinks}
+      resolvedLeftOptions={resolvedLeftOptions}
+      resolvedRightOptions={resolvedRightOptions}
+      right={right}
+      rightAccent={rightAccent}
+      rightCanGenerate={rightCanGenerate}
+      rightIsPrelaunch={rightIsPrelaunch}
+      rightOverall={rightOverall}
+      rightScoreStyle={rightScoreStyle}
+      scorecardCriteriaLabel={scorecardCriteriaLabel}
+      scorecardProvisionalNote={scorecardProvisionalNote}
+      showdownActionHint={showdownActionHint}
+      showdownActionLabel={showdownActionLabel}
+      showdownSlots={showdownSlots}
+      showdownSubtitle={showdownSubtitle}
+      slug={slug}
+      specRows={specRows}
+      summaryRows={summaryRows}
+      webPageJsonLd={webPageJsonLd}
+      winnerSummaryHeading={winnerSummaryHeading}
+    />
   );
 }

--- a/tests/compare-page-architecture.test.ts
+++ b/tests/compare-page-architecture.test.ts
@@ -24,6 +24,18 @@ const scorecardSource = readFileSync(
   'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-scorecard.ts',
   'utf8'
 );
+const copySource = readFileSync(
+  'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-copy.ts',
+  'utf8'
+);
+const specRowsSource = readFileSync(
+  'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-spec-rows.ts',
+  'utf8'
+);
+const detailContentSource = readFileSync(
+  'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_components/CompareDetailContent.tsx',
+  'utf8'
+);
 const generateCardSource = readFileSync(
   'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_components/CompareGenerateCard.tsx',
   'utf8'
@@ -32,19 +44,19 @@ const generateCardSource = readFileSync(
 test('comparison detail page delegates copy, helper, and media responsibilities', () => {
   const lineCount = pageSource.split('\n').length;
 
-  assert.ok(lineCount <= 1100, `comparison page should stay under 1100 lines after metadata split, got ${lineCount}`);
+  assert.ok(lineCount <= 500, `comparison page should stay under 500 lines after section extraction, got ${lineCount}`);
   assert.ok(pageSource.includes("from './_lib/compare-page-helpers'"));
   assert.ok(pageSource.includes("from './_lib/compare-page-overrides'"));
   assert.ok(pageSource.includes("from './_lib/compare-page-faq'"));
   assert.ok(pageSource.includes("from './_lib/compare-page-metadata'"));
   assert.ok(pageSource.includes("from './_lib/compare-page-scorecard'"));
-  assert.ok(pageSource.includes("from './_components/CompareGenerateCard'"));
-  assert.ok(pageSource.includes("from './_components/CompareShowdownMedia'"));
-  assert.ok(pageSource.includes("from './_components/CompareSpecValue'"));
+  assert.ok(pageSource.includes("from './_lib/compare-page-spec-rows'"));
+  assert.ok(pageSource.includes("from './_components/CompareDetailContent'"));
   assert.doesNotMatch(pageSource, /const COMPARE_PAGE_OVERRIDES/);
   assert.doesNotMatch(pageSource, /type ComparePageCopy =/);
   assert.doesNotMatch(pageSource, /const generatedFaqItems =/);
   assert.doesNotMatch(pageSource, /const comparisonMetrics = \[/);
+  assert.doesNotMatch(pageSource, /<section className=/);
   assert.doesNotMatch(pageSource, /buildSeoMetadata/);
 });
 
@@ -64,5 +76,10 @@ test('comparison detail split helpers own FAQ, scorecard, and generate card resp
   assert.match(scorecardSource, /export function deriveCompareStrengths/);
   assert.match(metadataSource, /export async function buildComparePageMetadata/);
   assert.match(metadataSource, /buildSeoMetadata/);
+  assert.match(copySource, /export function buildCompareDetailLabels/);
+  assert.match(specRowsSource, /export function buildCompareSpecRows/);
+  assert.match(detailContentSource, /export function CompareDetailContent/);
   assert.match(generateCardSource, /export function CompareGenerateCard/);
+  assert.match(detailContentSource, /CompareShowdownMedia/);
+  assert.match(detailContentSource, /CompareSpecValue/);
 });


### PR DESCRIPTION
## Summary
- move compare detail page rendering into a route-local CompareDetailContent component
- move key-spec row construction into a focused helper
- move compare label defaults into the copy helper
- tighten the comparison page architecture contract so page.tsx stays under 500 lines

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/compare-page-architecture.test.ts tests/fr-seo-localization.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false
- git diff --check -- frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/page.tsx frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_components/CompareDetailContent.tsx frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-copy.ts frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-spec-rows.ts tests/compare-page-architecture.test.ts
- npm --prefix frontend run lint
- npm run lint:exposure