### PR TITLE
Split examples main video feature

### DIFF
--- a/frontend/app/(localized)/[locale]/(marketing)/examples/_components/examples-main-video-feature.tsx
+++ b/frontend/app/(localized)/[locale]/(marketing)/examples/_components/examples-main-video-feature.tsx
@@ -1,0 +1,163 @@
+import clsx from 'clsx';
+import Link from 'next/link';
+import { AudioEqualizerBadge } from '@/components/ui/AudioEqualizerBadge';
+import { ExamplesHeroVideo } from '@/components/examples/ExamplesHeroVideo.client';
+import { DeferredSourcePrompt } from '@/components/i18n/DeferredSourcePrompt.client';
+
+type ExamplesMainVideoCopy = {
+  audioOn: string;
+  fullPrompt: string;
+  openExample: string;
+  openWatchPage: string;
+  preview: string;
+};
+
+export function ExamplesMainVideoFeature({
+  aspectRatio,
+  contentUrl,
+  copy,
+  durationSec,
+  engineLabel,
+  exampleHref,
+  hasAudio,
+  heroLine,
+  isPortrait,
+  locale,
+  mimeType,
+  modelHref,
+  poster,
+  promptFull,
+  title,
+}: {
+  aspectRatio: string;
+  contentUrl: string;
+  copy: ExamplesMainVideoCopy;
+  durationSec: number | null | undefined;
+  engineLabel: string;
+  exampleHref: string;
+  hasAudio: boolean;
+  heroLine: string | null;
+  isPortrait: boolean;
+  locale: string;
+  mimeType: string;
+  modelHref: string | null;
+  poster: string | null;
+  promptFull: string | null;
+  title: string;
+}) {
+  return (
+    <section className="mx-auto w-full max-w-[920px]">
+      <article className="group relative overflow-hidden rounded-[22px] border border-hairline bg-surface shadow-card">
+        <Link
+          href={exampleHref}
+          prefetch={false}
+          className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+          aria-label={`${copy.openWatchPage}: ${title}`}
+        >
+          <div
+            className="relative overflow-hidden bg-surface-on-media-dark-5"
+            style={{ aspectRatio: isPortrait ? '16 / 9' : aspectRatio }}
+          >
+            {isPortrait && poster ? (
+              <>
+                <div
+                  className="absolute inset-0 scale-110 bg-cover bg-center blur-2xl"
+                  style={{ backgroundImage: `url(${poster})` }}
+                  aria-hidden
+                />
+                <div className="absolute inset-0 bg-black/30" aria-hidden />
+              </>
+            ) : null}
+
+            <div className="absolute left-3 top-3 z-30 inline-flex items-center rounded-full bg-black/70 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-micro text-white shadow-sm">
+              {copy.preview}
+            </div>
+
+            <div
+              className={clsx(
+                'relative h-full w-full',
+                isPortrait ? 'flex items-center justify-center p-3 sm:p-4' : ''
+              )}
+            >
+              <ExamplesHeroVideo
+                className={clsx(
+                  isPortrait
+                    ? 'relative z-10 h-full w-auto max-w-full rounded-[18px] object-contain shadow-[0_18px_48px_rgba(15,23,42,0.28)]'
+                    : 'h-full w-full object-cover'
+                )}
+                src={contentUrl}
+                type={mimeType}
+                poster={poster ?? undefined}
+                posterFit={isPortrait ? 'contain' : 'cover'}
+                ariaLabel={title}
+                ariaHidden
+                controls={false}
+              />
+            </div>
+            <div className="pointer-events-none absolute inset-x-0 bottom-0 z-30 flex items-end justify-between gap-3 bg-gradient-to-t from-black/65 via-black/15 to-transparent px-3 py-3">
+              {hasAudio ? (
+                <AudioEqualizerBadge tone="light" size="sm" label={copy.audioOn} />
+              ) : (
+                <span />
+              )}
+              <span className="inline-flex items-center rounded-full bg-white/92 px-3 py-1.5 text-[11px] font-semibold text-black shadow-sm">
+                {copy.openWatchPage}
+              </span>
+            </div>
+          </div>
+        </Link>
+
+        <div className="space-y-2.5 px-5 py-4 text-left sm:px-6 sm:py-4.5">
+          <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-micro text-text-muted">
+            {modelHref ? (
+              <Link href={modelHref} prefetch={false} className="hover:text-text-primary">
+                {engineLabel}
+              </Link>
+            ) : (
+              <span>{engineLabel}</span>
+            )}
+            <span>
+              {aspectRatio ?? 'Auto'} · {durationSec}s
+            </span>
+          </div>
+
+          <h2 className="text-lg font-semibold leading-snug text-text-primary sm:text-xl">
+            {heroLine}
+          </h2>
+
+          {promptFull ? (
+            <DeferredSourcePrompt
+              locale={locale}
+              prompt={promptFull}
+              mode="details"
+              className="group"
+              summaryClassName="cursor-pointer list-none text-[11px] font-semibold uppercase tracking-micro text-text-muted transition hover:text-text-primary"
+              promptClassName="mt-2 whitespace-pre-line text-sm leading-relaxed text-text-secondary"
+              fallbackClassName="text-sm leading-relaxed text-text-secondary"
+              summaryLabel={copy.fullPrompt}
+            />
+          ) : null}
+
+          <div className="flex flex-wrap items-center gap-3 pt-0.5">
+            <Link
+              href={exampleHref}
+              prefetch={false}
+              className="inline-flex items-center rounded-full bg-text-primary px-4 py-2 text-sm font-semibold text-bg transition hover:opacity-90"
+            >
+              {copy.openExample}
+            </Link>
+            {modelHref ? (
+              <Link
+                href={modelHref}
+                prefetch={false}
+                className="inline-flex items-center rounded-full border border-hairline px-4 py-2 text-sm font-semibold text-text-primary transition hover:border-text-muted hover:bg-surface-2"
+              >
+                {engineLabel}
+              </Link>
+            ) : null}
+          </div>
+        </div>
+      </article>
+    </section>
+  );
+}

--- a/frontend/app/(localized)/[locale]/(marketing)/examples/page.tsx
+++ b/frontend/app/(localized)/[locale]/(marketing)/examples/page.tsx
@@ -11,9 +11,6 @@ import { buildMetadataUrls } from '@/lib/metadataUrls';
 import { buildSeoMetadata } from '@/lib/seo/metadata';
 import { getBreadcrumbLabels } from '@/lib/seo/breadcrumbs';
 import { buildOptimizedPosterUrl } from '@/lib/media-helpers';
-import { AudioEqualizerBadge } from '@/components/ui/AudioEqualizerBadge';
-import { ExamplesHeroVideo } from '@/components/examples/ExamplesHeroVideo.client';
-import { DeferredSourcePrompt } from '@/components/i18n/DeferredSourcePrompt.client';
 import { resolveExampleCanonicalSlug } from '@/lib/examples-links';
 import {
   getExampleModelLanding,
@@ -63,6 +60,7 @@ import {
 import {
   getExampleFamilyDescriptor,
 } from '@/lib/model-families';
+import { ExamplesMainVideoFeature } from './_components/examples-main-video-feature';
 import {
   buildExamplesNextStepLinks,
   getExamplesBrowseByModelLabel,
@@ -666,119 +664,23 @@ export default async function ExamplesPage(props: ExamplesPageProps) {
           </section>
 
           {mainVideo && mainVideoContentUrl ? (
-            <section className="mx-auto w-full max-w-[920px]">
-              <article className="group relative overflow-hidden rounded-[22px] border border-hairline bg-surface shadow-card">
-                <Link
-                  href={mainVideo.card.href}
-                  prefetch={false}
-                  className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
-                  aria-label={`${mainVideoCopy.openWatchPage}: ${mainVideoTitle}`}
-                >
-                  <div
-                    className="relative overflow-hidden bg-surface-on-media-dark-5"
-                    style={{ aspectRatio: mainVideoIsPortrait ? '16 / 9' : mainVideoAspectRatio }}
-                  >
-                    {mainVideoIsPortrait && mainVideoPoster ? (
-                      <>
-                        <div
-                          className="absolute inset-0 scale-110 bg-cover bg-center blur-2xl"
-                          style={{ backgroundImage: `url(${mainVideoPoster})` }}
-                          aria-hidden
-                        />
-                        <div className="absolute inset-0 bg-black/30" aria-hidden />
-                      </>
-                    ) : null}
-
-                    <div className="absolute left-3 top-3 z-30 inline-flex items-center rounded-full bg-black/70 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-micro text-white shadow-sm">
-                      {mainVideoCopy.preview}
-                    </div>
-
-                    <div
-                      className={clsx(
-                        'relative h-full w-full',
-                        mainVideoIsPortrait ? 'flex items-center justify-center p-3 sm:p-4' : ''
-                      )}
-                    >
-                      <ExamplesHeroVideo
-                        className={clsx(
-                          mainVideoIsPortrait
-                            ? 'relative z-10 h-full w-auto max-w-full rounded-[18px] object-contain shadow-[0_18px_48px_rgba(15,23,42,0.28)]'
-                            : 'h-full w-full object-cover'
-                        )}
-                        src={mainVideoContentUrl}
-                        type={mainVideoMimeType}
-                        poster={mainVideoPoster ?? undefined}
-                        posterFit={mainVideoIsPortrait ? 'contain' : 'cover'}
-                        ariaLabel={mainVideoTitle}
-                        ariaHidden
-                        controls={false}
-                      />
-                    </div>
-                    <div className="pointer-events-none absolute inset-x-0 bottom-0 z-30 flex items-end justify-between gap-3 bg-gradient-to-t from-black/65 via-black/15 to-transparent px-3 py-3">
-                      {mainVideo.video.hasAudio ? (
-                        <AudioEqualizerBadge tone="light" size="sm" label={mainVideoCopy.audioOn} />
-                      ) : (
-                        <span />
-                      )}
-                      <span className="inline-flex items-center rounded-full bg-white/92 px-3 py-1.5 text-[11px] font-semibold text-black shadow-sm">
-                        {mainVideoCopy.openWatchPage}
-                      </span>
-                    </div>
-                  </div>
-                </Link>
-
-                <div className="space-y-2.5 px-5 py-4 text-left sm:px-6 sm:py-4.5">
-                  <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-micro text-text-muted">
-                    {mainVideo.card.modelHref ? (
-                      <Link href={mainVideo.card.modelHref} prefetch={false} className="hover:text-text-primary">
-                        {mainVideo.card.engineLabel}
-                      </Link>
-                    ) : (
-                      <span>{mainVideo.card.engineLabel}</span>
-                    )}
-                    <span>
-                      {mainVideo.video.aspectRatio ?? 'Auto'} · {mainVideo.video.durationSec}s
-                    </span>
-                  </div>
-
-                  <h2 className="text-lg font-semibold leading-snug text-text-primary sm:text-xl">
-                    {mainVideoHeroLine}
-                  </h2>
-
-                  {mainVideoPromptFull ? (
-                    <DeferredSourcePrompt
-                      locale={locale}
-                      prompt={mainVideoPromptFull}
-                      mode="details"
-                      className="group"
-                      summaryClassName="cursor-pointer list-none text-[11px] font-semibold uppercase tracking-micro text-text-muted transition hover:text-text-primary"
-                      promptClassName="mt-2 whitespace-pre-line text-sm leading-relaxed text-text-secondary"
-                      fallbackClassName="text-sm leading-relaxed text-text-secondary"
-                      summaryLabel={mainVideoCopy.fullPrompt}
-                    />
-                  ) : null}
-
-                  <div className="flex flex-wrap items-center gap-3 pt-0.5">
-                    <Link
-                      href={mainVideo.card.href}
-                      prefetch={false}
-                      className="inline-flex items-center rounded-full bg-text-primary px-4 py-2 text-sm font-semibold text-bg transition hover:opacity-90"
-                    >
-                      {mainVideoCopy.openExample}
-                    </Link>
-                    {mainVideo.card.modelHref ? (
-                      <Link
-                        href={mainVideo.card.modelHref}
-                        prefetch={false}
-                        className="inline-flex items-center rounded-full border border-hairline px-4 py-2 text-sm font-semibold text-text-primary transition hover:border-text-muted hover:bg-surface-2"
-                      >
-                        {mainVideo.card.engineLabel}
-                      </Link>
-                    ) : null}
-                  </div>
-                </div>
-              </article>
-            </section>
+            <ExamplesMainVideoFeature
+              aspectRatio={mainVideoAspectRatio}
+              contentUrl={mainVideoContentUrl}
+              copy={mainVideoCopy}
+              durationSec={mainVideo.video.durationSec}
+              engineLabel={mainVideo.card.engineLabel}
+              exampleHref={mainVideo.card.href}
+              hasAudio={mainVideo.video.hasAudio}
+              heroLine={mainVideoHeroLine}
+              isPortrait={mainVideoIsPortrait}
+              locale={locale}
+              mimeType={mainVideoMimeType}
+              modelHref={mainVideo.card.modelHref ?? null}
+              poster={mainVideoPoster ?? null}
+              promptFull={mainVideoPromptFull}
+              title={mainVideoTitle}
+            />
           ) : null}
 
           {isModelLanding && selectedEngine && modelLinks.length ? (

--- a/tests/examples-pages-performance.test.ts
+++ b/tests/examples-pages-performance.test.ts
@@ -3,6 +3,10 @@ import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
 const examplesPageSource = readFileSync("frontend/app/(localized)/[locale]/(marketing)/examples/page.tsx", 'utf8');
+const examplesMainVideoFeatureSource = readFileSync(
+  "frontend/app/(localized)/[locale]/(marketing)/examples/_components/examples-main-video-feature.tsx",
+  'utf8'
+);
 const examplesHeroVideoSource = readFileSync('frontend/components/examples/ExamplesHeroVideo.client.tsx', 'utf8');
 const marketingNavSource = readFileSync('frontend/components/marketing/MarketingNav.tsx', 'utf8');
 
@@ -13,13 +17,14 @@ test('examples hero video keeps mobile rendering poster-first instead of autopla
 });
 
 test('examples model landing hero links do not prefetch RSC routes during initial render', () => {
+  assert.match(examplesPageSource, /<ExamplesMainVideoFeature/);
   assert.match(
-    examplesPageSource,
-    /<Link\s+href=\{mainVideo\.card\.href\}[\s\S]{0,220}?prefetch=\{false\}/
+    examplesMainVideoFeatureSource,
+    /<Link\s+[\s\S]{0,180}?href=\{exampleHref\}[\s\S]{0,220}?prefetch=\{false\}/
   );
   assert.match(
-    examplesPageSource,
-    /<Link\s+href=\{mainVideo\.card\.modelHref\}[\s\S]{0,220}?prefetch=\{false\}/
+    examplesMainVideoFeatureSource,
+    /<Link\s+[\s\S]{0,180}?href=\{modelHref\}[\s\S]{0,220}?prefetch=\{false\}/
   );
 });
 

--- a/tests/examples-route-architecture.test.ts
+++ b/tests/examples-route-architecture.test.ts
@@ -7,16 +7,20 @@ const root = process.cwd();
 const pagePath = join(root, 'frontend/app/(localized)/[locale]/(marketing)/examples/page.tsx');
 const utilsPath = join(root, 'frontend/app/(localized)/[locale]/(marketing)/examples/_lib/examples-route-utils.ts');
 const copyPath = join(root, 'frontend/app/(localized)/[locale]/(marketing)/examples/_lib/examples-page-copy.ts');
+const mainVideoFeaturePath = join(root, 'frontend/app/(localized)/[locale]/(marketing)/examples/_components/examples-main-video-feature.tsx');
 
 const pageSource = readFileSync(pagePath, 'utf8');
 const utilsSource = readFileSync(utilsPath, 'utf8');
 const copySource = readFileSync(copyPath, 'utf8');
+const mainVideoFeatureSource = readFileSync(mainVideoFeaturePath, 'utf8');
 
 test('examples route delegates URL, filter, and gallery helper logic', () => {
   assert.ok(existsSync(pagePath), 'examples route page should exist');
   assert.ok(existsSync(utilsPath), 'examples route helper module should exist');
   assert.ok(existsSync(copyPath), 'examples route copy helper module should exist');
+  assert.ok(existsSync(mainVideoFeaturePath), 'examples main video feature should exist');
 
+  assert.match(pageSource, /from '\.\/_components\/examples-main-video-feature'/, 'route should import main video feature');
   assert.match(pageSource, /from '\.\/_lib\/examples-route-utils'/, 'route should import examples helpers');
   assert.match(pageSource, /from '\.\/_lib\/examples-page-copy'/, 'route should import examples copy helpers');
   assert.match(pageSource, /export async function generateMetadata/, 'route should keep metadata orchestration');
@@ -30,9 +34,12 @@ test('examples route delegates URL, filter, and gallery helper logic', () => {
   assert.doesNotMatch(pageSource, /function getSort\(/, 'sort parsing belongs in helper module');
   assert.doesNotMatch(pageSource, /const rawNextStepLinks =/, 'model landing next-step copy belongs in copy helper module');
   assert.doesNotMatch(pageSource, /const galleryUiCopy =\s*locale ===/, 'localized gallery UI copy belongs in copy helper module');
+  assert.doesNotMatch(pageSource, /ExamplesHeroVideo/, 'main video hero rendering belongs in ExamplesMainVideoFeature');
+  assert.doesNotMatch(pageSource, /DeferredSourcePrompt/, 'main video prompt disclosure belongs in ExamplesMainVideoFeature');
+  assert.doesNotMatch(pageSource, /mainVideoCopy\.openExample/, 'main video CTAs belong in ExamplesMainVideoFeature');
 
   const lineCount = pageSource.split('\n').length;
-  assert.ok(lineCount <= 1000, `examples page should stay below 1000 lines after helper extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 900, `examples page should stay below 900 lines after main video extraction, got ${lineCount}`);
 });
 
 test('examples helper module exposes the route contract', () => {
@@ -99,4 +106,11 @@ test('examples page copy helper exposes localized route copy builders', () => {
   ]) {
     assert.match(copySource, new RegExp(`export function ${exportName}`), `${exportName} should be exported`);
   }
+});
+
+test('examples main video feature owns the hero media card', () => {
+  assert.match(mainVideoFeatureSource, /export function ExamplesMainVideoFeature/, 'main video feature should be exported');
+  assert.match(mainVideoFeatureSource, /ExamplesHeroVideo/, 'main video feature should own hero video rendering');
+  assert.match(mainVideoFeatureSource, /AudioEqualizerBadge/, 'main video feature should own audio badge rendering');
+  assert.match(mainVideoFeatureSource, /DeferredSourcePrompt/, 'main video feature should own prompt disclosure');
 });


### PR DESCRIPTION
## Summary
- move the examples model-landing main video hero card into a focused component
- keep prefetch=false coverage by updating the performance contract to inspect the extracted component
- tighten the examples route architecture contract around hero media ownership

## Checks
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/examples-route-architecture.test.ts tests/examples-pages-performance.test.ts tests/examples-hero-video-bot.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- git diff --check -- frontend/app/(localized)/[locale]/(marketing)/examples/page.tsx frontend/app/(localized)/[locale]/(marketing)/examples/_components/examples-main-video-feature.tsx tests/examples-route-architecture.test.ts tests/examples-pages-performance.test.ts
- npm --prefix frontend run lint
- npm run lint:exposure