### PR TITLE
Split upscale preview surface

### DIFF
--- a/frontend/src/components/tools/UpscaleWorkspace.tsx
+++ b/frontend/src/components/tools/UpscaleWorkspace.tsx
@@ -3,22 +3,18 @@
 /* eslint-disable @next/next/no-img-element */
 
 import Link from 'next/link';
-import { useMemo, useState, type PointerEvent } from 'react';
+import { useMemo, useState } from 'react';
 import {
   ArrowLeft,
   ArrowRight,
-  ChevronsLeftRight,
   Coins,
-  Download,
   Image as ImageIcon,
   LibraryBig,
   Loader2,
   RefreshCw,
-  Save,
   Upload,
   Video,
   WandSparkles,
-  ZoomIn,
 } from 'lucide-react';
 import { AppSidebar } from '@/components/AppSidebar';
 import { GroupedJobCard, type GroupedJobAction } from '@/components/GroupedJobCard';
@@ -51,24 +47,20 @@ import type { GroupSummary } from '@/types/groups';
 import type { Job } from '@/types/jobs';
 import { Label, SegmentButton } from './upscale/_components/upscale-workspace-controls';
 import { UpscaleHeroSummaryCard } from './upscale/_components/UpscaleHeroSummaryCard';
+import { UpscalePreviewCard } from './upscale/_components/UpscalePreviewCard';
 import { DEFAULT_UPSCALE_COPY } from './upscale/_lib/upscale-workspace-copy';
 import {
-  clampComparePosition,
   formatCurrency,
-  isOutputVideo,
   parseRecentImageVariantIndex,
-  PREVIEW_ZOOM_OPTIONS,
   resolveRecentUpscaleJobFromGroup,
   resolveRecentUpscaleMedia,
   resolveRecentUpscaleMediaFromGroup,
   resolveUpscaleEngineId,
-  SAMPLE_IMAGE_URL,
-  SOURCE_FALLBACK_HEIGHT,
-  SOURCE_FALLBACK_WIDTH,
 } from './upscale/_lib/upscale-workspace-helpers';
 import { useUpscaleLibraryAssets } from './upscale/_hooks/useUpscaleLibraryAssets';
 import { useUpscalePricingPreview } from './upscale/_hooks/useUpscalePricingPreview';
 import { useUpscalePreviewScroller } from './upscale/_hooks/useUpscalePreviewScroller';
+import { useUpscalePreviewState } from './upscale/_hooks/useUpscalePreviewState';
 import { useUpscaleRecentJobs } from './upscale/_hooks/useUpscaleRecentJobs';
 import { useUpscaleSourceMedia } from './upscale/_hooks/useUpscaleSourceMedia';
 import type {
@@ -99,8 +91,6 @@ export default function UpscaleWorkspace() {
   const [result, setResult] = useState<UpscaleToolResponse | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [comparePosition, setComparePosition] = useState(50);
-  const [compareDragging, setCompareDragging] = useState(false);
   const [previewMode, setPreviewMode] = useState<PreviewMode>('source');
   const [previewZoom, setPreviewZoom] = useState<PreviewZoom>('fit');
   const {
@@ -138,30 +128,42 @@ export default function UpscaleWorkspace() {
     targetResolution,
     upscaleFactor,
   });
-  const output = result?.output ?? null;
   const canRun = Boolean(user && mediaUrl.trim() && engine && !running && !uploading);
-  const hasResult = Boolean(output?.url);
-  const hasSourcePreview = Boolean(mediaUrl.trim());
-  const canCompare = hasResult && hasSourcePreview && result?.mediaType === mediaType;
-  const activePreviewMode: PreviewMode = hasResult ? (previewMode === 'compare' && !canCompare ? 'result' : previewMode) : 'source';
-  const sourcePreviewUrl = mediaUrl || SAMPLE_IMAGE_URL;
-  const resultPreviewUrl = output?.url || mediaUrl || SAMPLE_IMAGE_URL;
-  const sourcePreviewIsVideo = mediaType === 'video' && Boolean(mediaUrl);
-  const resultPreviewIsVideo = output ? isOutputVideo(output) : sourcePreviewIsVideo;
-  const compareEnabled = activePreviewMode === 'compare' && canCompare;
-  const previewZoomScale = previewZoom === 'fit' ? 1 : Number(previewZoom) / 100;
-  const isPixelZoom = previewZoom !== 'fit';
-  const mediaFitClass = 'object-contain';
-  const sourceWidth = source?.width ?? SOURCE_FALLBACK_WIDTH;
-  const sourceHeight = source?.height ?? SOURCE_FALLBACK_HEIGHT;
-  const previewFactor = mode === 'factor' ? upscaleFactor : 2;
-  const outputWidth = output?.width ?? Math.round(sourceWidth * previewFactor);
-  const outputHeight = output?.height ?? Math.round(sourceHeight * previewFactor);
-  const sourceSizeLabel = `${sourceWidth} x ${sourceHeight}`;
-  const outputSizeLabel = `${outputWidth} x ${outputHeight}`;
-  const zoomCanvasWidth = activePreviewMode === 'source' ? sourceWidth : outputWidth;
-  const zoomCanvasHeight = activePreviewMode === 'source' ? sourceHeight : outputHeight;
-  const mediaTypeLabel = mediaType === 'video' ? 'Video' : 'Image';
+  const {
+    activePreviewMode,
+    canCompare,
+    compareDragging,
+    compareEnabled,
+    comparePosition,
+    handleCompareKeyDown,
+    handleComparePointerDown,
+    handleComparePointerMove,
+    handleComparePointerUp,
+    hasResult,
+    hasSourcePreview,
+    isPixelZoom,
+    mediaFitClass,
+    mediaTypeLabel,
+    output,
+    outputSizeLabel,
+    previewZoomScale,
+    resultPreviewIsVideo,
+    resultPreviewUrl,
+    sourcePreviewIsVideo,
+    sourcePreviewUrl,
+    sourceSizeLabel,
+    zoomCanvasHeight,
+    zoomCanvasWidth,
+  } = useUpscalePreviewState({
+    mediaType,
+    mediaUrl,
+    mode,
+    previewMode,
+    previewZoom,
+    result,
+    source,
+    upscaleFactor,
+  });
   const previewScrollerRef = useUpscalePreviewScroller({
     activePreviewMode,
     isPixelZoom,
@@ -434,30 +436,6 @@ export default function UpscaleWorkspace() {
     }
   }
 
-  function updateComparePosition(event: PointerEvent<HTMLDivElement>) {
-    const rect = event.currentTarget.getBoundingClientRect();
-    const nextPosition = ((event.clientX - rect.left) / rect.width) * 100;
-    setComparePosition(clampComparePosition(nextPosition));
-  }
-
-  function handleComparePointerDown(event: PointerEvent<HTMLDivElement>) {
-    event.currentTarget.setPointerCapture(event.pointerId);
-    setCompareDragging(true);
-    updateComparePosition(event);
-  }
-
-  function handleComparePointerMove(event: PointerEvent<HTMLDivElement>) {
-    if (!compareDragging) return;
-    updateComparePosition(event);
-  }
-
-  function handleComparePointerUp(event: PointerEvent<HTMLDivElement>) {
-    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-      event.currentTarget.releasePointerCapture(event.pointerId);
-    }
-    setCompareDragging(false);
-  }
-
   if (authLoading) {
     return (
       <div className="flex min-h-screen flex-col bg-bg">
@@ -691,199 +669,36 @@ export default function UpscaleWorkspace() {
               </section>
 
               <section className="contents xl:block xl:space-y-4">
-                <Card className="order-2 overflow-hidden rounded-[14px] border border-border bg-surface p-0 shadow-card xl:order-none">
-                  <div className="flex flex-wrap items-start justify-between gap-3 px-4 py-4 sm:px-5">
-                    <div className="min-w-0">
-                      <h2 className="text-base font-semibold text-text-primary">Before / after preview</h2>
-                      <p className="mt-1 text-xs text-text-muted">Upload a source, choose a recipe, then compare the upscaled result.</p>
-                    </div>
-                    <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
-                      <div className="flex rounded-[10px] border border-border bg-bg p-1">
-                        {([
-                          ['source', copy.previewSource, false],
-                          ['result', copy.previewResult, !hasResult],
-                          ['compare', copy.previewCompare, !canCompare],
-                        ] as const).map(([modeOption, label, disabled]) => {
-                          const active = activePreviewMode === modeOption;
-                          return (
-                            <button
-                              key={modeOption}
-                              type="button"
-                              disabled={disabled}
-                              onClick={() => setPreviewMode(modeOption)}
-                              className={`min-h-8 rounded-[8px] px-3 text-xs font-semibold transition disabled:cursor-not-allowed disabled:opacity-45 ${
-                                active
-                                  ? 'bg-brand text-on-brand shadow-card'
-                                  : 'text-text-secondary hover:bg-surface hover:text-text-primary'
-                              }`}
-                            >
-                              {label}
-                            </button>
-                          );
-                        })}
-                      </div>
-                      {output?.url ? (
-                        <>
-                          <Button variant="outline" size="sm" onClick={handleSave} className="rounded-[10px] border-border bg-surface text-text-secondary hover:bg-surface-hover hover:text-text-primary">
-                            <Save className="h-4 w-4" />
-                            {copy.save}
-                          </Button>
-                          <Button variant="outline" size="sm" onClick={handleDownload} className="rounded-[10px] border-border bg-surface text-text-secondary hover:bg-surface-hover hover:text-text-primary">
-                            <Download className="h-4 w-4" />
-                            {copy.download}
-                          </Button>
-                        </>
-                      ) : null}
-                      <div
-                        className={`flex items-center gap-2 rounded-[12px] border px-2 py-1.5 shadow-[0_10px_28px_rgba(15,23,42,0.08)] transition ${
-                          isPixelZoom
-                            ? 'border-brand bg-brand text-on-brand'
-                            : 'border-border bg-surface text-text-primary ring-1 ring-border'
-                        }`}
-                      >
-                        <span
-                          className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-[9px] ${
-                            isPixelZoom
-                              ? 'bg-surface text-text-primary'
-                              : 'bg-brand text-on-brand'
-                          }`}
-                        >
-                          <ZoomIn className="h-4 w-4" />
-                        </span>
-                        <span className="hidden text-[11px] font-semibold uppercase tracking-[0.12em] sm:inline">
-                          {copy.previewZoom}
-                        </span>
-                        <select
-                          aria-label={copy.previewZoom}
-                          value={previewZoom}
-                          onChange={(event) => setPreviewZoom(event.currentTarget.value as PreviewZoom)}
-                          className="h-8 min-w-[82px] rounded-[8px] border border-border bg-surface px-2 text-xs font-semibold text-text-primary outline-none hover:bg-surface-hover focus-visible:ring-2 focus-visible:ring-ring"
-                        >
-                          {PREVIEW_ZOOM_OPTIONS.map((option) => (
-                            <option key={option.value} value={option.value}>
-                              {option.value === 'fit' ? copy.previewZoomFit : option.label}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div className="px-3 pb-3 sm:px-5 sm:pb-5">
-                    <div className="relative aspect-[4/3] min-h-[260px] max-h-[min(72vh,680px)] overflow-hidden rounded-[12px] border border-border bg-surface-3 sm:aspect-[16/9] sm:min-h-[340px] xl:aspect-[16/8] xl:min-h-[420px]">
-                      <div ref={previewScrollerRef} className={`absolute inset-0 ${isPixelZoom ? 'overflow-auto' : 'overflow-hidden'}`}>
-                        <div
-                          className={`relative h-full w-full ${
-                            compareEnabled ? 'cursor-ew-resize touch-none select-none' : ''
-                          } ${
-                            compareDragging ? 'ring-2 ring-ring' : ''
-                          }`}
-                          style={
-                            isPixelZoom
-                              ? {
-                                  width: `${Math.round(zoomCanvasWidth * previewZoomScale)}px`,
-                                  height: `${Math.round(zoomCanvasHeight * previewZoomScale)}px`,
-                                }
-                              : undefined
-                          }
-                          role={compareEnabled ? 'slider' : 'img'}
-                          aria-label={compareEnabled ? 'Compare source and upscaled preview' : activePreviewMode === 'result' ? 'Upscaled result preview' : 'Source preview'}
-                          aria-valuemin={compareEnabled ? 8 : undefined}
-                          aria-valuemax={compareEnabled ? 92 : undefined}
-                          aria-valuenow={compareEnabled ? Math.round(comparePosition) : undefined}
-                          tabIndex={0}
-                          onPointerDown={compareEnabled ? handleComparePointerDown : undefined}
-                          onPointerMove={compareEnabled ? handleComparePointerMove : undefined}
-                          onPointerUp={compareEnabled ? handleComparePointerUp : undefined}
-                          onPointerCancel={compareEnabled ? handleComparePointerUp : undefined}
-                          onKeyDown={(event) => {
-                            if (!compareEnabled) return;
-                            if (event.key === 'ArrowLeft') {
-                              event.preventDefault();
-                              setComparePosition((current) => clampComparePosition(current - 4));
-                            }
-                            if (event.key === 'ArrowRight') {
-                              event.preventDefault();
-                              setComparePosition((current) => clampComparePosition(current + 4));
-                            }
-                            if (event.key === 'Home') {
-                              event.preventDefault();
-                              setComparePosition(8);
-                            }
-                            if (event.key === 'End') {
-                              event.preventDefault();
-                              setComparePosition(92);
-                            }
-                          }}
-                        >
-                      {activePreviewMode === 'source' ? (
-                        sourcePreviewIsVideo ? (
-                          <video className={`absolute inset-0 h-full w-full ${mediaFitClass}`} src={sourcePreviewUrl} controls muted playsInline />
-                        ) : (
-                          <img className={`absolute inset-0 h-full w-full ${mediaFitClass}`} src={sourcePreviewUrl} alt="" draggable={false} />
-                        )
-                      ) : activePreviewMode === 'result' ? (
-                        resultPreviewIsVideo ? (
-                          <video className={`absolute inset-0 h-full w-full ${mediaFitClass}`} src={resultPreviewUrl} controls muted playsInline />
-                        ) : (
-                          <img className={`absolute inset-0 h-full w-full ${mediaFitClass}`} src={resultPreviewUrl} alt="" draggable={false} />
-                        )
-                      ) : resultPreviewIsVideo ? (
-                        <>
-                          <video className={`absolute inset-0 h-full w-full ${mediaFitClass}`} src={resultPreviewUrl} muted playsInline />
-                          <video
-                            className={`absolute inset-0 h-full w-full ${mediaFitClass}`}
-                            src={sourcePreviewUrl}
-                            muted
-                            playsInline
-                            style={{ clipPath: `inset(0 ${100 - comparePosition}% 0 0)` }}
-                          />
-                        </>
-                      ) : (
-                        <>
-                          <img className={`absolute inset-0 h-full w-full ${mediaFitClass}`} src={resultPreviewUrl} alt="" draggable={false} />
-                          <img
-                            className={`absolute inset-0 h-full w-full ${mediaFitClass}`}
-                            src={sourcePreviewUrl}
-                            alt=""
-                            draggable={false}
-                            style={{ clipPath: `inset(0 ${100 - comparePosition}% 0 0)` }}
-                          />
-                        </>
-                      )}
-
-                      {activePreviewMode === 'compare' ? (
-                        <>
-                          <div className="absolute inset-y-0 w-px bg-on-inverse shadow-[0_0_0_1px_var(--surface-on-media-dark-40)]" style={{ left: `${comparePosition}%` }} />
-                          <div
-                            className="absolute top-1/2 flex h-12 w-12 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-surface-on-media-70 bg-on-inverse text-brand shadow-float transition-transform hover:scale-105"
-                            style={{ left: `${comparePosition}%` }}
-                            aria-hidden="true"
-                          >
-                            <ChevronsLeftRight className="h-5 w-5" />
-                          </div>
-                        </>
-                      ) : null}
-
-                      <div className="absolute left-3 top-3 rounded-[8px] bg-surface-on-media-dark-80 px-3 py-2 text-on-inverse shadow-lg backdrop-blur sm:left-6 sm:top-6 sm:px-4 sm:py-3">
-                        <p className="text-xs font-semibold">
-                          {activePreviewMode === 'result' ? copy.previewResult : copy.previewSource}
-                        </p>
-                        <p className="mt-1 text-xs text-on-media-85">
-                          {activePreviewMode === 'result' ? outputSizeLabel : sourceSizeLabel}
-                        </p>
-                      </div>
-                      {activePreviewMode === 'compare' ? (
-                        <div className="absolute right-3 top-3 rounded-[8px] bg-surface-on-media-dark-80 px-3 py-2 text-on-inverse shadow-lg backdrop-blur sm:right-6 sm:top-6 sm:px-4 sm:py-3">
-                          <p className="text-xs font-semibold">{copy.previewResult}</p>
-                          <p className="mt-1 text-xs text-on-media-85">{outputSizeLabel}</p>
-                        </div>
-                      ) : null}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </Card>
+                <UpscalePreviewCard
+                  activePreviewMode={activePreviewMode}
+                  canCompare={canCompare}
+                  compareDragging={compareDragging}
+                  compareEnabled={compareEnabled}
+                  comparePosition={comparePosition}
+                  copy={copy}
+                  hasResult={hasResult}
+                  isPixelZoom={isPixelZoom}
+                  mediaFitClass={mediaFitClass}
+                  onCompareKeyDown={handleCompareKeyDown}
+                  onComparePointerDown={handleComparePointerDown}
+                  onComparePointerMove={handleComparePointerMove}
+                  onComparePointerUp={handleComparePointerUp}
+                  onDownload={handleDownload}
+                  onPreviewModeChange={setPreviewMode}
+                  onPreviewZoomChange={setPreviewZoom}
+                  onSave={handleSave}
+                  outputSizeLabel={outputSizeLabel}
+                  previewScrollerRef={previewScrollerRef}
+                  previewZoom={previewZoom}
+                  previewZoomScale={previewZoomScale}
+                  resultPreviewIsVideo={resultPreviewIsVideo}
+                  resultPreviewUrl={resultPreviewUrl}
+                  sourcePreviewIsVideo={sourcePreviewIsVideo}
+                  sourcePreviewUrl={sourcePreviewUrl}
+                  sourceSizeLabel={sourceSizeLabel}
+                  zoomCanvasHeight={zoomCanvasHeight}
+                  zoomCanvasWidth={zoomCanvasWidth}
+                />
 
                 <Card className="order-4 rounded-[14px] border border-border bg-surface p-5 shadow-card xl:order-none">
                   <div className="flex items-center justify-between gap-3">

--- a/frontend/src/components/tools/upscale/_components/UpscalePreviewCard.tsx
+++ b/frontend/src/components/tools/upscale/_components/UpscalePreviewCard.tsx
@@ -1,0 +1,248 @@
+/* eslint-disable @next/next/no-img-element */
+
+import type { KeyboardEventHandler, PointerEventHandler, Ref } from 'react';
+import { ChevronsLeftRight, Download, Save, ZoomIn } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { Card } from '@/components/ui/Card';
+import { PREVIEW_ZOOM_OPTIONS } from '../_lib/upscale-workspace-helpers';
+import type { PreviewMode, PreviewZoom } from '../_lib/upscale-workspace-types';
+
+type UpscalePreviewCopy = {
+  download: string;
+  previewCompare: string;
+  previewResult: string;
+  previewSource: string;
+  previewZoom: string;
+  previewZoomFit: string;
+  save: string;
+};
+
+export function UpscalePreviewCard({
+  activePreviewMode,
+  canCompare,
+  compareDragging,
+  compareEnabled,
+  comparePosition,
+  copy,
+  hasResult,
+  isPixelZoom,
+  mediaFitClass,
+  onCompareKeyDown,
+  onComparePointerDown,
+  onComparePointerMove,
+  onComparePointerUp,
+  onDownload,
+  onPreviewModeChange,
+  onPreviewZoomChange,
+  onSave,
+  outputSizeLabel,
+  previewScrollerRef,
+  previewZoom,
+  previewZoomScale,
+  resultPreviewIsVideo,
+  resultPreviewUrl,
+  sourcePreviewIsVideo,
+  sourcePreviewUrl,
+  sourceSizeLabel,
+  zoomCanvasHeight,
+  zoomCanvasWidth,
+}: {
+  activePreviewMode: PreviewMode;
+  canCompare: boolean;
+  compareDragging: boolean;
+  compareEnabled: boolean;
+  comparePosition: number;
+  copy: UpscalePreviewCopy;
+  hasResult: boolean;
+  isPixelZoom: boolean;
+  mediaFitClass: string;
+  onCompareKeyDown: KeyboardEventHandler<HTMLDivElement>;
+  onComparePointerDown: PointerEventHandler<HTMLDivElement>;
+  onComparePointerMove: PointerEventHandler<HTMLDivElement>;
+  onComparePointerUp: PointerEventHandler<HTMLDivElement>;
+  onDownload: () => void;
+  onPreviewModeChange: (mode: PreviewMode) => void;
+  onPreviewZoomChange: (zoom: PreviewZoom) => void;
+  onSave: () => void;
+  outputSizeLabel: string;
+  previewScrollerRef: Ref<HTMLDivElement>;
+  previewZoom: PreviewZoom;
+  previewZoomScale: number;
+  resultPreviewIsVideo: boolean;
+  resultPreviewUrl: string;
+  sourcePreviewIsVideo: boolean;
+  sourcePreviewUrl: string;
+  sourceSizeLabel: string;
+  zoomCanvasHeight: number;
+  zoomCanvasWidth: number;
+}) {
+  return (
+    <Card className="order-2 overflow-hidden rounded-[14px] border border-border bg-surface p-0 shadow-card xl:order-none">
+      <div className="flex flex-wrap items-start justify-between gap-3 px-4 py-4 sm:px-5">
+        <div className="min-w-0">
+          <h2 className="text-base font-semibold text-text-primary">Before / after preview</h2>
+          <p className="mt-1 text-xs text-text-muted">Upload a source, choose a recipe, then compare the upscaled result.</p>
+        </div>
+        <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
+          <div className="flex rounded-[10px] border border-border bg-bg p-1">
+            {([
+              ['source', copy.previewSource, false],
+              ['result', copy.previewResult, !hasResult],
+              ['compare', copy.previewCompare, !canCompare],
+            ] as const).map(([modeOption, label, disabled]) => {
+              const active = activePreviewMode === modeOption;
+              return (
+                <button
+                  key={modeOption}
+                  type="button"
+                  disabled={disabled}
+                  onClick={() => onPreviewModeChange(modeOption)}
+                  className={`min-h-8 rounded-[8px] px-3 text-xs font-semibold transition disabled:cursor-not-allowed disabled:opacity-45 ${
+                    active ? 'bg-brand text-on-brand shadow-card' : 'text-text-secondary hover:bg-surface hover:text-text-primary'
+                  }`}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+          {hasResult ? (
+            <>
+              <Button variant="outline" size="sm" onClick={onSave} className="rounded-[10px] border-border bg-surface text-text-secondary hover:bg-surface-hover hover:text-text-primary">
+                <Save className="h-4 w-4" />
+                {copy.save}
+              </Button>
+              <Button variant="outline" size="sm" onClick={onDownload} className="rounded-[10px] border-border bg-surface text-text-secondary hover:bg-surface-hover hover:text-text-primary">
+                <Download className="h-4 w-4" />
+                {copy.download}
+              </Button>
+            </>
+          ) : null}
+          <div
+            className={`flex items-center gap-2 rounded-[12px] border px-2 py-1.5 shadow-[0_10px_28px_rgba(15,23,42,0.08)] transition ${
+              isPixelZoom ? 'border-brand bg-brand text-on-brand' : 'border-border bg-surface text-text-primary ring-1 ring-border'
+            }`}
+          >
+            <span
+              className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-[9px] ${
+                isPixelZoom ? 'bg-surface text-text-primary' : 'bg-brand text-on-brand'
+              }`}
+            >
+              <ZoomIn className="h-4 w-4" />
+            </span>
+            <span className="hidden text-[11px] font-semibold uppercase tracking-[0.12em] sm:inline">
+              {copy.previewZoom}
+            </span>
+            <select
+              aria-label={copy.previewZoom}
+              value={previewZoom}
+              onChange={(event) => onPreviewZoomChange(event.currentTarget.value as PreviewZoom)}
+              className="h-8 min-w-[82px] rounded-[8px] border border-border bg-surface px-2 text-xs font-semibold text-text-primary outline-none hover:bg-surface-hover focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {PREVIEW_ZOOM_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.value === 'fit' ? copy.previewZoomFit : option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <div className="px-3 pb-3 sm:px-5 sm:pb-5">
+        <div className="relative aspect-[4/3] min-h-[260px] max-h-[min(72vh,680px)] overflow-hidden rounded-[12px] border border-border bg-surface-3 sm:aspect-[16/9] sm:min-h-[340px] xl:aspect-[16/8] xl:min-h-[420px]">
+          <div ref={previewScrollerRef} className={`absolute inset-0 ${isPixelZoom ? 'overflow-auto' : 'overflow-hidden'}`}>
+            <div
+              className={`relative h-full w-full ${compareEnabled ? 'cursor-ew-resize touch-none select-none' : ''} ${
+                compareDragging ? 'ring-2 ring-ring' : ''
+              }`}
+              style={
+                isPixelZoom
+                  ? {
+                      width: `${Math.round(zoomCanvasWidth * previewZoomScale)}px`,
+                      height: `${Math.round(zoomCanvasHeight * previewZoomScale)}px`,
+                    }
+                  : undefined
+              }
+              role={compareEnabled ? 'slider' : 'img'}
+              aria-label={compareEnabled ? 'Compare source and upscaled preview' : activePreviewMode === 'result' ? 'Upscaled result preview' : 'Source preview'}
+              aria-valuemin={compareEnabled ? 8 : undefined}
+              aria-valuemax={compareEnabled ? 92 : undefined}
+              aria-valuenow={compareEnabled ? Math.round(comparePosition) : undefined}
+              tabIndex={0}
+              onPointerDown={compareEnabled ? onComparePointerDown : undefined}
+              onPointerMove={compareEnabled ? onComparePointerMove : undefined}
+              onPointerUp={compareEnabled ? onComparePointerUp : undefined}
+              onPointerCancel={compareEnabled ? onComparePointerUp : undefined}
+              onKeyDown={onCompareKeyDown}
+            >
+              {activePreviewMode === 'source' ? (
+                sourcePreviewIsVideo ? (
+                  <video className={`absolute inset-0 h-full w-full ${mediaFitClass}`} src={sourcePreviewUrl} controls muted playsInline />
+                ) : (
+                  <img className={`absolute inset-0 h-full w-full ${mediaFitClass}`} src={sourcePreviewUrl} alt="" draggable={false} />
+                )
+              ) : activePreviewMode === 'result' ? (
+                resultPreviewIsVideo ? (
+                  <video className={`absolute inset-0 h-full w-full ${mediaFitClass}`} src={resultPreviewUrl} controls muted playsInline />
+                ) : (
+                  <img className={`absolute inset-0 h-full w-full ${mediaFitClass}`} src={resultPreviewUrl} alt="" draggable={false} />
+                )
+              ) : resultPreviewIsVideo ? (
+                <>
+                  <video className={`absolute inset-0 h-full w-full ${mediaFitClass}`} src={resultPreviewUrl} muted playsInline />
+                  <video
+                    className={`absolute inset-0 h-full w-full ${mediaFitClass}`}
+                    src={sourcePreviewUrl}
+                    muted
+                    playsInline
+                    style={{ clipPath: `inset(0 ${100 - comparePosition}% 0 0)` }}
+                  />
+                </>
+              ) : (
+                <>
+                  <img className={`absolute inset-0 h-full w-full ${mediaFitClass}`} src={resultPreviewUrl} alt="" draggable={false} />
+                  <img
+                    className={`absolute inset-0 h-full w-full ${mediaFitClass}`}
+                    src={sourcePreviewUrl}
+                    alt=""
+                    draggable={false}
+                    style={{ clipPath: `inset(0 ${100 - comparePosition}% 0 0)` }}
+                  />
+                </>
+              )}
+
+              {activePreviewMode === 'compare' ? (
+                <>
+                  <div className="absolute inset-y-0 w-px bg-on-inverse shadow-[0_0_0_1px_var(--surface-on-media-dark-40)]" style={{ left: `${comparePosition}%` }} />
+                  <div
+                    className="absolute top-1/2 flex h-12 w-12 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-surface-on-media-70 bg-on-inverse text-brand shadow-float transition-transform hover:scale-105"
+                    style={{ left: `${comparePosition}%` }}
+                    aria-hidden="true"
+                  >
+                    <ChevronsLeftRight className="h-5 w-5" />
+                  </div>
+                </>
+              ) : null}
+
+              <div className="absolute left-3 top-3 rounded-[8px] bg-surface-on-media-dark-80 px-3 py-2 text-on-inverse shadow-lg backdrop-blur sm:left-6 sm:top-6 sm:px-4 sm:py-3">
+                <p className="text-xs font-semibold">
+                  {activePreviewMode === 'result' ? copy.previewResult : copy.previewSource}
+                </p>
+                <p className="mt-1 text-xs text-on-media-85">
+                  {activePreviewMode === 'result' ? outputSizeLabel : sourceSizeLabel}
+                </p>
+              </div>
+              {activePreviewMode === 'compare' ? (
+                <div className="absolute right-3 top-3 rounded-[8px] bg-surface-on-media-dark-80 px-3 py-2 text-on-inverse shadow-lg backdrop-blur sm:right-6 sm:top-6 sm:px-4 sm:py-3">
+                  <p className="text-xs font-semibold">{copy.previewResult}</p>
+                  <p className="mt-1 text-xs text-on-media-85">{outputSizeLabel}</p>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/tools/upscale/_hooks/useUpscalePreviewState.ts
+++ b/frontend/src/components/tools/upscale/_hooks/useUpscalePreviewState.ts
@@ -1,0 +1,131 @@
+import { useState, type KeyboardEvent, type PointerEvent } from 'react';
+import type { UpscaleMediaType, UpscaleMode, UpscaleToolResponse } from '@/types/tools-upscale';
+import {
+  clampComparePosition,
+  isOutputVideo,
+  SAMPLE_IMAGE_URL,
+  SOURCE_FALLBACK_HEIGHT,
+  SOURCE_FALLBACK_WIDTH,
+} from '../_lib/upscale-workspace-helpers';
+import type { PreviewMode, PreviewZoom, UploadedAsset } from '../_lib/upscale-workspace-types';
+
+export function useUpscalePreviewState({
+  mediaType,
+  mediaUrl,
+  mode,
+  previewMode,
+  previewZoom,
+  result,
+  source,
+  upscaleFactor,
+}: {
+  mediaType: UpscaleMediaType;
+  mediaUrl: string;
+  mode: UpscaleMode;
+  previewMode: PreviewMode;
+  previewZoom: PreviewZoom;
+  result: UpscaleToolResponse | null;
+  source: UploadedAsset | null;
+  upscaleFactor: number;
+}) {
+  const [comparePosition, setComparePosition] = useState(50);
+  const [compareDragging, setCompareDragging] = useState(false);
+  const output = result?.output ?? null;
+  const hasResult = Boolean(output?.url);
+  const hasSourcePreview = Boolean(mediaUrl.trim());
+  const canCompare = hasResult && hasSourcePreview && result?.mediaType === mediaType;
+  const activePreviewMode: PreviewMode = hasResult ? (previewMode === 'compare' && !canCompare ? 'result' : previewMode) : 'source';
+  const sourcePreviewUrl = mediaUrl || SAMPLE_IMAGE_URL;
+  const resultPreviewUrl = output?.url || mediaUrl || SAMPLE_IMAGE_URL;
+  const sourcePreviewIsVideo = mediaType === 'video' && Boolean(mediaUrl);
+  const resultPreviewIsVideo = output ? isOutputVideo(output) : sourcePreviewIsVideo;
+  const compareEnabled = activePreviewMode === 'compare' && canCompare;
+  const previewZoomScale = previewZoom === 'fit' ? 1 : Number(previewZoom) / 100;
+  const isPixelZoom = previewZoom !== 'fit';
+  const mediaFitClass = 'object-contain';
+  const sourceWidth = source?.width ?? SOURCE_FALLBACK_WIDTH;
+  const sourceHeight = source?.height ?? SOURCE_FALLBACK_HEIGHT;
+  const previewFactor = mode === 'factor' ? upscaleFactor : 2;
+  const outputWidth = output?.width ?? Math.round(sourceWidth * previewFactor);
+  const outputHeight = output?.height ?? Math.round(sourceHeight * previewFactor);
+  const sourceSizeLabel = `${sourceWidth} x ${sourceHeight}`;
+  const outputSizeLabel = `${outputWidth} x ${outputHeight}`;
+  const zoomCanvasWidth = activePreviewMode === 'source' ? sourceWidth : outputWidth;
+  const zoomCanvasHeight = activePreviewMode === 'source' ? sourceHeight : outputHeight;
+  const mediaTypeLabel = mediaType === 'video' ? 'Video' : 'Image';
+
+  function updateComparePosition(event: PointerEvent<HTMLDivElement>) {
+    const rect = event.currentTarget.getBoundingClientRect();
+    const nextPosition = ((event.clientX - rect.left) / rect.width) * 100;
+    setComparePosition(clampComparePosition(nextPosition));
+  }
+
+  function handleComparePointerDown(event: PointerEvent<HTMLDivElement>) {
+    event.currentTarget.setPointerCapture(event.pointerId);
+    setCompareDragging(true);
+    updateComparePosition(event);
+  }
+
+  function handleComparePointerMove(event: PointerEvent<HTMLDivElement>) {
+    if (!compareDragging) return;
+    updateComparePosition(event);
+  }
+
+  function handleComparePointerUp(event: PointerEvent<HTMLDivElement>) {
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    setCompareDragging(false);
+  }
+
+  function handleCompareKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (!compareEnabled) return;
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      setComparePosition((current) => clampComparePosition(current - 4));
+    }
+    if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      setComparePosition((current) => clampComparePosition(current + 4));
+    }
+    if (event.key === 'Home') {
+      event.preventDefault();
+      setComparePosition(8);
+    }
+    if (event.key === 'End') {
+      event.preventDefault();
+      setComparePosition(92);
+    }
+  }
+
+  return {
+    activePreviewMode,
+    canCompare,
+    compareEnabled,
+    compareDragging,
+    comparePosition,
+    handleCompareKeyDown,
+    handleComparePointerDown,
+    handleComparePointerMove,
+    handleComparePointerUp,
+    hasResult,
+    hasSourcePreview,
+    isPixelZoom,
+    mediaFitClass,
+    mediaTypeLabel,
+    output,
+    outputHeight,
+    outputSizeLabel,
+    outputWidth,
+    previewZoomScale,
+    resultPreviewIsVideo,
+    resultPreviewUrl,
+    sourceHeight,
+    sourcePreviewIsVideo,
+    sourcePreviewUrl,
+    sourceSizeLabel,
+    sourceWidth,
+    zoomCanvasHeight,
+    zoomCanvasWidth,
+  };
+}

--- a/tests/upscale-workspace-architecture.test.ts
+++ b/tests/upscale-workspace-architecture.test.ts
@@ -11,10 +11,12 @@ const helpersPath = join(root, 'frontend/src/components/tools/upscale/_lib/upsca
 const libraryHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscaleLibraryAssets.ts');
 const pricingHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscalePricingPreview.ts');
 const previewScrollerHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscalePreviewScroller.ts');
+const previewStateHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscalePreviewState.ts');
 const recentJobsHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscaleRecentJobs.ts');
 const sourceMediaHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscaleSourceMedia.ts');
 const controlsPath = join(root, 'frontend/src/components/tools/upscale/_components/upscale-workspace-controls.tsx');
 const heroSummaryCardPath = join(root, 'frontend/src/components/tools/upscale/_components/UpscaleHeroSummaryCard.tsx');
+const previewCardPath = join(root, 'frontend/src/components/tools/upscale/_components/UpscalePreviewCard.tsx');
 
 const workspaceSource = readFileSync(workspacePath, 'utf8');
 
@@ -25,10 +27,12 @@ test('upscale workspace delegates copy, local types, and helper logic', () => {
   assert.ok(existsSync(libraryHookPath), 'upscale library asset loading should live in a colocated hook');
   assert.ok(existsSync(pricingHookPath), 'upscale pricing preview should live in a colocated hook');
   assert.ok(existsSync(previewScrollerHookPath), 'upscale preview scroller should live in a colocated hook');
+  assert.ok(existsSync(previewStateHookPath), 'upscale preview state should live in a colocated hook');
   assert.ok(existsSync(recentJobsHookPath), 'upscale recent jobs orchestration should live in a colocated hook');
   assert.ok(existsSync(sourceMediaHookPath), 'upscale source media orchestration should live in a colocated hook');
   assert.ok(existsSync(controlsPath), 'upscale workspace controls should live in colocated components');
   assert.ok(existsSync(heroSummaryCardPath), 'upscale hero summary should live in a colocated component');
+  assert.ok(existsSync(previewCardPath), 'upscale preview card should live in a colocated component');
 
   assert.match(workspaceSource, /from '\.\/upscale\/_lib\/upscale-workspace-copy'/, 'workspace should import upscale copy');
   assert.match(workspaceSource, /from '\.\/upscale\/_lib\/upscale-workspace-types'/, 'workspace should import upscale local types');
@@ -36,10 +40,12 @@ test('upscale workspace delegates copy, local types, and helper logic', () => {
   assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscaleLibraryAssets'/, 'workspace should import library hook');
   assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscalePricingPreview'/, 'workspace should import pricing hook');
   assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscalePreviewScroller'/, 'workspace should import preview scroller hook');
+  assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscalePreviewState'/, 'workspace should import preview state hook');
   assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscaleRecentJobs'/, 'workspace should import recent jobs hook');
   assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscaleSourceMedia'/, 'workspace should import source media hook');
   assert.match(workspaceSource, /from '\.\/upscale\/_components\/upscale-workspace-controls'/, 'workspace should import workspace controls');
   assert.match(workspaceSource, /from '\.\/upscale\/_components\/UpscaleHeroSummaryCard'/, 'workspace should import hero summary card');
+  assert.match(workspaceSource, /from '\.\/upscale\/_components\/UpscalePreviewCard'/, 'workspace should import preview card');
 });
 
 test('upscale workspace does not regain extracted ownership', () => {
@@ -65,9 +71,15 @@ test('upscale workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /requestAnimationFrame/, 'preview centering belongs in useUpscalePreviewScroller');
   assert.doesNotMatch(workspaceSource, /scrollLeft/, 'preview scroll position belongs in useUpscalePreviewScroller');
   assert.doesNotMatch(workspaceSource, /rounded-\[20px\] border border-border bg-surface-glass-90/, 'hero summary card belongs in UpscaleHeroSummaryCard');
+  assert.doesNotMatch(workspaceSource, /const sourcePreviewUrl =/, 'preview URL derivation belongs in useUpscalePreviewState');
+  assert.doesNotMatch(workspaceSource, /const zoomCanvasWidth =/, 'preview canvas sizing belongs in useUpscalePreviewState');
+  assert.doesNotMatch(workspaceSource, /function updateComparePosition\(/, 'compare slider updates belong in useUpscalePreviewState');
+  assert.doesNotMatch(workspaceSource, /setComparePosition/, 'compare keyboard updates belong in useUpscalePreviewState');
+  assert.doesNotMatch(workspaceSource, /Before \/ after preview/, 'preview JSX belongs in UpscalePreviewCard');
+  assert.doesNotMatch(workspaceSource, /PREVIEW_ZOOM_OPTIONS/, 'preview zoom controls belong in UpscalePreviewCard');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 1000, `UpscaleWorkspace should stay below 1000 lines after preview control extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 840, `UpscaleWorkspace should stay below 840 lines after preview extraction, got ${lineCount}`);
 });
 
 test('upscale helper modules expose the expected workspace contract', () => {
@@ -77,10 +89,12 @@ test('upscale helper modules expose the expected workspace contract', () => {
   const libraryHookSource = readFileSync(libraryHookPath, 'utf8');
   const pricingHookSource = readFileSync(pricingHookPath, 'utf8');
   const previewScrollerHookSource = readFileSync(previewScrollerHookPath, 'utf8');
+  const previewStateHookSource = readFileSync(previewStateHookPath, 'utf8');
   const recentJobsHookSource = readFileSync(recentJobsHookPath, 'utf8');
   const sourceMediaHookSource = readFileSync(sourceMediaHookPath, 'utf8');
   const controlsSource = readFileSync(controlsPath, 'utf8');
   const heroSummaryCardSource = readFileSync(heroSummaryCardPath, 'utf8');
+  const previewCardSource = readFileSync(previewCardPath, 'utf8');
 
   assert.match(copySource, /export const DEFAULT_UPSCALE_COPY =/, 'copy module should export default copy');
 
@@ -119,6 +133,11 @@ test('upscale helper modules expose the expected workspace contract', () => {
   assert.match(previewScrollerHookSource, /export function useUpscalePreviewScroller/, 'preview scroller hook should be exported');
   assert.match(previewScrollerHookSource, /requestAnimationFrame/, 'preview scroller hook should center zoomed previews');
   assert.match(previewScrollerHookSource, /scrollLeft/, 'preview scroller hook should own horizontal scroll positioning');
+  assert.match(previewStateHookSource, /export function useUpscalePreviewState/, 'preview state hook should be exported');
+  assert.match(previewStateHookSource, /clampComparePosition/, 'preview state hook should clamp compare slider positions');
+  assert.match(previewStateHookSource, /isOutputVideo/, 'preview state hook should resolve output media kind');
+  assert.match(previewStateHookSource, /SOURCE_FALLBACK_WIDTH/, 'preview state hook should own fallback preview sizing');
+  assert.match(previewStateHookSource, /handleCompareKeyDown/, 'preview state hook should own compare keyboard handling');
   assert.match(recentJobsHookSource, /export function useUpscaleRecentJobs/, 'recent jobs hook should be exported');
   assert.match(recentJobsHookSource, /useInfiniteJobs\(12, \{ surface: 'upscale' \}\)/, 'recent jobs hook should own the upscale feed');
   assert.match(recentJobsHookSource, /getJobStatus/, 'recent jobs hook should poll pending jobs');
@@ -131,4 +150,7 @@ test('upscale helper modules expose the expected workspace contract', () => {
   assert.match(controlsSource, /export function SegmentButton/, 'workspace segment button should be exported');
   assert.match(heroSummaryCardSource, /export function UpscaleHeroSummaryCard/, 'hero summary card should be exported');
   assert.match(heroSummaryCardSource, /WandSparkles/, 'hero summary card should own its action icon');
+  assert.match(previewCardSource, /export function UpscalePreviewCard/, 'preview card should be exported');
+  assert.match(previewCardSource, /PREVIEW_ZOOM_OPTIONS/, 'preview card should own zoom controls');
+  assert.match(previewCardSource, /ChevronsLeftRight/, 'preview card should own compare affordance');
 });


### PR DESCRIPTION
## Summary
- move upscale preview state and compare slider handling into a colocated hook
- extract the before/after preview surface into a route-local component
- extend the architecture contract test so the workspace does not regain preview ownership

## Checks
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/upscale-workspace-architecture.test.ts tests/upscale-pricing-preview.test.ts tests/upscale-route-bundling.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- git diff --check -- frontend/src/components/tools/UpscaleWorkspace.tsx frontend/src/components/tools/upscale/_components/UpscalePreviewCard.tsx frontend/src/components/tools/upscale/_hooks/useUpscalePreviewState.ts tests/upscale-workspace-architecture.test.ts
- npm --prefix frontend run lint
- npm run lint:exposure