### PR TITLE
Split image gallery selection hook

### DIFF
--- a/frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx
+++ b/frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx
@@ -15,25 +15,20 @@ import { ImageSettingsBar } from '@/components/ImageSettingsBar';
 import { ImageAdvancedSettings } from '@/components/ImageAdvancedSettings';
 import { saveImageToLibrary } from '@/lib/api';
 import type { ImageGenerationMode } from '@/types/image-generation';
-import type { GroupSummary } from '@/types/groups';
 import type { VideoGroup } from '@/types/video-groups';
 import type { MediaLightboxEntry } from '@/components/MediaLightbox';
 import { ImageCompositePreviewDock, type ImageCompositePreviewEntry } from '@/components/groups/ImageCompositePreviewDock';
 import { buildVideoGroupFromImageRun } from '@/lib/image-groups';
 import { useI18n } from '@/lib/i18n/I18nProvider';
 import { FEATURES } from '@/content/feature-flags';
-import {
-  clampRequestedImageCount,
-  getAspectRatioOptions,
-  getDefaultAspectRatio,
-} from '@/lib/image/inputSchema';
+import { clampRequestedImageCount } from '@/lib/image/inputSchema';
 import {
   GPT_IMAGE_2_SIZE_CONSTRAINTS,
   parseGptImage2SizeKey,
 } from '@/lib/image/gptImage2';
-import { authFetch } from '@/lib/authFetch';
 import { ImageAuthGateModal } from './_components/ImageAuthGateModal';
 import { ImageLibraryModal } from './_components/ImageLibraryModal';
+import { useImageGallerySelection } from './_hooks/useImageGallerySelection';
 import { useImageGenerationRunner } from './_hooks/useImageGenerationRunner';
 import { useImageWorkspaceHistory } from './_hooks/useImageWorkspaceHistory';
 import { useImageWorkspacePricing } from './_hooks/useImageWorkspacePricing';
@@ -49,9 +44,6 @@ import {
   mergeCopy,
   type ImageWorkspaceCopy,
 } from './_lib/image-workspace-copy';
-import {
-  findImageEngine,
-} from './_lib/image-workspace-utils';
 import {
   type HistoryEntry,
   type ImageEngineOption,
@@ -386,127 +378,18 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
     thinkingLevel,
   });
 
-  const handleSelectGalleryGroup = useCallback(
-    (group: GroupSummary) => {
-      const applyEntryDefaults = (entry: HistoryEntry) => {
-        const engineMatch = entry.engineId ? findImageEngine(engines, entry.engineId) : null;
-        if (engineMatch) {
-          setEngineId(engineMatch.id);
-          if (entry.mode) {
-            setMode(engineMatch.modes.includes(entry.mode) ? entry.mode : engineMatch.modes[0] ?? 't2i');
-          }
-        } else if (entry.mode) {
-          setMode(entry.mode);
-        }
-        if (typeof entry.prompt === 'string') {
-          setPrompt(entry.prompt);
-        }
-        if (engineMatch) {
-          const nextMode = engineMatch.modes.includes(entry.mode) ? entry.mode : engineMatch.modes[0] ?? 't2i';
-          const options = getAspectRatioOptions(engineMatch.engineCaps, nextMode);
-          const fallback = getDefaultAspectRatio(engineMatch.engineCaps, nextMode);
-          const nextAspect = entry.aspectRatio && options.includes(entry.aspectRatio) ? entry.aspectRatio : fallback;
-          setAspectRatio(nextAspect);
-        }
-      };
-
-      const fetchSnapshot = (jobId: string | null | undefined) => {
-        if (!jobId) return;
-        void authFetch(`/api/jobs/${encodeURIComponent(jobId)}`)
-          .then(async (response) => {
-            const payload = (await response.json().catch(() => null)) as
-              | { ok?: boolean; settingsSnapshot?: unknown }
-              | null;
-            if (!response.ok || !payload?.ok || !payload.settingsSnapshot) return;
-            applyImageSettingsSnapshot(payload.settingsSnapshot);
-          })
-          .catch(() => undefined);
-      };
-
-      const heroJobId = group.hero.jobId ?? group.hero.job?.jobId ?? group.id;
-      const heroUrl =
-        group.hero.thumbUrl ??
-        group.hero.videoUrl ??
-        group.previews.find((preview) => preview.thumbUrl ?? preview.videoUrl)?.thumbUrl ??
-        group.previews.find((preview) => preview.videoUrl ?? preview.thumbUrl)?.videoUrl ??
-        null;
-      const matchById = heroJobId
-        ? historyEntries.find((entry) => entry.id === heroJobId || entry.jobId === heroJobId)
-        : null;
-      const matchByUrl =
-        !matchById && heroUrl
-          ? historyEntries.find((entry) => entry.images.some((image) => image.url === heroUrl || image.thumbUrl === heroUrl))
-          : null;
-      const match = matchById ?? matchByUrl;
-      if (match) {
-        const index = heroUrl ? match.images.findIndex((image) => image.url === heroUrl || image.thumbUrl === heroUrl) : -1;
-        setSelectedPreviewEntryId(match.id);
-        setSelectedPreviewImageIndex(index >= 0 ? index : 0);
-        applyEntryDefaults(match);
-        fetchSnapshot(match.jobId ?? heroJobId);
-        return;
-      }
-
-      const previewUrls = group.previews
-        .map((preview) => preview.thumbUrl ?? preview.videoUrl)
-        .filter((url): url is string => Boolean(url));
-      if (!previewUrls.length && heroUrl) {
-        previewUrls.push(heroUrl);
-      }
-      if (!previewUrls.length) return;
-      const heroRenderUrls = Array.isArray(group.hero.job?.renderIds)
-        ? group.hero.job.renderIds.filter((url): url is string => typeof url === 'string' && url.length > 0)
-        : [];
-      const heroRenderThumbUrls = Array.isArray(group.hero.job?.renderThumbUrls)
-        ? group.hero.job.renderThumbUrls.filter((url): url is string => typeof url === 'string' && url.length > 0)
-        : [];
-      const fallbackImages =
-        heroRenderUrls.length > 0
-          ? heroRenderUrls.map((url, index) => ({
-              url,
-              thumbUrl: heroRenderThumbUrls[index] ?? (index === 0 ? group.hero.thumbUrl ?? null : null),
-            }))
-          : previewUrls.map((url) => ({ url, thumbUrl: url }));
-
-      const createdAt = Date.parse(group.createdAt ?? '');
-      const entry: HistoryEntry = {
-        id: group.id,
-        jobId: heroJobId ?? group.id,
-        engineId: group.hero.engineId ?? '',
-        engineLabel: group.hero.engineLabel ?? 'Image generation',
-        mode: 't2i',
-        prompt: group.hero.prompt ?? '',
-        createdAt: Number.isNaN(createdAt) ? Date.now() : createdAt,
-        description: group.hero.message ?? null,
-        images: fallbackImages,
-        aspectRatio: group.hero.aspectRatio ?? group.previews[0]?.aspectRatio ?? null,
-      };
-
-      setLocalHistory((prev) => {
-        if (prev.some((existing) => existing.id === entry.id)) return prev;
-        return [entry, ...prev].slice(0, 24);
-      });
-      const fallbackIndex = heroUrl
-        ? fallbackImages.findIndex((image) => image.url === heroUrl || image.thumbUrl === heroUrl)
-        : -1;
-      setSelectedPreviewEntryId(entry.id);
-      setSelectedPreviewImageIndex(fallbackIndex >= 0 ? fallbackIndex : 0);
-      applyEntryDefaults(entry);
-      fetchSnapshot(entry.jobId ?? heroJobId);
-    },
-    [
-      applyImageSettingsSnapshot,
-      engines,
-      historyEntries,
-      setAspectRatio,
-      setEngineId,
-      setLocalHistory,
-      setMode,
-      setPrompt,
-      setSelectedPreviewEntryId,
-      setSelectedPreviewImageIndex,
-    ]
-  );
+  const handleSelectGalleryGroup = useImageGallerySelection({
+    applyImageSettingsSnapshot,
+    engines,
+    historyEntries,
+    setAspectRatio,
+    setEngineId,
+    setLocalHistory,
+    setMode,
+    setPrompt,
+    setSelectedPreviewEntryId,
+    setSelectedPreviewImageIndex,
+  });
 
   const previewEntry = (() => {
     if (selectedPreviewEntryId) {

--- a/frontend/app/(core)/(workspace)/app/image/_hooks/useImageGallerySelection.ts
+++ b/frontend/app/(core)/(workspace)/app/image/_hooks/useImageGallerySelection.ts
@@ -1,0 +1,156 @@
+import { useCallback, type Dispatch, type SetStateAction } from 'react';
+import { authFetch } from '@/lib/authFetch';
+import {
+  getAspectRatioOptions,
+  getDefaultAspectRatio,
+} from '@/lib/image/inputSchema';
+import type { ImageGenerationMode } from '@/types/image-generation';
+import type { GroupSummary } from '@/types/groups';
+import { findImageEngine } from '../_lib/image-workspace-utils';
+import type { HistoryEntry, ImageEngineOption } from '../_lib/image-workspace-types';
+
+export function useImageGallerySelection({
+  applyImageSettingsSnapshot,
+  engines,
+  historyEntries,
+  setAspectRatio,
+  setEngineId,
+  setLocalHistory,
+  setMode,
+  setPrompt,
+  setSelectedPreviewEntryId,
+  setSelectedPreviewImageIndex,
+}: {
+  applyImageSettingsSnapshot: (snapshot: unknown) => void;
+  engines: ImageEngineOption[];
+  historyEntries: HistoryEntry[];
+  setAspectRatio: (value: string | null) => void;
+  setEngineId: (value: string) => void;
+  setLocalHistory: Dispatch<SetStateAction<HistoryEntry[]>>;
+  setMode: (value: ImageGenerationMode) => void;
+  setPrompt: (value: string) => void;
+  setSelectedPreviewEntryId: (value: string | null) => void;
+  setSelectedPreviewImageIndex: (value: number) => void;
+}) {
+  return useCallback(
+    (group: GroupSummary) => {
+      const applyEntryDefaults = (entry: HistoryEntry) => {
+        const engineMatch = entry.engineId ? findImageEngine(engines, entry.engineId) : null;
+        if (engineMatch) {
+          setEngineId(engineMatch.id);
+          if (entry.mode) {
+            setMode(engineMatch.modes.includes(entry.mode) ? entry.mode : engineMatch.modes[0] ?? 't2i');
+          }
+        } else if (entry.mode) {
+          setMode(entry.mode);
+        }
+        if (typeof entry.prompt === 'string') {
+          setPrompt(entry.prompt);
+        }
+        if (engineMatch) {
+          const nextMode = engineMatch.modes.includes(entry.mode) ? entry.mode : engineMatch.modes[0] ?? 't2i';
+          const options = getAspectRatioOptions(engineMatch.engineCaps, nextMode);
+          const fallback = getDefaultAspectRatio(engineMatch.engineCaps, nextMode);
+          const nextAspect = entry.aspectRatio && options.includes(entry.aspectRatio) ? entry.aspectRatio : fallback;
+          setAspectRatio(nextAspect);
+        }
+      };
+
+      const fetchSnapshot = (jobId: string | null | undefined) => {
+        if (!jobId) return;
+        void authFetch(`/api/jobs/${encodeURIComponent(jobId)}`)
+          .then(async (response) => {
+            const payload = (await response.json().catch(() => null)) as
+              | { ok?: boolean; settingsSnapshot?: unknown }
+              | null;
+            if (!response.ok || !payload?.ok || !payload.settingsSnapshot) return;
+            applyImageSettingsSnapshot(payload.settingsSnapshot);
+          })
+          .catch(() => undefined);
+      };
+
+      const heroJobId = group.hero.jobId ?? group.hero.job?.jobId ?? group.id;
+      const heroUrl =
+        group.hero.thumbUrl ??
+        group.hero.videoUrl ??
+        group.previews.find((preview) => preview.thumbUrl ?? preview.videoUrl)?.thumbUrl ??
+        group.previews.find((preview) => preview.videoUrl ?? preview.thumbUrl)?.videoUrl ??
+        null;
+      const matchById = heroJobId
+        ? historyEntries.find((entry) => entry.id === heroJobId || entry.jobId === heroJobId)
+        : null;
+      const matchByUrl =
+        !matchById && heroUrl
+          ? historyEntries.find((entry) => entry.images.some((image) => image.url === heroUrl || image.thumbUrl === heroUrl))
+          : null;
+      const match = matchById ?? matchByUrl;
+      if (match) {
+        const index = heroUrl ? match.images.findIndex((image) => image.url === heroUrl || image.thumbUrl === heroUrl) : -1;
+        setSelectedPreviewEntryId(match.id);
+        setSelectedPreviewImageIndex(index >= 0 ? index : 0);
+        applyEntryDefaults(match);
+        fetchSnapshot(match.jobId ?? heroJobId);
+        return;
+      }
+
+      const previewUrls = group.previews
+        .map((preview) => preview.thumbUrl ?? preview.videoUrl)
+        .filter((url): url is string => Boolean(url));
+      if (!previewUrls.length && heroUrl) {
+        previewUrls.push(heroUrl);
+      }
+      if (!previewUrls.length) return;
+      const heroRenderUrls = Array.isArray(group.hero.job?.renderIds)
+        ? group.hero.job.renderIds.filter((url): url is string => typeof url === 'string' && url.length > 0)
+        : [];
+      const heroRenderThumbUrls = Array.isArray(group.hero.job?.renderThumbUrls)
+        ? group.hero.job.renderThumbUrls.filter((url): url is string => typeof url === 'string' && url.length > 0)
+        : [];
+      const fallbackImages =
+        heroRenderUrls.length > 0
+          ? heroRenderUrls.map((url, index) => ({
+              url,
+              thumbUrl: heroRenderThumbUrls[index] ?? (index === 0 ? group.hero.thumbUrl ?? null : null),
+            }))
+          : previewUrls.map((url) => ({ url, thumbUrl: url }));
+
+      const createdAt = Date.parse(group.createdAt ?? '');
+      const entry: HistoryEntry = {
+        id: group.id,
+        jobId: heroJobId ?? group.id,
+        engineId: group.hero.engineId ?? '',
+        engineLabel: group.hero.engineLabel ?? 'Image generation',
+        mode: 't2i',
+        prompt: group.hero.prompt ?? '',
+        createdAt: Number.isNaN(createdAt) ? Date.now() : createdAt,
+        description: group.hero.message ?? null,
+        images: fallbackImages,
+        aspectRatio: group.hero.aspectRatio ?? group.previews[0]?.aspectRatio ?? null,
+      };
+
+      setLocalHistory((prev) => {
+        if (prev.some((existing) => existing.id === entry.id)) return prev;
+        return [entry, ...prev].slice(0, 24);
+      });
+      const fallbackIndex = heroUrl
+        ? fallbackImages.findIndex((image) => image.url === heroUrl || image.thumbUrl === heroUrl)
+        : -1;
+      setSelectedPreviewEntryId(entry.id);
+      setSelectedPreviewImageIndex(fallbackIndex >= 0 ? fallbackIndex : 0);
+      applyEntryDefaults(entry);
+      fetchSnapshot(entry.jobId ?? heroJobId);
+    },
+    [
+      applyImageSettingsSnapshot,
+      engines,
+      historyEntries,
+      setAspectRatio,
+      setEngineId,
+      setLocalHistory,
+      setMode,
+      setPrompt,
+      setSelectedPreviewEntryId,
+      setSelectedPreviewImageIndex,
+    ]
+  );
+}

--- a/tests/image-workspace-split-contract.test.ts
+++ b/tests/image-workspace-split-contract.test.ts
@@ -9,6 +9,7 @@ const workspacePath = path.join(imageDir, 'ImageWorkspace.tsx');
 const composerPersistenceHookPath = path.join(imageDir, '_hooks/useImageComposerPersistence.ts');
 const queryHydrationHookPath = path.join(imageDir, '_hooks/useImageWorkspaceQueryHydration.ts');
 const generationRunnerHookPath = path.join(imageDir, '_hooks/useImageGenerationRunner.ts');
+const gallerySelectionHookPath = path.join(imageDir, '_hooks/useImageGallerySelection.ts');
 
 const splitFiles = [
   '_components/ImageAuthGateModal.tsx',
@@ -19,6 +20,7 @@ const splitFiles = [
   '_hooks/useImageWorkspaceDesktopLayout.ts',
   '_hooks/useImageWorkspaceQueryHydration.ts',
   '_hooks/useImageGenerationRunner.ts',
+  '_hooks/useImageGallerySelection.ts',
   '_lib/image-workspace-character-references.ts',
   '_lib/image-workspace-copy.ts',
   '_lib/image-workspace-history.ts',
@@ -36,6 +38,7 @@ test('image workspace foundations are split from the route orchestrator', () => 
   const composerPersistenceHookSource = readFileSync(composerPersistenceHookPath, 'utf8');
   const queryHydrationHookSource = readFileSync(queryHydrationHookPath, 'utf8');
   const generationRunnerHookSource = readFileSync(generationRunnerHookPath, 'utf8');
+  const gallerySelectionHookSource = readFileSync(gallerySelectionHookPath, 'utf8');
 
   for (const file of splitFiles) {
     statSync(path.join(imageDir, file));
@@ -49,8 +52,8 @@ test('image workspace foundations are split from the route orchestrator', () => 
   assert.match(source, /from '\.\/_hooks\/useImageWorkspaceDesktopLayout'/);
   assert.match(source, /from '\.\/_hooks\/useImageWorkspaceQueryHydration'/);
   assert.match(source, /from '\.\/_hooks\/useImageGenerationRunner'/);
+  assert.match(source, /from '\.\/_hooks\/useImageGallerySelection'/);
   assert.match(source, /from '\.\/_lib\/image-workspace-copy'/);
-  assert.match(source, /from '\.\/_lib\/image-workspace-utils'/);
 
   assert.doesNotMatch(source, /const DEFAULT_COPY: ImageWorkspaceCopy =/);
   assert.doesNotMatch(source, /function ImageLibraryModal\(/);
@@ -71,6 +74,10 @@ test('image workspace foundations are split from the route orchestrator', () => 
   assert.doesNotMatch(source, /runImageGeneration/, 'generation submission belongs in useImageGenerationRunner');
   assert.doesNotMatch(source, /readBrowserSession/, 'auth preflight belongs in useImageGenerationRunner');
   assert.doesNotMatch(source, /validateGptImage2CustomImageSize/, 'custom size validation belongs in useImageGenerationRunner');
+  assert.doesNotMatch(source, /const fetchSnapshot =/, 'gallery snapshot hydration belongs in useImageGallerySelection');
+  assert.doesNotMatch(source, /const previewUrls =/, 'fallback gallery image derivation belongs in useImageGallerySelection');
+  assert.doesNotMatch(source, /findImageEngine/, 'gallery engine default selection belongs in useImageGallerySelection');
+  assert.doesNotMatch(source, /authFetch/, 'gallery API snapshot lookup belongs in useImageGallerySelection');
 
   assert.match(composerPersistenceHookSource, /export function useImageComposerPersistence/);
   assert.match(composerPersistenceHookSource, /parsePersistedImageComposerState/);
@@ -87,7 +94,12 @@ test('image workspace foundations are split from the route orchestrator', () => 
   assert.match(generationRunnerHookSource, /from '\.\.\/_lib\/image-workspace-history'/);
   assert.match(generationRunnerHookSource, /buildPendingGroup/);
   assert.match(generationRunnerHookSource, /buildCompletedGroup/);
+  assert.match(gallerySelectionHookSource, /export function useImageGallerySelection/);
+  assert.match(gallerySelectionHookSource, /findImageEngine/);
+  assert.match(gallerySelectionHookSource, /getAspectRatioOptions/);
+  assert.match(gallerySelectionHookSource, /authFetch/);
+  assert.match(gallerySelectionHookSource, /const previewUrls =/);
 
   const lineCount = source.split('\n').length;
-  assert.ok(lineCount <= 950, `ImageWorkspace should stay below 950 lines after generation runner extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 830, `ImageWorkspace should stay below 830 lines after gallery selection extraction, got ${lineCount}`);
 });


### PR DESCRIPTION
## Summary
- move image GalleryRail group selection and snapshot hydration into useImageGallerySelection
- keep ImageWorkspace focused on state wiring and rendering
- tighten the image workspace split contract around the extracted gallery logic

## Checks
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/image-workspace-split-contract.test.ts tests/image-preview-actions-hook-contract.test.ts tests/image-reference-slots-hook-contract.test.ts tests/image-settings-fields-hook-contract.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- git diff --check -- frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx frontend/app/(core)/(workspace)/app/image/_hooks/useImageGallerySelection.ts tests/image-workspace-split-contract.test.ts
- npm --prefix frontend run lint
- npm run lint:exposure