### PR TITLE
Split audio options section

### DIFF
--- a/frontend/app/(core)/(workspace)/app/audio/AudioWorkspace.tsx
+++ b/frontend/app/(core)/(workspace)/app/audio/AudioWorkspace.tsx
@@ -5,14 +5,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import {
   AudioLines,
-  ChevronDown,
-  Clock3,
-  Gauge,
-  Languages,
-  Mic2,
-  Play,
-  SlidersHorizontal,
-  Sparkles,
 } from 'lucide-react';
 
 import { useRequireAuth } from '@/hooks/useRequireAuth';
@@ -54,9 +46,10 @@ import {
 import AudioLatestRendersRail from './AudioLatestRendersRail';
 import { AudioGenerationDock } from './_components/audio-generation-dock';
 import { AudioGeneratedVideoPickerModal } from './_components/audio-generated-video-picker';
+import { AudioOptionsSection } from './_components/audio-options-section';
 import { AudioSourceVideoSection } from './_components/audio-source-video-section';
 import { AudioVoiceSection } from './_components/audio-voice-section';
-import { AudioModePicker, AudioSelectControl, ToggleRow } from './_components/audio-workspace-controls';
+import { AudioModePicker } from './_components/audio-workspace-controls';
 import { useAudioActiveJobPolling } from './_hooks/useAudioActiveJobPolling';
 import { useAudioGenerationRunner } from './_hooks/useAudioGenerationRunner';
 import { useAudioGeneratedVideos } from './_hooks/useAudioGeneratedVideos';
@@ -75,7 +68,6 @@ import {
   formatCurrency,
   inferOutputKind,
   probeVideoDuration,
-  resolveProviderLabel,
   resolveUiErrorMessage,
   uploadAsset,
 } from './_lib/audio-workspace-helpers';
@@ -720,127 +712,42 @@ export default function AudioWorkspace() {
                 />
               ) : null}
 
-              <div className="rounded-[12px] border border-hairline bg-surface p-4 shadow-card lg:col-span-2">
-                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-                  {showMood ? (
-                    <AudioSelectControl
-                      label={copy.controls.mood}
-                      value={mood}
-                      options={moodOptions}
-                      icon={Sparkles}
-                      onChange={(next) => {
-                        const nextMood = coerceAudioMood(next) ?? DEFAULT_MOOD;
-                        setMood(nextMood);
-                      }}
-                    />
-                  ) : null}
-                  {showVoiceGender ? (
-                    <AudioSelectControl
-                      label={copy.controls.voiceType}
-                      value={voiceGender}
-                      options={voiceGenderOptions}
-                      icon={Mic2}
-                      onChange={(next) => {
-                        const nextGender = coerceAudioVoiceGender(String(next)) ?? DEFAULT_VOICE_GENDER;
-                        setVoiceGender(nextGender);
-                      }}
-                    />
-                  ) : null}
-                  {showVoiceFields ? (
-                    <AudioSelectControl
-                      label={copy.controls.voice}
-                      value={voiceProfile}
-                      options={voiceProfileOptions}
-                      icon={AudioLines}
-                      onChange={(next) => {
-                        setVoiceProfile(coerceAudioVoiceProfile(String(next)) ?? DEFAULT_VOICE_PROFILE);
-                      }}
-                    />
-                  ) : null}
-                  {showVoiceFields ? (
-                    <AudioSelectControl
-                      label={copy.controls.delivery}
-                      value={voiceDelivery}
-                      options={voiceDeliveryOptions}
-                      icon={Play}
-                      onChange={(next) => {
-                        const nextDelivery = coerceAudioVoiceDelivery(String(next)) ?? DEFAULT_VOICE_DELIVERY;
-                        setVoiceDelivery(nextDelivery);
-                      }}
-                    />
-                  ) : null}
-                  {showIntensity ? (
-                    <AudioSelectControl
-                      label={copy.controls.intensity}
-                      value={intensity}
-                      options={intensityOptions}
-                      icon={Gauge}
-                      onChange={(next) => {
-                        const nextIntensity = coerceAudioIntensity(next) ?? DEFAULT_INTENSITY;
-                        setIntensity(nextIntensity);
-                      }}
-                    />
-                  ) : null}
-                  {showVoiceFields ? (
-                    <AudioSelectControl
-                      label={copy.controls.language}
-                      value={language}
-                      options={languageOptions}
-                      icon={Languages}
-                      onChange={(next) => {
-                        const nextLanguage = coerceAudioLanguage(String(next)) ?? DEFAULT_LANGUAGE;
-                        setLanguage(nextLanguage);
-                      }}
-                    />
-                  ) : null}
-                  {showManualDuration ? (
-                    <AudioSelectControl
-                      label={copy.controls.duration}
-                      value={manualDurationSec}
-                      options={durationOptions}
-                      icon={Clock3}
-                      onChange={(next) => {
-                        const numericDuration = Number(next);
-                        if (durationOptions.some((option) => option.value === numericDuration)) {
-                          setManualDurationSec(numericDuration);
-                        }
-                      }}
-                    />
-                  ) : null}
-                </div>
-
-                <details className="group mt-4 rounded-[10px] border border-hairline bg-bg">
-                  <summary className="flex cursor-pointer list-none items-center justify-between gap-4 px-4 py-3">
-                    <span className="inline-flex items-center gap-2 text-sm font-semibold text-text-primary">
-                      <UIIcon icon={SlidersHorizontal} size={16} />
-                      {copy.controls.advanced.title}
-                    </span>
-                    <ChevronDown className="h-4 w-4 text-text-muted transition group-open:rotate-180" aria-hidden />
-                  </summary>
-                  <div className="grid gap-3 border-t border-hairline p-4 md:grid-cols-2">
-                    {showMusicToggle ? (
-                      <ToggleRow
-                        label={copy.controls.musicToggle.label}
-                        description={copy.controls.musicToggle.description}
-                        checked={musicEnabled}
-                        onChange={setMusicEnabled}
-                      />
-                    ) : null}
-                    {showExportToggle ? (
-                      <ToggleRow
-                        label={copy.controls.exportToggle.label}
-                        description={copy.controls.exportToggle.description}
-                        checked={exportAudioFile}
-                        onChange={setExportAudioFile}
-                      />
-                    ) : null}
-                    <div className="rounded-[10px] border border-hairline bg-surface px-4 py-3">
-                      <p className="text-sm font-semibold text-text-primary">{copy.controls.providerStack}</p>
-                      <p className="mt-1 text-sm text-text-secondary">{resolveProviderLabel(copy, pack)}</p>
-                    </div>
-                  </div>
-                </details>
-              </div>
+              <AudioOptionsSection
+                copy={copy}
+                durationOptions={durationOptions}
+                exportAudioFile={exportAudioFile}
+                intensity={intensity}
+                intensityOptions={intensityOptions}
+                language={language}
+                languageOptions={languageOptions}
+                manualDurationSec={manualDurationSec}
+                mood={mood}
+                moodOptions={moodOptions}
+                musicEnabled={musicEnabled}
+                onExportAudioFileChange={setExportAudioFile}
+                onIntensityChange={setIntensity}
+                onLanguageChange={setLanguage}
+                onManualDurationChange={setManualDurationSec}
+                onMoodChange={setMood}
+                onMusicEnabledChange={setMusicEnabled}
+                onVoiceDeliveryChange={setVoiceDelivery}
+                onVoiceGenderChange={setVoiceGender}
+                onVoiceProfileChange={setVoiceProfile}
+                pack={pack}
+                showExportToggle={showExportToggle}
+                showIntensity={showIntensity}
+                showManualDuration={showManualDuration}
+                showMood={showMood}
+                showMusicToggle={showMusicToggle}
+                showVoiceFields={showVoiceFields}
+                showVoiceGender={showVoiceGender}
+                voiceDelivery={voiceDelivery}
+                voiceDeliveryOptions={voiceDeliveryOptions}
+                voiceGender={voiceGender}
+                voiceGenderOptions={voiceGenderOptions}
+                voiceProfile={voiceProfile}
+                voiceProfileOptions={voiceProfileOptions}
+              />
             </section>
 
             <div className="xl:hidden">

--- a/frontend/app/(core)/(workspace)/app/audio/_components/audio-options-section.tsx
+++ b/frontend/app/(core)/(workspace)/app/audio/_components/audio-options-section.tsx
@@ -1,0 +1,224 @@
+import {
+  AudioLines,
+  ChevronDown,
+  Clock3,
+  Gauge,
+  Languages,
+  Mic2,
+  Play,
+  SlidersHorizontal,
+  Sparkles,
+} from 'lucide-react';
+
+import { UIIcon } from '@/components/ui/UIIcon';
+import {
+  coerceAudioIntensity,
+  coerceAudioLanguage,
+  coerceAudioMood,
+  coerceAudioVoiceDelivery,
+  coerceAudioVoiceGender,
+  coerceAudioVoiceProfile,
+  type AudioIntensity,
+  type AudioLanguage,
+  type AudioMood,
+  type AudioPackId,
+  type AudioVoiceDelivery,
+  type AudioVoiceGender,
+  type AudioVoiceProfile,
+} from '@/lib/audio-generation';
+import {
+  DEFAULT_INTENSITY,
+  DEFAULT_LANGUAGE,
+  DEFAULT_MOOD,
+  DEFAULT_VOICE_DELIVERY,
+  DEFAULT_VOICE_GENDER,
+  DEFAULT_VOICE_PROFILE,
+  resolveProviderLabel,
+} from '../_lib/audio-workspace-helpers';
+import type { AudioWorkspaceCopy } from '../copy';
+import { AudioSelectControl, ToggleRow } from './audio-workspace-controls';
+
+type AudioOption = {
+  value: string | number | boolean;
+  label: string;
+  disabled?: boolean;
+};
+
+export function AudioOptionsSection({
+  copy,
+  durationOptions,
+  exportAudioFile,
+  intensity,
+  intensityOptions,
+  language,
+  languageOptions,
+  manualDurationSec,
+  mood,
+  moodOptions,
+  musicEnabled,
+  onExportAudioFileChange,
+  onIntensityChange,
+  onLanguageChange,
+  onManualDurationChange,
+  onMoodChange,
+  onMusicEnabledChange,
+  onVoiceDeliveryChange,
+  onVoiceGenderChange,
+  onVoiceProfileChange,
+  pack,
+  showExportToggle,
+  showIntensity,
+  showManualDuration,
+  showMood,
+  showMusicToggle,
+  showVoiceFields,
+  showVoiceGender,
+  voiceDelivery,
+  voiceDeliveryOptions,
+  voiceGender,
+  voiceGenderOptions,
+  voiceProfile,
+  voiceProfileOptions,
+}: {
+  copy: AudioWorkspaceCopy;
+  durationOptions: AudioOption[];
+  exportAudioFile: boolean;
+  intensity: AudioIntensity;
+  intensityOptions: AudioOption[];
+  language: AudioLanguage;
+  languageOptions: AudioOption[];
+  manualDurationSec: number;
+  mood: AudioMood;
+  moodOptions: AudioOption[];
+  musicEnabled: boolean;
+  onExportAudioFileChange: (next: boolean) => void;
+  onIntensityChange: (next: AudioIntensity) => void;
+  onLanguageChange: (next: AudioLanguage) => void;
+  onManualDurationChange: (next: number) => void;
+  onMoodChange: (next: AudioMood) => void;
+  onMusicEnabledChange: (next: boolean) => void;
+  onVoiceDeliveryChange: (next: AudioVoiceDelivery) => void;
+  onVoiceGenderChange: (next: AudioVoiceGender) => void;
+  onVoiceProfileChange: (next: AudioVoiceProfile) => void;
+  pack: AudioPackId;
+  showExportToggle: boolean;
+  showIntensity: boolean;
+  showManualDuration: boolean;
+  showMood: boolean;
+  showMusicToggle: boolean;
+  showVoiceFields: boolean;
+  showVoiceGender: boolean;
+  voiceDelivery: AudioVoiceDelivery;
+  voiceDeliveryOptions: AudioOption[];
+  voiceGender: AudioVoiceGender;
+  voiceGenderOptions: AudioOption[];
+  voiceProfile: AudioVoiceProfile;
+  voiceProfileOptions: AudioOption[];
+}) {
+  return (
+    <div className="rounded-[12px] border border-hairline bg-surface p-4 shadow-card lg:col-span-2">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {showMood ? (
+          <AudioSelectControl
+            label={copy.controls.mood}
+            value={mood}
+            options={moodOptions}
+            icon={Sparkles}
+            onChange={(next) => onMoodChange(coerceAudioMood(next) ?? DEFAULT_MOOD)}
+          />
+        ) : null}
+        {showVoiceGender ? (
+          <AudioSelectControl
+            label={copy.controls.voiceType}
+            value={voiceGender}
+            options={voiceGenderOptions}
+            icon={Mic2}
+            onChange={(next) => onVoiceGenderChange(coerceAudioVoiceGender(String(next)) ?? DEFAULT_VOICE_GENDER)}
+          />
+        ) : null}
+        {showVoiceFields ? (
+          <AudioSelectControl
+            label={copy.controls.voice}
+            value={voiceProfile}
+            options={voiceProfileOptions}
+            icon={AudioLines}
+            onChange={(next) => onVoiceProfileChange(coerceAudioVoiceProfile(String(next)) ?? DEFAULT_VOICE_PROFILE)}
+          />
+        ) : null}
+        {showVoiceFields ? (
+          <AudioSelectControl
+            label={copy.controls.delivery}
+            value={voiceDelivery}
+            options={voiceDeliveryOptions}
+            icon={Play}
+            onChange={(next) => onVoiceDeliveryChange(coerceAudioVoiceDelivery(String(next)) ?? DEFAULT_VOICE_DELIVERY)}
+          />
+        ) : null}
+        {showIntensity ? (
+          <AudioSelectControl
+            label={copy.controls.intensity}
+            value={intensity}
+            options={intensityOptions}
+            icon={Gauge}
+            onChange={(next) => onIntensityChange(coerceAudioIntensity(next) ?? DEFAULT_INTENSITY)}
+          />
+        ) : null}
+        {showVoiceFields ? (
+          <AudioSelectControl
+            label={copy.controls.language}
+            value={language}
+            options={languageOptions}
+            icon={Languages}
+            onChange={(next) => onLanguageChange(coerceAudioLanguage(String(next)) ?? DEFAULT_LANGUAGE)}
+          />
+        ) : null}
+        {showManualDuration ? (
+          <AudioSelectControl
+            label={copy.controls.duration}
+            value={manualDurationSec}
+            options={durationOptions}
+            icon={Clock3}
+            onChange={(next) => {
+              const numericDuration = Number(next);
+              if (durationOptions.some((option) => option.value === numericDuration)) {
+                onManualDurationChange(numericDuration);
+              }
+            }}
+          />
+        ) : null}
+      </div>
+
+      <details className="group mt-4 rounded-[10px] border border-hairline bg-bg">
+        <summary className="flex cursor-pointer list-none items-center justify-between gap-4 px-4 py-3">
+          <span className="inline-flex items-center gap-2 text-sm font-semibold text-text-primary">
+            <UIIcon icon={SlidersHorizontal} size={16} />
+            {copy.controls.advanced.title}
+          </span>
+          <ChevronDown className="h-4 w-4 text-text-muted transition group-open:rotate-180" aria-hidden />
+        </summary>
+        <div className="grid gap-3 border-t border-hairline p-4 md:grid-cols-2">
+          {showMusicToggle ? (
+            <ToggleRow
+              label={copy.controls.musicToggle.label}
+              description={copy.controls.musicToggle.description}
+              checked={musicEnabled}
+              onChange={onMusicEnabledChange}
+            />
+          ) : null}
+          {showExportToggle ? (
+            <ToggleRow
+              label={copy.controls.exportToggle.label}
+              description={copy.controls.exportToggle.description}
+              checked={exportAudioFile}
+              onChange={onExportAudioFileChange}
+            />
+          ) : null}
+          <div className="rounded-[10px] border border-hairline bg-surface px-4 py-3">
+            <p className="text-sm font-semibold text-text-primary">{copy.controls.providerStack}</p>
+            <p className="mt-1 text-sm text-text-secondary">{resolveProviderLabel(copy, pack)}</p>
+          </div>
+        </div>
+      </details>
+    </div>
+  );
+}

--- a/tests/audio-workspace-architecture.test.ts
+++ b/tests/audio-workspace-architecture.test.ts
@@ -8,6 +8,7 @@ const audioDir = join(root, 'frontend/app/(core)/(workspace)/app/audio');
 const workspacePath = join(audioDir, 'AudioWorkspace.tsx');
 const controlsPath = join(audioDir, '_components/audio-workspace-controls.tsx');
 const generatedPickerPath = join(audioDir, '_components/audio-generated-video-picker.tsx');
+const optionsSectionPath = join(audioDir, '_components/audio-options-section.tsx');
 const sourceVideoSectionPath = join(audioDir, '_components/audio-source-video-section.tsx');
 const generationDockPath = join(audioDir, '_components/audio-generation-dock.tsx');
 const voiceSectionPath = join(audioDir, '_components/audio-voice-section.tsx');
@@ -22,6 +23,7 @@ const workspaceSource = readFileSync(workspacePath, 'utf8');
 test('audio workspace delegates local controls, helpers, and contracts', () => {
   assert.ok(existsSync(controlsPath), 'audio control components should live in a route-local component module');
   assert.ok(existsSync(generatedPickerPath), 'generated video picker should live in a route-local component module');
+  assert.ok(existsSync(optionsSectionPath), 'audio options section should live in a route-local component module');
   assert.ok(existsSync(sourceVideoSectionPath), 'source video section should live in a route-local component module');
   assert.ok(existsSync(generationDockPath), 'generation dock should live in a route-local component module');
   assert.ok(existsSync(voiceSectionPath), 'voice section should live in a route-local component module');
@@ -33,6 +35,7 @@ test('audio workspace delegates local controls, helpers, and contracts', () => {
 
   assert.match(workspaceSource, /from '\.\/_components\/audio-workspace-controls'/);
   assert.match(workspaceSource, /from '\.\/_components\/audio-generated-video-picker'/);
+  assert.match(workspaceSource, /from '\.\/_components\/audio-options-section'/);
   assert.match(workspaceSource, /from '\.\/_components\/audio-source-video-section'/);
   assert.match(workspaceSource, /from '\.\/_components\/audio-generation-dock'/);
   assert.match(workspaceSource, /from '\.\/_components\/audio-voice-section'/);
@@ -60,14 +63,18 @@ test('audio workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /surface=video&limit=60/, 'generated video loading belongs in useAudioGeneratedVideos');
   assert.doesNotMatch(workspaceSource, /runAudioGenerate/, 'audio generation submission belongs in useAudioGenerationRunner');
   assert.doesNotMatch(workspaceSource, /resolveUiErrorMessage\(error, copy\.messages\.generationFailed/, 'generation failure mapping belongs in useAudioGenerationRunner');
+  assert.doesNotMatch(workspaceSource, /<AudioSelectControl/, 'audio option selectors belong in audio-options-section.tsx');
+  assert.doesNotMatch(workspaceSource, /copy\.controls\.providerStack/, 'provider stack UI belongs in audio-options-section.tsx');
+  assert.doesNotMatch(workspaceSource, /SlidersHorizontal/, 'advanced options UI belongs in audio-options-section.tsx');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 890, `AudioWorkspace should stay below 890 lines after section extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 800, `AudioWorkspace should stay below 800 lines after options section extraction, got ${lineCount}`);
 });
 
 test('audio helper modules expose the expected workspace contract', () => {
   const controlsSource = readFileSync(controlsPath, 'utf8');
   const generatedPickerSource = readFileSync(generatedPickerPath, 'utf8');
+  const optionsSectionSource = readFileSync(optionsSectionPath, 'utf8');
   const sourceVideoSectionSource = readFileSync(sourceVideoSectionPath, 'utf8');
   const generationDockSource = readFileSync(generationDockPath, 'utf8');
   const voiceSectionSource = readFileSync(voiceSectionPath, 'utf8');
@@ -90,6 +97,10 @@ test('audio helper modules expose the expected workspace contract', () => {
     /export function AudioGeneratedVideoPickerModal/,
     'AudioGeneratedVideoPickerModal should be exported'
   );
+  assert.match(optionsSectionSource, /export function AudioOptionsSection/, 'AudioOptionsSection should be exported');
+  assert.match(optionsSectionSource, /AudioSelectControl/, 'audio options section should own select controls');
+  assert.match(optionsSectionSource, /resolveProviderLabel/, 'audio options section should own provider stack rendering');
+  assert.match(optionsSectionSource, /SlidersHorizontal/, 'audio options section should own advanced options UI');
   assert.match(sourceVideoSectionSource, /export function AudioSourceVideoSection/, 'AudioSourceVideoSection should be exported');
   assert.match(sourceVideoSectionSource, /copy\.source\.useGenerated/, 'source video section should own generated picker trigger copy');
   assert.match(generationDockSource, /export function AudioGenerationDock/, 'AudioGenerationDock should be exported');


### PR DESCRIPTION
## Summary
- move audio option selectors, advanced toggles, and provider stack UI into AudioOptionsSection
- keep AudioWorkspace focused on state restoration, generation, and layout wiring
- tighten the audio workspace architecture contract around options ownership

## Checks
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/audio-workspace-architecture.test.ts tests/audio-generate-validation.test.ts tests/audio-generation-config.test.ts tests/audio-provider-routing.test.ts tests/audio-mix.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- git diff --check -- frontend/app/(core)/(workspace)/app/audio/AudioWorkspace.tsx frontend/app/(core)/(workspace)/app/audio/_components/audio-options-section.tsx tests/audio-workspace-architecture.test.ts
- npm --prefix frontend run lint
- npm run lint:exposure