### PR TITLE
Split Fal webhook provisional jobs

### DIFF
--- a/frontend/server/fal-webhook-handler.ts
+++ b/frontend/server/fal-webhook-handler.ts
@@ -1,5 +1,7 @@
 import { query } from '@/lib/db';
 import { maybeAutoRefundWalletCharge } from './fal-webhook-refunds';
+import { createProvisionalJobFromWebhook } from './fal-webhook-provisional';
+import type { AppJobRow } from './fal-webhook-types';
 import { normalizeMediaUrl } from '@/lib/media';
 import { resolveFalModelId } from '@/lib/fal-catalog';
 import { getFalClient } from '@/lib/fal-client';
@@ -27,7 +29,6 @@ import {
   extractImageUrlsFromPayload,
   extractMediaUrls,
   fallbackThumbnail,
-  findFirstString,
   formatAspectRatioLabel,
   getUpscaleToolMediaType,
   inferEngineFromPayload,
@@ -38,128 +39,6 @@ import {
   type FalWebhookPayload,
   type WebhookIdentifiers,
 } from './fal-webhook-mapping';
-
-type AppJobRow = {
-  job_id: string;
-  user_id: string | null;
-  engine_id: string;
-  engine_label: string | null;
-  payment_status: string | null;
-  pricing_snapshot: unknown;
-  vendor_account_id: string | null;
-  currency: string | null;
-  final_price_cents: number | string | null;
-  duration_sec: number | null;
-  status: string;
-  progress: number;
-  video_url: string | null;
-  preview_video_url: string | null;
-  keyframe_urls: unknown;
-  thumb_url: string | null;
-  aspect_ratio: string | null;
-  preview_frame: string | null;
-  message: string | null;
-  has_audio: boolean | null;
-  render_ids: unknown;
-  hero_render_id: string | null;
-  created_at: string;
-  settings_snapshot: unknown;
-};
-
-async function createProvisionalJobFromWebhook(params: {
-  requestId: string;
-  payload: FalWebhookPayload;
-  identifiers: WebhookIdentifiers;
-}): Promise<AppJobRow | null> {
-  const placeholderThumb = '/assets/frames/thumb-16x9.svg';
-  const jobId =
-    (params.identifiers.jobId && params.identifiers.jobId.trim().length
-      ? params.identifiers.jobId.trim()
-      : null) ??
-    (params.requestId.startsWith('job_') ? params.requestId : `job_${params.requestId}`);
-
-  let engineId = findFirstString(params.payload, ['engine_id', 'engineId', 'model']) ?? 'fal-unknown';
-  let engineLabel = findFirstString(params.payload, ['engine_label', 'engineLabel']) ?? engineId;
-  if (!engineId || engineId === 'fal-unknown') {
-    const inferred = await inferEngineFromPayload(params.payload);
-    engineId = inferred.engineId;
-    if (!engineLabel || engineLabel === 'fal-unknown' || engineLabel === engineId) {
-      engineLabel = inferred.engineLabel ?? engineId;
-    }
-  }
-  if (!engineId || engineId === 'fal-unknown') {
-    console.warn('[fal-webhook] provisional job has unknown engine', {
-      requestId: params.requestId,
-      fallbackModel: findFirstString(params.payload, ['model', 'model_slug', 'modelId', 'model_id']),
-      provider: findFirstString(params.payload, ['provider']),
-    });
-  }
-  const prompt =
-    findFirstString(params.payload, ['prompt', 'description', 'text']) ?? '[webhook recovery]';
-  const aspectRatio = findFirstString(params.payload, ['aspect_ratio', 'aspectRatio']) ?? null;
-  const durationString = findFirstString(params.payload, ['duration', 'duration_seconds', 'durationSec']);
-  const parsedDuration = durationString ? Number.parseInt(durationString, 10) : 0;
-  const normalizedDuration = Number.isFinite(parsedDuration) && parsedDuration > 0 ? parsedDuration : 0;
-  const media = extractMediaUrls(params.payload.result ?? params.payload.response ?? params.payload.data ?? null);
-  const normalizedVideoUrl = media.videoUrl ? normalizeMediaUrl(media.videoUrl) : null;
-  const normalizedThumbUrl = media.thumbUrl ? normalizeMediaUrl(media.thumbUrl) : null;
-  const statusInfo = normalizeStatus(params.payload.status, 'queued', 0);
-
-  const inserted = await query<AppJobRow>(
-    `INSERT INTO app_jobs (
-       job_id,
-       user_id,
-       engine_id,
-       engine_label,
-       duration_sec,
-       prompt,
-       thumb_url,
-       aspect_ratio,
-       preview_frame,
-       provider_job_id,
-       status,
-       progress,
-       visibility,
-       indexable,
-       provisional,
-       has_audio,
-       video_url
-     )
-     VALUES (
-       $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17
-     )
-     ON CONFLICT (job_id) DO UPDATE
-       SET provider_job_id = COALESCE(EXCLUDED.provider_job_id, app_jobs.provider_job_id),
-           thumb_url = COALESCE(EXCLUDED.thumb_url, app_jobs.thumb_url),
-           preview_frame = COALESCE(EXCLUDED.preview_frame, app_jobs.preview_frame),
-           video_url = COALESCE(EXCLUDED.video_url, app_jobs.video_url),
-           status = EXCLUDED.status,
-           progress = EXCLUDED.progress,
-           updated_at = NOW()
-     RETURNING job_id, user_id, engine_id, engine_label, duration_sec, status, progress, video_url, to_jsonb(app_jobs)->>'preview_video_url' AS preview_video_url, to_jsonb(app_jobs)->'keyframe_urls' AS keyframe_urls, thumb_url, aspect_ratio, preview_frame, message, has_audio, render_ids, hero_render_id`,
-    [
-      jobId,
-      null,
-      engineId,
-      engineLabel || engineId,
-      normalizedDuration,
-      prompt,
-      normalizedThumbUrl ?? placeholderThumb,
-      aspectRatio,
-      normalizedThumbUrl ?? placeholderThumb,
-      params.requestId,
-      statusInfo.status,
-      statusInfo.progress,
-      'private',
-      false,
-      true,
-      false,
-      normalizedVideoUrl,
-    ]
-  );
-
-  return inserted[0] ?? null;
-}
 
 export async function updateJobFromFalWebhook(rawPayload: unknown): Promise<void> {
   const payload = (rawPayload ?? {}) as FalWebhookPayload;

--- a/frontend/server/fal-webhook-provisional.ts
+++ b/frontend/server/fal-webhook-provisional.ts
@@ -1,0 +1,99 @@
+import { query } from '@/lib/db';
+import { normalizeMediaUrl } from '@/lib/media';
+import { extractMediaUrls, findFirstString, inferEngineFromPayload, normalizeStatus, type FalWebhookPayload, type WebhookIdentifiers } from './fal-webhook-mapping';
+import type { AppJobRow } from './fal-webhook-types';
+
+export async function createProvisionalJobFromWebhook(params: {
+  requestId: string;
+  payload: FalWebhookPayload;
+  identifiers: WebhookIdentifiers;
+}): Promise<AppJobRow | null> {
+  const placeholderThumb = '/assets/frames/thumb-16x9.svg';
+  const jobId =
+    (params.identifiers.jobId && params.identifiers.jobId.trim().length
+      ? params.identifiers.jobId.trim()
+      : null) ??
+    (params.requestId.startsWith('job_') ? params.requestId : `job_${params.requestId}`);
+
+  let engineId = findFirstString(params.payload, ['engine_id', 'engineId', 'model']) ?? 'fal-unknown';
+  let engineLabel = findFirstString(params.payload, ['engine_label', 'engineLabel']) ?? engineId;
+  if (!engineId || engineId === 'fal-unknown') {
+    const inferred = await inferEngineFromPayload(params.payload);
+    engineId = inferred.engineId;
+    if (!engineLabel || engineLabel === 'fal-unknown' || engineLabel === engineId) {
+      engineLabel = inferred.engineLabel ?? engineId;
+    }
+  }
+  if (!engineId || engineId === 'fal-unknown') {
+    console.warn('[fal-webhook] provisional job has unknown engine', {
+      requestId: params.requestId,
+      fallbackModel: findFirstString(params.payload, ['model', 'model_slug', 'modelId', 'model_id']),
+      provider: findFirstString(params.payload, ['provider']),
+    });
+  }
+  const prompt =
+    findFirstString(params.payload, ['prompt', 'description', 'text']) ?? '[webhook recovery]';
+  const aspectRatio = findFirstString(params.payload, ['aspect_ratio', 'aspectRatio']) ?? null;
+  const durationString = findFirstString(params.payload, ['duration', 'duration_seconds', 'durationSec']);
+  const parsedDuration = durationString ? Number.parseInt(durationString, 10) : 0;
+  const normalizedDuration = Number.isFinite(parsedDuration) && parsedDuration > 0 ? parsedDuration : 0;
+  const media = extractMediaUrls(params.payload.result ?? params.payload.response ?? params.payload.data ?? null);
+  const normalizedVideoUrl = media.videoUrl ? normalizeMediaUrl(media.videoUrl) : null;
+  const normalizedThumbUrl = media.thumbUrl ? normalizeMediaUrl(media.thumbUrl) : null;
+  const statusInfo = normalizeStatus(params.payload.status, 'queued', 0);
+
+  const inserted = await query<AppJobRow>(
+    `INSERT INTO app_jobs (
+       job_id,
+       user_id,
+       engine_id,
+       engine_label,
+       duration_sec,
+       prompt,
+       thumb_url,
+       aspect_ratio,
+       preview_frame,
+       provider_job_id,
+       status,
+       progress,
+       visibility,
+       indexable,
+       provisional,
+       has_audio,
+       video_url
+     )
+     VALUES (
+       $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17
+     )
+     ON CONFLICT (job_id) DO UPDATE
+       SET provider_job_id = COALESCE(EXCLUDED.provider_job_id, app_jobs.provider_job_id),
+           thumb_url = COALESCE(EXCLUDED.thumb_url, app_jobs.thumb_url),
+           preview_frame = COALESCE(EXCLUDED.preview_frame, app_jobs.preview_frame),
+           video_url = COALESCE(EXCLUDED.video_url, app_jobs.video_url),
+           status = EXCLUDED.status,
+           progress = EXCLUDED.progress,
+           updated_at = NOW()
+     RETURNING job_id, user_id, engine_id, engine_label, duration_sec, status, progress, video_url, to_jsonb(app_jobs)->>'preview_video_url' AS preview_video_url, to_jsonb(app_jobs)->'keyframe_urls' AS keyframe_urls, thumb_url, aspect_ratio, preview_frame, message, has_audio, render_ids, hero_render_id`,
+    [
+      jobId,
+      null,
+      engineId,
+      engineLabel || engineId,
+      normalizedDuration,
+      prompt,
+      normalizedThumbUrl ?? placeholderThumb,
+      aspectRatio,
+      normalizedThumbUrl ?? placeholderThumb,
+      params.requestId,
+      statusInfo.status,
+      statusInfo.progress,
+      'private',
+      false,
+      true,
+      false,
+      normalizedVideoUrl,
+    ]
+  );
+
+  return inserted[0] ?? null;
+}

--- a/frontend/server/fal-webhook-types.ts
+++ b/frontend/server/fal-webhook-types.ts
@@ -1,0 +1,26 @@
+export type AppJobRow = {
+  job_id: string;
+  user_id: string | null;
+  engine_id: string;
+  engine_label: string | null;
+  payment_status: string | null;
+  pricing_snapshot: unknown;
+  vendor_account_id: string | null;
+  currency: string | null;
+  final_price_cents: number | string | null;
+  duration_sec: number | null;
+  status: string;
+  progress: number;
+  video_url: string | null;
+  preview_video_url: string | null;
+  keyframe_urls: unknown;
+  thumb_url: string | null;
+  aspect_ratio: string | null;
+  preview_frame: string | null;
+  message: string | null;
+  has_audio: boolean | null;
+  render_ids: unknown;
+  hero_render_id: string | null;
+  created_at: string;
+  settings_snapshot: unknown;
+};

--- a/tests/fal-webhook-architecture.test.ts
+++ b/tests/fal-webhook-architecture.test.ts
@@ -7,16 +7,24 @@ const root = process.cwd();
 const handlerPath = join(root, 'frontend/server/fal-webhook-handler.ts');
 const mappingPath = join(root, 'frontend/server/fal-webhook-mapping.ts');
 const refundsPath = join(root, 'frontend/server/fal-webhook-refunds.ts');
+const provisionalPath = join(root, 'frontend/server/fal-webhook-provisional.ts');
+const typesPath = join(root, 'frontend/server/fal-webhook-types.ts');
 
 const handlerSource = readFileSync(handlerPath, 'utf8');
 const mappingSource = readFileSync(mappingPath, 'utf8');
 const refundsSource = readFileSync(refundsPath, 'utf8');
+const provisionalSource = readFileSync(provisionalPath, 'utf8');
+const typesSource = readFileSync(typesPath, 'utf8');
 
-test('Fal webhook handler delegates mapping, payload extraction, and refund helpers', () => {
+test('Fal webhook handler delegates mapping, payload extraction, provisional job, and refund helpers', () => {
   assert.ok(existsSync(mappingPath), 'Fal webhook mapping helpers should live in a sibling server module');
   assert.ok(existsSync(refundsPath), 'Fal webhook refund helpers should live in a sibling server module');
+  assert.ok(existsSync(provisionalPath), 'Fal webhook provisional job recovery should live in a sibling server module');
+  assert.ok(existsSync(typesPath), 'Fal webhook row contracts should live in a sibling server module');
   assert.match(handlerSource, /from '\.\/fal-webhook-mapping'/, 'webhook handler should import mapping helpers');
   assert.match(handlerSource, /from '\.\/fal-webhook-refunds'/, 'webhook handler should import refund helpers');
+  assert.match(handlerSource, /from '\.\/fal-webhook-provisional'/, 'webhook handler should import provisional job helpers');
+  assert.match(handlerSource, /from '\.\/fal-webhook-types'/, 'webhook handler should import shared row types');
 
   for (const implementationName of [
     'fallbackThumbnail',
@@ -35,6 +43,7 @@ test('Fal webhook handler delegates mapping, payload extraction, and refund help
     'coerceNumber',
     'normalizeCurrency',
     'maybeAutoRefundWalletCharge',
+    'createProvisionalJobFromWebhook',
   ]) {
     assert.doesNotMatch(
       handlerSource,
@@ -46,9 +55,10 @@ test('Fal webhook handler delegates mapping, payload extraction, and refund help
   assert.doesNotMatch(handlerSource, /PROVIDER_ENGINE_MAP/, 'provider engine mapping belongs in fal-webhook-mapping.ts');
   assert.doesNotMatch(handlerSource, /ERROR_MESSAGE_KEYS/, 'error message key mapping belongs in fal-webhook-mapping.ts');
   assert.doesNotMatch(handlerSource, /listUpscaleToolEngines/, 'tool engine media lookup belongs in fal-webhook-mapping.ts');
+  assert.doesNotMatch(handlerSource, /type AppJobRow =/, 'AppJobRow belongs in fal-webhook-types.ts');
 
   const lineCount = handlerSource.split('\n').length;
-  assert.ok(lineCount <= 820, `Fal webhook handler should stay below 820 lines after refund extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 690, `Fal webhook handler should stay below 690 lines after provisional job extraction, got ${lineCount}`);
 });
 
 test('Fal webhook mapping module exposes the expected helper contract', () => {
@@ -81,4 +91,7 @@ test('Fal webhook mapping module exposes the expected helper contract', () => {
   assert.match(refundsSource, /function coerceNumber\(/, 'numeric coercion should be private to refund helpers');
   assert.match(refundsSource, /function normalizeCurrency\(/, 'currency normalization should be private to refund helpers');
   assert.match(refundsSource, /export async function maybeAutoRefundWalletCharge/);
+  assert.match(provisionalSource, /export async function createProvisionalJobFromWebhook/);
+  assert.match(provisionalSource, /normalizeStatus/);
+  assert.match(typesSource, /export type AppJobRow =/);
 });


### PR DESCRIPTION
## Summary
- move provisional job recovery from Fal webhooks into fal-webhook-provisional.ts
- move AppJobRow into fal-webhook-types.ts for shared server contracts
- keep fal-webhook-handler.ts focused on lifecycle/media resolution
- update webhook architecture checks for the new boundaries

## Checks
- ./node_modules/.bin/tsx --tsconfig frontend/tsconfig.json --test tests/fal-webhook-architecture.test.ts tests/fal-response-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- frontend/server/fal-webhook-handler.ts frontend/server/fal-webhook-provisional.ts frontend/server/fal-webhook-types.ts tests/fal-webhook-architecture.test.ts