### PR TITLE
Split moderation playlist state

### DIFF
--- a/frontend/components/admin/ModerationTable.tsx
+++ b/frontend/components/admin/ModerationTable.tsx
@@ -3,9 +3,8 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import clsx from 'clsx';
-import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react';
+import { useCallback, useEffect, useMemo, useState, useTransition } from 'react';
 import { VideoThumbnailEditor } from '@/components/admin/VideoThumbnailEditor.client';
-import { ModerationPlaylistControls } from '@/components/admin/moderation/ModerationPlaylistControls';
 import {
   BUCKET_OPTIONS,
   SURFACE_OPTIONS,
@@ -20,6 +19,7 @@ import {
 } from '@/components/admin/moderation/moderation-table-utils';
 import { Button, ButtonLink } from '@/components/ui/Button';
 import { authFetch } from '@/lib/authFetch';
+import { useModerationPlaylists } from '@/components/admin/moderation/useModerationPlaylists';
 import { isPlaceholderMediaUrl, normalizeMediaUrl } from '@/lib/media';
 
 export type PlaylistOption = {
@@ -79,15 +79,6 @@ export function ModerationTable({
   initialSurface = 'video',
   embedded = false,
 }: ModerationTableProps) {
-  const initialPlaylistAssignments = useMemo(
-    () =>
-      videos.reduce<Record<string, PlaylistTag[]>>((acc, video) => {
-        acc[video.id] = video.assignedPlaylists ?? [];
-        return acc;
-      }, {}),
-    [videos]
-  );
-
   const [items, setItems] = useState(videos);
   const [bucket, setBucket] = useState<ModerationBucket>(initialBucket);
   const [surface, setSurface] = useState<ModerationSurface>(initialSurface);
@@ -96,14 +87,8 @@ export function ModerationTable({
   const [error, setError] = useState<string | null>(null);
   const [isLoadingMore, setLoadingMore] = useState(false);
   const [isLoadingBucket, setLoadingBucket] = useState(false);
-  const [playlists, setPlaylists] = useState<PlaylistOption[]>([]);
-  const [playlistsLoading, setPlaylistsLoading] = useState(true);
-  const [playlistFetchError, setPlaylistFetchError] = useState<string | null>(null);
-  const [playlistAssignments, setPlaylistAssignments] = useState<Record<string, PlaylistTag[]>>(initialPlaylistAssignments);
-  const [playlistStatus, setPlaylistStatus] = useState<Record<string, { loading: boolean; message: string | null; error: string | null }>>({});
   const [viewMode, setViewMode] = useState<ModerationViewMode>('wall');
   const [selectedVideoId, setSelectedVideoId] = useState<string | null>(videos[0]?.id ?? null);
-  const playlistAssignmentsRef = useRef<Record<string, PlaylistTag[]>>({});
 
   const displayItems = useMemo(() => [...items].sort(compareChronologically), [items]);
   const hasVideos = displayItems.length > 0;
@@ -111,6 +96,15 @@ export function ModerationTable({
     () => displayItems.find((item) => item.id === selectedVideoId) ?? displayItems[0] ?? null,
     [displayItems, selectedVideoId]
   );
+
+  const {
+    appendPlaylistAssignments,
+    clearPlaylistStatus,
+    playlistAssignments,
+    playlistFetchError,
+    renderPlaylistControls,
+    replacePlaylistAssignments,
+  } = useModerationPlaylists(videos);
 
   const stats = useMemo(() => {
     const total = items.length;
@@ -120,17 +114,6 @@ export function ModerationTable({
     const seoWatchCount = items.filter((item) => item.seoWatch).length;
     return { total, publishedCount, legacyMismatchCount, notPublishedCount, seoWatchCount };
   }, [items]);
-
-  const updateStatusMessage = useCallback((videoId: string, patch: Partial<{ loading: boolean; message: string | null; error: string | null }>) => {
-    setPlaylistStatus((prev) => ({
-      ...prev,
-      [videoId]: {
-        loading: patch.loading ?? prev[videoId]?.loading ?? false,
-        message: patch.message ?? (patch.message === null ? null : prev[videoId]?.message ?? null),
-        error: patch.error ?? (patch.error === null ? null : prev[videoId]?.error ?? null),
-      },
-    }));
-  }, []);
 
   const handleThumbnailUpdated = useCallback((videoId: string, thumbUrl: string) => {
     setItems((prev) =>
@@ -146,27 +129,6 @@ export function ModerationTable({
     );
   }, []);
 
-  const scheduleStatusClear = useCallback((videoId: string, field: 'message' | 'error', value: string, delay = 2500) => {
-    window.setTimeout(() => {
-      setPlaylistStatus((prev) => {
-        const current = prev[videoId];
-        if (!current) return prev;
-        if (current[field] !== value) return prev;
-        return {
-          ...prev,
-          [videoId]: {
-            ...current,
-            [field]: null,
-          },
-        };
-      });
-    }, delay);
-  }, []);
-
-  useEffect(() => {
-    playlistAssignmentsRef.current = playlistAssignments;
-  }, [playlistAssignments]);
-
   useEffect(() => {
     if (!displayItems.length) {
       setSelectedVideoId(null);
@@ -176,59 +138,6 @@ export function ModerationTable({
       setSelectedVideoId(displayItems[0]?.id ?? null);
     }
   }, [displayItems, selectedVideoId]);
-
-  const orderedPlaylists = useMemo(() => {
-    return [...playlists].sort((a, b) => {
-      const aTarget = Boolean(a.usageTargets?.length);
-      const bTarget = Boolean(b.usageTargets?.length);
-      if (aTarget && !bTarget) return -1;
-      if (bTarget && !aTarget) return 1;
-      return a.name.localeCompare(b.name);
-    });
-  }, [playlists]);
-
-  const getPlaylistName = useCallback(
-    (playlistId: string) => orderedPlaylists.find((playlist) => playlist.id === playlistId)?.name ?? 'Playlist',
-    [orderedPlaylists]
-  );
-
-  useEffect(() => {
-    let cancelled = false;
-
-    async function loadPlaylists() {
-      setPlaylistsLoading(true);
-      setPlaylistFetchError(null);
-      try {
-        const response = await authFetch('/api/admin/playlists', { cache: 'no-store' });
-        const json = await response.json().catch(() => null);
-        if (!response.ok || !json?.ok || !Array.isArray(json.playlists)) {
-          throw new Error(json?.error ?? `Failed to load playlists (${response.status})`);
-        }
-        if (cancelled) return;
-        setPlaylists(
-          (json.playlists as Array<{ id: string; name: string; slug: string; usageTargets?: string[] }>).map((playlist) => ({
-            id: playlist.id,
-            name: playlist.name,
-            slug: playlist.slug,
-            usageTargets: Array.isArray(playlist.usageTargets) ? playlist.usageTargets : [],
-          }))
-        );
-      } catch (playlistError) {
-        if (!cancelled) {
-          setPlaylistFetchError(playlistError instanceof Error ? playlistError.message : 'Failed to load playlists');
-        }
-      } finally {
-        if (!cancelled) {
-          setPlaylistsLoading(false);
-        }
-      }
-    }
-
-    void loadPlaylists();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   const loadBucket = useCallback(
     async (nextBucket: ModerationBucket, options?: { append?: boolean; surface?: ModerationSurface }) => {
@@ -275,24 +184,13 @@ export function ModerationTable({
             });
             return merged;
           });
-          setPlaylistAssignments((current) => {
-            const nextAssignments = { ...current };
-            incoming.forEach((item) => {
-              nextAssignments[item.id] = item.assignedPlaylists ?? [];
-            });
-            return nextAssignments;
-          });
+          appendPlaylistAssignments(incoming);
         } else {
           setBucket(nextBucket);
           setSurface(nextSurface);
           setItems(incoming);
-          setPlaylistAssignments(
-            incoming.reduce<Record<string, PlaylistTag[]>>((acc, item) => {
-              acc[item.id] = item.assignedPlaylists ?? [];
-              return acc;
-            }, {})
-          );
-          setPlaylistStatus({});
+          replacePlaylistAssignments(incoming);
+          clearPlaylistStatus();
         }
 
         setNextCursor(typeof json.nextCursor === 'string' ? json.nextCursor : null);
@@ -307,7 +205,7 @@ export function ModerationTable({
         }
       }
     },
-    [nextCursor, surface]
+    [appendPlaylistAssignments, clearPlaylistStatus, nextCursor, replacePlaylistAssignments, surface]
   );
 
   const updateVisibility = useCallback(
@@ -347,120 +245,6 @@ export function ModerationTable({
       });
     },
     [bucket, startTransition]
-  );
-
-  const handleAssignToPlaylist = useCallback(
-    async (video: ModerationVideo, playlistId: string) => {
-      if (!playlistId) return;
-      const existing = playlistAssignmentsRef.current[video.id] ?? [];
-      if (existing.some((entry) => entry.id === playlistId)) {
-        const playlistName = getPlaylistName(playlistId);
-        updateStatusMessage(video.id, { loading: false, message: `Already in ${playlistName}`, error: null });
-        scheduleStatusClear(video.id, 'message', `Already in ${playlistName}`, 2000);
-        return;
-      }
-
-      const playlistName = getPlaylistName(playlistId);
-      updateStatusMessage(video.id, { loading: true, message: null, error: null });
-      try {
-        const response = await authFetch(`/api/admin/playlists/${playlistId}/items`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ videoId: video.id }),
-        });
-        const json = await response.json().catch(() => null);
-        if (!response.ok || !json?.ok) {
-          throw new Error(json?.error ?? 'Failed to assign playlist');
-        }
-        setPlaylistAssignments((prev) => {
-          const current = prev[video.id] ?? [];
-          if (current.some((entry) => entry.id === playlistId)) {
-            return prev;
-          }
-          return {
-            ...prev,
-            [video.id]: [...current, { id: playlistId, name: playlistName }],
-          };
-        });
-        const successMessage = `Added to ${playlistName}`;
-        updateStatusMessage(video.id, { loading: false, message: successMessage, error: null });
-        scheduleStatusClear(video.id, 'message', successMessage);
-      } catch (assignError) {
-        updateStatusMessage(video.id, {
-          loading: false,
-          error: assignError instanceof Error ? assignError.message : 'Failed to assign playlist',
-        });
-        if (assignError instanceof Error) {
-          scheduleStatusClear(video.id, 'error', assignError.message, 3500);
-        }
-      }
-    },
-    [getPlaylistName, scheduleStatusClear, updateStatusMessage]
-  );
-
-  const handleRemoveFromPlaylist = useCallback(
-    async (video: ModerationVideo, playlistId: string) => {
-      const playlistName = getPlaylistName(playlistId);
-      updateStatusMessage(video.id, { loading: true, error: null, message: null });
-      try {
-        const url = `/api/admin/playlists/${playlistId}/items?videoId=${encodeURIComponent(video.id)}`;
-        const response = await authFetch(url, { method: 'DELETE' });
-        const json = await response.json().catch(() => null);
-        if (!response.ok || !json?.ok) {
-          throw new Error(json?.error ?? 'Failed to remove from playlist');
-        }
-        setPlaylistAssignments((prev) => {
-          const current = prev[video.id] ?? [];
-          const filtered = current.filter((entry) => entry.id !== playlistId);
-          if (!filtered.length) {
-            const nextAssignments = { ...prev };
-            delete nextAssignments[video.id];
-            return nextAssignments;
-          }
-          return {
-            ...prev,
-            [video.id]: filtered,
-          };
-        });
-        updateStatusMessage(video.id, { loading: false, message: `Removed from ${playlistName}`, error: null });
-        scheduleStatusClear(video.id, 'message', `Removed from ${playlistName}`);
-      } catch (removeError) {
-        updateStatusMessage(video.id, {
-          loading: false,
-          error: removeError instanceof Error ? removeError.message : 'Failed to remove from playlist',
-        });
-        if (removeError instanceof Error) {
-          scheduleStatusClear(video.id, 'error', removeError.message, 3500);
-        }
-      }
-    },
-    [getPlaylistName, scheduleStatusClear, updateStatusMessage]
-  );
-
-  const renderPlaylistControls = useCallback(
-    (video: ModerationVideo, options?: { compact?: boolean; emphasizeAssigned?: boolean; enabled?: boolean }) => {
-      const compact = options?.compact ?? false;
-      const emphasizeAssigned = options?.emphasizeAssigned ?? false;
-      const enabled = options?.enabled ?? true;
-      const assignedPlaylists = playlistAssignments[video.id] ?? [];
-      const playlistState = playlistStatus[video.id];
-
-      return (
-        <ModerationPlaylistControls
-          assignedPlaylists={assignedPlaylists}
-          compact={compact}
-          emphasizeAssigned={emphasizeAssigned}
-          enabled={enabled}
-          isLoadingPlaylists={playlistsLoading}
-          onAssign={(targetVideo, playlistId) => void handleAssignToPlaylist(targetVideo, playlistId)}
-          onRemove={(targetVideo, playlistId) => void handleRemoveFromPlaylist(targetVideo, playlistId)}
-          orderedPlaylists={orderedPlaylists}
-          playlistState={playlistState}
-          video={video}
-        />
-      );
-    },
-    [handleAssignToPlaylist, handleRemoveFromPlaylist, orderedPlaylists, playlistAssignments, playlistStatus, playlistsLoading]
   );
 
   const renderModerationActions = useCallback(

--- a/frontend/components/admin/moderation/useModerationPlaylists.tsx
+++ b/frontend/components/admin/moderation/useModerationPlaylists.tsx
@@ -1,0 +1,249 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { authFetch } from '@/lib/authFetch';
+import type { ModerationVideo, PlaylistOption, PlaylistTag } from '@/components/admin/ModerationTable';
+import { ModerationPlaylistControls } from './ModerationPlaylistControls';
+
+type PlaylistStatus = Record<string, { loading: boolean; message: string | null; error: string | null }>;
+
+function buildPlaylistAssignments(videos: ModerationVideo[]): Record<string, PlaylistTag[]> {
+  return videos.reduce<Record<string, PlaylistTag[]>>((acc, video) => {
+    acc[video.id] = video.assignedPlaylists ?? [];
+    return acc;
+  }, {});
+}
+
+export function useModerationPlaylists(videos: ModerationVideo[]) {
+  const initialPlaylistAssignments = useMemo(() => buildPlaylistAssignments(videos), [videos]);
+  const [playlists, setPlaylists] = useState<PlaylistOption[]>([]);
+  const [playlistsLoading, setPlaylistsLoading] = useState(true);
+  const [playlistFetchError, setPlaylistFetchError] = useState<string | null>(null);
+  const [playlistAssignments, setPlaylistAssignments] = useState<Record<string, PlaylistTag[]>>(initialPlaylistAssignments);
+  const [playlistStatus, setPlaylistStatus] = useState<PlaylistStatus>({});
+  const playlistAssignmentsRef = useRef<Record<string, PlaylistTag[]>>({});
+
+  useEffect(() => {
+    playlistAssignmentsRef.current = playlistAssignments;
+  }, [playlistAssignments]);
+
+  const orderedPlaylists = useMemo(() => {
+    return [...playlists].sort((a, b) => {
+      const aTarget = Boolean(a.usageTargets?.length);
+      const bTarget = Boolean(b.usageTargets?.length);
+      if (aTarget && !bTarget) return -1;
+      if (bTarget && !aTarget) return 1;
+      return a.name.localeCompare(b.name);
+    });
+  }, [playlists]);
+
+  const getPlaylistName = useCallback(
+    (playlistId: string) => orderedPlaylists.find((playlist) => playlist.id === playlistId)?.name ?? 'Playlist',
+    [orderedPlaylists]
+  );
+
+  const updateStatusMessage = useCallback((videoId: string, patch: Partial<{ loading: boolean; message: string | null; error: string | null }>) => {
+    setPlaylistStatus((prev) => ({
+      ...prev,
+      [videoId]: {
+        loading: patch.loading ?? prev[videoId]?.loading ?? false,
+        message: patch.message ?? (patch.message === null ? null : prev[videoId]?.message ?? null),
+        error: patch.error ?? (patch.error === null ? null : prev[videoId]?.error ?? null),
+      },
+    }));
+  }, []);
+
+  const scheduleStatusClear = useCallback((videoId: string, field: 'message' | 'error', value: string, delay = 2500) => {
+    window.setTimeout(() => {
+      setPlaylistStatus((prev) => {
+        const current = prev[videoId];
+        if (!current) return prev;
+        if (current[field] !== value) return prev;
+        return {
+          ...prev,
+          [videoId]: {
+            ...current,
+            [field]: null,
+          },
+        };
+      });
+    }, delay);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadPlaylists() {
+      setPlaylistsLoading(true);
+      setPlaylistFetchError(null);
+      try {
+        const response = await authFetch('/api/admin/playlists', { cache: 'no-store' });
+        const json = await response.json().catch(() => null);
+        if (!response.ok || !json?.ok || !Array.isArray(json.playlists)) {
+          throw new Error(json?.error ?? `Failed to load playlists (${response.status})`);
+        }
+        if (cancelled) return;
+        setPlaylists(
+          (json.playlists as Array<{ id: string; name: string; slug: string; usageTargets?: string[] }>).map((playlist) => ({
+            id: playlist.id,
+            name: playlist.name,
+            slug: playlist.slug,
+            usageTargets: Array.isArray(playlist.usageTargets) ? playlist.usageTargets : [],
+          }))
+        );
+      } catch (playlistError) {
+        if (!cancelled) {
+          setPlaylistFetchError(playlistError instanceof Error ? playlistError.message : 'Failed to load playlists');
+        }
+      } finally {
+        if (!cancelled) {
+          setPlaylistsLoading(false);
+        }
+      }
+    }
+
+    void loadPlaylists();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const appendPlaylistAssignments = useCallback((incoming: ModerationVideo[]) => {
+    setPlaylistAssignments((current) => {
+      const nextAssignments = { ...current };
+      incoming.forEach((item) => {
+        nextAssignments[item.id] = item.assignedPlaylists ?? [];
+      });
+      return nextAssignments;
+    });
+  }, []);
+
+  const replacePlaylistAssignments = useCallback((incoming: ModerationVideo[]) => {
+    setPlaylistAssignments(buildPlaylistAssignments(incoming));
+  }, []);
+
+  const clearPlaylistStatus = useCallback(() => {
+    setPlaylistStatus({});
+  }, []);
+
+  const handleAssignToPlaylist = useCallback(
+    async (video: ModerationVideo, playlistId: string) => {
+      if (!playlistId) return;
+      const existing = playlistAssignmentsRef.current[video.id] ?? [];
+      if (existing.some((entry) => entry.id === playlistId)) {
+        const playlistName = getPlaylistName(playlistId);
+        updateStatusMessage(video.id, { loading: false, message: `Already in ${playlistName}`, error: null });
+        scheduleStatusClear(video.id, 'message', `Already in ${playlistName}`, 2000);
+        return;
+      }
+
+      const playlistName = getPlaylistName(playlistId);
+      updateStatusMessage(video.id, { loading: true, message: null, error: null });
+      try {
+        const response = await authFetch(`/api/admin/playlists/${playlistId}/items`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ videoId: video.id }),
+        });
+        const json = await response.json().catch(() => null);
+        if (!response.ok || !json?.ok) {
+          throw new Error(json?.error ?? 'Failed to assign playlist');
+        }
+        setPlaylistAssignments((prev) => {
+          const current = prev[video.id] ?? [];
+          if (current.some((entry) => entry.id === playlistId)) {
+            return prev;
+          }
+          return {
+            ...prev,
+            [video.id]: [...current, { id: playlistId, name: playlistName }],
+          };
+        });
+        const successMessage = `Added to ${playlistName}`;
+        updateStatusMessage(video.id, { loading: false, message: successMessage, error: null });
+        scheduleStatusClear(video.id, 'message', successMessage);
+      } catch (assignError) {
+        updateStatusMessage(video.id, {
+          loading: false,
+          error: assignError instanceof Error ? assignError.message : 'Failed to assign playlist',
+        });
+        if (assignError instanceof Error) {
+          scheduleStatusClear(video.id, 'error', assignError.message, 3500);
+        }
+      }
+    },
+    [getPlaylistName, scheduleStatusClear, updateStatusMessage]
+  );
+
+  const handleRemoveFromPlaylist = useCallback(
+    async (video: ModerationVideo, playlistId: string) => {
+      const playlistName = getPlaylistName(playlistId);
+      updateStatusMessage(video.id, { loading: true, error: null, message: null });
+      try {
+        const url = `/api/admin/playlists/${playlistId}/items?videoId=${encodeURIComponent(video.id)}`;
+        const response = await authFetch(url, { method: 'DELETE' });
+        const json = await response.json().catch(() => null);
+        if (!response.ok || !json?.ok) {
+          throw new Error(json?.error ?? 'Failed to remove from playlist');
+        }
+        setPlaylistAssignments((prev) => {
+          const current = prev[video.id] ?? [];
+          const filtered = current.filter((entry) => entry.id !== playlistId);
+          if (!filtered.length) {
+            const nextAssignments = { ...prev };
+            delete nextAssignments[video.id];
+            return nextAssignments;
+          }
+          return {
+            ...prev,
+            [video.id]: filtered,
+          };
+        });
+        updateStatusMessage(video.id, { loading: false, message: `Removed from ${playlistName}`, error: null });
+        scheduleStatusClear(video.id, 'message', `Removed from ${playlistName}`);
+      } catch (removeError) {
+        updateStatusMessage(video.id, {
+          loading: false,
+          error: removeError instanceof Error ? removeError.message : 'Failed to remove from playlist',
+        });
+        if (removeError instanceof Error) {
+          scheduleStatusClear(video.id, 'error', removeError.message, 3500);
+        }
+      }
+    },
+    [getPlaylistName, scheduleStatusClear, updateStatusMessage]
+  );
+
+  const renderPlaylistControls = useCallback(
+    (video: ModerationVideo, options?: { compact?: boolean; emphasizeAssigned?: boolean; enabled?: boolean }) => {
+      const compact = options?.compact ?? false;
+      const emphasizeAssigned = options?.emphasizeAssigned ?? false;
+      const enabled = options?.enabled ?? true;
+      const assignedPlaylists = playlistAssignments[video.id] ?? [];
+      const playlistState = playlistStatus[video.id];
+
+      return (
+        <ModerationPlaylistControls
+          assignedPlaylists={assignedPlaylists}
+          compact={compact}
+          emphasizeAssigned={emphasizeAssigned}
+          enabled={enabled}
+          isLoadingPlaylists={playlistsLoading}
+          onAssign={(targetVideo, playlistId) => void handleAssignToPlaylist(targetVideo, playlistId)}
+          onRemove={(targetVideo, playlistId) => void handleRemoveFromPlaylist(targetVideo, playlistId)}
+          orderedPlaylists={orderedPlaylists}
+          playlistState={playlistState}
+          video={video}
+        />
+      );
+    },
+    [handleAssignToPlaylist, handleRemoveFromPlaylist, orderedPlaylists, playlistAssignments, playlistStatus, playlistsLoading]
+  );
+
+  return {
+    appendPlaylistAssignments,
+    clearPlaylistStatus,
+    playlistAssignments,
+    playlistFetchError,
+    renderPlaylistControls,
+    replacePlaylistAssignments,
+  };
+}

--- a/tests/moderation-table-architecture.test.ts
+++ b/tests/moderation-table-architecture.test.ts
@@ -7,17 +7,21 @@ const root = process.cwd();
 const tablePath = join(root, 'frontend/components/admin/ModerationTable.tsx');
 const utilsPath = join(root, 'frontend/components/admin/moderation/moderation-table-utils.tsx');
 const playlistControlsPath = join(root, 'frontend/components/admin/moderation/ModerationPlaylistControls.tsx');
+const playlistHookPath = join(root, 'frontend/components/admin/moderation/useModerationPlaylists.tsx');
 
 const tableSource = readFileSync(tablePath, 'utf8');
 const utilsSource = readFileSync(utilsPath, 'utf8');
 const playlistControlsSource = readFileSync(playlistControlsPath, 'utf8');
+const playlistHookSource = readFileSync(playlistHookPath, 'utf8');
 
-test('moderation table delegates helper pills and playlist controls', () => {
+test('moderation table delegates helper pills, playlist controls, and playlist state', () => {
   assert.ok(existsSync(tablePath), 'moderation table should exist');
   assert.ok(existsSync(utilsPath), 'moderation helper/pill module should exist');
   assert.ok(existsSync(playlistControlsPath), 'moderation playlist controls should exist');
+  assert.ok(existsSync(playlistHookPath), 'moderation playlist state should live in a focused hook');
   assert.match(tableSource, /from '@\/components\/admin\/moderation\/moderation-table-utils'/);
-  assert.match(tableSource, /from '@\/components\/admin\/moderation\/ModerationPlaylistControls'/);
+  assert.match(tableSource, /from '@\/components\/admin\/moderation\/useModerationPlaylists'/);
+  assert.doesNotMatch(tableSource, /from '@\/components\/admin\/moderation\/ModerationPlaylistControls'/);
 });
 
 test('moderation table does not regain extracted ownership', () => {
@@ -33,13 +37,17 @@ test('moderation table does not regain extracted ownership', () => {
     /function matchesBucket\(/,
     /function PublicationPill\(/,
     /function StatePill\(/,
+    /const \[playlists, setPlaylists\]/,
+    /const \[playlistAssignments, setPlaylistAssignments\]/,
+    /handleAssignToPlaylist/,
+    /handleRemoveFromPlaylist/,
     /<select[\s\S]*Select playlist/,
   ]) {
     assert.doesNotMatch(tableSource, pattern);
   }
 
   const lineCount = tableSource.split('\n').length;
-  assert.ok(lineCount <= 985, `ModerationTable should stay below 985 lines after helper extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 790, `ModerationTable should stay below 790 lines after playlist hook extraction, got ${lineCount}`);
 });
 
 test('moderation helper modules expose the expected contract', () => {
@@ -62,4 +70,8 @@ test('moderation helper modules expose the expected contract', () => {
   assert.match(playlistControlsSource, /Select playlist/);
   assert.match(playlistControlsSource, /onAssign/);
   assert.match(playlistControlsSource, /onRemove/);
+  assert.match(playlistHookSource, /export function useModerationPlaylists/);
+  assert.match(playlistHookSource, /appendPlaylistAssignments/);
+  assert.match(playlistHookSource, /replacePlaylistAssignments/);
+  assert.match(playlistHookSource, /renderPlaylistControls/);
 });


### PR DESCRIPTION
## Summary
- move moderation playlist loading, assignment state, status messages, and assign/remove handlers into useModerationPlaylists
- keep ModerationTable focused on queue state, visibility updates, and layout rendering
- tighten the moderation table architecture contract to prevent playlist logic from drifting back

## Checks
- ./node_modules/.bin/tsx --tsconfig frontend/tsconfig.json --test tests/moderation-table-architecture.test.ts tests/admin-playlists-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- frontend/components/admin/ModerationTable.tsx frontend/components/admin/moderation/useModerationPlaylists.tsx tests/moderation-table-architecture.test.ts