### PR TITLE
Split compare page helper modules

### DIFF
--- a/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-data-loaders.ts
+++ b/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-data-loaders.ts
@@ -1,0 +1,90 @@
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+import { isDatabaseConfigured } from '@/lib/db';
+import { getPublicVideosByIds } from '@/server/videos';
+import type { EngineKeySpecsEntry, EngineKeySpecsFile, EngineScore, EngineScoresFile, ShowdownEntry } from './compare-page-types';
+
+export async function loadEngineScores(): Promise<Map<string, EngineScore>> {
+  const candidates = [
+    path.join(process.cwd(), 'data', 'benchmarks', 'engine-scores.v1.json'),
+    path.join(process.cwd(), '..', 'data', 'benchmarks', 'engine-scores.v1.json'),
+  ];
+  for (const candidate of candidates) {
+    try {
+      const raw = await fs.readFile(candidate, 'utf8');
+      const data = JSON.parse(raw) as EngineScoresFile;
+      const map = new Map<string, EngineScore>();
+      (data.scores ?? []).forEach((entry) => {
+        const key = entry.modelSlug ?? entry.engineId;
+        if (key) {
+          map.set(key, entry);
+        }
+      });
+      return map;
+    } catch {
+      // keep trying
+    }
+  }
+  return new Map();
+}
+
+export async function loadEngineKeySpecs(): Promise<Map<string, EngineKeySpecsEntry>> {
+  const candidates = [
+    path.join(process.cwd(), 'data', 'benchmarks', 'engine-key-specs.v1.json'),
+    path.join(process.cwd(), '..', 'data', 'benchmarks', 'engine-key-specs.v1.json'),
+  ];
+  for (const candidate of candidates) {
+    try {
+      const raw = await fs.readFile(candidate, 'utf8');
+      const data = JSON.parse(raw) as EngineKeySpecsFile;
+      const map = new Map<string, EngineKeySpecsEntry>();
+      (data.specs ?? []).forEach((entry) => {
+        const key = entry.modelSlug ?? entry.engineId;
+        if (key) {
+          map.set(key, entry);
+        }
+      });
+      return map;
+    } catch {
+      // keep trying
+    }
+  }
+  return new Map();
+}
+
+export async function hydrateShowdowns(
+  entries: Array<ShowdownEntry | null>
+): Promise<Array<ShowdownEntry | null>> {
+  const jobIds = new Set<string>();
+  entries.forEach((entry) => {
+    if (!entry) return;
+    if (entry.left.jobId) jobIds.add(entry.left.jobId);
+    if (entry.right.jobId) jobIds.add(entry.right.jobId);
+  });
+  if (!jobIds.size || !isDatabaseConfigured()) {
+    return entries;
+  }
+  try {
+    const videos = await getPublicVideosByIds(Array.from(jobIds));
+    return entries.map((entry) => {
+      if (!entry) return entry;
+      const leftVideo = entry.left.jobId ? videos.get(entry.left.jobId) : null;
+      const rightVideo = entry.right.jobId ? videos.get(entry.right.jobId) : null;
+      return {
+        ...entry,
+        left: {
+          ...entry.left,
+          videoUrl: leftVideo?.videoUrl ?? entry.left.videoUrl,
+          posterUrl: leftVideo?.thumbUrl ?? entry.left.posterUrl,
+        },
+        right: {
+          ...entry.right,
+          videoUrl: rightVideo?.videoUrl ?? entry.right.videoUrl,
+          posterUrl: rightVideo?.thumbUrl ?? entry.right.posterUrl,
+        },
+      };
+    });
+  } catch {
+    return entries;
+  }
+}

--- a/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-helpers.ts
+++ b/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-helpers.ts
@@ -1,24 +1,16 @@
 import type { CSSProperties } from 'react';
-import path from 'node:path';
-import { promises as fs } from 'node:fs';
 import type { AppLocale } from '@/i18n/locales';
 import { localePathnames } from '@/i18n/locales';
 import { canonicalizeFalModelSlug } from '@/config/falEngines';
-import { isDatabaseConfigured } from '@/lib/db';
 import { computeMarketingPriceRange } from '@/lib/pricing-marketing';
 import { applyDisplayedPriceMarginCents } from '@/lib/pricing-display';
-import { getPublicVideosByIds } from '@/server/videos';
 import type { EngineCaps } from '@/types/engines';
 import { CATALOG_BY_SLUG, EXCLUDED_ENGINE_SLUGS, MODELS_SLUG_MAP } from './compare-page-config';
 import type {
   ComparePricingDisplay,
   CompareSpecValues,
   EngineCatalogEntry,
-  EngineKeySpecsEntry,
-  EngineKeySpecsFile,
   EngineScore,
-  EngineScoresFile,
-  ShowdownEntry,
 } from './compare-page-types';
 
 export function reverseCompareSlug(slug: string) {
@@ -58,108 +50,12 @@ export function stripAudioReferencesForSilentPair(template: string, pairHasNativ
     );
 }
 
-const LOCALIZED_BEST_FOR: Partial<Record<AppLocale, Record<string, string>>> = {
-  fr: {
-    'Ads and B-roll': 'Publicités et plans B-roll',
-    'Budget Veo drafts': 'Tests Veo à petit budget',
-    'Cinematic dialogue': 'Dialogue cinématographique',
-    'Cinematic motion with camera lock': 'Mouvement cinématographique avec caméra verrouillée',
-    'Cinematic shots': 'Plans cinématographiques',
-    'Fast Seedance tests, reference tests, and shot planning':
-      'Tests Seedance rapides, tests de références et préparation des plans',
-    'Fast cinematic drafts with modify and reframe': 'Tests cinématographiques rapides avec modify et reframe',
-    'Fast iterations': 'Itérations rapides',
-    'Flagship multi-shot video with native audio and references':
-      'Vidéo multi-plans premium avec audio natif et références',
-    'General purpose video': 'Vidéo polyvalente',
-    'Grounded stills and wide-format image edits': 'Stills réalistes et retouches d’images grand format',
-    'Multi-shot cinematic control': 'Contrôle cinématographique multi-plans',
-    'Multi-shot testing at lower cost': 'Tests multi-plans à moindre coût',
-    'Premium cinematic generation with modify and reframe': 'Génération cinématographique premium avec modify et reframe',
-    'Premium product stories': 'Histoires produit premium',
-    'Prompts or image loops': 'Prompts ou boucles à partir d’images',
-    'Rapid social clips': 'Clips sociaux rapides',
-    'Studio-grade Sora renders': 'Rendus Sora de niveau studio',
-    'Stylised text or image motion': 'Animation stylisée de texte ou d’image',
-  },
-  es: {
-    'Ads and B-roll': 'Anuncios y planos B-roll',
-    'Budget Veo drafts': 'Borradores Veo de bajo coste',
-    'Cinematic dialogue': 'Diálogo cinematográfico',
-    'Cinematic motion with camera lock': 'Movimiento cinematográfico con cámara bloqueada',
-    'Cinematic shots': 'Planos cinematográficos',
-    'Fast Seedance tests, reference tests, and shot planning':
-      'Borradores rápidos de Seedance, pruebas de referencias y planificación de planos',
-    'Fast cinematic drafts with modify and reframe': 'Borradores cinematográficos rápidos con modify y reframe',
-    'Fast iterations': 'Iteraciones rápidas',
-    'Flagship multi-shot video with native audio and references':
-      'Video multi-shot premium con audio nativo y referencias',
-    'General purpose video': 'Video de uso general',
-    'Grounded stills and wide-format image edits': 'Imágenes fijas realistas y ediciones panorámicas',
-    'Multi-shot cinematic control': 'Control cinematográfico multi-shot',
-    'Multi-shot testing at lower cost': 'Pruebas multi-shot con menor coste',
-    'Premium cinematic generation with modify and reframe': 'Generación cinematográfica premium con modify y reframe',
-    'Premium product stories': 'Historias de producto premium',
-    'Prompts or image loops': 'Prompts o bucles desde imágenes',
-    'Rapid social clips': 'Clips sociales rápidos',
-    'Studio-grade Sora renders': 'Renders de Sora con nivel de estudio',
-    'Stylised text or image motion': 'Movimiento estilizado de texto o imagen',
-  },
-};
-
-export const LOCALIZED_SHOWDOWN_TITLES: Partial<Record<AppLocale, Record<string, string>>> = {
-  fr: {
-    'Fast Motion + Physics (16:9)': 'Mouvement rapide + physique (16:9)',
-    'UGC Talking Head + Lip Sync (9:16)': 'Face caméra UGC + synchronisation labiale (9:16)',
-    'UGC Talking Head (9:16)': 'Face caméra UGC (9:16)',
-    'Hands + Product Demo + On-screen Text': 'Mains + démo produit + texte à l’écran',
-  },
-  es: {
-    'Fast Motion + Physics (16:9)': 'Movimiento rápido + física (16:9)',
-    'UGC Talking Head + Lip Sync (9:16)': 'UGC talking head + sincronización labial (9:16)',
-    'UGC Talking Head (9:16)': 'UGC talking head (9:16)',
-    'Hands + Product Demo + On-screen Text': 'Manos + demo de producto + texto en pantalla',
-  },
-};
-
-export const LOCALIZED_SHOWDOWN_TESTS: Partial<Record<AppLocale, Record<string, string>>> = {
-  fr: {
-    'Human Fidelity + Audio/Lip Sync + Prompt Adherence':
-      'Fidélité humaine + audio/synchronisation labiale + adhérence au prompt',
-    'Human Fidelity + Prompt Adherence + Vertical Framing':
-      'Fidélité humaine + adhérence au prompt + cadrage vertical',
-    'Motion Realism + Temporal Consistency + Visual Quality':
-      'Réalisme du mouvement + cohérence temporelle + qualité visuelle',
-    'Hands/Fingers + Text & UI Legibility + Prompt Adherence':
-      'Mains/doigts + lisibilité du texte et de l’interface + adhérence au prompt',
-  },
-  es: {
-    'Human Fidelity + Audio/Lip Sync + Prompt Adherence':
-      'Fidelidad humana + audio/sincronización labial + adherencia al prompt',
-    'Human Fidelity + Prompt Adherence + Vertical Framing':
-      'Fidelidad humana + adherencia al prompt + encuadre vertical',
-    'Motion Realism + Temporal Consistency + Visual Quality':
-      'Realismo del movimiento + consistencia temporal + calidad visual',
-    'Hands/Fingers + Text & UI Legibility + Prompt Adherence':
-      'Manos/dedos + legibilidad de texto e interfaz + adherencia al prompt',
-  },
-};
-
-export function localizeMappedValue(
-  value: string,
-  locale: AppLocale,
-  translations: Partial<Record<AppLocale, Record<string, string>>>
-): string {
-  if (locale === 'en') return value;
-  return translations[locale]?.[value] ?? value;
-}
-
-export function localizeBestFor(value: string | null | undefined, locale: AppLocale): string | null {
-  const normalized = value?.trim();
-  if (!normalized) return null;
-  if (locale === 'en') return normalized;
-  return LOCALIZED_BEST_FOR[locale]?.[normalized] ?? null;
-}
+export {
+  LOCALIZED_SHOWDOWN_TESTS,
+  LOCALIZED_SHOWDOWN_TITLES,
+  localizeBestFor,
+  localizeMappedValue,
+} from './compare-page-localization';
 
 export function formatEngineName(entry: EngineCatalogEntry): string {
   return entry.marketingName || entry.modelSlug.replace(/-/g, ' ');
@@ -289,90 +185,7 @@ export function resolveExcludedCompareRedirect({
   return `${localePrefix}/${modelsBase}/${preferred}`.replace(/\/{2,}/g, '/');
 }
 
-export async function loadEngineScores(): Promise<Map<string, EngineScore>> {
-  const candidates = [
-    path.join(process.cwd(), 'data', 'benchmarks', 'engine-scores.v1.json'),
-    path.join(process.cwd(), '..', 'data', 'benchmarks', 'engine-scores.v1.json'),
-  ];
-  for (const candidate of candidates) {
-    try {
-      const raw = await fs.readFile(candidate, 'utf8');
-      const data = JSON.parse(raw) as EngineScoresFile;
-      const map = new Map<string, EngineScore>();
-      (data.scores ?? []).forEach((entry) => {
-        const key = entry.modelSlug ?? entry.engineId;
-        if (key) {
-          map.set(key, entry);
-        }
-      });
-      return map;
-    } catch {
-      // keep trying
-    }
-  }
-  return new Map();
-}
-
-export async function loadEngineKeySpecs(): Promise<Map<string, EngineKeySpecsEntry>> {
-  const candidates = [
-    path.join(process.cwd(), 'data', 'benchmarks', 'engine-key-specs.v1.json'),
-    path.join(process.cwd(), '..', 'data', 'benchmarks', 'engine-key-specs.v1.json'),
-  ];
-  for (const candidate of candidates) {
-    try {
-      const raw = await fs.readFile(candidate, 'utf8');
-      const data = JSON.parse(raw) as EngineKeySpecsFile;
-      const map = new Map<string, EngineKeySpecsEntry>();
-      (data.specs ?? []).forEach((entry) => {
-        const key = entry.modelSlug ?? entry.engineId;
-        if (key) {
-          map.set(key, entry);
-        }
-      });
-      return map;
-    } catch {
-      // keep trying
-    }
-  }
-  return new Map();
-}
-
-export async function hydrateShowdowns(
-  entries: Array<ShowdownEntry | null>
-): Promise<Array<ShowdownEntry | null>> {
-  const jobIds = new Set<string>();
-  entries.forEach((entry) => {
-    if (!entry) return;
-    if (entry.left.jobId) jobIds.add(entry.left.jobId);
-    if (entry.right.jobId) jobIds.add(entry.right.jobId);
-  });
-  if (!jobIds.size || !isDatabaseConfigured()) {
-    return entries;
-  }
-  try {
-    const videos = await getPublicVideosByIds(Array.from(jobIds));
-    return entries.map((entry) => {
-      if (!entry) return entry;
-      const leftVideo = entry.left.jobId ? videos.get(entry.left.jobId) : null;
-      const rightVideo = entry.right.jobId ? videos.get(entry.right.jobId) : null;
-      return {
-        ...entry,
-        left: {
-          ...entry.left,
-          videoUrl: leftVideo?.videoUrl ?? entry.left.videoUrl,
-          posterUrl: leftVideo?.thumbUrl ?? entry.left.posterUrl,
-        },
-        right: {
-          ...entry.right,
-          videoUrl: rightVideo?.videoUrl ?? entry.right.videoUrl,
-          posterUrl: rightVideo?.thumbUrl ?? entry.right.posterUrl,
-        },
-      };
-    });
-  } catch {
-    return entries;
-  }
-}
+export { hydrateShowdowns, loadEngineKeySpecs, loadEngineScores } from './compare-page-data-loaders';
 
 export function getPricePerSecondCents(entry: EngineCatalogEntry): number | null {
   const perSecond = entry.engine?.pricingDetails?.perSecondCents;

--- a/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-localization.ts
+++ b/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-localization.ts
@@ -1,0 +1,104 @@
+import type { AppLocale } from '@/i18n/locales';
+
+const LOCALIZED_BEST_FOR: Partial<Record<AppLocale, Record<string, string>>> = {
+  fr: {
+    'Ads and B-roll': 'Publicités et plans B-roll',
+    'Budget Veo drafts': 'Tests Veo à petit budget',
+    'Cinematic dialogue': 'Dialogue cinématographique',
+    'Cinematic motion with camera lock': 'Mouvement cinématographique avec caméra verrouillée',
+    'Cinematic shots': 'Plans cinématographiques',
+    'Fast Seedance tests, reference tests, and shot planning':
+      'Tests Seedance rapides, tests de références et préparation des plans',
+    'Fast cinematic drafts with modify and reframe': 'Tests cinématographiques rapides avec modify et reframe',
+    'Fast iterations': 'Itérations rapides',
+    'Flagship multi-shot video with native audio and references':
+      'Vidéo multi-plans premium avec audio natif et références',
+    'General purpose video': 'Vidéo polyvalente',
+    'Grounded stills and wide-format image edits': 'Stills réalistes et retouches d’images grand format',
+    'Multi-shot cinematic control': 'Contrôle cinématographique multi-plans',
+    'Multi-shot testing at lower cost': 'Tests multi-plans à moindre coût',
+    'Premium cinematic generation with modify and reframe': 'Génération cinématographique premium avec modify et reframe',
+    'Premium product stories': 'Histoires produit premium',
+    'Prompts or image loops': 'Prompts ou boucles à partir d’images',
+    'Rapid social clips': 'Clips sociaux rapides',
+    'Studio-grade Sora renders': 'Rendus Sora de niveau studio',
+    'Stylised text or image motion': 'Animation stylisée de texte ou d’image',
+  },
+  es: {
+    'Ads and B-roll': 'Anuncios y planos B-roll',
+    'Budget Veo drafts': 'Borradores Veo de bajo coste',
+    'Cinematic dialogue': 'Diálogo cinematográfico',
+    'Cinematic motion with camera lock': 'Movimiento cinematográfico con cámara bloqueada',
+    'Cinematic shots': 'Planos cinematográficos',
+    'Fast Seedance tests, reference tests, and shot planning':
+      'Borradores rápidos de Seedance, pruebas de referencias y planificación de planos',
+    'Fast cinematic drafts with modify and reframe': 'Borradores cinematográficos rápidos con modify y reframe',
+    'Fast iterations': 'Iteraciones rápidas',
+    'Flagship multi-shot video with native audio and references':
+      'Video multi-shot premium con audio nativo y referencias',
+    'General purpose video': 'Video de uso general',
+    'Grounded stills and wide-format image edits': 'Imágenes fijas realistas y ediciones panorámicas',
+    'Multi-shot cinematic control': 'Control cinematográfico multi-shot',
+    'Multi-shot testing at lower cost': 'Pruebas multi-shot con menor coste',
+    'Premium cinematic generation with modify and reframe': 'Generación cinematográfica premium con modify y reframe',
+    'Premium product stories': 'Historias de producto premium',
+    'Prompts or image loops': 'Prompts o bucles desde imágenes',
+    'Rapid social clips': 'Clips sociales rápidos',
+    'Studio-grade Sora renders': 'Renders de Sora con nivel de estudio',
+    'Stylised text or image motion': 'Movimiento estilizado de texto o imagen',
+  },
+};
+
+export const LOCALIZED_SHOWDOWN_TITLES: Partial<Record<AppLocale, Record<string, string>>> = {
+  fr: {
+    'Fast Motion + Physics (16:9)': 'Mouvement rapide + physique (16:9)',
+    'UGC Talking Head + Lip Sync (9:16)': 'Face caméra UGC + synchronisation labiale (9:16)',
+    'UGC Talking Head (9:16)': 'Face caméra UGC (9:16)',
+    'Hands + Product Demo + On-screen Text': 'Mains + démo produit + texte à l’écran',
+  },
+  es: {
+    'Fast Motion + Physics (16:9)': 'Movimiento rápido + física (16:9)',
+    'UGC Talking Head + Lip Sync (9:16)': 'UGC talking head + sincronización labial (9:16)',
+    'UGC Talking Head (9:16)': 'UGC talking head (9:16)',
+    'Hands + Product Demo + On-screen Text': 'Manos + demo de producto + texto en pantalla',
+  },
+};
+
+export const LOCALIZED_SHOWDOWN_TESTS: Partial<Record<AppLocale, Record<string, string>>> = {
+  fr: {
+    'Human Fidelity + Audio/Lip Sync + Prompt Adherence':
+      'Fidélité humaine + audio/synchronisation labiale + adhérence au prompt',
+    'Human Fidelity + Prompt Adherence + Vertical Framing':
+      'Fidélité humaine + adhérence au prompt + cadrage vertical',
+    'Motion Realism + Temporal Consistency + Visual Quality':
+      'Réalisme du mouvement + cohérence temporelle + qualité visuelle',
+    'Hands/Fingers + Text & UI Legibility + Prompt Adherence':
+      'Mains/doigts + lisibilité du texte et de l’interface + adhérence au prompt',
+  },
+  es: {
+    'Human Fidelity + Audio/Lip Sync + Prompt Adherence':
+      'Fidelidad humana + audio/sincronización labial + adherencia al prompt',
+    'Human Fidelity + Prompt Adherence + Vertical Framing':
+      'Fidelidad humana + adherencia al prompt + encuadre vertical',
+    'Motion Realism + Temporal Consistency + Visual Quality':
+      'Realismo del movimiento + consistencia temporal + calidad visual',
+    'Hands/Fingers + Text & UI Legibility + Prompt Adherence':
+      'Manos/dedos + legibilidad de texto e interfaz + adherencia al prompt',
+  },
+};
+
+export function localizeMappedValue(
+  value: string,
+  locale: AppLocale,
+  translations: Partial<Record<AppLocale, Record<string, string>>>
+): string {
+  if (locale === 'en') return value;
+  return translations[locale]?.[value] ?? value;
+}
+
+export function localizeBestFor(value: string | null | undefined, locale: AppLocale): string | null {
+  const normalized = value?.trim();
+  if (!normalized) return null;
+  if (locale === 'en') return normalized;
+  return LOCALIZED_BEST_FOR[locale]?.[normalized] ?? null;
+}

--- a/tests/compare-page-architecture.test.ts
+++ b/tests/compare-page-architecture.test.ts
@@ -8,6 +8,14 @@ const helperSource = readFileSync(
   'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-helpers.ts',
   'utf8'
 );
+const loaderSource = readFileSync(
+  'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-data-loaders.ts',
+  'utf8'
+);
+const localizationSource = readFileSync(
+  'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-localization.ts',
+  'utf8'
+);
 const overrideSource = readFileSync(
   'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides.ts',
   'utf8'
@@ -61,11 +69,17 @@ test('comparison detail page delegates copy, helper, and media responsibilities'
 });
 
 test('comparison detail helpers own routing, pricing, specs, and localized overrides', () => {
+  const helperLineCount = helperSource.split('\n').length;
+
+  assert.ok(helperLineCount <= 760, `compare-page-helpers.ts should stay below 760 lines after helper extraction, got ${helperLineCount}`);
   assert.match(helperSource, /export function getCanonicalCompareSlug/);
-  assert.match(helperSource, /export async function loadEngineScores/);
+  assert.match(helperSource, /from '\.\/compare-page-data-loaders'/);
+  assert.match(helperSource, /from '\.\/compare-page-localization'/);
   assert.match(helperSource, /export async function resolvePricingDisplay/);
   assert.match(helperSource, /export function buildSpecValues/);
   assert.match(overrideSource, /export function getComparePageOverride/);
+  assert.doesNotMatch(helperSource, /const LOCALIZED_BEST_FOR/);
+  assert.doesNotMatch(helperSource, /export async function loadEngineScores/);
 });
 
 test('comparison detail split helpers own FAQ, scorecard, and generate card responsibilities', () => {
@@ -82,4 +96,15 @@ test('comparison detail split helpers own FAQ, scorecard, and generate card resp
   assert.match(generateCardSource, /export function CompareGenerateCard/);
   assert.match(detailContentSource, /CompareShowdownMedia/);
   assert.match(detailContentSource, /CompareSpecValue/);
+});
+
+test('comparison detail data and localization helpers expose focused contracts', () => {
+  assert.match(loaderSource, /export async function loadEngineScores/);
+  assert.match(loaderSource, /export async function loadEngineKeySpecs/);
+  assert.match(loaderSource, /export async function hydrateShowdowns/);
+  assert.match(localizationSource, /const LOCALIZED_BEST_FOR/);
+  assert.match(localizationSource, /export const LOCALIZED_SHOWDOWN_TITLES/);
+  assert.match(localizationSource, /export const LOCALIZED_SHOWDOWN_TESTS/);
+  assert.match(localizationSource, /export function localizeMappedValue/);
+  assert.match(localizationSource, /export function localizeBestFor/);
 });


### PR DESCRIPTION
## Summary
- move comparison localization maps/helpers into compare-page-localization.ts
- move benchmark score/spec loading and showdown hydration into compare-page-data-loaders.ts
- keep compare-page-helpers.ts exporting the same public contract for existing route imports
- tighten the compare architecture contract for the new helper boundaries

## Checks
- ./node_modules/.bin/tsx --tsconfig frontend/tsconfig.json --test tests/compare-page-architecture.test.ts tests/best-for-detail-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-helpers.ts frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-data-loaders.ts frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-localization.ts tests/compare-page-architecture.test.ts