### PR TITLE
Split character builder start section

### DIFF
--- a/frontend/src/components/tools/CharacterBuilderWorkspace.tsx
+++ b/frontend/src/components/tools/CharacterBuilderWorkspace.tsx
@@ -10,7 +10,6 @@ import useSWR from 'swr';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import {
   ArrowLeft,
-  Upload,
 } from 'lucide-react';
 import { MediaLightbox, type MediaLightboxEntry } from '@/components/MediaLightbox';
 import { Button, ButtonLink } from '@/components/ui/Button';
@@ -40,14 +39,13 @@ import {
   HairEditorPanel,
   IconChoiceCard,
   MultiToggleGroup,
-  OutputPreviewCard,
   REALISM_CARD_META,
-  ReferenceSlot,
   SectionTitle,
   SegmentedControl,
   StyleChoiceCard,
   type BuildLookSectionKey,
 } from './character-builder/_components/character-builder-workspace-components';
+import { CharacterBuilderStartSection } from './character-builder/_components/character-builder-start-section';
 import {
   CharacterBuilderAuthGateModal,
   CharacterBuilderDisabledState,
@@ -399,112 +397,22 @@ export default function CharacterBuilderPage() {
               <div className="min-w-0 flex-1 space-y-6">
                 <Card className="overflow-visible border border-border p-6 lg:p-7">
                   <div className="space-y-6">
-                    <section className="space-y-4">
-                      <SectionTitle title={copy.top.start} />
-                      <div className="grid gap-4 md:grid-cols-2 md:items-stretch">
-                        <OutputPreviewCard
-                          selected={state.outputMode === 'character-sheet'}
-                          title={copy.generatePanel.sheetTitle}
-                          subtitle={copy.generatePanel.sheetBody}
-                          mode="character-sheet"
-                          onClick={() =>
-                            setState((previous) => ({
-                              ...previous,
-                              outputMode: 'character-sheet',
-                              outputOptions: {
-                                ...previous.outputOptions,
-                                fullBodyRequired: true,
-                              },
-                            }))
-                          }
-                        />
-                        <OutputPreviewCard
-                          selected={state.outputMode === 'portrait-reference'}
-                          title={copy.generatePanel.portraitTitle}
-                          subtitle={copy.generatePanel.portraitBody}
-                          mode="portrait-reference"
-                          onClick={() =>
-                            setState((previous) => ({
-                              ...previous,
-                              outputMode: 'portrait-reference',
-                              outputOptions: {
-                                ...previous.outputOptions,
-                                fullBodyRequired: false,
-                              },
-                            }))
-                          }
-                        />
-                      </div>
-
-                      <div className="grid gap-4 lg:grid-cols-2">
-                        <ReferenceSlot
-                          title={copy.references.identityTitle}
-                          subtitle={copy.references.identityBody}
-                          image={identityReference}
-                          onUpload={() => {
-                            if (!user) {
-                              openAuthGate();
-                              return;
-                            }
-                            identityFileRef.current?.click();
-                          }}
-                          onOpenLibrary={() => {
-                            if (!user) {
-                              openAuthGate();
-                              return;
-                            }
-                            setLibraryModalRole('identity');
-                          }}
-                          removeLabel={copy.references.remove}
-                          libraryLabel={copy.library.open}
-                          optionalLabel={copy.sections.optional}
-                          onRemove={removeIdentityReference}
-                        />
-                        {showStyleReferenceSlot || styleReference ? (
-                          <ReferenceSlot
-                            title={copy.references.styleTitle}
-                            subtitle={copy.references.styleBody}
-                            image={styleReference}
-                            onUpload={() => {
-                              if (!user) {
-                                openAuthGate();
-                                return;
-                              }
-                              styleFileRef.current?.click();
-                            }}
-                            onOpenLibrary={() => {
-                              if (!user) {
-                                openAuthGate();
-                                return;
-                              }
-                              setShowStyleReferenceSlot(true);
-                              setLibraryModalRole('style');
-                            }}
-                            removeLabel={copy.references.remove}
-                            libraryLabel={copy.library.open}
-                            optionalLabel={copy.sections.optional}
-                            onRemove={removeStyleReference}
-                          />
-                        ) : (
-                          <button
-                            type="button"
-                            onClick={() => setShowStyleReferenceSlot(true)}
-                            className="flex min-h-[180px] flex-col items-center justify-center rounded-card border border-dashed border-border bg-bg/40 px-4 py-6 text-center transition hover:border-border-hover hover:bg-surface-hover"
-                          >
-                            <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-brand/10 text-brand">
-                              <Upload className="h-5 w-5" />
-                            </span>
-                            <div className="mt-3 flex items-center justify-center gap-2">
-                              <p className="text-sm font-semibold text-text-primary">{copy.references.addInspiration}</p>
-                              <span className="rounded-full border border-border bg-surface px-2 py-0.5 text-[10px] font-semibold uppercase tracking-micro text-text-secondary">
-                                {copy.sections.optional}
-                              </span>
-                            </div>
-                            <p className="mt-1 text-xs text-text-secondary">{copy.references.addInspirationBody}</p>
-                          </button>
-                        )}
-                      </div>
-                    </section>
+                    <CharacterBuilderStartSection
+                      canUseReferences={Boolean(user)}
+                      copy={copy}
+                      identityFileRef={identityFileRef}
+                      identityReference={identityReference}
+                      onAuthRequired={openAuthGate}
+                      onRemoveIdentityReference={removeIdentityReference}
+                      onRemoveStyleReference={removeStyleReference}
+                      outputMode={state.outputMode}
+                      setLibraryModalRole={setLibraryModalRole}
+                      setShowStyleReferenceSlot={setShowStyleReferenceSlot}
+                      setState={setState}
+                      showStyleReferenceSlot={showStyleReferenceSlot}
+                      styleFileRef={styleFileRef}
+                      styleReference={styleReference}
+                    />
 
                     <section className="space-y-4 border-t border-border pt-6">
                       <SectionTitle title={copy.top.buildLook}>

--- a/frontend/src/components/tools/character-builder/_components/character-builder-start-section.tsx
+++ b/frontend/src/components/tools/character-builder/_components/character-builder-start-section.tsx
@@ -1,0 +1,154 @@
+import type { Dispatch, RefObject, SetStateAction } from 'react';
+import { Upload } from 'lucide-react';
+import type {
+  CharacterBuilderReferenceImage,
+  CharacterBuilderState,
+} from '@/types/character-builder';
+import type { CharacterCopy } from '../_lib/character-builder-copy';
+import { OutputPreviewCard, ReferenceSlot, SectionTitle } from './character-builder-workspace-components';
+
+export function CharacterBuilderStartSection({
+  canUseReferences,
+  copy,
+  identityFileRef,
+  identityReference,
+  onAuthRequired,
+  onRemoveIdentityReference,
+  onRemoveStyleReference,
+  outputMode,
+  setLibraryModalRole,
+  setShowStyleReferenceSlot,
+  setState,
+  showStyleReferenceSlot,
+  styleFileRef,
+  styleReference,
+}: {
+  canUseReferences: boolean;
+  copy: CharacterCopy;
+  identityFileRef: RefObject<HTMLInputElement | null>;
+  identityReference: CharacterBuilderReferenceImage | null;
+  onAuthRequired: () => void;
+  onRemoveIdentityReference: () => void;
+  onRemoveStyleReference: () => void;
+  outputMode: CharacterBuilderState['outputMode'];
+  setLibraryModalRole: Dispatch<SetStateAction<CharacterBuilderReferenceImage['role'] | null>>;
+  setShowStyleReferenceSlot: Dispatch<SetStateAction<boolean>>;
+  setState: Dispatch<SetStateAction<CharacterBuilderState>>;
+  showStyleReferenceSlot: boolean;
+  styleFileRef: RefObject<HTMLInputElement | null>;
+  styleReference: CharacterBuilderReferenceImage | null;
+}) {
+  const openIdentityUpload = () => {
+    if (!canUseReferences) {
+      onAuthRequired();
+      return;
+    }
+    identityFileRef.current?.click();
+  };
+  const openStyleUpload = () => {
+    if (!canUseReferences) {
+      onAuthRequired();
+      return;
+    }
+    styleFileRef.current?.click();
+  };
+  const openIdentityLibrary = () => {
+    if (!canUseReferences) {
+      onAuthRequired();
+      return;
+    }
+    setLibraryModalRole('identity');
+  };
+  const openStyleLibrary = () => {
+    if (!canUseReferences) {
+      onAuthRequired();
+      return;
+    }
+    setShowStyleReferenceSlot(true);
+    setLibraryModalRole('style');
+  };
+
+  return (
+    <section className="space-y-4">
+      <SectionTitle title={copy.top.start} />
+      <div className="grid gap-4 md:grid-cols-2 md:items-stretch">
+        <OutputPreviewCard
+          selected={outputMode === 'character-sheet'}
+          title={copy.generatePanel.sheetTitle}
+          subtitle={copy.generatePanel.sheetBody}
+          mode="character-sheet"
+          onClick={() =>
+            setState((previous) => ({
+              ...previous,
+              outputMode: 'character-sheet',
+              outputOptions: {
+                ...previous.outputOptions,
+                fullBodyRequired: true,
+              },
+            }))
+          }
+        />
+        <OutputPreviewCard
+          selected={outputMode === 'portrait-reference'}
+          title={copy.generatePanel.portraitTitle}
+          subtitle={copy.generatePanel.portraitBody}
+          mode="portrait-reference"
+          onClick={() =>
+            setState((previous) => ({
+              ...previous,
+              outputMode: 'portrait-reference',
+              outputOptions: {
+                ...previous.outputOptions,
+                fullBodyRequired: false,
+              },
+            }))
+          }
+        />
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <ReferenceSlot
+          title={copy.references.identityTitle}
+          subtitle={copy.references.identityBody}
+          image={identityReference}
+          onUpload={openIdentityUpload}
+          onOpenLibrary={openIdentityLibrary}
+          removeLabel={copy.references.remove}
+          libraryLabel={copy.library.open}
+          optionalLabel={copy.sections.optional}
+          onRemove={onRemoveIdentityReference}
+        />
+        {showStyleReferenceSlot || styleReference ? (
+          <ReferenceSlot
+            title={copy.references.styleTitle}
+            subtitle={copy.references.styleBody}
+            image={styleReference}
+            onUpload={openStyleUpload}
+            onOpenLibrary={openStyleLibrary}
+            removeLabel={copy.references.remove}
+            libraryLabel={copy.library.open}
+            optionalLabel={copy.sections.optional}
+            onRemove={onRemoveStyleReference}
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => setShowStyleReferenceSlot(true)}
+            className="flex min-h-[180px] flex-col items-center justify-center rounded-card border border-dashed border-border bg-bg/40 px-4 py-6 text-center transition hover:border-border-hover hover:bg-surface-hover"
+          >
+            <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-brand/10 text-brand">
+              <Upload className="h-5 w-5" />
+            </span>
+            <div className="mt-3 flex items-center justify-center gap-2">
+              <p className="text-sm font-semibold text-text-primary">{copy.references.addInspiration}</p>
+              <span className="rounded-full border border-border bg-surface px-2 py-0.5 text-[10px] font-semibold uppercase tracking-micro text-text-secondary">
+                {copy.sections.optional}
+              </span>
+            </div>
+            <p className="mt-1 text-xs text-text-secondary">{copy.references.addInspirationBody}</p>
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/tests/character-builder-workspace-architecture.test.ts
+++ b/tests/character-builder-workspace-architecture.test.ts
@@ -16,6 +16,7 @@ const referenceLibraryPath = join(root, 'frontend/src/components/tools/character
 const resultCardsPath = join(root, 'frontend/src/components/tools/character-builder/_components/character-builder-result-cards.tsx');
 const resultsGalleryPath = join(root, 'frontend/src/components/tools/character-builder/_components/character-builder-results-gallery.tsx');
 const pageShellPath = join(root, 'frontend/src/components/tools/character-builder/_components/character-builder-page-shell.tsx');
+const startSectionPath = join(root, 'frontend/src/components/tools/character-builder/_components/character-builder-start-section.tsx');
 const optionsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderOptions.ts');
 const historicalResultsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderHistoricalResults.ts');
 const pendingRunsHookPath = join(root, 'frontend/src/components/tools/character-builder/_hooks/useCharacterBuilderPendingRunsSync.ts');
@@ -42,6 +43,7 @@ test('character builder workspace delegates copy, local types, and helper logic'
   assert.ok(existsSync(resultCardsPath), 'result card components should live in a focused component module');
   assert.ok(existsSync(resultsGalleryPath), 'result gallery composition should live in a focused component module');
   assert.ok(existsSync(pageShellPath), 'page shell and auth modal chrome should live in a focused component module');
+  assert.ok(existsSync(startSectionPath), 'start section composition should live in a focused component module');
   assert.ok(existsSync(optionsHookPath), 'localized option derivation should live in a focused hook');
   assert.ok(existsSync(historicalResultsHookPath), 'historical result derivation should live in a focused hook');
   assert.ok(existsSync(pendingRunsHookPath), 'pending run polling should live in a focused hook');
@@ -56,6 +58,7 @@ test('character builder workspace delegates copy, local types, and helper logic'
 
   assert.match(workspaceSource, /from '\.\/character-builder\/_components\/character-builder-workspace-components'/, 'workspace should import UI components');
   assert.match(workspaceSource, /from '\.\/character-builder\/_components\/character-builder-page-shell'/, 'workspace should import page shell components');
+  assert.match(workspaceSource, /from '\.\/character-builder\/_components\/character-builder-start-section'/, 'workspace should import start section component');
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderOptions'/, 'workspace should import localized options hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderHistoricalResults'/, 'workspace should import historical results hook');
   assert.match(workspaceSource, /from '\.\/character-builder\/_hooks\/useCharacterBuilderPendingRunsSync'/, 'workspace should import pending run sync hook');
@@ -115,9 +118,12 @@ test('character builder workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /function removeMustRemainTag\(/, 'must-remain tag removal belongs in useCharacterBuilderTraitActions');
   assert.doesNotMatch(workspaceSource, /const identitySummary =/, 'look summary derivation belongs in useCharacterBuilderLookSummaries');
   assert.doesNotMatch(workspaceSource, /const accessoriesFeaturesSummary =/, 'accessory summary derivation belongs in useCharacterBuilderLookSummaries');
+  assert.doesNotMatch(workspaceSource, /<OutputPreviewCard/, 'output mode selection belongs in CharacterBuilderStartSection');
+  assert.doesNotMatch(workspaceSource, /<ReferenceSlot/, 'reference slot composition belongs in CharacterBuilderStartSection');
+  assert.doesNotMatch(workspaceSource, /copy\.references\.addInspiration/, 'style inspiration empty slot belongs in CharacterBuilderStartSection');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 1050, `CharacterBuilderWorkspace should stay below 1050 lines after hook extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 970, `CharacterBuilderWorkspace should stay below 970 lines after start section extraction, got ${lineCount}`);
 });
 
 test('character builder helper modules expose the expected workspace contract', () => {
@@ -132,6 +138,7 @@ test('character builder helper modules expose the expected workspace contract', 
   const resultCardsSource = readFileSync(resultCardsPath, 'utf8');
   const resultsGallerySource = readFileSync(resultsGalleryPath, 'utf8');
   const pageShellSource = readFileSync(pageShellPath, 'utf8');
+  const startSectionSource = readFileSync(startSectionPath, 'utf8');
   const optionsHookSource = readFileSync(optionsHookPath, 'utf8');
   const historicalResultsHookSource = readFileSync(historicalResultsHookPath, 'utf8');
   const pendingRunsHookSource = readFileSync(pendingRunsHookPath, 'utf8');
@@ -211,6 +218,10 @@ test('character builder helper modules expose the expected workspace contract', 
   }
 
   assert.match(generateDockSource, /export function CharacterBuilderStickyDock/, 'CharacterBuilderStickyDock should be exported');
+  assert.match(startSectionSource, /export function CharacterBuilderStartSection/, 'CharacterBuilderStartSection should be exported');
+  assert.match(startSectionSource, /OutputPreviewCard/, 'start section should own output mode selection');
+  assert.match(startSectionSource, /ReferenceSlot/, 'start section should own reference slot composition');
+  assert.match(startSectionSource, /copy\.references\.addInspiration/, 'start section should own style inspiration empty slot');
 
   for (const exportName of [
     'HairEditorPanel',


### PR DESCRIPTION
## Summary
- move Character Builder output-mode and reference-slot start section into a focused component
- keep auth-gate/reference wiring in the workspace through explicit props
- tighten the character builder architecture contract around start section ownership

## Checks
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/character-builder-workspace-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- git diff --check -- frontend/src/components/tools/CharacterBuilderWorkspace.tsx frontend/src/components/tools/character-builder/_components/character-builder-start-section.tsx tests/character-builder-workspace-architecture.test.ts
- npm --prefix frontend run lint
- npm run lint:exposure