### PR TITLE
Split header nav helpers

### DIFF
--- a/frontend/components/HeaderBar.tsx
+++ b/frontend/components/HeaderBar.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import { NAV_ITEMS } from '@/components/AppSidebar';
 import Link from 'next/link';
 import { useEffect, useMemo, useRef, useState, useId } from 'react';
-import { ChevronDown, Image as ImageIcon, ListVideo, Moon, Sparkles, Sun, Wallet } from 'lucide-react';
+import { ChevronDown, Moon, Sun, Wallet } from 'lucide-react';
 import { ReconsentPrompt } from '@/components/legal/ReconsentPrompt';
 import { AppLanguageToggle } from '@/components/AppLanguageToggle';
 import { useI18n } from '@/lib/i18n/I18nProvider';
@@ -12,50 +12,15 @@ import { usePathname } from 'next/navigation';
 import { Button, ButtonLink } from '@/components/ui/Button';
 import { UIIcon } from '@/components/ui/UIIcon';
 import { MARKETING_NAV_DROPDOWNS, MARKETING_TOP_NAV_LINKS } from '@/config/navigation';
-import type { LocalizedLinkHref } from '@/i18n/navigation';
 import { SERVICE_NOTICE_POLLING_INTERVAL_MS } from '@/lib/service-notice-polling';
 import { HeaderLogoMark } from '@/components/header/HeaderLogoMark';
+import {
+  getGuestMobileNavItems,
+  GUEST_MOBILE_NAV_ICONS,
+  normalizeMarketingLinks,
+  resolveLocalizedHref,
+} from '@/components/header/header-nav-helpers';
 import { useHeaderAccountState } from '@/components/header/useHeaderAccountState';
-
-function resolveLocalizedHref(href: LocalizedLinkHref): string {
-  if (typeof href === 'string') {
-    return href;
-  }
-  const pathname = typeof href.pathname === 'string' ? href.pathname : '';
-  const params = 'params' in href ? href.params : undefined;
-  let resolved = pathname;
-  if (params) {
-    Object.entries(params).forEach(([key, value]) => {
-      resolved = resolved.replace(`[${key}]`, encodeURIComponent(String(value)));
-    });
-  }
-  const query = 'query' in href ? href.query : undefined;
-  if (query) {
-    const search = new URLSearchParams();
-    Object.entries(query).forEach(([key, value]) => {
-      if (typeof value === 'string' || typeof value === 'number') {
-        search.set(key, String(value));
-      }
-    });
-    const suffix = search.toString();
-    if (suffix) {
-      resolved = `${resolved}?${suffix}`;
-    }
-  }
-  return resolved;
-}
-
-const MARKETING_TOP_NAV_HREF_BY_KEY: Record<string, string> = Object.fromEntries(
-  MARKETING_TOP_NAV_LINKS.map((item) => [item.key, item.href])
-);
-
-const GUEST_MOBILE_NAV_ITEM_IDS = new Set(['generate', 'generate-image', 'jobs']);
-
-const GUEST_MOBILE_NAV_ICONS = {
-  generate: Sparkles,
-  'generate-image': ImageIcon,
-  jobs: ListVideo,
-} as const;
 
 export function HeaderBar() {
   const { locale, t } = useI18n();
@@ -268,31 +233,9 @@ export function HeaderBar() {
   }, [email]);
 
   const rawMarketingLinks = t('nav.links', MARKETING_TOP_NAV_LINKS);
-  const marketingLinks = useMemo(() => {
-    const source = Array.isArray(rawMarketingLinks) ? rawMarketingLinks : [];
-    const normalized: Array<{ key: string; href: string }> = [];
-    const seen = new Set<string>();
-
-    for (const entry of source) {
-      if (!entry || typeof entry !== 'object') continue;
-      const key = (entry as { key?: unknown }).key;
-      if (typeof key !== 'string' || seen.has(key)) continue;
-      const allowedHref = MARKETING_TOP_NAV_HREF_BY_KEY[key];
-      if (!allowedHref) continue;
-      seen.add(key);
-      normalized.push({ key, href: allowedHref });
-    }
-
-    if (normalized.length) {
-      return normalized;
-    }
-    return MARKETING_TOP_NAV_LINKS.map((item) => ({ key: item.key, href: item.href }));
-  }, [rawMarketingLinks]);
+  const marketingLinks = useMemo(() => normalizeMarketingLinks(rawMarketingLinks), [rawMarketingLinks]);
   const isAuthenticated = Boolean(email);
-  const guestMobileNavItems = useMemo(
-    () => NAV_ITEMS.filter((item) => GUEST_MOBILE_NAV_ITEM_IDS.has(item.id)),
-    []
-  );
+  const guestMobileNavItems = useMemo(() => getGuestMobileNavItems(), []);
 
   return (
     <>

--- a/frontend/components/header/header-nav-helpers.ts
+++ b/frontend/components/header/header-nav-helpers.ts
@@ -1,0 +1,74 @@
+import { Image as ImageIcon, ListVideo, type LucideIcon, Sparkles } from 'lucide-react';
+import { NAV_ITEMS } from '@/components/AppSidebar';
+import { MARKETING_TOP_NAV_LINKS } from '@/config/navigation';
+import type { LocalizedLinkHref } from '@/i18n/navigation';
+
+export type HeaderMarketingLink = {
+  key: string;
+  href: string;
+};
+
+const MARKETING_TOP_NAV_HREF_BY_KEY: Record<string, string> = Object.fromEntries(
+  MARKETING_TOP_NAV_LINKS.map((item) => [item.key, item.href])
+);
+
+const GUEST_MOBILE_NAV_ITEM_IDS = new Set(['generate', 'generate-image', 'jobs']);
+
+export const GUEST_MOBILE_NAV_ICONS = {
+  generate: Sparkles,
+  'generate-image': ImageIcon,
+  jobs: ListVideo,
+} satisfies Record<string, LucideIcon>;
+
+export function resolveLocalizedHref(href: LocalizedLinkHref): string {
+  if (typeof href === 'string') {
+    return href;
+  }
+  const pathname = typeof href.pathname === 'string' ? href.pathname : '';
+  const params = 'params' in href ? href.params : undefined;
+  let resolved = pathname;
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      resolved = resolved.replace(`[${key}]`, encodeURIComponent(String(value)));
+    });
+  }
+  const query = 'query' in href ? href.query : undefined;
+  if (query) {
+    const search = new URLSearchParams();
+    Object.entries(query).forEach(([key, value]) => {
+      if (typeof value === 'string' || typeof value === 'number') {
+        search.set(key, String(value));
+      }
+    });
+    const suffix = search.toString();
+    if (suffix) {
+      resolved = `${resolved}?${suffix}`;
+    }
+  }
+  return resolved;
+}
+
+export function normalizeMarketingLinks(rawMarketingLinks: unknown): HeaderMarketingLink[] {
+  const source = Array.isArray(rawMarketingLinks) ? rawMarketingLinks : [];
+  const normalized: HeaderMarketingLink[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of source) {
+    if (!entry || typeof entry !== 'object') continue;
+    const key = (entry as { key?: unknown }).key;
+    if (typeof key !== 'string' || seen.has(key)) continue;
+    const allowedHref = MARKETING_TOP_NAV_HREF_BY_KEY[key];
+    if (!allowedHref) continue;
+    seen.add(key);
+    normalized.push({ key, href: allowedHref });
+  }
+
+  if (normalized.length) {
+    return normalized;
+  }
+  return MARKETING_TOP_NAV_LINKS.map((item) => ({ key: item.key, href: item.href }));
+}
+
+export function getGuestMobileNavItems() {
+  return NAV_ITEMS.filter((item) => GUEST_MOBILE_NAV_ITEM_IDS.has(item.id));
+}

--- a/tests/header-bar-architecture.test.ts
+++ b/tests/header-bar-architecture.test.ts
@@ -7,18 +7,25 @@ const root = process.cwd();
 const headerPath = join(root, 'frontend/components/HeaderBar.tsx');
 const accountHookPath = join(root, 'frontend/components/header/useHeaderAccountState.ts');
 const logoPath = join(root, 'frontend/components/header/HeaderLogoMark.tsx');
+const navHelpersPath = join(root, 'frontend/components/header/header-nav-helpers.ts');
 
 const headerSource = readFileSync(headerPath, 'utf8');
 const accountHookSource = readFileSync(accountHookPath, 'utf8');
 const logoSource = readFileSync(logoPath, 'utf8');
+const navHelpersSource = readFileSync(navHelpersPath, 'utf8');
 
-test('header bar delegates account state and logo rendering', () => {
+test('header bar delegates account, logo, and nav helper responsibilities', () => {
   assert.ok(existsSync(accountHookPath), 'header account state should live in a focused hook');
   assert.ok(existsSync(logoPath), 'header logo mark should live in a focused component');
+  assert.ok(existsSync(navHelpersPath), 'header nav normalization should live in a focused helper');
   assert.match(headerSource, /from '@\/components\/header\/useHeaderAccountState'/);
   assert.match(headerSource, /from '@\/components\/header\/HeaderLogoMark'/);
+  assert.match(headerSource, /from '@\/components\/header\/header-nav-helpers'/);
   assert.match(accountHookSource, /export function useHeaderAccountState/);
   assert.match(logoSource, /export function HeaderLogoMark/);
+  assert.match(navHelpersSource, /export function resolveLocalizedHref/);
+  assert.match(navHelpersSource, /export function normalizeMarketingLinks/);
+  assert.match(navHelpersSource, /export function getGuestMobileNavItems/);
 });
 
 test('header bar does not regain auth session ownership', () => {
@@ -29,7 +36,9 @@ test('header bar does not regain auth session ownership', () => {
   assert.doesNotMatch(headerSource, /clearLastKnownAccount/, 'account cleanup belongs in useHeaderAccountState.ts');
   assert.doesNotMatch(headerSource, /setLogoutIntent/, 'logout intent belongs in useHeaderAccountState.ts');
   assert.doesNotMatch(headerSource, /function LogoMark\(/, 'logo rendering belongs in HeaderLogoMark.tsx');
+  assert.doesNotMatch(headerSource, /function resolveLocalizedHref\(/, 'localized href resolution belongs in header-nav-helpers.ts');
+  assert.doesNotMatch(headerSource, /MARKETING_TOP_NAV_HREF_BY_KEY/, 'marketing link allowlisting belongs in header-nav-helpers.ts');
 
   const lineCount = headerSource.split('\n').length;
-  assert.ok(lineCount <= 830, `HeaderBar.tsx should stay below 830 lines after account hook extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 780, `HeaderBar.tsx should stay below 780 lines after nav helper extraction, got ${lineCount}`);
 });


### PR DESCRIPTION
## Summary
- move localized href resolution and marketing nav allowlisting out of HeaderBar
- centralize guest mobile nav icon/item helpers
- tighten the header architecture contract around the new helper module

## Checks
- ./node_modules/.bin/tsx --tsconfig frontend/tsconfig.json --test tests/header-bar-architecture.test.ts tests/dark-mode-theme.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- frontend/components/HeaderBar.tsx frontend/components/header/header-nav-helpers.ts tests/header-bar-architecture.test.ts