### PR TITLE
Split character builder workspace hooks

### DIFF
--- a/frontend/src/components/tools/CharacterBuilderWorkspace.tsx
+++ b/frontend/src/components/tools/CharacterBuilderWorkspace.tsx
@@ -23,14 +23,11 @@ import {
   createDefaultCharacterBuilderState,
   getCharacterFormatMultiplier,
   normalizeCharacterFormatMode,
-  normalizeTraitsForSourceMode,
 } from '@/lib/character-builder';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { FEATURES } from '@/content/feature-flags';
 import type {
   CharacterBuilderState,
-  CharacterBuilderTraitSource,
-  CharacterBuilderTraits,
   CharacterBuilderReferenceImage,
 } from '@/types/character-builder';
 import {
@@ -59,6 +56,7 @@ import {
 } from './character-builder/_components/character-builder-page-shell';
 import { useCharacterBuilderHistoricalResults } from './character-builder/_hooks/useCharacterBuilderHistoricalResults';
 import { useCharacterBuilderJobSnapshotLoader } from './character-builder/_hooks/useCharacterBuilderJobSnapshotLoader';
+import { useCharacterBuilderLookSummaries } from './character-builder/_hooks/useCharacterBuilderLookSummaries';
 import { useCharacterBuilderGenerationRunner } from './character-builder/_hooks/useCharacterBuilderGenerationRunner';
 import { useCharacterBuilderOptions } from './character-builder/_hooks/useCharacterBuilderOptions';
 import { useCharacterBuilderPersistence } from './character-builder/_hooks/useCharacterBuilderPersistence';
@@ -66,23 +64,15 @@ import { useCharacterBuilderPendingRunsSync } from './character-builder/_hooks/u
 import { useCharacterBuilderReferenceAssets } from './character-builder/_hooks/useCharacterBuilderReferenceAssets';
 import { useCharacterBuilderResultActions } from './character-builder/_hooks/useCharacterBuilderResultActions';
 import { useCharacterBuilderResultsInfiniteScroll } from './character-builder/_hooks/useCharacterBuilderResultsInfiniteScroll';
+import { useCharacterBuilderTraitActions } from './character-builder/_hooks/useCharacterBuilderTraitActions';
 import { DEFAULT_CHARACTER_COPY, type CharacterCopy } from './character-builder/_lib/character-builder-copy';
 import {
-  buildResetCharacterBuilderState,
-  countConfiguredSecondaryControls,
-  findChoiceLabel,
   getCharacterBillingProductKey,
   getFlattenedResults,
-  getHairSummary,
-  getOutfitSummary,
   getRefByRole,
   hasCustomOutfitSettings,
   hasCustomHairSettings,
   INITIAL_LOADING_REQUEST_COUNTS,
-  normalizeTag,
-  removeReferenceImage,
-  serializeResettableCharacterBuilderState,
-  summarizeCustomText,
 } from './character-builder/_lib/character-builder-helpers';
 import type {
   BillingProductResponse,
@@ -233,25 +223,51 @@ export default function CharacterBuilderPage() {
   });
   const hasCompletedResults = flattenedResults.length > 0;
   const hasResults = hasCompletedResults || pendingRuns.length > 0 || historicalResults.length > 0;
-  const secondaryControlsCount = countConfiguredSecondaryControls(state, hasIdentityReference);
-  const resetState = useMemo(() => buildResetCharacterBuilderState(state), [state]);
-  const canResetBuilder = useMemo(
-    () => serializeResettableCharacterBuilderState(state) !== serializeResettableCharacterBuilderState(resetState),
-    [resetState, state]
-  );
-  const hairSummary = getHairSummary(state.traits, { hairColor: hairColorOptions, hairLength: hairLengthOptions, hairstyle: hairstyleOptions }, copy);
-  const outfitSummary = getOutfitSummary(state.traits, outfitOptions, copy);
-  const accessoriesFeaturesSummary = [
-    ...accessoryOptions.filter((option) => state.traits.accessories.includes(option.id)).map((option) => option.label),
-    ...distinctiveOptions
-      .filter((option) => state.traits.distinctiveFeatures.includes(option.id))
-      .map((option) => option.label),
-    summarizeCustomText(state.traits.customDetailsDescription),
-  ]
-    .filter(Boolean)
-    .join(' · ');
-  const identitySummary = `${findChoiceLabel(genderOptions, state.traits.genderPresentation.value) ?? copy.open} · ${findChoiceLabel(ageOptions, state.traits.ageRange.value) ?? copy.open}`;
-  const realismSummary = findChoiceLabel(realismOptions, state.traits.realismStyle) ?? copy.summary.photoreal;
+  const {
+    accessoriesFeaturesSummary,
+    canResetBuilder,
+    hairSummary,
+    identitySummary,
+    outfitSummary,
+    realismSummary,
+    resetState,
+    secondaryControlsCount,
+  } = useCharacterBuilderLookSummaries({
+    accessoryOptions,
+    ageOptions,
+    copy,
+    distinctiveOptions,
+    genderOptions,
+    hairColorOptions,
+    hairLengthOptions,
+    hairstyleOptions,
+    hasIdentityReference,
+    outfitOptions,
+    realismOptions,
+    state,
+  });
+  const {
+    addMustRemainTag,
+    handleResetBuilder,
+    handleSelectResult,
+    removeIdentityReference,
+    removeMustRemainTag,
+    removeStyleReference,
+    toggleListValue,
+    updateTrait,
+  } = useCharacterBuilderTraitActions({
+    copy,
+    mustRemainDraft,
+    resetState,
+    setActiveBuildSection,
+    setAdvancedOpen,
+    setError,
+    setHairOpen,
+    setMustRemainDraft,
+    setShowStyleReferenceSlot,
+    setState,
+    setStatusMessage,
+  });
   const jobIdFromQuery = searchParams?.get('job')?.trim() ?? null;
   const billingProductKey = getCharacterBillingProductKey(state.qualityMode);
   useCharacterBuilderPendingRunsSync({
@@ -288,96 +304,6 @@ export default function CharacterBuilderPage() {
       ? Number(((billingProductData.unitPriceCents * getCharacterFormatMultiplier(state.formatMode, state.qualityMode)) / 100).toFixed(2))
       : null;
   const isActionLoading = (key: LoadingRequestKey): boolean => (loadingActions[key] ?? 0) > 0;
-
-  function updateTrait<K extends keyof Pick<
-    CharacterBuilderTraits,
-    | 'genderPresentation'
-    | 'ageRange'
-    | 'skinTone'
-    | 'faceCues'
-    | 'hairColor'
-    | 'hairLength'
-    | 'hairstyle'
-    | 'eyeColor'
-    | 'bodyBuild'
-    | 'outfitStyle'
-  >>(key: K, value: string | 'auto') {
-    setState((previous) => {
-      const nextTraits = {
-        ...previous.traits,
-        [key]: {
-          value,
-          source: (value === 'auto' ? 'auto' : 'manual') as CharacterBuilderTraitSource,
-        },
-      } as CharacterBuilderTraits;
-
-      if (key === 'hairColor' || key === 'hairLength' || key === 'hairstyle') {
-        nextTraits.hairEnabled = hasCustomHairSettings(nextTraits);
-      }
-
-      if (key === 'outfitStyle') {
-        nextTraits.outfitEnabled = hasCustomOutfitSettings(nextTraits);
-      }
-
-      return {
-        ...previous,
-        traits: nextTraits,
-      };
-    });
-  }
-
-  function toggleListValue(key: 'accessories' | 'distinctiveFeatures', value: string) {
-    setState((previous) => {
-      const current = previous.traits[key];
-      const nextValues = current.includes(value)
-        ? current.filter((entry) => entry !== value)
-        : [...current, value];
-      return {
-        ...previous,
-        traits: {
-          ...previous.traits,
-          [key]: nextValues,
-        },
-      };
-    });
-  }
-
-  const handleResetBuilder = useCallback(() => {
-    setState(resetState);
-    setAdvancedOpen(false);
-    setHairOpen(false);
-    setActiveBuildSection('identity');
-    setShowStyleReferenceSlot(Boolean(getRefByRole(resetState.referenceImages, 'style')));
-    setMustRemainDraft('');
-    setError(null);
-    setStatusMessage(copy.resetDone);
-  }, [copy.resetDone, resetState]);
-
-  function addMustRemainTag() {
-    const tag = normalizeTag(mustRemainDraft);
-    if (!tag) return;
-    setState((previous) => ({
-      ...previous,
-      mustRemainVisible: previous.mustRemainVisible.includes(tag)
-        ? previous.mustRemainVisible
-        : [...previous.mustRemainVisible, tag],
-    }));
-    setMustRemainDraft('');
-  }
-
-  function removeMustRemainTag(tag: string) {
-    setState((previous) => ({
-      ...previous,
-      mustRemainVisible: previous.mustRemainVisible.filter((entry) => entry !== tag),
-    }));
-  }
-
-  const handleSelectResult = useCallback((resultId: string) => {
-    setState((previous) => ({
-      ...previous,
-      selectedResultId: resultId,
-    }));
-  }, []);
 
   function renderResultsGallery(variant: 'desktop' | 'mobile') {
     return (
@@ -532,18 +458,7 @@ export default function CharacterBuilderPage() {
                           removeLabel={copy.references.remove}
                           libraryLabel={copy.library.open}
                           optionalLabel={copy.sections.optional}
-                          onRemove={() =>
-                            setState((previous) => ({
-                              ...previous,
-                              sourceMode: previous.sourceMode === 'reference-image' ? 'scratch' : previous.sourceMode,
-                              referenceStrength: previous.sourceMode === 'reference-image' ? null : previous.referenceStrength,
-                              referenceImages: removeReferenceImage(previous.referenceImages, 'identity'),
-                              traits:
-                                previous.sourceMode === 'reference-image'
-                                  ? normalizeTraitsForSourceMode(previous.traits, 'scratch')
-                                  : previous.traits,
-                            }))
-                          }
+                          onRemove={removeIdentityReference}
                         />
                         {showStyleReferenceSlot || styleReference ? (
                           <ReferenceSlot
@@ -568,13 +483,7 @@ export default function CharacterBuilderPage() {
                             removeLabel={copy.references.remove}
                             libraryLabel={copy.library.open}
                             optionalLabel={copy.sections.optional}
-                            onRemove={() => {
-                              setShowStyleReferenceSlot(false);
-                              setState((previous) => ({
-                                ...previous,
-                                referenceImages: removeReferenceImage(previous.referenceImages, 'style'),
-                              }));
-                            }}
+                            onRemove={removeStyleReference}
                           />
                         ) : (
                           <button

--- a/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderLookSummaries.ts
+++ b/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderLookSummaries.ts
@@ -1,0 +1,78 @@
+import { useMemo } from 'react';
+import type { CharacterBuilderState } from '@/types/character-builder';
+import type { CharacterCopy } from '../_lib/character-builder-copy';
+import type { ChoiceOption, ToggleItem } from '../_lib/character-builder-types';
+import {
+  buildResetCharacterBuilderState,
+  countConfiguredSecondaryControls,
+  findChoiceLabel,
+  getHairSummary,
+  getOutfitSummary,
+  serializeResettableCharacterBuilderState,
+  summarizeCustomText,
+} from '../_lib/character-builder-helpers';
+
+type UseCharacterBuilderLookSummariesOptions = {
+  accessoryOptions: ToggleItem[];
+  ageOptions: ChoiceOption[];
+  copy: CharacterCopy;
+  distinctiveOptions: ToggleItem[];
+  genderOptions: ChoiceOption[];
+  hairColorOptions: ChoiceOption[];
+  hairLengthOptions: ChoiceOption[];
+  hairstyleOptions: ChoiceOption[];
+  hasIdentityReference: boolean;
+  outfitOptions: ChoiceOption[];
+  realismOptions: ChoiceOption[];
+  state: CharacterBuilderState;
+};
+
+export function useCharacterBuilderLookSummaries({
+  accessoryOptions,
+  ageOptions,
+  copy,
+  distinctiveOptions,
+  genderOptions,
+  hairColorOptions,
+  hairLengthOptions,
+  hairstyleOptions,
+  hasIdentityReference,
+  outfitOptions,
+  realismOptions,
+  state,
+}: UseCharacterBuilderLookSummariesOptions) {
+  const secondaryControlsCount = countConfiguredSecondaryControls(state, hasIdentityReference);
+  const resetState = useMemo(() => buildResetCharacterBuilderState(state), [state]);
+  const canResetBuilder = useMemo(
+    () => serializeResettableCharacterBuilderState(state) !== serializeResettableCharacterBuilderState(resetState),
+    [resetState, state]
+  );
+  const hairSummary = getHairSummary(
+    state.traits,
+    { hairColor: hairColorOptions, hairLength: hairLengthOptions, hairstyle: hairstyleOptions },
+    copy
+  );
+  const outfitSummary = getOutfitSummary(state.traits, outfitOptions, copy);
+  const accessoriesFeaturesSummary = [
+    ...accessoryOptions.filter((option) => state.traits.accessories.includes(option.id)).map((option) => option.label),
+    ...distinctiveOptions
+      .filter((option) => state.traits.distinctiveFeatures.includes(option.id))
+      .map((option) => option.label),
+    summarizeCustomText(state.traits.customDetailsDescription),
+  ]
+    .filter(Boolean)
+    .join(' · ');
+  const identitySummary = `${findChoiceLabel(genderOptions, state.traits.genderPresentation.value) ?? copy.open} · ${findChoiceLabel(ageOptions, state.traits.ageRange.value) ?? copy.open}`;
+  const realismSummary = findChoiceLabel(realismOptions, state.traits.realismStyle) ?? copy.summary.photoreal;
+
+  return {
+    accessoriesFeaturesSummary,
+    canResetBuilder,
+    hairSummary,
+    identitySummary,
+    outfitSummary,
+    realismSummary,
+    resetState,
+    secondaryControlsCount,
+  };
+}

--- a/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderTraitActions.ts
+++ b/frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderTraitActions.ts
@@ -1,0 +1,184 @@
+import type { Dispatch, SetStateAction } from 'react';
+import { useCallback } from 'react';
+import { normalizeTraitsForSourceMode } from '@/lib/character-builder';
+import type {
+  CharacterBuilderState,
+  CharacterBuilderTraitSource,
+  CharacterBuilderTraits,
+  CharacterBuilderReferenceImage,
+} from '@/types/character-builder';
+import type { BuildLookSectionKey } from '../_components/character-builder-workspace-components';
+import type { CharacterCopy } from '../_lib/character-builder-copy';
+import {
+  getRefByRole,
+  hasCustomHairSettings,
+  hasCustomOutfitSettings,
+  normalizeTag,
+} from '../_lib/character-builder-helpers';
+
+type TraitChoiceKey = keyof Pick<
+  CharacterBuilderTraits,
+  | 'genderPresentation'
+  | 'ageRange'
+  | 'skinTone'
+  | 'faceCues'
+  | 'hairColor'
+  | 'hairLength'
+  | 'hairstyle'
+  | 'eyeColor'
+  | 'bodyBuild'
+  | 'outfitStyle'
+>;
+
+type UseCharacterBuilderTraitActionsOptions = {
+  copy: CharacterCopy;
+  mustRemainDraft: string;
+  resetState: CharacterBuilderState;
+  setActiveBuildSection: Dispatch<SetStateAction<BuildLookSectionKey>>;
+  setAdvancedOpen: Dispatch<SetStateAction<boolean>>;
+  setError: Dispatch<SetStateAction<string | null>>;
+  setHairOpen: Dispatch<SetStateAction<boolean>>;
+  setMustRemainDraft: Dispatch<SetStateAction<string>>;
+  setShowStyleReferenceSlot: Dispatch<SetStateAction<boolean>>;
+  setState: Dispatch<SetStateAction<CharacterBuilderState>>;
+  setStatusMessage: Dispatch<SetStateAction<string | null>>;
+};
+
+export function useCharacterBuilderTraitActions({
+  copy,
+  mustRemainDraft,
+  resetState,
+  setActiveBuildSection,
+  setAdvancedOpen,
+  setError,
+  setHairOpen,
+  setMustRemainDraft,
+  setShowStyleReferenceSlot,
+  setState,
+  setStatusMessage,
+}: UseCharacterBuilderTraitActionsOptions) {
+  const updateTrait = useCallback(<K extends TraitChoiceKey>(key: K, value: string | 'auto') => {
+    setState((previous) => {
+      const nextTraits = {
+        ...previous.traits,
+        [key]: {
+          value,
+          source: (value === 'auto' ? 'auto' : 'manual') as CharacterBuilderTraitSource,
+        },
+      } as CharacterBuilderTraits;
+
+      if (key === 'hairColor' || key === 'hairLength' || key === 'hairstyle') {
+        nextTraits.hairEnabled = hasCustomHairSettings(nextTraits);
+      }
+
+      if (key === 'outfitStyle') {
+        nextTraits.outfitEnabled = hasCustomOutfitSettings(nextTraits);
+      }
+
+      return {
+        ...previous,
+        traits: nextTraits,
+      };
+    });
+  }, [setState]);
+
+  const toggleListValue = useCallback((key: 'accessories' | 'distinctiveFeatures', value: string) => {
+    setState((previous) => {
+      const current = previous.traits[key];
+      const nextValues = current.includes(value)
+        ? current.filter((entry) => entry !== value)
+        : [...current, value];
+      return {
+        ...previous,
+        traits: {
+          ...previous.traits,
+          [key]: nextValues,
+        },
+      };
+    });
+  }, [setState]);
+
+  const handleResetBuilder = useCallback(() => {
+    setState(resetState);
+    setAdvancedOpen(false);
+    setHairOpen(false);
+    setActiveBuildSection('identity');
+    setShowStyleReferenceSlot(Boolean(getRefByRole(resetState.referenceImages, 'style')));
+    setMustRemainDraft('');
+    setError(null);
+    setStatusMessage(copy.resetDone);
+  }, [
+    copy.resetDone,
+    resetState,
+    setActiveBuildSection,
+    setAdvancedOpen,
+    setError,
+    setHairOpen,
+    setMustRemainDraft,
+    setShowStyleReferenceSlot,
+    setState,
+    setStatusMessage,
+  ]);
+
+  const addMustRemainTag = useCallback(() => {
+    const tag = normalizeTag(mustRemainDraft);
+    if (!tag) return;
+    setState((previous) => ({
+      ...previous,
+      mustRemainVisible: previous.mustRemainVisible.includes(tag)
+        ? previous.mustRemainVisible
+        : [...previous.mustRemainVisible, tag],
+    }));
+    setMustRemainDraft('');
+  }, [mustRemainDraft, setMustRemainDraft, setState]);
+
+  const removeMustRemainTag = useCallback((tag: string) => {
+    setState((previous) => ({
+      ...previous,
+      mustRemainVisible: previous.mustRemainVisible.filter((entry) => entry !== tag),
+    }));
+  }, [setState]);
+
+  const handleSelectResult = useCallback((resultId: string) => {
+    setState((previous) => ({
+      ...previous,
+      selectedResultId: resultId,
+    }));
+  }, [setState]);
+
+  const removeIdentityReference = useCallback(() => {
+    setState((previous) => ({
+      ...previous,
+      sourceMode: previous.sourceMode === 'reference-image' ? 'scratch' : previous.sourceMode,
+      referenceStrength: previous.sourceMode === 'reference-image' ? null : previous.referenceStrength,
+      referenceImages: previous.referenceImages.filter(
+        (image: CharacterBuilderReferenceImage) => image.role !== 'identity'
+      ),
+      traits:
+        previous.sourceMode === 'reference-image'
+          ? normalizeTraitsForSourceMode(previous.traits, 'scratch')
+          : previous.traits,
+    }));
+  }, [setState]);
+
+  const removeStyleReference = useCallback(() => {
+    setShowStyleReferenceSlot(false);
+    setState((previous) => ({
+      ...previous,
+      referenceImages: previous.referenceImages.filter(
+        (image: CharacterBuilderReferenceImage) => image.role !== 'style'
+      ),
+    }));
+  }, [setShowStyleReferenceSlot, setState]);
+
+  return {
+    addMustRemainTag,
+    handleResetBuilder,
+    handleSelectResult,
+    removeIdentityReference,
+    removeMustRemainTag,
+    removeStyleReference,
+    toggleListValue,
+    updateTrait,
+  };
+}

--- a/tests/character-builder-workspace-architecture.test.ts
+++ b/tests/character-builder-workspace-architecture.test.ts
@@ -25,6 +25,8 @@ const referenceAssetsHookPath = join(root, 'frontend/src/components/tools/charac
 const resultActionsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderResultActions.ts');
 const resultsInfiniteScrollHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderResultsInfiniteScroll.ts');
 const persistenceHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderPersistence.ts');
+const lookSummariesHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderLookSummaries.ts');
+const traitActionsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderTraitActions.ts');
 
 const workspaceSource = readFileSync(workspacePath, 'utf8');
 
@@ -49,6 +51,8 @@ test('character builder workspace delegates copy, local types, and helper logic'
   assert.ok(existsSync(resultActionsHookPath), 'result actions should live in a focused hook');
   assert.ok(existsSync(resultsInfiniteScrollHookPath), 'result infinite scroll should live in a focused hook');
   assert.ok(existsSync(persistenceHookPath), 'local persistence should live in a focused hook');
+  assert.ok(existsSync(lookSummariesHookPath), 'look summaries should live in a focused hook');
+  assert.ok(existsSync(traitActionsHookPath), 'trait actions should live in a focused hook');
 
   assert.match(workspaceSource, /from '\.\/character-builder\/_components\/character-builder-workspace-components'/, 'workspace should import UI components');
   assert.match(workspaceSource, /from '\.\/character-builder\/_components\/character-builder-page-shell'/, 'workspace should import page shell components');
@@ -61,6 +65,8 @@ test('character builder workspace delegates copy, local types, and helper logic'
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderResultActions'/, 'workspace should import result actions hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderResultsInfiniteScroll'/, 'workspace should import result infinite scroll hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderPersistence'/, 'workspace should import persistence hook');
+  assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderLookSummaries'/, 'workspace should import look summaries hook');
+  assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderTraitActions'/, 'workspace should import trait actions hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_lib\/character-builder-copy'/, 'workspace should import character copy');
   assert.match(workspaceSource, /from '\.\/character-builder\/_lib\/character-builder-types'/, 'workspace should import local types');
   assert.match(workspaceSource, /from '\.\/character-builder\/_lib\/character-builder-helpers'/, 'workspace should import helpers');
@@ -103,9 +109,15 @@ test('character builder workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /readPersistedState\(\)/, 'local hydration belongs in useCharacterBuilderPersistence');
   assert.doesNotMatch(workspaceSource, /writePersistedPendingRuns/, 'pending run persistence belongs in useCharacterBuilderPersistence');
   assert.doesNotMatch(workspaceSource, /visitorSanitizedRef/, 'visitor cleanup tracking belongs in useCharacterBuilderPersistence');
+  assert.doesNotMatch(workspaceSource, /function updateTrait</, 'trait updates belong in useCharacterBuilderTraitActions');
+  assert.doesNotMatch(workspaceSource, /function toggleListValue\(/, 'trait list toggles belong in useCharacterBuilderTraitActions');
+  assert.doesNotMatch(workspaceSource, /function addMustRemainTag\(/, 'must-remain tag creation belongs in useCharacterBuilderTraitActions');
+  assert.doesNotMatch(workspaceSource, /function removeMustRemainTag\(/, 'must-remain tag removal belongs in useCharacterBuilderTraitActions');
+  assert.doesNotMatch(workspaceSource, /const identitySummary =/, 'look summary derivation belongs in useCharacterBuilderLookSummaries');
+  assert.doesNotMatch(workspaceSource, /const accessoriesFeaturesSummary =/, 'accessory summary derivation belongs in useCharacterBuilderLookSummaries');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 1145, `CharacterBuilderWorkspace should stay below 1145 lines after shell extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 1050, `CharacterBuilderWorkspace should stay below 1050 lines after hook extraction, got ${lineCount}`);
 });
 
 test('character builder helper modules expose the expected workspace contract', () => {
@@ -129,6 +141,8 @@ test('character builder helper modules expose the expected workspace contract', 
   const resultActionsHookSource = readFileSync(resultActionsHookPath, 'utf8');
   const resultsInfiniteScrollHookSource = readFileSync(resultsInfiniteScrollHookPath, 'utf8');
   const persistenceHookSource = readFileSync(persistenceHookPath, 'utf8');
+  const lookSummariesHookSource = readFileSync(lookSummariesHookPath, 'utf8');
+  const traitActionsHookSource = readFileSync(traitActionsHookPath, 'utf8');
 
   assert.match(copySource, /export const DEFAULT_CHARACTER_COPY =/, 'copy module should export default copy');
   assert.match(copySource, /export type CharacterCopy =/, 'copy module should export copy type');
@@ -259,4 +273,10 @@ test('character builder helper modules expose the expected workspace contract', 
   assert.match(persistenceHookSource, /export function useCharacterBuilderPersistence/, 'persistence hook should be exported');
   assert.match(persistenceHookSource, /readPersistedState/, 'persistence hook should own local hydration');
   assert.match(persistenceHookSource, /writePersistedPendingRuns/, 'persistence hook should own pending run persistence');
+  assert.match(lookSummariesHookSource, /export function useCharacterBuilderLookSummaries/, 'look summaries hook should be exported');
+  assert.match(lookSummariesHookSource, /getHairSummary/, 'look summaries hook should own hair summary derivation');
+  assert.match(lookSummariesHookSource, /countConfiguredSecondaryControls/, 'look summaries hook should own secondary control counts');
+  assert.match(traitActionsHookSource, /export function useCharacterBuilderTraitActions/, 'trait actions hook should be exported');
+  assert.match(traitActionsHookSource, /const updateTrait = useCallback/, 'trait actions hook should own trait updates');
+  assert.match(traitActionsHookSource, /const handleResetBuilder = useCallback/, 'trait actions hook should own reset orchestration');
 });


### PR DESCRIPTION
## Summary
- move Character Builder look summary derivation into useCharacterBuilderLookSummaries
- move trait updates, reset, tag actions, and reference removal into useCharacterBuilderTraitActions
- tighten the workspace architecture contract so the main workspace stays below 1050 lines

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/character-builder-workspace-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false
- git diff --check -- frontend/src/components/tools/CharacterBuilderWorkspace.tsx frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderLookSummaries.ts frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderTraitActions.ts tests/character-builder-workspace-architecture.test.ts
- npm --prefix frontend run lint
- npm run lint:exposure