### PR TITLE
Split settings control state hook

### DIFF
--- a/frontend/components/SettingsControls.tsx
+++ b/frontend/components/SettingsControls.tsx
@@ -1,17 +1,14 @@
 "use client";
 
 import clsx from 'clsx';
-import { useEffect, useMemo, useRef, useState } from 'react';
-import type { MutableRefObject } from 'react';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
-import { useI18n } from '@/lib/i18n/I18nProvider';
 import { formatResolutionLabel } from '@/lib/resolution-labels';
-import { DEFAULT_CONTROLS_COPY, mergeControlsCopy } from '@/components/settings-controls/settings-control-copy';
-import { matchesDurationOptionValue, parseDurationOptionValue } from '@/components/settings-controls/settings-control-duration';
+import { matchesDurationOptionValue } from '@/components/settings-controls/settings-control-duration';
 import { SettingsGenericAdvancedFields } from '@/components/settings-controls/settings-control-generic-fields';
 import { FieldGroup, RangeWithInput } from '@/components/settings-controls/settings-control-parts';
 import type { SettingsControlsProps } from '@/components/settings-controls/settings-control-types';
+import { useSettingsControlState } from '@/components/settings-controls/useSettingsControlState';
 
 export { DEFAULT_CONTROLS_COPY, mergeControlsCopy } from '@/components/settings-controls/settings-control-copy';
 
@@ -66,127 +63,67 @@ export function SettingsControls({
   onAdvancedFieldChange,
   variant = 'full',
 }: SettingsControlsProps) {
-  const { t } = useI18n();
-  const localizedControls = t('workspace.generate.controls', DEFAULT_CONTROLS_COPY) as
-    | Partial<typeof DEFAULT_CONTROLS_COPY>
-    | undefined;
-  const controlsCopy = useMemo(() => mergeControlsCopy(localizedControls), [localizedControls]);
-  const [seed, setSeed] = useState<string>('');
-  const [guidance, setGuidance] = useState<number | null>(null);
-  const [initInfluence, setInitInfluence] = useState<number | null>(null);
-  const [promptStrength, setPromptStrength] = useState<number | null>(null);
-  const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
-  const [internalCfgScale, setInternalCfgScale] = useState<number | null>(null);
   const showCore = variant !== 'advanced';
-
-  useEffect(() => {
-    setInternalCfgScale(null);
-  }, [engine.id, mode]);
-
-
-  const enumeratedDurationOptions = useMemo(() => {
-    if (!caps?.duration) return null;
-    if ('options' in caps.duration) {
-      return caps.duration.options.map(parseDurationOptionValue).filter((entry) => entry.value > 0);
-    }
-    return null;
-  }, [caps]);
-  const durationMaxSeconds = useMemo(() => {
-    if (!enumeratedDurationOptions || enumeratedDurationOptions.length === 0) {
-      return engine.maxDurationSec;
-    }
-    return Math.max(...enumeratedDurationOptions.map((option) => option.value));
-  }, [engine.maxDurationSec, enumeratedDurationOptions]);
-
-  const durationRange = useMemo(() => {
-    if (!caps?.duration) return null;
-    return 'min' in caps.duration ? caps.duration : null;
-  }, [caps]);
-
-  const frameOptions = useMemo(() => {
-    if (!caps?.frames || caps.frames.length === 0) return null;
-    return caps.frames;
-  }, [caps]);
-
-  useEffect(() => {
-    if (!enumeratedDurationOptions || !enumeratedDurationOptions.length) return;
-    if (enumeratedDurationOptions.some((option) => matchesDurationOptionValue(option, durationOption, durationSec))) return;
-    const fallback = enumeratedDurationOptions[0];
-    onDurationChange(fallback.raw);
-  }, [enumeratedDurationOptions, durationOption, durationSec, onDurationChange]);
-
-  useEffect(() => {
-    if (!frameOptions || !frameOptions.length) return;
-    if (typeof numFrames === 'number' && frameOptions.includes(numFrames)) return;
-    const fallback = frameOptions[0];
-    onNumFramesChange?.(fallback);
-  }, [frameOptions, numFrames, onNumFramesChange]);
-
-  const durationOptionsContainerRef = useRef<HTMLDivElement | null>(null);
-  const durationSliderRef = useRef<HTMLInputElement | null>(null);
-  const frameOptionsContainerRef = useRef<HTMLDivElement | null>(null);
-  const isLtxFastLong = (engine.id === 'ltx-2-fast' || engine.id === 'ltx-2-3-fast') && durationSec > 10;
-
-  useEffect(() => {
-    const target = focusRefs?.duration;
-    if (!target) return;
-    let node: HTMLElement | null = null;
-    if (frameOptions && frameOptions.length) {
-      node = frameOptionsContainerRef.current;
-    } else if (enumeratedDurationOptions && enumeratedDurationOptions.length) {
-      node = durationOptionsContainerRef.current;
-    } else if (durationRange) {
-      node = durationSliderRef.current;
-    }
-    if (typeof target === 'function') {
-      target(node as never);
-    } else if (target) {
-      (target as MutableRefObject<HTMLElement | null>).current = node;
-    }
-  }, [focusRefs?.duration, frameOptions, enumeratedDurationOptions, durationRange]);
-
-  const resolutionOptions = useMemo(() => {
-    const base = caps?.resolution && caps.resolution.length ? caps.resolution : engine.resolutions;
-    if (isLtxFastLong) return base.filter((value) => value === '1080p');
-    return base;
-  }, [caps?.resolution, engine.resolutions, isLtxFastLong]);
-
-  const aspectOptions = useMemo(() => {
-    if (caps) {
-      if (caps.aspectRatio && caps.aspectRatio.length) return caps.aspectRatio;
-      return [];
-    }
-    return engine.aspectRatios;
-  }, [caps, engine.aspectRatios]);
-  const resolutionLocked = Boolean(caps?.resolutionLocked);
-  const showResolutionControl = resolutionOptions.length > 0;
-  const showAspectControl = aspectOptions.length > 0;
-  const showAudioToggle = Boolean(showAudioControl && typeof audioEnabled === 'boolean');
-  const canToggleAudio = Boolean(onAudioChange) && !audioControlDisabled;
-  const audioIncluded = Boolean(engine.audio) && mode !== 'r2v' && !showAudioToggle;
-  const resolvedDurationManagedLabel = durationManagedLabel ?? controlsCopy.duration.managed;
-  const effectiveCfgScale =
-    typeof cfgScale === 'number'
-      ? cfgScale
-      : internalCfgScale ?? engine.params.cfg_scale?.default ?? 0.5;
-
-  const audioNotice = audioControlNote ?? (audioIncluded ? controlsCopy.core.audioIncluded : null);
-  const hasGenericAdvancedFields = advancedFields.length > 0 && typeof onAdvancedFieldChange === 'function';
-
-  const advancedHasContent = Boolean(
-    (showLoopControl && typeof loopEnabled === 'boolean' && onLoopChange) ||
-      !showSeedanceControls ||
-      engine.params.promptStrength ||
-      engine.params.guidance ||
-      (mode === 'i2v' && engine.params.initInfluence) ||
-      (showExtendControl && engine.extend) ||
-      engine.keyframes ||
-      showKlingV3Controls ||
-      showSeedanceControls ||
-      showSafetyCheckerControl ||
-      engine.params.cfg_scale ||
-      hasGenericAdvancedFields
-  );
+  const {
+    advancedHasContent,
+    aspectOptions,
+    audioNotice,
+    canToggleAudio,
+    controlsCopy,
+    durationMaxSeconds,
+    durationOptionsContainerRef,
+    durationRange,
+    durationSliderRef,
+    effectiveCfgScale,
+    enumeratedDurationOptions,
+    frameOptions,
+    frameOptionsContainerRef,
+    guidance,
+    hasGenericAdvancedFields,
+    initInfluence,
+    isAdvancedOpen,
+    isLtxFastLong,
+    promptStrength,
+    resolutionLocked,
+    resolutionOptions,
+    resolvedDurationManagedLabel,
+    seed,
+    setGuidance,
+    setInitInfluence,
+    setInternalCfgScale,
+    setIsAdvancedOpen,
+    setPromptStrength,
+    setSeed,
+    showAspectControl,
+    showAudioToggle,
+    showResolutionControl,
+  } = useSettingsControlState({
+    advancedFields,
+    audioControlDisabled,
+    audioControlNote,
+    audioEnabled,
+    caps,
+    cfgScale,
+    durationManagedLabel,
+    durationOption,
+    durationSec,
+    engine,
+    focusRefs,
+    loopEnabled,
+    mode,
+    numFrames,
+    onAdvancedFieldChange,
+    onAudioChange,
+    onDurationChange,
+    onLoopChange,
+    onNumFramesChange,
+    showAudioControl,
+    showExtendControl,
+    showKlingV3Controls,
+    showLoopControl,
+    showSafetyCheckerControl,
+    showSeedanceControls,
+  });
 
   if (variant === 'advanced') {
     if (!advancedHasContent) return null;

--- a/frontend/components/settings-controls/useSettingsControlState.ts
+++ b/frontend/components/settings-controls/useSettingsControlState.ts
@@ -1,0 +1,217 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { MutableRefObject } from 'react';
+import { useI18n } from '@/lib/i18n/I18nProvider';
+import { DEFAULT_CONTROLS_COPY, mergeControlsCopy } from '@/components/settings-controls/settings-control-copy';
+import { matchesDurationOptionValue, parseDurationOptionValue } from '@/components/settings-controls/settings-control-duration';
+import type { SettingsControlsProps } from '@/components/settings-controls/settings-control-types';
+
+type UseSettingsControlStateOptions = Pick<
+  SettingsControlsProps,
+  | 'advancedFields'
+  | 'audioControlDisabled'
+  | 'audioControlNote'
+  | 'audioEnabled'
+  | 'caps'
+  | 'cfgScale'
+  | 'durationManagedLabel'
+  | 'durationOption'
+  | 'durationSec'
+  | 'engine'
+  | 'focusRefs'
+  | 'loopEnabled'
+  | 'mode'
+  | 'numFrames'
+  | 'onAdvancedFieldChange'
+  | 'onAudioChange'
+  | 'onDurationChange'
+  | 'onLoopChange'
+  | 'onNumFramesChange'
+  | 'showAudioControl'
+  | 'showExtendControl'
+  | 'showKlingV3Controls'
+  | 'showLoopControl'
+  | 'showSafetyCheckerControl'
+  | 'showSeedanceControls'
+>;
+
+export function useSettingsControlState({
+  advancedFields = [],
+  audioControlDisabled = false,
+  audioControlNote,
+  audioEnabled,
+  caps,
+  cfgScale,
+  durationManagedLabel,
+  durationOption,
+  durationSec,
+  engine,
+  focusRefs,
+  loopEnabled,
+  mode,
+  numFrames,
+  onAdvancedFieldChange,
+  onAudioChange,
+  onDurationChange,
+  onLoopChange,
+  onNumFramesChange,
+  showAudioControl = false,
+  showExtendControl = true,
+  showKlingV3Controls = false,
+  showLoopControl = false,
+  showSafetyCheckerControl = false,
+  showSeedanceControls = false,
+}: UseSettingsControlStateOptions) {
+  const { t } = useI18n();
+  const localizedControls = t('workspace.generate.controls', DEFAULT_CONTROLS_COPY) as
+    | Partial<typeof DEFAULT_CONTROLS_COPY>
+    | undefined;
+  const controlsCopy = useMemo(() => mergeControlsCopy(localizedControls), [localizedControls]);
+  const [seed, setSeed] = useState<string>('');
+  const [guidance, setGuidance] = useState<number | null>(null);
+  const [initInfluence, setInitInfluence] = useState<number | null>(null);
+  const [promptStrength, setPromptStrength] = useState<number | null>(null);
+  const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
+  const [internalCfgScale, setInternalCfgScale] = useState<number | null>(null);
+
+  useEffect(() => {
+    setInternalCfgScale(null);
+  }, [engine.id, mode]);
+
+  const enumeratedDurationOptions = useMemo(() => {
+    if (!caps?.duration) return null;
+    if ('options' in caps.duration) {
+      return caps.duration.options.map(parseDurationOptionValue).filter((entry) => entry.value > 0);
+    }
+    return null;
+  }, [caps]);
+  const durationMaxSeconds = useMemo(() => {
+    if (!enumeratedDurationOptions || enumeratedDurationOptions.length === 0) {
+      return engine.maxDurationSec;
+    }
+    return Math.max(...enumeratedDurationOptions.map((option) => option.value));
+  }, [engine.maxDurationSec, enumeratedDurationOptions]);
+
+  const durationRange = useMemo(() => {
+    if (!caps?.duration) return null;
+    return 'min' in caps.duration ? caps.duration : null;
+  }, [caps]);
+
+  const frameOptions = useMemo(() => {
+    if (!caps?.frames || caps.frames.length === 0) return null;
+    return caps.frames;
+  }, [caps]);
+
+  useEffect(() => {
+    if (!enumeratedDurationOptions || !enumeratedDurationOptions.length) return;
+    if (enumeratedDurationOptions.some((option) => matchesDurationOptionValue(option, durationOption, durationSec))) return;
+    const fallback = enumeratedDurationOptions[0];
+    onDurationChange(fallback.raw);
+  }, [enumeratedDurationOptions, durationOption, durationSec, onDurationChange]);
+
+  useEffect(() => {
+    if (!frameOptions || !frameOptions.length) return;
+    if (typeof numFrames === 'number' && frameOptions.includes(numFrames)) return;
+    const fallback = frameOptions[0];
+    onNumFramesChange?.(fallback);
+  }, [frameOptions, numFrames, onNumFramesChange]);
+
+  const durationOptionsContainerRef = useRef<HTMLDivElement | null>(null);
+  const durationSliderRef = useRef<HTMLInputElement | null>(null);
+  const frameOptionsContainerRef = useRef<HTMLDivElement | null>(null);
+  const isLtxFastLong = (engine.id === 'ltx-2-fast' || engine.id === 'ltx-2-3-fast') && durationSec > 10;
+
+  useEffect(() => {
+    const target = focusRefs?.duration;
+    if (!target) return;
+    let node: HTMLElement | null = null;
+    if (frameOptions && frameOptions.length) {
+      node = frameOptionsContainerRef.current;
+    } else if (enumeratedDurationOptions && enumeratedDurationOptions.length) {
+      node = durationOptionsContainerRef.current;
+    } else if (durationRange) {
+      node = durationSliderRef.current;
+    }
+    if (typeof target === 'function') {
+      target(node as never);
+    } else if (target) {
+      (target as MutableRefObject<HTMLElement | null>).current = node;
+    }
+  }, [focusRefs?.duration, frameOptions, enumeratedDurationOptions, durationRange]);
+
+  const resolutionOptions = useMemo(() => {
+    const base = caps?.resolution && caps.resolution.length ? caps.resolution : engine.resolutions;
+    if (isLtxFastLong) return base.filter((value) => value === '1080p');
+    return base;
+  }, [caps?.resolution, engine.resolutions, isLtxFastLong]);
+
+  const aspectOptions = useMemo(() => {
+    if (caps) {
+      if (caps.aspectRatio && caps.aspectRatio.length) return caps.aspectRatio;
+      return [];
+    }
+    return engine.aspectRatios;
+  }, [caps, engine.aspectRatios]);
+  const resolutionLocked = Boolean(caps?.resolutionLocked);
+  const showResolutionControl = resolutionOptions.length > 0;
+  const showAspectControl = aspectOptions.length > 0;
+  const showAudioToggle = Boolean(showAudioControl && typeof audioEnabled === 'boolean');
+  const canToggleAudio = Boolean(onAudioChange) && !audioControlDisabled;
+  const audioIncluded = Boolean(engine.audio) && mode !== 'r2v' && !showAudioToggle;
+  const resolvedDurationManagedLabel = durationManagedLabel ?? controlsCopy.duration.managed;
+  const effectiveCfgScale =
+    typeof cfgScale === 'number'
+      ? cfgScale
+      : internalCfgScale ?? engine.params.cfg_scale?.default ?? 0.5;
+  const audioNotice = audioControlNote ?? (audioIncluded ? controlsCopy.core.audioIncluded : null);
+  const hasGenericAdvancedFields = advancedFields.length > 0 && typeof onAdvancedFieldChange === 'function';
+
+  const advancedHasContent = Boolean(
+    (showLoopControl && typeof loopEnabled === 'boolean' && onLoopChange) ||
+      !showSeedanceControls ||
+      engine.params.promptStrength ||
+      engine.params.guidance ||
+      (mode === 'i2v' && engine.params.initInfluence) ||
+      (showExtendControl && engine.extend) ||
+      engine.keyframes ||
+      showKlingV3Controls ||
+      showSeedanceControls ||
+      showSafetyCheckerControl ||
+      engine.params.cfg_scale ||
+      hasGenericAdvancedFields
+  );
+
+  return {
+    advancedHasContent,
+    aspectOptions,
+    audioNotice,
+    canToggleAudio,
+    controlsCopy,
+    durationMaxSeconds,
+    durationOptionsContainerRef,
+    durationRange,
+    durationSliderRef,
+    effectiveCfgScale,
+    enumeratedDurationOptions,
+    frameOptions,
+    frameOptionsContainerRef,
+    guidance,
+    hasGenericAdvancedFields,
+    initInfluence,
+    isAdvancedOpen,
+    isLtxFastLong,
+    promptStrength,
+    resolutionLocked,
+    resolutionOptions,
+    seed,
+    setGuidance,
+    setInitInfluence,
+    setInternalCfgScale,
+    setIsAdvancedOpen,
+    setPromptStrength,
+    setSeed,
+    showAspectControl,
+    showAudioToggle,
+    showResolutionControl,
+    resolvedDurationManagedLabel,
+  };
+}

--- a/tests/settings-controls-architecture.test.ts
+++ b/tests/settings-controls-architecture.test.ts
@@ -10,6 +10,7 @@ const durationPath = join(root, 'frontend/components/settings-controls/settings-
 const copyPath = join(root, 'frontend/components/settings-controls/settings-control-copy.ts');
 const genericFieldsPath = join(root, 'frontend/components/settings-controls/settings-control-generic-fields.tsx');
 const typesPath = join(root, 'frontend/components/settings-controls/settings-control-types.ts');
+const stateHookPath = join(root, 'frontend/components/settings-controls/useSettingsControlState.ts');
 
 const controlsSource = readFileSync(controlsPath, 'utf8');
 const partsSource = readFileSync(partsPath, 'utf8');
@@ -17,6 +18,7 @@ const durationSource = readFileSync(durationPath, 'utf8');
 const copySource = readFileSync(copyPath, 'utf8');
 const genericFieldsSource = readFileSync(genericFieldsPath, 'utf8');
 const typesSource = readFileSync(typesPath, 'utf8');
+const stateHookSource = readFileSync(stateHookPath, 'utf8');
 
 test('settings controls delegates reusable control parts and duration helpers', () => {
   assert.ok(existsSync(partsPath), 'settings control subcomponents should live in a focused module');
@@ -24,12 +26,14 @@ test('settings controls delegates reusable control parts and duration helpers', 
   assert.ok(existsSync(copyPath), 'settings controls copy should live in a focused module');
   assert.ok(existsSync(genericFieldsPath), 'generic advanced fields should live in a focused module');
   assert.ok(existsSync(typesPath), 'settings controls props contract should live in a focused module');
+  assert.ok(existsSync(stateHookPath), 'settings control derived state should live in a focused hook');
 
   assert.match(controlsSource, /from '@\/components\/settings-controls\/settings-control-parts'/);
   assert.match(controlsSource, /from '@\/components\/settings-controls\/settings-control-duration'/);
   assert.match(controlsSource, /from '@\/components\/settings-controls\/settings-control-copy'/);
   assert.match(controlsSource, /from '@\/components\/settings-controls\/settings-control-generic-fields'/);
   assert.match(controlsSource, /from '@\/components\/settings-controls\/settings-control-types'/);
+  assert.match(controlsSource, /from '@\/components\/settings-controls\/useSettingsControlState'/);
 });
 
 test('settings controls does not regain extracted ownership', () => {
@@ -43,9 +47,12 @@ test('settings controls does not regain extracted ownership', () => {
   assert.doesNotMatch(controlsSource, /<select[\s\S]*field\.values/, 'generic enum field rendering belongs in settings-control-generic-fields.tsx');
   assert.doesNotMatch(controlsSource, /interface Props/, 'settings controls prop contract belongs in settings-control-types.ts');
   assert.doesNotMatch(controlsSource, /EngineInputField/, 'advanced field prop typing belongs in settings-control-types.ts');
+  assert.doesNotMatch(controlsSource, /useEffect\(/, 'derived option syncing belongs in useSettingsControlState');
+  assert.doesNotMatch(controlsSource, /parseDurationOptionValue/, 'duration option normalization belongs in useSettingsControlState');
+  assert.doesNotMatch(controlsSource, /const resolutionOptions =/, 'resolution option derivation belongs in useSettingsControlState');
 
   const lineCount = controlsSource.split('\n').length;
-  assert.ok(lineCount <= 1010, `SettingsControls should stay below 1010 lines after props contract extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 950, `SettingsControls should stay below 950 lines after state hook extraction, got ${lineCount}`);
 });
 
 test('settings control helper modules expose the expected contract', () => {
@@ -61,4 +68,8 @@ test('settings control helper modules expose the expected contract', () => {
   assert.match(genericFieldsSource, /field\.type === 'number'/);
   assert.match(typesSource, /export interface SettingsControlsProps/);
   assert.match(typesSource, /EngineInputField/);
+  assert.match(stateHookSource, /export function useSettingsControlState/);
+  assert.match(stateHookSource, /parseDurationOptionValue/);
+  assert.match(stateHookSource, /matchesDurationOptionValue/);
+  assert.match(stateHookSource, /setInternalCfgScale\(null\)/);
 });


### PR DESCRIPTION
## Summary
- move SettingsControls derived option state, focus refs, and sync effects into useSettingsControlState
- keep SettingsControls focused on rendering controls
- tighten the SettingsControls architecture contract and line-count guard

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/settings-controls-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false
- git diff --check -- frontend/components/SettingsControls.tsx frontend/components/settings-controls/useSettingsControlState.ts tests/settings-controls-architecture.test.ts
- npm --prefix frontend run lint
- npm run lint:exposure