### PR TITLE
Split upscale recent rail

### DIFF
--- a/frontend/src/components/tools/UpscaleWorkspace.tsx
+++ b/frontend/src/components/tools/UpscaleWorkspace.tsx
@@ -6,7 +6,6 @@ import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import {
   ArrowLeft,
-  ArrowRight,
   Coins,
   Image as ImageIcon,
   LibraryBig,
@@ -17,7 +16,7 @@ import {
   WandSparkles,
 } from 'lucide-react';
 import { AppSidebar } from '@/components/AppSidebar';
-import { GroupedJobCard, type GroupedJobAction } from '@/components/GroupedJobCard';
+import type { GroupedJobAction } from '@/components/GroupedJobCard';
 import { HeaderBar } from '@/components/HeaderBar';
 import { Button, ButtonLink } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
@@ -48,6 +47,7 @@ import type { Job } from '@/types/jobs';
 import { Label, SegmentButton } from './upscale/_components/upscale-workspace-controls';
 import { UpscaleHeroSummaryCard } from './upscale/_components/UpscaleHeroSummaryCard';
 import { UpscalePreviewCard } from './upscale/_components/UpscalePreviewCard';
+import { UpscaleRecentRail } from './upscale/_components/UpscaleRecentRail';
 import { DEFAULT_UPSCALE_COPY } from './upscale/_lib/upscale-workspace-copy';
 import {
   formatCurrency,
@@ -700,45 +700,14 @@ export default function UpscaleWorkspace() {
                   zoomCanvasWidth={zoomCanvasWidth}
                 />
 
-                <Card className="order-4 rounded-[14px] border border-border bg-surface p-5 shadow-card xl:order-none">
-                  <div className="flex items-center justify-between gap-3">
-                    <div>
-                      <h2 className="text-base font-semibold text-text-primary">{copy.recentTitle}</h2>
-                      <p className="mt-1 text-xs text-text-muted">Reuse finished assets in Image, Video, or Library.</p>
-                    </div>
-                    <Link href="/app/library" className="inline-flex items-center gap-1 text-xs font-semibold text-text-secondary hover:text-text-primary">
-                      View library
-                      <ArrowRight className="h-3.5 w-3.5" />
-                    </Link>
-                  </div>
-                  <div className="mt-4 flex gap-3 overflow-x-auto pb-1">
-                    {recentGroups.slice(0, 8).map((group) => {
-                      const active = activeRecentGroupId === group.id;
-                      return (
-                        <div
-                          key={group.id}
-                          className={`w-[258px] shrink-0 rounded-[14px] transition ${
-                            active ? 'ring-2 ring-brand ring-offset-2 ring-offset-bg' : ''
-                          }`}
-                        >
-                          <GroupedJobCard
-                            group={group}
-                            onOpen={selectRecentUpscale}
-                            onAction={handleRecentGroupAction}
-                            menuVariant="gallery-image"
-                            allowRemove={false}
-                            savingToLibrary={savingRecentGroupId === group.id}
-                          />
-                        </div>
-                      );
-                    })}
-                    {!recentGroups.length ? (
-                      <div className="w-full rounded-[12px] border border-dashed border-border bg-bg p-4 text-sm text-text-muted">
-                        No upscale runs yet.
-                      </div>
-                    ) : null}
-                  </div>
-                </Card>
+                <UpscaleRecentRail
+                  activeGroupId={activeRecentGroupId}
+                  copy={copy}
+                  groups={recentGroups}
+                  onAction={handleRecentGroupAction}
+                  onOpen={selectRecentUpscale}
+                  savingGroupId={savingRecentGroupId}
+                />
               </section>
             </div>
           </div>

--- a/frontend/src/components/tools/upscale/_components/UpscaleRecentRail.tsx
+++ b/frontend/src/components/tools/upscale/_components/UpscaleRecentRail.tsx
@@ -1,0 +1,67 @@
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import { GroupedJobCard, type GroupedJobAction } from '@/components/GroupedJobCard';
+import { Card } from '@/components/ui/Card';
+import type { GroupSummary } from '@/types/groups';
+
+type UpscaleRecentRailCopy = {
+  recentTitle: string;
+};
+
+export function UpscaleRecentRail({
+  activeGroupId,
+  copy,
+  groups,
+  onAction,
+  onOpen,
+  savingGroupId,
+}: {
+  activeGroupId: string | null;
+  copy: UpscaleRecentRailCopy;
+  groups: GroupSummary[];
+  onAction: (group: GroupSummary, action: GroupedJobAction) => void;
+  onOpen: (group: GroupSummary) => void;
+  savingGroupId: string | null;
+}) {
+  return (
+    <Card className="order-4 rounded-[14px] border border-border bg-surface p-5 shadow-card xl:order-none">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-base font-semibold text-text-primary">{copy.recentTitle}</h2>
+          <p className="mt-1 text-xs text-text-muted">Reuse finished assets in Image, Video, or Library.</p>
+        </div>
+        <Link href="/app/library" className="inline-flex items-center gap-1 text-xs font-semibold text-text-secondary hover:text-text-primary">
+          View library
+          <ArrowRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
+      <div className="mt-4 flex gap-3 overflow-x-auto pb-1">
+        {groups.slice(0, 8).map((group) => {
+          const active = activeGroupId === group.id;
+          return (
+            <div
+              key={group.id}
+              className={`w-[258px] shrink-0 rounded-[14px] transition ${
+                active ? 'ring-2 ring-brand ring-offset-2 ring-offset-bg' : ''
+              }`}
+            >
+              <GroupedJobCard
+                group={group}
+                onOpen={onOpen}
+                onAction={onAction}
+                menuVariant="gallery-image"
+                allowRemove={false}
+                savingToLibrary={savingGroupId === group.id}
+              />
+            </div>
+          );
+        })}
+        {!groups.length ? (
+          <div className="w-full rounded-[12px] border border-dashed border-border bg-bg p-4 text-sm text-text-muted">
+            No upscale runs yet.
+          </div>
+        ) : null}
+      </div>
+    </Card>
+  );
+}

--- a/tests/upscale-workspace-architecture.test.ts
+++ b/tests/upscale-workspace-architecture.test.ts
@@ -17,6 +17,7 @@ const sourceMediaHookPath = join(root, 'frontend/src/components/tools/upscale/_h
 const controlsPath = join(root, 'frontend/src/components/tools/upscale/_components/upscale-workspace-controls.tsx');
 const heroSummaryCardPath = join(root, 'frontend/src/components/tools/upscale/_components/UpscaleHeroSummaryCard.tsx');
 const previewCardPath = join(root, 'frontend/src/components/tools/upscale/_components/UpscalePreviewCard.tsx');
+const recentRailPath = join(root, 'frontend/src/components/tools/upscale/_components/UpscaleRecentRail.tsx');
 
 const workspaceSource = readFileSync(workspacePath, 'utf8');
 
@@ -33,6 +34,7 @@ test('upscale workspace delegates copy, local types, and helper logic', () => {
   assert.ok(existsSync(controlsPath), 'upscale workspace controls should live in colocated components');
   assert.ok(existsSync(heroSummaryCardPath), 'upscale hero summary should live in a colocated component');
   assert.ok(existsSync(previewCardPath), 'upscale preview card should live in a colocated component');
+  assert.ok(existsSync(recentRailPath), 'upscale recent rail should live in a colocated component');
 
   assert.match(workspaceSource, /from '\.\/upscale\/_lib\/upscale-workspace-copy'/, 'workspace should import upscale copy');
   assert.match(workspaceSource, /from '\.\/upscale\/_lib\/upscale-workspace-types'/, 'workspace should import upscale local types');
@@ -46,6 +48,7 @@ test('upscale workspace delegates copy, local types, and helper logic', () => {
   assert.match(workspaceSource, /from '\.\/upscale\/_components\/upscale-workspace-controls'/, 'workspace should import workspace controls');
   assert.match(workspaceSource, /from '\.\/upscale\/_components\/UpscaleHeroSummaryCard'/, 'workspace should import hero summary card');
   assert.match(workspaceSource, /from '\.\/upscale\/_components\/UpscalePreviewCard'/, 'workspace should import preview card');
+  assert.match(workspaceSource, /from '\.\/upscale\/_components\/UpscaleRecentRail'/, 'workspace should import recent rail');
 });
 
 test('upscale workspace does not regain extracted ownership', () => {
@@ -77,9 +80,12 @@ test('upscale workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /setComparePosition/, 'compare keyboard updates belong in useUpscalePreviewState');
   assert.doesNotMatch(workspaceSource, /Before \/ after preview/, 'preview JSX belongs in UpscalePreviewCard');
   assert.doesNotMatch(workspaceSource, /PREVIEW_ZOOM_OPTIONS/, 'preview zoom controls belong in UpscalePreviewCard');
+  assert.doesNotMatch(workspaceSource, /recentGroups\.slice/, 'recent rail rendering belongs in UpscaleRecentRail');
+  assert.doesNotMatch(workspaceSource, /Reuse finished assets/, 'recent rail copy belongs in UpscaleRecentRail');
+  assert.doesNotMatch(workspaceSource, /<GroupedJobCard/, 'recent job cards belong in UpscaleRecentRail');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 840, `UpscaleWorkspace should stay below 840 lines after preview extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 790, `UpscaleWorkspace should stay below 790 lines after recent rail extraction, got ${lineCount}`);
 });
 
 test('upscale helper modules expose the expected workspace contract', () => {
@@ -95,6 +101,7 @@ test('upscale helper modules expose the expected workspace contract', () => {
   const controlsSource = readFileSync(controlsPath, 'utf8');
   const heroSummaryCardSource = readFileSync(heroSummaryCardPath, 'utf8');
   const previewCardSource = readFileSync(previewCardPath, 'utf8');
+  const recentRailSource = readFileSync(recentRailPath, 'utf8');
 
   assert.match(copySource, /export const DEFAULT_UPSCALE_COPY =/, 'copy module should export default copy');
 
@@ -153,4 +160,7 @@ test('upscale helper modules expose the expected workspace contract', () => {
   assert.match(previewCardSource, /export function UpscalePreviewCard/, 'preview card should be exported');
   assert.match(previewCardSource, /PREVIEW_ZOOM_OPTIONS/, 'preview card should own zoom controls');
   assert.match(previewCardSource, /ChevronsLeftRight/, 'preview card should own compare affordance');
+  assert.match(recentRailSource, /export function UpscaleRecentRail/, 'recent rail should be exported');
+  assert.match(recentRailSource, /GroupedJobCard/, 'recent rail should own grouped card rendering');
+  assert.match(recentRailSource, /\/app\/library/, 'recent rail should own its library link');
 });


### PR DESCRIPTION
## Summary
- move the Upscale recent jobs rail into a colocated component
- keep recent job action orchestration in the workspace while moving list rendering out
- extend the architecture contract so recent rail JSX does not drift back into the workspace

## Checks
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/upscale-workspace-architecture.test.ts tests/upscale-pricing-preview.test.ts tests/upscale-route-bundling.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- git diff --check -- frontend/src/components/tools/UpscaleWorkspace.tsx frontend/src/components/tools/upscale/_components/UpscaleRecentRail.tsx tests/upscale-workspace-architecture.test.ts
- npm --prefix frontend run lint
- npm run lint:exposure