### PR TITLE
Split upscale input panels

### DIFF
--- a/frontend/src/components/tools/UpscaleWorkspace.tsx
+++ b/frontend/src/components/tools/UpscaleWorkspace.tsx
@@ -6,22 +6,13 @@ import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import {
   ArrowLeft,
-  Coins,
-  Image as ImageIcon,
-  LibraryBig,
-  Loader2,
   RefreshCw,
-  Upload,
-  Video,
-  WandSparkles,
 } from 'lucide-react';
 import { AppSidebar } from '@/components/AppSidebar';
 import type { GroupedJobAction } from '@/components/GroupedJobCard';
 import { HeaderBar } from '@/components/HeaderBar';
 import { Button, ButtonLink } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
-import { Input } from '@/components/ui/Input';
-import { SelectMenu } from '@/components/ui/SelectMenu';
 import { AssetLibraryBrowser } from '@/components/library/AssetLibraryBrowser';
 import { authFetch } from '@/lib/authFetch';
 import { runUpscaleTool, saveAssetToLibrary } from '@/lib/api';
@@ -44,7 +35,7 @@ import type {
 } from '@/types/tools-upscale';
 import type { GroupSummary } from '@/types/groups';
 import type { Job } from '@/types/jobs';
-import { Label, SegmentButton } from './upscale/_components/upscale-workspace-controls';
+import { UpscaleRecipePanel, UpscaleSourcePanel } from './upscale/_components/UpscaleInputPanels';
 import { UpscaleHeroSummaryCard } from './upscale/_components/UpscaleHeroSummaryCard';
 import { UpscalePreviewCard } from './upscale/_components/UpscalePreviewCard';
 import { UpscaleRecentRail } from './upscale/_components/UpscaleRecentRail';
@@ -225,6 +216,13 @@ export default function UpscaleWorkspace() {
     setUpscaleFactor(nextEngine.defaultUpscaleFactor);
     setTargetResolution(nextEngine.defaultTargetResolution ?? '1080p');
     setOutputFormat(nextEngine.defaultOutputFormat);
+  }
+
+  function changeMediaUrl(nextUrl: string) {
+    setMediaUrl(nextUrl);
+    setSource(null);
+    setResult(null);
+    setPreviewMode('source');
   }
 
   async function handleRun() {
@@ -513,159 +511,42 @@ export default function UpscaleWorkspace() {
 
             <div className="mt-5 grid gap-5 xl:grid-cols-[360px_minmax(0,1fr)]">
               <section className="contents xl:sticky xl:top-5 xl:block xl:space-y-4 xl:self-start">
-                <Card className="order-1 rounded-[14px] border border-border bg-surface p-5 shadow-card xl:order-none">
-                  <div className="mb-5 flex items-start justify-between gap-3">
-                    <div className="flex min-w-0 items-start gap-3">
-                      <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-surface-2 text-xs font-semibold text-text-secondary">1</span>
-                      <div>
-                        <h2 className="text-base font-semibold text-text-primary">Source asset</h2>
-                        <p className="mt-1 text-xs text-text-muted">Add the asset you want to upscale.</p>
-                      </div>
-                    </div>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      onClick={openLibraryModal}
-                      disabled={!user || running || uploading}
-                      className="h-9 shrink-0 rounded-[10px] border-border bg-surface px-3 text-xs text-text-secondary hover:bg-surface-hover hover:text-text-primary"
-                    >
-                      <LibraryBig className="h-4 w-4" />
-                      {copy.library}
-                    </Button>
-                  </div>
+                <UpscaleSourcePanel
+                  copy={copy}
+                  isAuthenticated={Boolean(user)}
+                  mediaType={mediaType}
+                  mediaUrl={mediaUrl}
+                  onLibraryOpen={openLibraryModal}
+                  onMediaTypeChange={changeMediaType}
+                  onMediaUrlChange={changeMediaUrl}
+                  onUpload={handleUpload}
+                  running={running}
+                  sourceName={source?.name}
+                  uploading={uploading}
+                />
 
-                  <div className="grid grid-cols-2 gap-2">
-                    <SegmentButton active={mediaType === 'image'} disabled={running || uploading} onClick={() => changeMediaType('image')}>
-                      <ImageIcon className="h-4 w-4" />
-                      {copy.image}
-                    </SegmentButton>
-                    <SegmentButton active={mediaType === 'video'} disabled={running || uploading} onClick={() => changeMediaType('video')}>
-                      <Video className="h-4 w-4" />
-                      {copy.video}
-                    </SegmentButton>
-                  </div>
-
-                  <label className="mt-4 block cursor-pointer rounded-[12px] border border-dashed border-border bg-bg p-8 text-center transition hover:border-border-hover hover:bg-surface-hover">
-                    <input
-                      type="file"
-                      accept={mediaType === 'image' ? 'image/*' : 'video/*'}
-                      onChange={handleUpload}
-                      disabled={!user || uploading || running}
-                      className="sr-only"
-                    />
-                    <span className="mx-auto inline-flex h-11 w-11 items-center justify-center rounded-full bg-surface text-text-primary shadow-card">
-                      {uploading ? <Loader2 className="h-5 w-5 animate-spin" /> : <Upload className="h-5 w-5" />}
-                    </span>
-                    <span className="mt-3 block text-sm font-semibold text-text-primary">Drop file here</span>
-                    <span className="mt-1 block text-xs text-text-muted">{source?.name ?? (mediaType === 'video' ? 'MP4, WebM, MOV' : 'PNG, JPG, WebP up to 200MB')}</span>
-                  </label>
-
-                  <div className="my-4 flex items-center gap-3">
-                    <span className="h-px flex-1 bg-hairline" />
-                    <span className="text-[11px] text-text-muted">or</span>
-                    <span className="h-px flex-1 bg-hairline" />
-                  </div>
-
-                  <label className="block">
-                    <Label>Paste image or video URL</Label>
-                    <Input
-                      value={mediaUrl}
-                      onChange={(event) => {
-                        setMediaUrl(event.target.value);
-                        setSource(null);
-                        setResult(null);
-                        setPreviewMode('source');
-                      }}
-                      placeholder="https://example.com/asset.mp4"
-                      disabled={running || uploading}
-                      className="rounded-[10px] border-border bg-surface text-sm text-text-primary placeholder:text-text-muted"
-                    />
-                  </label>
-                </Card>
-
-                <Card className="order-3 rounded-[14px] border border-border bg-surface p-5 shadow-card xl:order-none">
-                  <div className="mb-5 flex items-start gap-3">
-                    <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-surface-2 text-xs font-semibold text-text-secondary">2</span>
-                    <div>
-                      <h2 className="text-base font-semibold text-text-primary">{copy.settingsTitle}</h2>
-                      <p className="mt-1 text-xs text-text-muted">Choose how you want to enhance your asset.</p>
-                    </div>
-                  </div>
-
-                  <div className="space-y-4">
-                    <label className="block">
-                      <Label>{copy.engine}</Label>
-                      <SelectMenu
-                        value={engine?.id ?? engineId}
-                        onChange={(value) => changeEngine(value as UpscaleToolEngineId)}
-                        options={engines.map((entry) => ({ value: entry.id, label: entry.label }))}
-                        disabled={running}
-                      />
-                    </label>
-
-                    <div className="grid grid-cols-2 gap-3">
-                      <label className="block">
-                        <Label>{copy.mode}</Label>
-                        <SelectMenu
-                          value={mode}
-                          onChange={(value) => setMode(value as UpscaleMode)}
-                          options={(engine?.supportedModes ?? ['factor']).map((entry) => ({
-                            value: entry,
-                            label: entry === 'target' ? copy.target : copy.factor,
-                          }))}
-                          disabled={running}
-                        />
-                      </label>
-                      <label className="block">
-                        <Label>{mode === 'target' ? copy.target : copy.factor}</Label>
-                        {mode === 'target' ? (
-                          <SelectMenu
-                            value={targetResolution}
-                            onChange={(value) => setTargetResolution(value as UpscaleTargetResolution)}
-                            options={(engine?.supportedTargetResolutions ?? ['1080p']).map((entry) => ({ value: entry, label: entry }))}
-                            disabled={running}
-                          />
-                        ) : (
-                          <SelectMenu
-                            value={upscaleFactor}
-                            onChange={(value) => setUpscaleFactor(Number(value))}
-                            options={(engine?.supportedUpscaleFactors ?? [2]).map((entry) => ({ value: entry, label: `${entry}x` }))}
-                            disabled={running}
-                          />
-                        )}
-                      </label>
-                    </div>
-
-                    <label className="block">
-                      <Label>{copy.output}</Label>
-                      <SelectMenu
-                        value={outputFormat}
-                        onChange={(value) => setOutputFormat(value as UpscaleOutputFormat)}
-                        options={(engine?.supportedOutputFormats ?? ['jpg']).map((entry) => ({ value: entry, label: entry.toUpperCase() }))}
-                        disabled={running}
-                      />
-                    </label>
-                  </div>
-
-                  <div className="mt-5 flex items-center gap-3 rounded-[12px] border border-border bg-bg px-4 py-3">
-                    <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-surface text-text-primary shadow-card">
-                      <Coins className="h-5 w-5" />
-                    </span>
-                    <div className="min-w-0 flex-1">
-                      <p className="text-xs font-medium text-text-muted">{copy.priceEyebrow}</p>
-                      <p className="mt-1 text-xl font-semibold leading-none text-text-primary">{priceLabel}</p>
-                      <p className="mt-1 text-xs text-text-muted">{priceHint}</p>
-                    </div>
-                  </div>
-
-                  <Button className="mt-5 w-full rounded-[10px] bg-brand py-3 text-on-brand hover:bg-brand-hover" size="lg" onClick={handleRun} disabled={!canRun}>
-                    {running ? <Loader2 className="h-4 w-4 animate-spin" /> : <WandSparkles className="h-4 w-4" />}
-                    {running ? copy.running : copy.run}
-                  </Button>
-                  {message ? <p className="mt-3 text-sm text-text-muted">{message}</p> : null}
-                  {error ? <p className="mt-3 text-sm font-medium text-error">{error}</p> : null}
-                </Card>
+                <UpscaleRecipePanel
+                  canRun={canRun}
+                  copy={copy}
+                  engine={engine}
+                  engineId={engineId}
+                  engines={engines}
+                  error={error}
+                  message={message}
+                  mode={mode}
+                  onEngineChange={changeEngine}
+                  onModeChange={setMode}
+                  onOutputFormatChange={setOutputFormat}
+                  onRun={handleRun}
+                  onTargetResolutionChange={setTargetResolution}
+                  onUpscaleFactorChange={setUpscaleFactor}
+                  outputFormat={outputFormat}
+                  priceHint={priceHint}
+                  priceLabel={priceLabel}
+                  running={running}
+                  targetResolution={targetResolution}
+                  upscaleFactor={upscaleFactor}
+                />
               </section>
 
               <section className="contents xl:block xl:space-y-4">

--- a/frontend/src/components/tools/upscale/_components/UpscaleInputPanels.tsx
+++ b/frontend/src/components/tools/upscale/_components/UpscaleInputPanels.tsx
@@ -1,0 +1,256 @@
+import type { ChangeEventHandler } from 'react';
+import { Coins, Image as ImageIcon, LibraryBig, Loader2, Upload, Video, WandSparkles } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { Card } from '@/components/ui/Card';
+import { Input } from '@/components/ui/Input';
+import { SelectMenu } from '@/components/ui/SelectMenu';
+import type {
+  UpscaleMediaType,
+  UpscaleMode,
+  UpscaleOutputFormat,
+  UpscaleTargetResolution,
+  UpscaleToolEngineDefinition,
+  UpscaleToolEngineId,
+} from '@/types/tools-upscale';
+import { Label, SegmentButton } from './upscale-workspace-controls';
+
+type UpscaleInputPanelCopy = {
+  engine: string;
+  factor: string;
+  image: string;
+  library: string;
+  mediaType: string;
+  mode: string;
+  output: string;
+  priceEyebrow: string;
+  run: string;
+  running: string;
+  settingsTitle: string;
+  target: string;
+  video: string;
+};
+
+export function UpscaleSourcePanel({
+  copy,
+  isAuthenticated,
+  mediaType,
+  mediaUrl,
+  onLibraryOpen,
+  onMediaTypeChange,
+  onMediaUrlChange,
+  onUpload,
+  running,
+  sourceName,
+  uploading,
+}: {
+  copy: Pick<UpscaleInputPanelCopy, 'image' | 'library' | 'video'>;
+  isAuthenticated: boolean;
+  mediaType: UpscaleMediaType;
+  mediaUrl: string;
+  onLibraryOpen: () => void;
+  onMediaTypeChange: (mediaType: UpscaleMediaType) => void;
+  onMediaUrlChange: (mediaUrl: string) => void;
+  onUpload: ChangeEventHandler<HTMLInputElement>;
+  running: boolean;
+  sourceName?: string | null;
+  uploading: boolean;
+}) {
+  return (
+    <Card className="order-1 rounded-[14px] border border-border bg-surface p-5 shadow-card xl:order-none">
+      <div className="mb-5 flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-start gap-3">
+          <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-surface-2 text-xs font-semibold text-text-secondary">1</span>
+          <div>
+            <h2 className="text-base font-semibold text-text-primary">Source asset</h2>
+            <p className="mt-1 text-xs text-text-muted">Add the asset you want to upscale.</p>
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onLibraryOpen}
+          disabled={!isAuthenticated || running || uploading}
+          className="h-9 shrink-0 rounded-[10px] border-border bg-surface px-3 text-xs text-text-secondary hover:bg-surface-hover hover:text-text-primary"
+        >
+          <LibraryBig className="h-4 w-4" />
+          {copy.library}
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <SegmentButton active={mediaType === 'image'} disabled={running || uploading} onClick={() => onMediaTypeChange('image')}>
+          <ImageIcon className="h-4 w-4" />
+          {copy.image}
+        </SegmentButton>
+        <SegmentButton active={mediaType === 'video'} disabled={running || uploading} onClick={() => onMediaTypeChange('video')}>
+          <Video className="h-4 w-4" />
+          {copy.video}
+        </SegmentButton>
+      </div>
+
+      <label className="mt-4 block cursor-pointer rounded-[12px] border border-dashed border-border bg-bg p-8 text-center transition hover:border-border-hover hover:bg-surface-hover">
+        <input
+          type="file"
+          accept={mediaType === 'image' ? 'image/*' : 'video/*'}
+          onChange={onUpload}
+          disabled={!isAuthenticated || uploading || running}
+          className="sr-only"
+        />
+        <span className="mx-auto inline-flex h-11 w-11 items-center justify-center rounded-full bg-surface text-text-primary shadow-card">
+          {uploading ? <Loader2 className="h-5 w-5 animate-spin" /> : <Upload className="h-5 w-5" />}
+        </span>
+        <span className="mt-3 block text-sm font-semibold text-text-primary">Drop file here</span>
+        <span className="mt-1 block text-xs text-text-muted">
+          {sourceName ?? (mediaType === 'video' ? 'MP4, WebM, MOV' : 'PNG, JPG, WebP up to 200MB')}
+        </span>
+      </label>
+
+      <div className="my-4 flex items-center gap-3">
+        <span className="h-px flex-1 bg-hairline" />
+        <span className="text-[11px] text-text-muted">or</span>
+        <span className="h-px flex-1 bg-hairline" />
+      </div>
+
+      <label className="block">
+        <Label>Paste image or video URL</Label>
+        <Input
+          value={mediaUrl}
+          onChange={(event) => onMediaUrlChange(event.target.value)}
+          placeholder="https://example.com/asset.mp4"
+          disabled={running || uploading}
+          className="rounded-[10px] border-border bg-surface text-sm text-text-primary placeholder:text-text-muted"
+        />
+      </label>
+    </Card>
+  );
+}
+
+export function UpscaleRecipePanel({
+  canRun,
+  copy,
+  engine,
+  engineId,
+  engines,
+  error,
+  message,
+  mode,
+  onEngineChange,
+  onModeChange,
+  onOutputFormatChange,
+  onRun,
+  onTargetResolutionChange,
+  onUpscaleFactorChange,
+  outputFormat,
+  priceHint,
+  priceLabel,
+  running,
+  targetResolution,
+  upscaleFactor,
+}: {
+  canRun: boolean;
+  copy: Pick<UpscaleInputPanelCopy, 'engine' | 'factor' | 'mode' | 'output' | 'priceEyebrow' | 'run' | 'running' | 'settingsTitle' | 'target'>;
+  engine: UpscaleToolEngineDefinition | undefined;
+  engineId: UpscaleToolEngineId;
+  engines: readonly UpscaleToolEngineDefinition[];
+  error: string | null;
+  message: string | null;
+  mode: UpscaleMode;
+  onEngineChange: (engineId: UpscaleToolEngineId) => void;
+  onModeChange: (mode: UpscaleMode) => void;
+  onOutputFormatChange: (outputFormat: UpscaleOutputFormat) => void;
+  onRun: () => void;
+  onTargetResolutionChange: (targetResolution: UpscaleTargetResolution) => void;
+  onUpscaleFactorChange: (factor: number) => void;
+  outputFormat: UpscaleOutputFormat;
+  priceHint: string;
+  priceLabel: string;
+  running: boolean;
+  targetResolution: UpscaleTargetResolution;
+  upscaleFactor: number;
+}) {
+  return (
+    <Card className="order-3 rounded-[14px] border border-border bg-surface p-5 shadow-card xl:order-none">
+      <div className="mb-5 flex items-start gap-3">
+        <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-surface-2 text-xs font-semibold text-text-secondary">2</span>
+        <div>
+          <h2 className="text-base font-semibold text-text-primary">{copy.settingsTitle}</h2>
+          <p className="mt-1 text-xs text-text-muted">Choose how you want to enhance your asset.</p>
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <label className="block">
+          <Label>{copy.engine}</Label>
+          <SelectMenu
+            value={engine?.id ?? engineId}
+            onChange={(value) => onEngineChange(value as UpscaleToolEngineId)}
+            options={engines.map((entry) => ({ value: entry.id, label: entry.label }))}
+            disabled={running}
+          />
+        </label>
+
+        <div className="grid grid-cols-2 gap-3">
+          <label className="block">
+            <Label>{copy.mode}</Label>
+            <SelectMenu
+              value={mode}
+              onChange={(value) => onModeChange(value as UpscaleMode)}
+              options={(engine?.supportedModes ?? ['factor']).map((entry) => ({
+                value: entry,
+                label: entry === 'target' ? copy.target : copy.factor,
+              }))}
+              disabled={running}
+            />
+          </label>
+          <label className="block">
+            <Label>{mode === 'target' ? copy.target : copy.factor}</Label>
+            {mode === 'target' ? (
+              <SelectMenu
+                value={targetResolution}
+                onChange={(value) => onTargetResolutionChange(value as UpscaleTargetResolution)}
+                options={(engine?.supportedTargetResolutions ?? ['1080p']).map((entry) => ({ value: entry, label: entry }))}
+                disabled={running}
+              />
+            ) : (
+              <SelectMenu
+                value={upscaleFactor}
+                onChange={(value) => onUpscaleFactorChange(Number(value))}
+                options={(engine?.supportedUpscaleFactors ?? [2]).map((entry) => ({ value: entry, label: `${entry}x` }))}
+                disabled={running}
+              />
+            )}
+          </label>
+        </div>
+
+        <label className="block">
+          <Label>{copy.output}</Label>
+          <SelectMenu
+            value={outputFormat}
+            onChange={(value) => onOutputFormatChange(value as UpscaleOutputFormat)}
+            options={(engine?.supportedOutputFormats ?? ['jpg']).map((entry) => ({ value: entry, label: entry.toUpperCase() }))}
+            disabled={running}
+          />
+        </label>
+      </div>
+
+      <div className="mt-5 flex items-center gap-3 rounded-[12px] border border-border bg-bg px-4 py-3">
+        <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-surface text-text-primary shadow-card">
+          <Coins className="h-5 w-5" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-medium text-text-muted">{copy.priceEyebrow}</p>
+          <p className="mt-1 text-xl font-semibold leading-none text-text-primary">{priceLabel}</p>
+          <p className="mt-1 text-xs text-text-muted">{priceHint}</p>
+        </div>
+      </div>
+
+      <Button className="mt-5 w-full rounded-[10px] bg-brand py-3 text-on-brand hover:bg-brand-hover" size="lg" onClick={onRun} disabled={!canRun}>
+        {running ? <Loader2 className="h-4 w-4 animate-spin" /> : <WandSparkles className="h-4 w-4" />}
+        {running ? copy.running : copy.run}
+      </Button>
+      {message ? <p className="mt-3 text-sm text-text-muted">{message}</p> : null}
+      {error ? <p className="mt-3 text-sm font-medium text-error">{error}</p> : null}
+    </Card>
+  );
+}

--- a/tests/upscale-workspace-architecture.test.ts
+++ b/tests/upscale-workspace-architecture.test.ts
@@ -15,6 +15,7 @@ const previewStateHookPath = join(root, 'frontend/src/components/tools/upscale/_
 const recentJobsHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscaleRecentJobs.ts');
 const sourceMediaHookPath = join(root, 'frontend/src/components/tools/upscale/_hooks/useUpscaleSourceMedia.ts');
 const controlsPath = join(root, 'frontend/src/components/tools/upscale/_components/upscale-workspace-controls.tsx');
+const inputPanelsPath = join(root, 'frontend/src/components/tools/upscale/_components/UpscaleInputPanels.tsx');
 const heroSummaryCardPath = join(root, 'frontend/src/components/tools/upscale/_components/UpscaleHeroSummaryCard.tsx');
 const previewCardPath = join(root, 'frontend/src/components/tools/upscale/_components/UpscalePreviewCard.tsx');
 const recentRailPath = join(root, 'frontend/src/components/tools/upscale/_components/UpscaleRecentRail.tsx');
@@ -32,6 +33,7 @@ test('upscale workspace delegates copy, local types, and helper logic', () => {
   assert.ok(existsSync(recentJobsHookPath), 'upscale recent jobs orchestration should live in a colocated hook');
   assert.ok(existsSync(sourceMediaHookPath), 'upscale source media orchestration should live in a colocated hook');
   assert.ok(existsSync(controlsPath), 'upscale workspace controls should live in colocated components');
+  assert.ok(existsSync(inputPanelsPath), 'upscale input panels should live in colocated components');
   assert.ok(existsSync(heroSummaryCardPath), 'upscale hero summary should live in a colocated component');
   assert.ok(existsSync(previewCardPath), 'upscale preview card should live in a colocated component');
   assert.ok(existsSync(recentRailPath), 'upscale recent rail should live in a colocated component');
@@ -45,7 +47,7 @@ test('upscale workspace delegates copy, local types, and helper logic', () => {
   assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscalePreviewState'/, 'workspace should import preview state hook');
   assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscaleRecentJobs'/, 'workspace should import recent jobs hook');
   assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscaleSourceMedia'/, 'workspace should import source media hook');
-  assert.match(workspaceSource, /from '\.\/upscale\/_components\/upscale-workspace-controls'/, 'workspace should import workspace controls');
+  assert.match(workspaceSource, /from '\.\/upscale\/_components\/UpscaleInputPanels'/, 'workspace should import input panels');
   assert.match(workspaceSource, /from '\.\/upscale\/_components\/UpscaleHeroSummaryCard'/, 'workspace should import hero summary card');
   assert.match(workspaceSource, /from '\.\/upscale\/_components\/UpscalePreviewCard'/, 'workspace should import preview card');
   assert.match(workspaceSource, /from '\.\/upscale\/_components\/UpscaleRecentRail'/, 'workspace should import recent rail');
@@ -83,9 +85,13 @@ test('upscale workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /recentGroups\.slice/, 'recent rail rendering belongs in UpscaleRecentRail');
   assert.doesNotMatch(workspaceSource, /Reuse finished assets/, 'recent rail copy belongs in UpscaleRecentRail');
   assert.doesNotMatch(workspaceSource, /<GroupedJobCard/, 'recent job cards belong in UpscaleRecentRail');
+  assert.doesNotMatch(workspaceSource, /Source asset/, 'source panel JSX belongs in UpscaleInputPanels');
+  assert.doesNotMatch(workspaceSource, /Drop file here/, 'upload dropzone JSX belongs in UpscaleInputPanels');
+  assert.doesNotMatch(workspaceSource, /Choose how you want to enhance/, 'recipe panel JSX belongs in UpscaleInputPanels');
+  assert.doesNotMatch(workspaceSource, /<SelectMenu/, 'recipe selectors belong in UpscaleInputPanels');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 790, `UpscaleWorkspace should stay below 790 lines after recent rail extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 670, `UpscaleWorkspace should stay below 670 lines after input panel extraction, got ${lineCount}`);
 });
 
 test('upscale helper modules expose the expected workspace contract', () => {
@@ -99,6 +105,7 @@ test('upscale helper modules expose the expected workspace contract', () => {
   const recentJobsHookSource = readFileSync(recentJobsHookPath, 'utf8');
   const sourceMediaHookSource = readFileSync(sourceMediaHookPath, 'utf8');
   const controlsSource = readFileSync(controlsPath, 'utf8');
+  const inputPanelsSource = readFileSync(inputPanelsPath, 'utf8');
   const heroSummaryCardSource = readFileSync(heroSummaryCardPath, 'utf8');
   const previewCardSource = readFileSync(previewCardPath, 'utf8');
   const recentRailSource = readFileSync(recentRailPath, 'utf8');
@@ -155,6 +162,10 @@ test('upscale helper modules expose the expected workspace contract', () => {
   assert.match(sourceMediaHookSource, /new window\.Image/, 'source media hook should hydrate image dimensions');
   assert.match(controlsSource, /export function Label/, 'workspace label component should be exported');
   assert.match(controlsSource, /export function SegmentButton/, 'workspace segment button should be exported');
+  assert.match(inputPanelsSource, /export function UpscaleSourcePanel/, 'source panel should be exported');
+  assert.match(inputPanelsSource, /export function UpscaleRecipePanel/, 'recipe panel should be exported');
+  assert.match(inputPanelsSource, /SegmentButton/, 'input panels should own media type controls');
+  assert.match(inputPanelsSource, /SelectMenu/, 'input panels should own recipe selectors');
   assert.match(heroSummaryCardSource, /export function UpscaleHeroSummaryCard/, 'hero summary card should be exported');
   assert.match(heroSummaryCardSource, /WandSparkles/, 'hero summary card should own its action icon');
   assert.match(previewCardSource, /export function UpscalePreviewCard/, 'preview card should be exported');


### PR DESCRIPTION
## Summary
- move the Upscale source and recipe panels into colocated components
- keep workspace-level state and submission orchestration in UpscaleWorkspace
- tighten the architecture contract so input panel JSX and selectors stay out of the workspace

## Checks
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/upscale-workspace-architecture.test.ts tests/upscale-pricing-preview.test.ts tests/upscale-route-bundling.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- git diff --check -- frontend/src/components/tools/UpscaleWorkspace.tsx frontend/src/components/tools/upscale/_components/UpscaleInputPanels.tsx tests/upscale-workspace-architecture.test.ts
- npm --prefix frontend run lint
- npm run lint:exposure