### PR TITLE
Split angle output panel

### DIFF
--- a/frontend/src/components/tools/AngleWorkspace.tsx
+++ b/frontend/src/components/tools/AngleWorkspace.tsx
@@ -24,7 +24,6 @@ import { Button, ButtonLink } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
 import { saveImageToLibrary, useInfiniteJobs } from '@/lib/api';
 import { authFetch } from '@/lib/authFetch';
-import { suggestDownloadFilename, triggerAppDownload } from '@/lib/download';
 import { useI18n } from '@/lib/i18n/I18nProvider';
 import { resolveAngleEngineForParams } from '@/lib/tools-angle';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
@@ -33,12 +32,11 @@ import type { AngleToolEngineId, AngleToolNumericParams, AngleToolResponse } fro
 import { AngleAuthGateModal } from './angle/_components/angle-auth-gate-modal';
 import { AngleImageLibraryModal } from './angle/_components/angle-image-library-modal';
 import { AngleOrbitSelector } from './angle/_components/angle-orbit-selector';
-import { AngleOutputMosaic } from './angle/_components/angle-output-mosaic';
+import { AngleOutputPanel } from './angle/_components/angle-output-panel';
 import { AngleRecentJobModal } from './angle/_components/angle-recent-job-modal';
 import { useAngleGenerationRunner } from './angle/_hooks/useAngleGenerationRunner';
 import { DEFAULT_ANGLE_COPY, type AngleCopy } from './angle/_lib/angle-workspace-copy';
 import {
-  ANGLE_GUEST_EXAMPLE_OUTPUT_URL,
   ANGLE_GUEST_EXAMPLE_SOURCE_URL,
   ANGLE_TOOL_STORAGE_KEY,
   cleanupSourcePreview,
@@ -132,7 +130,6 @@ export default function AngleToolPage() {
     return Number((billingProductData.unitPriceCents / 100).toFixed(4));
   }, [billingProductData?.unitPriceCents]);
 
-  const selectedOutput = result?.outputs[selectedOutputIndex] ?? null;
   const { stableJobs: angleJobs } = useInfiniteJobs(12, { surface: 'angle' });
   const recentAngleJobs = useMemo<RecentAngleJobEntry[]>(() => {
     const currentJobId = result?.jobId ?? null;
@@ -760,115 +757,20 @@ export default function AngleToolPage() {
                 </div>
               </Card>
 
-              <Card className="border border-border bg-surface p-5">
-                <div className="flex h-full flex-col gap-4">
-                  <div>
-                    <p className="text-xs font-semibold uppercase tracking-micro text-text-muted">{copy.output}</p>
-                    <h2 className="mt-1 text-lg font-semibold text-text-primary">{copy.outputTitle}</h2>
-                  </div>
-
-                  {selectedOutput ? (
-                    <>
-                      <div className="relative">
-                        <AngleOutputMosaic
-                          outputs={(result?.outputs ?? []).map((output) => ({ url: output.url, thumbUrl: output.thumbUrl ?? output.url }))}
-                          selectedIndex={selectedOutputIndex}
-                          onSelect={setSelectedOutputIndex}
-                          onDownload={(url) => triggerAppDownload(url, suggestDownloadFilename(url, `angle-preview-${Date.now()}`))}
-                          onAddToLibrary={(url) => handleAddOutputToLibrary(url)}
-                          libraryDisabled={Boolean(selectedOutput?.persisted) || Boolean(savingOutputUrl)}
-                          copy={copy}
-                        />
-
-                        {generating ? (
-                          <div className="absolute inset-0 flex items-center justify-center rounded-card bg-surface-on-media-dark-45 backdrop-blur-[2px]">
-                            <div className="rounded-card border border-white/20 bg-surface-on-media-dark-55 px-4 py-3 text-center text-on-inverse shadow-card">
-                              <div className="flex items-center justify-center gap-2 text-sm font-medium">
-                                <Loader2 className="h-4 w-4 animate-spin" />
-                                {copy.generatingOverlayTitle}
-                              </div>
-                              <p className="mt-1 text-xs text-on-inverse/80">{copy.generatingOverlayBody}</p>
-                            </div>
-                          </div>
-                        ) : null}
-                      </div>
-
-                      <div className="rounded-card border border-border bg-bg p-4">
-                        <div className="flex flex-wrap items-center gap-2 text-xs text-text-muted">
-                          <span>{copy.latency}: {result?.latencyMs ?? 0} ms</span>
-                          <span>·</span>
-                          <span>{formatUsdCompact(result?.pricing.actualCostUsd ?? result?.pricing.estimatedCostUsd ?? null)}</span>
-                        </div>
-                        {result?.applied.safeApplied ? (
-                          <p className="mt-2 text-xs text-warning">{copy.safeGuardrails}</p>
-                        ) : null}
-                      </div>
-
-                    </>
-                  ) : !user && sourceImage?.source === 'example' ? (
-                    <div className="overflow-hidden rounded-card border border-border bg-bg">
-                      <div className="relative overflow-hidden bg-[radial-gradient(circle_at_top,rgba(59,130,246,0.12),transparent_38%),linear-gradient(180deg,rgba(255,255,255,0.02),rgba(15,23,42,0.06))]">
-                        <img src={ANGLE_GUEST_EXAMPLE_OUTPUT_URL} alt="" className="max-h-[420px] w-full object-contain" />
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="flex min-h-[420px] items-center justify-center rounded-card border border-dashed border-border bg-bg p-6 text-center">
-                      <div>
-                        {generating ? (
-                          <>
-                            <div className="flex items-center justify-center gap-2 text-sm font-medium text-text-primary">
-                              <Loader2 className="h-4 w-4 animate-spin" />
-                              {copy.generatingOverlayTitle}
-                            </div>
-                            <p className="mt-2 text-xs text-text-muted">
-                              {copy.generatingOverlayBody}
-                            </p>
-                          </>
-                        ) : (
-                          <>
-                            <p className="text-sm font-medium text-text-primary">{copy.emptyTitle}</p>
-                            <p className="mt-2 text-xs text-text-muted">{copy.emptyBody}</p>
-                          </>
-                        )}
-                      </div>
-                    </div>
-                  )}
-
-                  {recentAngleJobs.length ? (
-                    <div className="rounded-card border border-border bg-bg p-4">
-                      <div className="mb-3 flex items-center justify-between gap-3">
-                        <p className="text-xs font-semibold uppercase tracking-micro text-text-muted">{copy.previousJobs}</p>
-                        <Link href="/jobs" className="text-xs font-medium text-brand hover:underline">
-                          {copy.openJobs}
-                        </Link>
-                      </div>
-                      <div className="grid grid-cols-4 gap-2">
-                        {recentAngleJobs.map((entry) => (
-                          <button
-                            key={entry.jobId}
-                            type="button"
-                            onClick={() => {
-                              setActiveRecentJobId(entry.jobId);
-                              setActiveRecentOutputIndex(0);
-                            }}
-                            className="overflow-hidden rounded-card border border-border bg-surface text-left transition hover:border-brand/40"
-                          >
-                            <div className="h-20 w-full overflow-hidden bg-bg">
-                              <AngleOutputMosaic outputs={entry.outputs} compact copy={copy} />
-                            </div>
-                            <div className="px-2 py-1.5">
-                              <p className="truncate text-[10px] font-medium text-text-primary">{entry.engineLabel}</p>
-                              <p className="truncate text-[10px] text-text-muted">
-                              {new Date(entry.createdAt).toLocaleDateString(locale)}
-                              </p>
-                            </div>
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                  ) : null}
-                </div>
-              </Card>
+              <AngleOutputPanel
+                copy={copy}
+                generating={generating}
+                locale={locale}
+                onAddOutputToLibrary={handleAddOutputToLibrary}
+                onRecentJobOpen={setActiveRecentJobId}
+                onRecentOutputIndexReset={() => setActiveRecentOutputIndex(0)}
+                onSelectedOutputIndexChange={setSelectedOutputIndex}
+                recentAngleJobs={recentAngleJobs}
+                result={result}
+                savingOutputUrl={savingOutputUrl}
+                selectedOutputIndex={selectedOutputIndex}
+                showGuestExampleOutput={!user && sourceImage?.source === 'example'}
+              />
             </div>
           </div>
         </main>

--- a/frontend/src/components/tools/angle/_components/angle-output-panel.tsx
+++ b/frontend/src/components/tools/angle/_components/angle-output-panel.tsx
@@ -1,0 +1,155 @@
+/* eslint-disable @next/next/no-img-element */
+
+import Link from 'next/link';
+import { Loader2 } from 'lucide-react';
+import { Card } from '@/components/ui/Card';
+import { suggestDownloadFilename, triggerAppDownload } from '@/lib/download';
+import type { AngleToolResponse } from '@/types/tools-angle';
+import {
+  ANGLE_GUEST_EXAMPLE_OUTPUT_URL,
+  formatUsdCompact,
+} from '../_lib/angle-workspace-helpers';
+import type { AngleCopy } from '../_lib/angle-workspace-copy';
+import type { RecentAngleJobEntry } from '../_lib/angle-workspace-types';
+import { AngleOutputMosaic } from './angle-output-mosaic';
+
+export function AngleOutputPanel({
+  copy,
+  generating,
+  locale,
+  onAddOutputToLibrary,
+  onRecentJobOpen,
+  onRecentOutputIndexReset,
+  onSelectedOutputIndexChange,
+  recentAngleJobs,
+  result,
+  savingOutputUrl,
+  selectedOutputIndex,
+  showGuestExampleOutput,
+}: {
+  copy: AngleCopy;
+  generating: boolean;
+  locale: string;
+  onAddOutputToLibrary: (url: string) => void;
+  onRecentJobOpen: (jobId: string) => void;
+  onRecentOutputIndexReset: () => void;
+  onSelectedOutputIndexChange: (index: number) => void;
+  recentAngleJobs: RecentAngleJobEntry[];
+  result: AngleToolResponse | null;
+  savingOutputUrl: string | null;
+  selectedOutputIndex: number;
+  showGuestExampleOutput: boolean;
+}) {
+  const selectedOutput = result?.outputs[selectedOutputIndex] ?? null;
+
+  return (
+    <Card className="border border-border bg-surface p-5">
+      <div className="flex h-full flex-col gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-micro text-text-muted">{copy.output}</p>
+          <h2 className="mt-1 text-lg font-semibold text-text-primary">{copy.outputTitle}</h2>
+        </div>
+
+        {selectedOutput ? (
+          <>
+            <div className="relative">
+              <AngleOutputMosaic
+                outputs={(result?.outputs ?? []).map((output) => ({ url: output.url, thumbUrl: output.thumbUrl ?? output.url }))}
+                selectedIndex={selectedOutputIndex}
+                onSelect={onSelectedOutputIndexChange}
+                onDownload={(url) => triggerAppDownload(url, suggestDownloadFilename(url, `angle-preview-${Date.now()}`))}
+                onAddToLibrary={(url) => onAddOutputToLibrary(url)}
+                libraryDisabled={Boolean(selectedOutput?.persisted) || Boolean(savingOutputUrl)}
+                copy={copy}
+              />
+
+              {generating ? (
+                <div className="absolute inset-0 flex items-center justify-center rounded-card bg-surface-on-media-dark-45 backdrop-blur-[2px]">
+                  <div className="rounded-card border border-white/20 bg-surface-on-media-dark-55 px-4 py-3 text-center text-on-inverse shadow-card">
+                    <div className="flex items-center justify-center gap-2 text-sm font-medium">
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      {copy.generatingOverlayTitle}
+                    </div>
+                    <p className="mt-1 text-xs text-on-inverse/80">{copy.generatingOverlayBody}</p>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+
+            <div className="rounded-card border border-border bg-bg p-4">
+              <div className="flex flex-wrap items-center gap-2 text-xs text-text-muted">
+                <span>{copy.latency}: {result?.latencyMs ?? 0} ms</span>
+                <span>·</span>
+                <span>{formatUsdCompact(result?.pricing.actualCostUsd ?? result?.pricing.estimatedCostUsd ?? null)}</span>
+              </div>
+              {result?.applied.safeApplied ? (
+                <p className="mt-2 text-xs text-warning">{copy.safeGuardrails}</p>
+              ) : null}
+            </div>
+          </>
+        ) : showGuestExampleOutput ? (
+          <div className="overflow-hidden rounded-card border border-border bg-bg">
+            <div className="relative overflow-hidden bg-[radial-gradient(circle_at_top,rgba(59,130,246,0.12),transparent_38%),linear-gradient(180deg,rgba(255,255,255,0.02),rgba(15,23,42,0.06))]">
+              <img src={ANGLE_GUEST_EXAMPLE_OUTPUT_URL} alt="" className="max-h-[420px] w-full object-contain" />
+            </div>
+          </div>
+        ) : (
+          <div className="flex min-h-[420px] items-center justify-center rounded-card border border-dashed border-border bg-bg p-6 text-center">
+            <div>
+              {generating ? (
+                <>
+                  <div className="flex items-center justify-center gap-2 text-sm font-medium text-text-primary">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    {copy.generatingOverlayTitle}
+                  </div>
+                  <p className="mt-2 text-xs text-text-muted">
+                    {copy.generatingOverlayBody}
+                  </p>
+                </>
+              ) : (
+                <>
+                  <p className="text-sm font-medium text-text-primary">{copy.emptyTitle}</p>
+                  <p className="mt-2 text-xs text-text-muted">{copy.emptyBody}</p>
+                </>
+              )}
+            </div>
+          </div>
+        )}
+
+        {recentAngleJobs.length ? (
+          <div className="rounded-card border border-border bg-bg p-4">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <p className="text-xs font-semibold uppercase tracking-micro text-text-muted">{copy.previousJobs}</p>
+              <Link href="/jobs" className="text-xs font-medium text-brand hover:underline">
+                {copy.openJobs}
+              </Link>
+            </div>
+            <div className="grid grid-cols-4 gap-2">
+              {recentAngleJobs.map((entry) => (
+                <button
+                  key={entry.jobId}
+                  type="button"
+                  onClick={() => {
+                    onRecentJobOpen(entry.jobId);
+                    onRecentOutputIndexReset();
+                  }}
+                  className="overflow-hidden rounded-card border border-border bg-surface text-left transition hover:border-brand/40"
+                >
+                  <div className="h-20 w-full overflow-hidden bg-bg">
+                    <AngleOutputMosaic outputs={entry.outputs} compact copy={copy} />
+                  </div>
+                  <div className="px-2 py-1.5">
+                    <p className="truncate text-[10px] font-medium text-text-primary">{entry.engineLabel}</p>
+                    <p className="truncate text-[10px] text-text-muted">
+                      {new Date(entry.createdAt).toLocaleDateString(locale)}
+                    </p>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </Card>
+  );
+}

--- a/tests/angle-workspace-architecture.test.ts
+++ b/tests/angle-workspace-architecture.test.ts
@@ -9,6 +9,7 @@ const componentsDir = join(root, 'frontend/src/components/tools/angle/_component
 const libraryModalPath = join(componentsDir, 'angle-image-library-modal.tsx');
 const orbitSelectorPath = join(componentsDir, 'angle-orbit-selector.tsx');
 const outputMosaicPath = join(componentsDir, 'angle-output-mosaic.tsx');
+const outputPanelPath = join(componentsDir, 'angle-output-panel.tsx');
 const recentJobModalPath = join(componentsDir, 'angle-recent-job-modal.tsx');
 const authGateModalPath = join(componentsDir, 'angle-auth-gate-modal.tsx');
 const generationRunnerHookPath = join(root, 'frontend/src/components/tools/angle/_hooks/useAngleGenerationRunner.ts');
@@ -22,6 +23,7 @@ test('angle workspace delegates copy, local types, and helper logic', () => {
   assert.ok(existsSync(libraryModalPath), 'angle library modal should live in a colocated component module');
   assert.ok(existsSync(orbitSelectorPath), 'angle orbit selector should live in a colocated component module');
   assert.ok(existsSync(outputMosaicPath), 'angle output mosaic should live in a colocated component module');
+  assert.ok(existsSync(outputPanelPath), 'angle output panel should live in a colocated component module');
   assert.ok(existsSync(recentJobModalPath), 'angle recent job modal should live in a colocated component module');
   assert.ok(existsSync(authGateModalPath), 'angle auth gate modal should live in a colocated component module');
   assert.ok(existsSync(generationRunnerHookPath), 'angle generation runner should live in a colocated hook');
@@ -31,7 +33,7 @@ test('angle workspace delegates copy, local types, and helper logic', () => {
 
   assert.match(workspaceSource, /from '\.\/angle\/_components\/angle-image-library-modal'/, 'workspace should import angle library modal');
   assert.match(workspaceSource, /from '\.\/angle\/_components\/angle-orbit-selector'/, 'workspace should import angle orbit selector');
-  assert.match(workspaceSource, /from '\.\/angle\/_components\/angle-output-mosaic'/, 'workspace should import angle output mosaic');
+  assert.match(workspaceSource, /from '\.\/angle\/_components\/angle-output-panel'/, 'workspace should import angle output panel');
   assert.match(workspaceSource, /from '\.\/angle\/_components\/angle-recent-job-modal'/, 'workspace should import angle recent job modal');
   assert.match(workspaceSource, /from '\.\/angle\/_components\/angle-auth-gate-modal'/, 'workspace should import angle auth gate modal');
   assert.match(workspaceSource, /from '\.\/angle\/_hooks\/useAngleGenerationRunner'/, 'workspace should import angle generation runner');
@@ -54,15 +56,19 @@ test('angle workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /emitClientMetric\('tool_start'/, 'generation analytics belongs in useAngleGenerationRunner');
   assert.doesNotMatch(workspaceSource, /z-\[10040\]/, 'recent job dialog JSX belongs in angle-recent-job-modal.tsx');
   assert.doesNotMatch(workspaceSource, /z-\[10050\]/, 'auth gate dialog JSX belongs in angle-auth-gate-modal.tsx');
+  assert.doesNotMatch(workspaceSource, /ANGLE_GUEST_EXAMPLE_OUTPUT_URL/, 'guest output preview belongs in angle-output-panel.tsx');
+  assert.doesNotMatch(workspaceSource, /copy\.previousJobs/, 'recent output rail belongs in angle-output-panel.tsx');
+  assert.doesNotMatch(workspaceSource, /angle-preview-/, 'output download wiring belongs in angle-output-panel.tsx');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 920, `AngleWorkspace should stay below 920 lines after dialog extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 820, `AngleWorkspace should stay below 820 lines after output panel extraction, got ${lineCount}`);
 });
 
 test('angle helper modules expose the expected workspace contract', () => {
   const libraryModalSource = readFileSync(libraryModalPath, 'utf8');
   const orbitSelectorSource = readFileSync(orbitSelectorPath, 'utf8');
   const outputMosaicSource = readFileSync(outputMosaicPath, 'utf8');
+  const outputPanelSource = readFileSync(outputPanelPath, 'utf8');
   const recentJobModalSource = readFileSync(recentJobModalPath, 'utf8');
   const authGateModalSource = readFileSync(authGateModalPath, 'utf8');
   const generationRunnerHookSource = readFileSync(generationRunnerHookPath, 'utf8');
@@ -74,6 +80,10 @@ test('angle helper modules expose the expected workspace contract', () => {
   assert.match(orbitSelectorSource, /export function AngleOrbitSelector/, 'orbit selector module should export AngleOrbitSelector');
   assert.match(orbitSelectorSource, /dynamic\(\(\) => import\('@\/components\/tools\/AngleOrbitCanvas'\)/, 'orbit selector should own the dynamic canvas import');
   assert.match(outputMosaicSource, /export function AngleOutputMosaic/, 'output mosaic module should export AngleOutputMosaic');
+  assert.match(outputPanelSource, /export function AngleOutputPanel/, 'output panel module should export AngleOutputPanel');
+  assert.match(outputPanelSource, /ANGLE_GUEST_EXAMPLE_OUTPUT_URL/, 'output panel should own guest output preview');
+  assert.match(outputPanelSource, /AngleOutputMosaic/, 'output panel should own output mosaic composition');
+  assert.match(outputPanelSource, /triggerAppDownload/, 'output panel should own output downloads');
   assert.match(recentJobModalSource, /export function AngleRecentJobModal/, 'recent job modal module should export AngleRecentJobModal');
   assert.match(recentJobModalSource, /AngleOutputMosaic/, 'recent job modal should own recent output mosaic composition');
   assert.match(authGateModalSource, /export function AngleAuthGateModal/, 'auth gate modal module should export AngleAuthGateModal');


### PR DESCRIPTION
## Summary
- move Angle output rendering, downloads, guest example, and recent output rail into AngleOutputPanel
- keep AngleWorkspace focused on state and orchestration
- tighten the Angle workspace architecture contract around output panel ownership

## Checks
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/angle-workspace-architecture.test.ts tests/angle-orbit-canvas-contract.test.ts tests/angle-server-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- git diff --check -- frontend/src/components/tools/AngleWorkspace.tsx frontend/src/components/tools/angle/_components/angle-output-panel.tsx tests/angle-workspace-architecture.test.ts
- npm --prefix frontend run lint
- npm run lint:exposure