### PR TITLE
Split upscale server persistence

### DIFF
--- a/frontend/src/server/tools/upscale-constants.ts
+++ b/frontend/src/server/tools/upscale-constants.ts
@@ -1,0 +1,2 @@
+export const UPSCALE_TOOL_EVENT_NAME = 'tool_upscale_generate';
+export const UPSCALE_PLACEHOLDER_THUMB = '/assets/frames/thumb-1x1.svg';

--- a/frontend/src/server/tools/upscale-errors.ts
+++ b/frontend/src/server/tools/upscale-errors.ts
@@ -1,0 +1,13 @@
+export class UpscaleToolError extends Error {
+  status: number;
+  code: string;
+  detail?: unknown;
+
+  constructor(message: string, options?: { status?: number; code?: string; detail?: unknown }) {
+    super(message);
+    this.name = 'UpscaleToolError';
+    this.status = options?.status ?? 500;
+    this.code = options?.code ?? 'upscale_tool_error';
+    this.detail = options?.detail;
+  }
+}

--- a/frontend/src/server/tools/upscale-job-persistence.ts
+++ b/frontend/src/server/tools/upscale-job-persistence.ts
@@ -1,0 +1,233 @@
+import { isDatabaseConfigured, query, type QueryExecutor, withDbTransaction } from '@/lib/db';
+import { getResultProviderMode } from '@/lib/result-provider';
+import { ensureBillingSchema } from '@/lib/schema';
+import type { Currency } from '@/lib/currency';
+import { reserveWalletChargeInExecutor } from '@/lib/wallet';
+import type { PricingSnapshot } from '@/types/engines';
+import type { UpscaleToolEngineId } from '@/types/tools-upscale';
+import { UPSCALE_PLACEHOLDER_THUMB, UPSCALE_TOOL_EVENT_NAME } from './upscale-constants';
+import { UpscaleToolError } from './upscale-errors';
+import { UPSCALE_SURFACE } from './upscale-request-utils';
+
+export type PendingUpscaleReceipt = {
+  userId: string;
+  amountCents: number;
+  currency: string;
+  description: string;
+  jobId: string;
+  surface: typeof UPSCALE_SURFACE;
+  billingProductKey: string;
+  snapshot: PricingSnapshot;
+  applicationFeeCents: number | null;
+  vendorAccountId: string | null;
+};
+
+export type CreateUpscaleInitialJobParams = {
+  userId: string;
+  jobId: string;
+  description: string;
+  amountCents: number;
+  currency: string;
+  billingProductKey: string;
+  pricingSnapshotJson: string;
+  applicationFeeCents: number | null;
+  vendorAccountId: string | null;
+  engineId: UpscaleToolEngineId;
+  engineLabel: string;
+  durationSec: number;
+  promptSummary: string;
+  settingsSnapshotJson: string;
+  preferredCurrency: Currency | null;
+};
+
+export async function recordUpscaleRefundReceipt(receipt: PendingUpscaleReceipt, label: string, priceOnly: boolean) {
+  try {
+    await query(
+      `INSERT INTO app_receipts (
+         user_id,
+         type,
+         amount_cents,
+         currency,
+         description,
+         job_id,
+         surface,
+         billing_product_key,
+         pricing_snapshot,
+         application_fee_cents,
+         vendor_account_id,
+         platform_revenue_cents,
+         destination_acct
+       )
+       VALUES ($1,'refund',$2,$3,$4,$5,$6,$7,$8::jsonb,$9,$10,$11,$12)
+       ON CONFLICT DO NOTHING`,
+      [
+        receipt.userId,
+        receipt.amountCents,
+        receipt.currency,
+        label,
+        receipt.jobId,
+        receipt.surface,
+        receipt.billingProductKey,
+        JSON.stringify(receipt.snapshot),
+        priceOnly ? null : 0,
+        priceOnly ? null : receipt.vendorAccountId,
+        priceOnly ? null : 0,
+        priceOnly ? null : receipt.vendorAccountId,
+      ]
+    );
+  } catch (error) {
+    console.warn('[tools/upscale] failed to record refund receipt', error);
+  }
+}
+
+async function insertProvisionalUpscaleJob(
+  executor: QueryExecutor,
+  params: Omit<CreateUpscaleInitialJobParams, 'description' | 'preferredCurrency' | 'applicationFeeCents'>
+) {
+  await executor.query(
+    `INSERT INTO app_jobs (
+       job_id,
+       user_id,
+       surface,
+       billing_product_key,
+       engine_id,
+       engine_label,
+       duration_sec,
+       prompt,
+       thumb_url,
+       preview_frame,
+       status,
+       progress,
+       final_price_cents,
+       pricing_snapshot,
+       settings_snapshot,
+       currency,
+       vendor_account_id,
+       payment_status,
+       visibility,
+       indexable,
+       provisional
+     )
+     VALUES (
+       $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,'pending',0,$11,$12::jsonb,$13::jsonb,$14,$15,'paid_wallet','private',FALSE,TRUE
+     )`,
+    [
+      params.jobId,
+      params.userId,
+      UPSCALE_SURFACE,
+      params.billingProductKey,
+      params.engineId,
+      params.engineLabel,
+      Math.max(1, Math.ceil(params.durationSec)),
+      params.promptSummary,
+      UPSCALE_PLACEHOLDER_THUMB,
+      UPSCALE_PLACEHOLDER_THUMB,
+      params.amountCents,
+      params.pricingSnapshotJson,
+      params.settingsSnapshotJson,
+      params.currency,
+      params.vendorAccountId,
+    ]
+  );
+}
+
+async function createUpscaleInitialJobInExecutor(
+  executor: QueryExecutor,
+  params: CreateUpscaleInitialJobParams
+): Promise<void> {
+  const reserveResult = await reserveWalletChargeInExecutor(
+    executor,
+    {
+      userId: params.userId,
+      amountCents: params.amountCents,
+      currency: params.currency,
+      description: params.description,
+      jobId: params.jobId,
+      surface: UPSCALE_SURFACE,
+      billingProductKey: params.billingProductKey,
+      pricingSnapshotJson: params.pricingSnapshotJson,
+      applicationFeeCents: params.applicationFeeCents,
+      vendorAccountId: params.vendorAccountId,
+      stripePaymentIntentId: null,
+      stripeChargeId: null,
+    },
+    { preferredCurrency: params.preferredCurrency }
+  );
+
+  if (!reserveResult.ok) {
+    if (reserveResult.errorCode === 'currency_mismatch') {
+      const lockedCurrency = (reserveResult.preferredCurrency ?? 'usd').toUpperCase();
+      throw new UpscaleToolError(`Wallet currency locked to ${lockedCurrency}. Contact support to request a change.`, {
+        status: 409,
+        code: 'wallet_currency_mismatch',
+        detail: { lockedCurrency },
+      });
+    }
+
+    throw new UpscaleToolError('Insufficient wallet balance for this upscale run.', {
+      status: 402,
+      code: 'insufficient_wallet_funds',
+      detail: {
+        balanceCents: reserveResult.balanceCents,
+        requiredCents: Math.max(0, params.amountCents - reserveResult.balanceCents),
+      },
+    });
+  }
+
+  await insertProvisionalUpscaleJob(executor, {
+    userId: params.userId,
+    jobId: params.jobId,
+    amountCents: params.amountCents,
+    currency: params.currency,
+    billingProductKey: params.billingProductKey,
+    pricingSnapshotJson: params.pricingSnapshotJson,
+    vendorAccountId: params.vendorAccountId,
+    engineId: params.engineId,
+    engineLabel: params.engineLabel,
+    durationSec: params.durationSec,
+    promptSummary: params.promptSummary,
+    settingsSnapshotJson: params.settingsSnapshotJson,
+  });
+}
+
+export async function createAtomicInitialUpscaleJob(params: CreateUpscaleInitialJobParams): Promise<void> {
+  try {
+    await withDbTransaction(async (executor) => {
+      await executor.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [params.jobId]);
+      await createUpscaleInitialJobInExecutor(executor, params);
+    });
+  } catch (error) {
+    if (error instanceof UpscaleToolError) throw error;
+    throw new UpscaleToolError('Failed to save upscale job.', {
+      status: 500,
+      code: 'job_persist_failed',
+      detail: error instanceof Error ? error.message : error,
+    });
+  }
+}
+
+export async function insertUpscaleToolEvent(params: {
+  jobId: string;
+  engineId: UpscaleToolEngineId;
+  providerJobId?: string | null;
+  payload: Record<string, unknown>;
+}) {
+  if (!isDatabaseConfigured()) return;
+  try {
+    await ensureBillingSchema();
+    await query(
+      `INSERT INTO fal_queue_log (job_id, provider, provider_job_id, engine_id, status, payload)
+       VALUES ($1,$2,$3,$4,$5,$6::jsonb)`,
+      [
+        params.jobId,
+        getResultProviderMode(),
+        params.providerJobId ?? null,
+        params.engineId,
+        UPSCALE_TOOL_EVENT_NAME,
+        JSON.stringify(params.payload),
+      ]
+    );
+  } catch (error) {
+    console.warn('[tools/upscale] failed to persist event log', error);
+  }
+}

--- a/frontend/src/server/tools/upscale-output-persistence.ts
+++ b/frontend/src/server/tools/upscale-output-persistence.ts
@@ -1,0 +1,129 @@
+import { resolveUpscaleOutputFetchTimeoutMs } from '@/lib/tools-upscale';
+import { isStorageConfigured, recordUserAsset, uploadFileBuffer, uploadImageToStorage } from '@/server/storage';
+import type { UpscaleMediaType, UpscaleOutputFormat, UpscaleToolEngineId, UpscaleToolOutput } from '@/types/tools-upscale';
+import { formatToImageMime, formatToVideoMime } from './upscale-request-utils';
+
+export async function persistUpscaleOutput(params: {
+  output: UpscaleToolOutput;
+  mediaType: UpscaleMediaType;
+  userId: string;
+  jobId: string;
+  providerJobId?: string | null;
+  engineId: UpscaleToolEngineId;
+  engineLabel: string;
+  outputFormat: UpscaleOutputFormat;
+  durationSec?: number | null;
+}): Promise<UpscaleToolOutput> {
+  const { output, mediaType, userId, jobId, providerJobId, engineId, engineLabel, outputFormat, durationSec } = params;
+  if (!isStorageConfigured() || !output.url) return output;
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(),
+      resolveUpscaleOutputFetchTimeoutMs({ mediaType, durationSec })
+    );
+    let response: Response;
+    try {
+      response = await fetch(output.url, { signal: controller.signal });
+    } finally {
+      clearTimeout(timeout);
+    }
+    if (!response.ok) throw new Error(`fetch failed (${response.status})`);
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (!buffer.length) throw new Error('empty output');
+
+    if (mediaType === 'image') {
+      const mimeHeader = response.headers.get('content-type') ?? '';
+      const mime =
+        typeof output.mimeType === 'string' && output.mimeType.startsWith('image/')
+          ? output.mimeType
+          : mimeHeader.startsWith('image/')
+            ? mimeHeader
+            : formatToImageMime(outputFormat);
+      const upload = await uploadImageToStorage({
+        data: buffer,
+        mime,
+        userId,
+        prefix: 'upscale',
+        fileName: `upscale-${engineId}.${mime.split('/')[1] || 'png'}`,
+      });
+      const assetId = await recordUserAsset({
+        userId,
+        url: upload.url,
+        mime: upload.mime,
+        width: upload.width ?? output.width ?? null,
+        height: upload.height ?? output.height ?? null,
+        size: upload.size,
+        source: 'upscale',
+        metadata: {
+          originUrl: output.url,
+          jobId,
+          providerJobId: providerJobId ?? null,
+          tool: 'upscale',
+          engineId,
+          engineLabel,
+        },
+      });
+      return {
+        ...output,
+        url: upload.url,
+        width: upload.width ?? output.width ?? null,
+        height: upload.height ?? output.height ?? null,
+        mimeType: upload.mime,
+        originUrl: output.url,
+        assetId,
+        source: 'upscale',
+        persisted: true,
+      };
+    }
+
+    const mimeHeader = response.headers.get('content-type') ?? '';
+    const mime =
+      typeof output.mimeType === 'string' && (output.mimeType.startsWith('video/') || output.mimeType === 'image/gif')
+        ? output.mimeType
+        : mimeHeader.startsWith('video/') || mimeHeader === 'image/gif'
+          ? mimeHeader
+          : formatToVideoMime(outputFormat);
+    const upload = await uploadFileBuffer({
+      data: buffer,
+      mime,
+      userId,
+      prefix: 'upscale',
+      fileName: `upscale-${engineId}.${outputFormat === 'gif' ? 'gif' : outputFormat}`,
+    });
+    const assetId = await recordUserAsset({
+      userId,
+      url: upload.url,
+      mime,
+      width: output.width ?? null,
+      height: output.height ?? null,
+      size: buffer.length,
+      source: 'upscale',
+      metadata: {
+        originUrl: output.url,
+        jobId,
+        providerJobId: providerJobId ?? null,
+        tool: 'upscale',
+        engineId,
+        engineLabel,
+      },
+    });
+    return {
+      ...output,
+      url: upload.url,
+      mimeType: mime,
+      originUrl: output.url,
+      assetId,
+      source: 'upscale',
+      persisted: true,
+    };
+  } catch (error) {
+    console.warn('[tools/upscale] failed to persist output', {
+      engineId,
+      jobId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return output;
+  }
+}

--- a/frontend/src/server/tools/upscale.ts
+++ b/frontend/src/server/tools/upscale.ts
@@ -1,33 +1,24 @@
 import { randomUUID } from 'crypto';
 import { ApiError, ValidationError } from '@fal-ai/client';
 import { getUpscaleToolEngine } from '@/config/tools-upscale-engines';
-import { isDatabaseConfigured, query, type QueryExecutor, withDbTransaction } from '@/lib/db';
+import { query } from '@/lib/db';
 import { getFalClient } from '@/lib/fal-client';
-import { getResultProviderMode } from '@/lib/result-provider';
-import { ensureBillingSchema } from '@/lib/schema';
 import { computeBillingProductSnapshot } from '@/lib/billing-products';
-import { getPlatformFeeCents } from '@/lib/pricing';
-import { getUserPreferredCurrency, type Currency } from '@/lib/currency';
-import { reserveWalletChargeInExecutor } from '@/lib/wallet';
-import { receiptsPriceOnlyEnabled } from '@/lib/env';
-import { isStorageConfigured, recordUserAsset, uploadFileBuffer, uploadImageToStorage } from '@/server/storage';
 import { buildStoredImageRenderEntries, resolveHeroThumbFromRenders } from '@/lib/image-renders';
+import { getPlatformFeeCents } from '@/lib/pricing';
+import { getUserPreferredCurrency } from '@/lib/currency';
+import { receiptsPriceOnlyEnabled } from '@/lib/env';
 import { ensureReusableAsset, upsertLegacyJobOutputs } from '@/server/media-library';
 import {
   UPSCALE_VIDEO_DYNAMIC_MARGIN_MULTIPLIER,
   clampUpscaleFactor,
   estimateImageUpscaleCostUsd,
   estimateVideoUpscaleCostUsd,
-  resolveUpscaleOutputFetchTimeoutMs,
   resolveUpscaleMode,
   resolveUpscaleOutputFormat,
   resolveUpscaleTargetResolution,
 } from '@/lib/tools-upscale';
 import type {
-  UpscaleMediaType,
-  UpscaleOutputFormat,
-  UpscaleToolEngineId,
-  UpscaleToolOutput,
   UpscaleToolRequest,
   UpscaleToolResponse,
 } from '@/types/tools-upscale';
@@ -40,15 +31,21 @@ import {
   cloneUpscalePricingWithDynamicTotal,
   extractUpscaleActualCostUsd,
   extractUpscaleOutput,
-  formatToImageMime,
-  formatToVideoMime,
   parseUpscaleRequestId,
   toUpscaleValidationMessage,
   type VideoMetadata,
 } from './upscale-request-utils';
+import { UPSCALE_PLACEHOLDER_THUMB, UPSCALE_TOOL_EVENT_NAME } from './upscale-constants';
+import { UpscaleToolError } from './upscale-errors';
+export { UpscaleToolError } from './upscale-errors';
+import {
+  createAtomicInitialUpscaleJob,
+  insertUpscaleToolEvent,
+  recordUpscaleRefundReceipt,
+  type PendingUpscaleReceipt,
+} from './upscale-job-persistence';
+import { persistUpscaleOutput } from './upscale-output-persistence';
 
-const TOOL_EVENT_NAME = 'tool_upscale_generate';
-const PLACEHOLDER_THUMB = '/assets/frames/thumb-1x1.svg';
 
 type RunUpscaleToolInput = UpscaleToolRequest & {
   userId: string;
@@ -69,371 +66,9 @@ export type RunUpscaleToolDependencies = {
   detectVideoMetadata?: (videoUrl: string, options?: { timeoutMs?: number }) => Promise<VideoMetadata | null>;
 };
 
-type PendingUpscaleReceipt = {
-  userId: string;
-  amountCents: number;
-  currency: string;
-  description: string;
-  jobId: string;
-  surface: typeof UPSCALE_SURFACE;
-  billingProductKey: string;
-  snapshot: PricingSnapshot;
-  applicationFeeCents: number | null;
-  vendorAccountId: string | null;
-};
-
-type CreateUpscaleInitialJobParams = {
-  userId: string;
-  jobId: string;
-  description: string;
-  amountCents: number;
-  currency: string;
-  billingProductKey: string;
-  pricingSnapshotJson: string;
-  applicationFeeCents: number | null;
-  vendorAccountId: string | null;
-  engineId: UpscaleToolEngineId;
-  engineLabel: string;
-  durationSec: number;
-  promptSummary: string;
-  settingsSnapshotJson: string;
-  preferredCurrency: Currency | null;
-};
-
-export class UpscaleToolError extends Error {
-  status: number;
-  code: string;
-  detail?: unknown;
-
-  constructor(message: string, options?: { status?: number; code?: string; detail?: unknown }) {
-    super(message);
-    this.name = 'UpscaleToolError';
-    this.status = options?.status ?? 500;
-    this.code = options?.code ?? 'upscale_tool_error';
-    this.detail = options?.detail;
-  }
-}
-
 function usdToCredits(value: number | null | undefined): number | null {
   if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return null;
   return Math.max(1, Math.round(value * 100));
-}
-
-async function recordUpscaleRefundReceipt(receipt: PendingUpscaleReceipt, label: string, priceOnly: boolean) {
-  try {
-    await query(
-      `INSERT INTO app_receipts (
-         user_id,
-         type,
-         amount_cents,
-         currency,
-         description,
-         job_id,
-         surface,
-         billing_product_key,
-         pricing_snapshot,
-         application_fee_cents,
-         vendor_account_id,
-         platform_revenue_cents,
-         destination_acct
-       )
-       VALUES ($1,'refund',$2,$3,$4,$5,$6,$7,$8::jsonb,$9,$10,$11,$12)
-       ON CONFLICT DO NOTHING`,
-      [
-        receipt.userId,
-        receipt.amountCents,
-        receipt.currency,
-        label,
-        receipt.jobId,
-        receipt.surface,
-        receipt.billingProductKey,
-        JSON.stringify(receipt.snapshot),
-        priceOnly ? null : 0,
-        priceOnly ? null : receipt.vendorAccountId,
-        priceOnly ? null : 0,
-        priceOnly ? null : receipt.vendorAccountId,
-      ]
-    );
-  } catch (error) {
-    console.warn('[tools/upscale] failed to record refund receipt', error);
-  }
-}
-
-async function insertProvisionalUpscaleJob(
-  executor: QueryExecutor,
-  params: Omit<CreateUpscaleInitialJobParams, 'description' | 'preferredCurrency' | 'applicationFeeCents'>
-) {
-  await executor.query(
-    `INSERT INTO app_jobs (
-       job_id,
-       user_id,
-       surface,
-       billing_product_key,
-       engine_id,
-       engine_label,
-       duration_sec,
-       prompt,
-       thumb_url,
-       preview_frame,
-       status,
-       progress,
-       final_price_cents,
-       pricing_snapshot,
-       settings_snapshot,
-       currency,
-       vendor_account_id,
-       payment_status,
-       visibility,
-       indexable,
-       provisional
-     )
-     VALUES (
-       $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,'pending',0,$11,$12::jsonb,$13::jsonb,$14,$15,'paid_wallet','private',FALSE,TRUE
-     )`,
-    [
-      params.jobId,
-      params.userId,
-      UPSCALE_SURFACE,
-      params.billingProductKey,
-      params.engineId,
-      params.engineLabel,
-      Math.max(1, Math.ceil(params.durationSec)),
-      params.promptSummary,
-      PLACEHOLDER_THUMB,
-      PLACEHOLDER_THUMB,
-      params.amountCents,
-      params.pricingSnapshotJson,
-      params.settingsSnapshotJson,
-      params.currency,
-      params.vendorAccountId,
-    ]
-  );
-}
-
-async function createUpscaleInitialJobInExecutor(
-  executor: QueryExecutor,
-  params: CreateUpscaleInitialJobParams
-): Promise<void> {
-  const reserveResult = await reserveWalletChargeInExecutor(
-    executor,
-    {
-      userId: params.userId,
-      amountCents: params.amountCents,
-      currency: params.currency,
-      description: params.description,
-      jobId: params.jobId,
-      surface: UPSCALE_SURFACE,
-      billingProductKey: params.billingProductKey,
-      pricingSnapshotJson: params.pricingSnapshotJson,
-      applicationFeeCents: params.applicationFeeCents,
-      vendorAccountId: params.vendorAccountId,
-      stripePaymentIntentId: null,
-      stripeChargeId: null,
-    },
-    { preferredCurrency: params.preferredCurrency }
-  );
-
-  if (!reserveResult.ok) {
-    if (reserveResult.errorCode === 'currency_mismatch') {
-      const lockedCurrency = (reserveResult.preferredCurrency ?? 'usd').toUpperCase();
-      throw new UpscaleToolError(`Wallet currency locked to ${lockedCurrency}. Contact support to request a change.`, {
-        status: 409,
-        code: 'wallet_currency_mismatch',
-        detail: { lockedCurrency },
-      });
-    }
-
-    throw new UpscaleToolError('Insufficient wallet balance for this upscale run.', {
-      status: 402,
-      code: 'insufficient_wallet_funds',
-      detail: {
-        balanceCents: reserveResult.balanceCents,
-        requiredCents: Math.max(0, params.amountCents - reserveResult.balanceCents),
-      },
-    });
-  }
-
-  await insertProvisionalUpscaleJob(executor, {
-    userId: params.userId,
-    jobId: params.jobId,
-    amountCents: params.amountCents,
-    currency: params.currency,
-    billingProductKey: params.billingProductKey,
-    pricingSnapshotJson: params.pricingSnapshotJson,
-    vendorAccountId: params.vendorAccountId,
-    engineId: params.engineId,
-    engineLabel: params.engineLabel,
-    durationSec: params.durationSec,
-    promptSummary: params.promptSummary,
-    settingsSnapshotJson: params.settingsSnapshotJson,
-  });
-}
-
-async function createAtomicInitialUpscaleJob(params: CreateUpscaleInitialJobParams): Promise<void> {
-  try {
-    await withDbTransaction(async (executor) => {
-      await executor.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [params.jobId]);
-      await createUpscaleInitialJobInExecutor(executor, params);
-    });
-  } catch (error) {
-    if (error instanceof UpscaleToolError) throw error;
-    throw new UpscaleToolError('Failed to save upscale job.', {
-      status: 500,
-      code: 'job_persist_failed',
-      detail: error instanceof Error ? error.message : error,
-    });
-  }
-}
-
-async function insertToolEvent(params: {
-  jobId: string;
-  engineId: UpscaleToolEngineId;
-  providerJobId?: string | null;
-  payload: Record<string, unknown>;
-}) {
-  if (!isDatabaseConfigured()) return;
-  try {
-    await ensureBillingSchema();
-    await query(
-      `INSERT INTO fal_queue_log (job_id, provider, provider_job_id, engine_id, status, payload)
-       VALUES ($1,$2,$3,$4,$5,$6::jsonb)`,
-      [
-        params.jobId,
-        getResultProviderMode(),
-        params.providerJobId ?? null,
-        params.engineId,
-        TOOL_EVENT_NAME,
-        JSON.stringify(params.payload),
-      ]
-    );
-  } catch (error) {
-    console.warn('[tools/upscale] failed to persist event log', error);
-  }
-}
-
-async function persistUpscaleOutput(params: {
-  output: UpscaleToolOutput;
-  mediaType: UpscaleMediaType;
-  userId: string;
-  jobId: string;
-  providerJobId?: string | null;
-  engineId: UpscaleToolEngineId;
-  engineLabel: string;
-  outputFormat: UpscaleOutputFormat;
-  durationSec?: number | null;
-}): Promise<UpscaleToolOutput> {
-  const { output, mediaType, userId, jobId, providerJobId, engineId, engineLabel, outputFormat, durationSec } = params;
-  if (!isStorageConfigured() || !output.url) return output;
-
-  try {
-    const controller = new AbortController();
-    const timeout = setTimeout(
-      () => controller.abort(),
-      resolveUpscaleOutputFetchTimeoutMs({ mediaType, durationSec })
-    );
-    let response: Response;
-    try {
-      response = await fetch(output.url, { signal: controller.signal });
-    } finally {
-      clearTimeout(timeout);
-    }
-    if (!response.ok) throw new Error(`fetch failed (${response.status})`);
-    const buffer = Buffer.from(await response.arrayBuffer());
-    if (!buffer.length) throw new Error('empty output');
-
-    if (mediaType === 'image') {
-      const mimeHeader = response.headers.get('content-type') ?? '';
-      const mime =
-        typeof output.mimeType === 'string' && output.mimeType.startsWith('image/')
-          ? output.mimeType
-          : mimeHeader.startsWith('image/')
-            ? mimeHeader
-            : formatToImageMime(outputFormat);
-      const upload = await uploadImageToStorage({
-        data: buffer,
-        mime,
-        userId,
-        prefix: 'upscale',
-        fileName: `upscale-${engineId}.${mime.split('/')[1] || 'png'}`,
-      });
-      const assetId = await recordUserAsset({
-        userId,
-        url: upload.url,
-        mime: upload.mime,
-        width: upload.width ?? output.width ?? null,
-        height: upload.height ?? output.height ?? null,
-        size: upload.size,
-        source: 'upscale',
-        metadata: {
-          originUrl: output.url,
-          jobId,
-          providerJobId: providerJobId ?? null,
-          tool: 'upscale',
-          engineId,
-          engineLabel,
-        },
-      });
-      return {
-        ...output,
-        url: upload.url,
-        width: upload.width ?? output.width ?? null,
-        height: upload.height ?? output.height ?? null,
-        mimeType: upload.mime,
-        originUrl: output.url,
-        assetId,
-        source: 'upscale',
-        persisted: true,
-      };
-    }
-
-    const mimeHeader = response.headers.get('content-type') ?? '';
-    const mime =
-      typeof output.mimeType === 'string' && (output.mimeType.startsWith('video/') || output.mimeType === 'image/gif')
-        ? output.mimeType
-        : mimeHeader.startsWith('video/') || mimeHeader === 'image/gif'
-          ? mimeHeader
-          : formatToVideoMime(outputFormat);
-    const upload = await uploadFileBuffer({
-      data: buffer,
-      mime,
-      userId,
-      prefix: 'upscale',
-      fileName: `upscale-${engineId}.${outputFormat === 'gif' ? 'gif' : outputFormat}`,
-    });
-    const assetId = await recordUserAsset({
-      userId,
-      url: upload.url,
-      mime,
-      width: output.width ?? null,
-      height: output.height ?? null,
-      size: buffer.length,
-      source: 'upscale',
-      metadata: {
-        originUrl: output.url,
-        jobId,
-        providerJobId: providerJobId ?? null,
-        tool: 'upscale',
-        engineId,
-        engineLabel,
-      },
-    });
-    return {
-      ...output,
-      url: upload.url,
-      mimeType: mime,
-      originUrl: output.url,
-      assetId,
-      source: 'upscale',
-      persisted: true,
-    };
-  } catch (error) {
-    console.warn('[tools/upscale] failed to persist output', {
-      engineId,
-      jobId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return output;
-  }
 }
 
 export async function runUpscaleToolBase(
@@ -632,7 +267,7 @@ export async function runUpscaleToolBase(
       durationSec: videoMetadata?.durationSec ?? null,
     });
 
-    let thumbUrl = PLACEHOLDER_THUMB;
+    let thumbUrl = UPSCALE_PLACEHOLDER_THUMB;
     let renderIdsJson: string | null = null;
     let heroRenderId: string | null = null;
     if (mediaType === 'image') {
@@ -654,7 +289,7 @@ export async function runUpscaleToolBase(
       const renderEntries = buildStoredImageRenderEntries([outputWithThumb]);
       renderIdsJson = JSON.stringify(renderEntries);
       heroRenderId = outputWithThumb.url;
-      thumbUrl = resolveHeroThumbFromRenders([outputWithThumb]) ?? outputWithThumb.url ?? PLACEHOLDER_THUMB;
+      thumbUrl = resolveHeroThumbFromRenders([outputWithThumb]) ?? outputWithThumb.url ?? UPSCALE_PLACEHOLDER_THUMB;
       persistedOutput.thumbUrl = outputWithThumb.thumbUrl;
     }
 
@@ -720,12 +355,12 @@ export async function runUpscaleToolBase(
       console.warn('[tools/upscale] failed to persist media asset', { jobId }, assetError);
     });
 
-    await insertToolEvent({
+    await insertUpscaleToolEvent({
       jobId,
       engineId: engine.id,
       providerJobId: requestId,
       payload: {
-        event: TOOL_EVENT_NAME,
+        event: UPSCALE_TOOL_EVENT_NAME,
         userId: input.userId,
         status: 'success',
         engine: {
@@ -820,12 +455,12 @@ export async function runUpscaleToolBase(
       console.warn('[tools/upscale] failed to mark job as failed', updateError);
     }
 
-    await insertToolEvent({
+    await insertUpscaleToolEvent({
       jobId,
       engineId: engine.id,
       providerJobId,
       payload: {
-        event: TOOL_EVENT_NAME,
+        event: UPSCALE_TOOL_EVENT_NAME,
         userId: input.userId,
         status: 'error',
         engine: {

--- a/tests/upscale-server-architecture.test.ts
+++ b/tests/upscale-server-architecture.test.ts
@@ -6,17 +6,33 @@ import test from 'node:test';
 const root = process.cwd();
 const serverPath = join(root, 'frontend/src/server/tools/upscale.ts');
 const requestUtilsPath = join(root, 'frontend/src/server/tools/upscale-request-utils.ts');
+const jobPersistencePath = join(root, 'frontend/src/server/tools/upscale-job-persistence.ts');
+const outputPersistencePath = join(root, 'frontend/src/server/tools/upscale-output-persistence.ts');
+const errorsPath = join(root, 'frontend/src/server/tools/upscale-errors.ts');
+const constantsPath = join(root, 'frontend/src/server/tools/upscale-constants.ts');
 
 const serverSource = readFileSync(serverPath, 'utf8');
 const requestUtilsSource = readFileSync(requestUtilsPath, 'utf8');
+const jobPersistenceSource = readFileSync(jobPersistencePath, 'utf8');
+const outputPersistenceSource = readFileSync(outputPersistencePath, 'utf8');
+const errorsSource = readFileSync(errorsPath, 'utf8');
+const constantsSource = readFileSync(constantsPath, 'utf8');
 
 test('upscale server delegates request and provider normalization helpers', () => {
   assert.ok(existsSync(requestUtilsPath), 'upscale request helpers should live in a server-local utility module');
+  assert.ok(existsSync(jobPersistencePath), 'upscale job persistence should live in a focused server module');
+  assert.ok(existsSync(outputPersistencePath), 'upscale output persistence should live in a focused server module');
+  assert.ok(existsSync(errorsPath), 'upscale errors should live in a small shared server module');
+  assert.ok(existsSync(constantsPath), 'upscale constants should live in a small shared server module');
   assert.match(
     serverSource,
     /from '\.\/upscale-request-utils'/,
     'upscale server orchestration should import request/provider helpers'
   );
+  assert.match(serverSource, /from '\.\/upscale-job-persistence'/);
+  assert.match(serverSource, /from '\.\/upscale-output-persistence'/);
+  assert.match(serverSource, /from '\.\/upscale-errors'/);
+  assert.match(serverSource, /from '\.\/upscale-constants'/);
 
   for (const implementationName of [
     'normalizeFalUrl',
@@ -31,6 +47,12 @@ test('upscale server delegates request and provider normalization helpers', () =
     'buildSettingsSnapshot',
     'clonePricingWithDynamicTotal',
     'toValidationMessage',
+    'recordUpscaleRefundReceipt',
+    'insertProvisionalUpscaleJob',
+    'createUpscaleInitialJobInExecutor',
+    'createAtomicInitialUpscaleJob',
+    'insertUpscaleToolEvent',
+    'persistUpscaleOutput',
   ]) {
     assert.doesNotMatch(
       serverSource,
@@ -40,7 +62,7 @@ test('upscale server delegates request and provider normalization helpers', () =
   }
 
   const lineCount = serverSource.split('\n').length;
-  assert.ok(lineCount <= 900, `upscale server orchestrator should stay below 900 lines after helper extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 560, `upscale server orchestrator should stay below 560 lines after persistence extraction, got ${lineCount}`);
 });
 
 test('upscale request utils expose the expected pure helper contract', () => {
@@ -67,4 +89,16 @@ test('upscale request utils expose the expected pure helper contract', () => {
   assert.match(requestUtilsSource, /export type VideoMetadata =/, 'VideoMetadata should move with provider request helpers');
   assert.match(requestUtilsSource, /function normalizeFalUrl\(/, 'Fal URL normalization should be private to request helpers');
   assert.match(requestUtilsSource, /function seedVideoFormat\(/, 'video format mapping should be private to request helpers');
+});
+
+test('upscale persistence modules expose job, event, output, and error contracts', () => {
+  for (const exportName of ['recordUpscaleRefundReceipt', 'createAtomicInitialUpscaleJob', 'insertUpscaleToolEvent']) {
+    assert.match(jobPersistenceSource, new RegExp(`export async function ${exportName}`));
+  }
+  assert.match(jobPersistenceSource, /export type PendingUpscaleReceipt/);
+  assert.match(jobPersistenceSource, /export type CreateUpscaleInitialJobParams/);
+  assert.match(outputPersistenceSource, /export async function persistUpscaleOutput/);
+  assert.match(errorsSource, /export class UpscaleToolError/);
+  assert.match(constantsSource, /export const UPSCALE_TOOL_EVENT_NAME/);
+  assert.match(constantsSource, /export const UPSCALE_PLACEHOLDER_THUMB/);
 });


### PR DESCRIPTION
## Summary
- keep runUpscaleToolBase focused on pricing, provider execution, and response shaping
- move wallet reservation, provisional jobs, refund receipts, and event logging into upscale-job-persistence.ts
- move storage persistence into upscale-output-persistence.ts
- move shared error and constants into small local modules
- tighten the server architecture contract to keep the orchestrator below 560 lines

## Checks
- ./node_modules/.bin/tsx --tsconfig frontend/tsconfig.json --test tests/upscale-server-architecture.test.ts tests/upscale-pricing-preview.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- frontend/src/server/tools/upscale.ts frontend/src/server/tools/upscale-job-persistence.ts frontend/src/server/tools/upscale-output-persistence.ts frontend/src/server/tools/upscale-errors.ts frontend/src/server/tools/upscale-constants.ts tests/upscale-server-architecture.test.ts