### PR TITLE
Split settings engine advanced controls

### DIFF
--- a/frontend/components/SettingsControls.tsx
+++ b/frontend/components/SettingsControls.tsx
@@ -5,6 +5,10 @@ import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { formatResolutionLabel } from '@/lib/resolution-labels';
 import { matchesDurationOptionValue } from '@/components/settings-controls/settings-control-duration';
+import {
+  SettingsKlingV3Controls,
+  SettingsSeedanceAdvancedControls,
+} from '@/components/settings-controls/settings-control-engine-advanced';
 import { SettingsGenericAdvancedFields } from '@/components/settings-controls/settings-control-generic-fields';
 import { FieldGroup, RangeWithInput } from '@/components/settings-controls/settings-control-parts';
 import type { SettingsControlsProps } from '@/components/settings-controls/settings-control-types';
@@ -291,119 +295,28 @@ export function SettingsControls({
             ) : null}
 
             {showKlingV3Controls ? (
-              <div className="space-y-3">
-                <span className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">Kling v3 controls</span>
-                <div className="grid gap-3 md:grid-cols-2">
-                  <label className="flex flex-col gap-1.5 text-sm text-text-secondary">
-                    <span className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">Shot type</span>
-                    <div className="flex flex-wrap gap-2">
-                      {(['customize', 'intelligent'] as const).map((option) => (
-                        <Button
-                          key={option}
-                          type="button"
-                          size="sm"
-                          variant="outline"
-                          disabled={mode === 'i2v'}
-                          onClick={() => {
-                            if (mode === 'i2v') return;
-                            onKlingShotTypeChange?.(option);
-                          }}
-                          className={clsx(
-                            'min-h-0 h-auto px-3 py-1.5 text-[13px]',
-                            option === klingShotType
-                              ? 'border-brand bg-brand text-on-brand'
-                              : 'border-hairline bg-surface text-text-secondary hover:border-text-muted hover:bg-surface-2'
-                          )}
-                        >
-                          {option}
-                        </Button>
-                      ))}
-                    </div>
-                    {mode === 'i2v' ? (
-                      <span className="text-[11px] text-text-muted">Shot type is locked to customize for image-to-video.</span>
-                    ) : null}
-                  </label>
-                  {showKlingV3VoiceControls ? (
-                    <label className="flex flex-col gap-1.5 text-sm text-text-secondary">
-                      <span className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">Voice IDs (CSV)</span>
-                      <input
-                        type="text"
-                        placeholder="voice_1, voice_2"
-                        value={voiceIdsValue}
-                        onChange={(e) => onVoiceIdsChange?.(e.currentTarget.value)}
-                        className="h-10 rounded-input border border-border bg-surface px-3 text-sm text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                      />
-                      <span className="text-[11px] text-text-muted">Voice control pricing: $0.392/s</span>
-                      {voiceControlActive ? (
-                        <span className="text-[11px] text-text-muted">Audio locked on while voice control is enabled.</span>
-                      ) : null}
-                    </label>
-                  ) : null}
-                </div>
-              </div>
+              <SettingsKlingV3Controls
+                klingShotType={klingShotType}
+                layout="compact"
+                mode={mode}
+                onKlingShotTypeChange={onKlingShotTypeChange}
+                onVoiceIdsChange={onVoiceIdsChange}
+                showVoiceControls={showKlingV3VoiceControls}
+                voiceControlActive={voiceControlActive}
+                voiceIdsValue={voiceIdsValue}
+              />
             ) : null}
 
             {showSeedanceControls ? (
-              <div className="space-y-3">
-                <span className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">Seedance advanced</span>
-                <div className="grid gap-3 md:grid-cols-3">
-                  <label className="flex flex-col gap-1.5 text-sm text-text-secondary">
-                    <span className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">Seed</span>
-                    <input
-                      type="number"
-                      placeholder="-1 for random"
-                      value={seedValue}
-                      onChange={(e) => onSeedChange?.(e.currentTarget.value)}
-                      className="h-10 rounded-input border border-border bg-surface px-3 text-sm text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    />
-                    <span className="text-[11px] text-text-muted">Use -1 for random.</span>
-                  </label>
-                  <label className="flex flex-col gap-1.5 text-sm text-text-secondary">
-                    <span className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">Camera fixed</span>
-                    <div className="flex flex-wrap gap-2">
-                      {[true, false].map((option) => (
-                        <Button
-                          key={option ? 'camera-on' : 'camera-off'}
-                          type="button"
-                          size="sm"
-                          variant="outline"
-                          onClick={() => onCameraFixedChange?.(option)}
-                          className={clsx(
-                            'min-h-0 h-auto px-3 py-1.5 text-[13px]',
-                            option === cameraFixed
-                              ? 'border-brand bg-brand text-on-brand'
-                              : 'border-hairline bg-surface text-text-secondary hover:border-text-muted hover:bg-surface-2'
-                          )}
-                        >
-                          {option ? 'On' : 'Off'}
-                        </Button>
-                      ))}
-                    </div>
-                  </label>
-                  <label className="flex flex-col gap-1.5 text-sm text-text-secondary">
-                    <span className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">Safety checker</span>
-                    <div className="flex flex-wrap gap-2">
-                      {[true, false].map((option) => (
-                        <Button
-                          key={option ? 'safety-on' : 'safety-off'}
-                          type="button"
-                          size="sm"
-                          variant="outline"
-                          onClick={() => onSafetyCheckerChange?.(option)}
-                          className={clsx(
-                            'min-h-0 h-auto px-3 py-1.5 text-[13px]',
-                            option === safetyChecker
-                              ? 'border-brand bg-brand text-on-brand'
-                              : 'border-hairline bg-surface text-text-secondary hover:border-text-muted hover:bg-surface-2'
-                          )}
-                        >
-                          {option ? 'On' : 'Off'}
-                        </Button>
-                      ))}
-                    </div>
-                  </label>
-                </div>
-              </div>
+              <SettingsSeedanceAdvancedControls
+                cameraFixed={cameraFixed}
+                layout="compact"
+                onCameraFixedChange={onCameraFixedChange}
+                onSafetyCheckerChange={onSafetyCheckerChange}
+                onSeedChange={onSeedChange}
+                safetyChecker={safetyChecker}
+                seedValue={seedValue}
+              />
             ) : null}
 
             {engine.params.cfg_scale ? (
@@ -795,121 +708,28 @@ export function SettingsControls({
             )}
 
             {showKlingV3Controls && (
-              <div className="space-y-2">
-                <span className="text-[12px] uppercase tracking-micro text-text-muted">Kling v3 controls</span>
-                <div className="space-y-2 rounded-input border border-border bg-surface p-3">
-                  <label className="flex flex-col gap-2 text-sm text-text-secondary">
-                    <span className="text-[12px] uppercase tracking-micro text-text-muted">Shot type</span>
-                    <div className="flex flex-wrap gap-2">
-                      {(['customize', 'intelligent'] as const).map((option) => (
-                        <Button
-                          key={option}
-                          type="button"
-                          size="sm"
-                          variant="outline"
-                          disabled={mode === 'i2v'}
-                          onClick={() => {
-                            if (mode === 'i2v') return;
-                            onKlingShotTypeChange?.(option);
-                          }}
-                          className={clsx(
-                            'min-h-0 h-auto px-3 py-1.5 text-[13px]',
-                            option === klingShotType
-                              ? 'border-brand bg-brand text-on-brand'
-                              : 'border-hairline bg-surface text-text-secondary hover:border-text-muted hover:bg-surface-2'
-                          )}
-                        >
-                          {option}
-                        </Button>
-                      ))}
-                    </div>
-                    {mode === 'i2v' && (
-                      <span className="text-[11px] text-text-muted">
-                        Shot type is locked to customize for image-to-video.
-                      </span>
-                    )}
-                  </label>
-                  {showKlingV3VoiceControls ? (
-                    <label className="flex flex-col gap-2 text-sm text-text-secondary">
-                      <span className="text-[12px] uppercase tracking-micro text-text-muted">Voice IDs (CSV)</span>
-                      <input
-                        type="text"
-                        placeholder="voice_1, voice_2"
-                        value={voiceIdsValue}
-                        onChange={(e) => onVoiceIdsChange?.(e.currentTarget.value)}
-                        className="rounded-input border border-border bg-surface px-3 py-2 text-sm text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                      />
-                      <span className="text-[11px] text-text-muted">Voice control pricing: $0.392/s</span>
-                      {voiceControlActive && (
-                        <span className="text-[11px] text-text-muted">Audio locked on while voice control is enabled.</span>
-                      )}
-                    </label>
-                  ) : null}
-                </div>
-              </div>
+              <SettingsKlingV3Controls
+                klingShotType={klingShotType}
+                layout="panel"
+                mode={mode}
+                onKlingShotTypeChange={onKlingShotTypeChange}
+                onVoiceIdsChange={onVoiceIdsChange}
+                showVoiceControls={showKlingV3VoiceControls}
+                voiceControlActive={voiceControlActive}
+                voiceIdsValue={voiceIdsValue}
+              />
             )}
 
             {showSeedanceControls && (
-              <div className="space-y-2">
-                <span className="text-[12px] uppercase tracking-micro text-text-muted">Seedance advanced</span>
-                <div className="space-y-3 rounded-input border border-border bg-surface p-3">
-                  <label className="flex flex-col gap-2 text-sm text-text-secondary">
-                    <span className="text-[12px] uppercase tracking-micro text-text-muted">Seed</span>
-                    <input
-                      type="number"
-                      placeholder="-1 for random"
-                      value={seedValue}
-                      onChange={(e) => onSeedChange?.(e.currentTarget.value)}
-                      className="rounded-input border border-border bg-surface px-3 py-2 text-sm text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    />
-                    <span className="text-[11px] text-text-muted">Use -1 for random.</span>
-                  </label>
-                  <label className="flex flex-col gap-2 text-sm text-text-secondary">
-                    <span className="text-[12px] uppercase tracking-micro text-text-muted">Camera fixed</span>
-                    <div className="flex flex-wrap gap-2">
-                      {[true, false].map((option) => (
-                        <Button
-                          key={option ? 'on' : 'off'}
-                          type="button"
-                          size="sm"
-                          variant="outline"
-                          onClick={() => onCameraFixedChange?.(option)}
-                          className={clsx(
-                            'min-h-0 h-auto px-3 py-1.5 text-[13px]',
-                            option === cameraFixed
-                              ? 'border-brand bg-brand text-on-brand'
-                              : 'border-hairline bg-surface text-text-secondary hover:border-text-muted hover:bg-surface-2'
-                          )}
-                        >
-                          {option ? 'On' : 'Off'}
-                        </Button>
-                      ))}
-                    </div>
-                  </label>
-                  <label className="flex flex-col gap-2 text-sm text-text-secondary">
-                    <span className="text-[12px] uppercase tracking-micro text-text-muted">Safety checker</span>
-                    <div className="flex flex-wrap gap-2">
-                      {[true, false].map((option) => (
-                        <Button
-                          key={option ? 'on' : 'off'}
-                          type="button"
-                          size="sm"
-                          variant="outline"
-                          onClick={() => onSafetyCheckerChange?.(option)}
-                          className={clsx(
-                            'min-h-0 h-auto px-3 py-1.5 text-[13px]',
-                            option === safetyChecker
-                              ? 'border-brand bg-brand text-on-brand'
-                              : 'border-hairline bg-surface text-text-secondary hover:border-text-muted hover:bg-surface-2'
-                          )}
-                        >
-                          {option ? 'On' : 'Off'}
-                        </Button>
-                      ))}
-                    </div>
-                  </label>
-                </div>
-              </div>
+              <SettingsSeedanceAdvancedControls
+                cameraFixed={cameraFixed}
+                layout="panel"
+                onCameraFixedChange={onCameraFixedChange}
+                onSafetyCheckerChange={onSafetyCheckerChange}
+                onSeedChange={onSeedChange}
+                safetyChecker={safetyChecker}
+                seedValue={seedValue}
+              />
             )}
 
             {engine.params.cfg_scale && (

--- a/frontend/components/settings-controls/settings-control-engine-advanced.tsx
+++ b/frontend/components/settings-controls/settings-control-engine-advanced.tsx
@@ -1,0 +1,205 @@
+import clsx from 'clsx';
+import { Button } from '@/components/ui/Button';
+import type { Mode } from '@/types/engines';
+
+type SettingsEngineAdvancedLayout = 'compact' | 'panel';
+
+type SettingsKlingV3ControlsProps = {
+  klingShotType: 'customize' | 'intelligent';
+  layout: SettingsEngineAdvancedLayout;
+  mode: Mode;
+  onKlingShotTypeChange?: (value: 'customize' | 'intelligent') => void;
+  onVoiceIdsChange?: (value: string) => void;
+  showVoiceControls: boolean;
+  voiceControlActive: boolean;
+  voiceIdsValue: string;
+};
+
+type SettingsSeedanceAdvancedControlsProps = {
+  cameraFixed: boolean;
+  layout: SettingsEngineAdvancedLayout;
+  onCameraFixedChange?: (value: boolean) => void;
+  onSafetyCheckerChange?: (value: boolean) => void;
+  onSeedChange?: (value: string) => void;
+  safetyChecker: boolean;
+  seedValue: string;
+};
+
+const toggleButtonClass =
+  'min-h-0 h-auto px-3 py-1.5 text-[13px]';
+
+function activeToggleClass(active: boolean) {
+  return active
+    ? 'border-brand bg-brand text-on-brand'
+    : 'border-hairline bg-surface text-text-secondary hover:border-text-muted hover:bg-surface-2';
+}
+
+export function SettingsKlingV3Controls({
+  klingShotType,
+  layout,
+  mode,
+  onKlingShotTypeChange,
+  onVoiceIdsChange,
+  showVoiceControls,
+  voiceControlActive,
+  voiceIdsValue,
+}: SettingsKlingV3ControlsProps) {
+  const isCompact = layout === 'compact';
+  const labelClass = isCompact
+    ? 'text-[11px] font-semibold uppercase tracking-micro text-text-muted'
+    : 'text-[12px] uppercase tracking-micro text-text-muted';
+  const fieldClass = isCompact
+    ? 'flex flex-col gap-1.5 text-sm text-text-secondary'
+    : 'flex flex-col gap-2 text-sm text-text-secondary';
+  const inputClass = isCompact
+    ? 'h-10 rounded-input border border-border bg-surface px-3 text-sm text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+    : 'rounded-input border border-border bg-surface px-3 py-2 text-sm text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+
+  const body = (
+    <>
+      <label className={fieldClass}>
+        <span className={labelClass}>Shot type</span>
+        <div className="flex flex-wrap gap-2">
+          {(['customize', 'intelligent'] as const).map((option) => (
+            <Button
+              key={option}
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={mode === 'i2v'}
+              onClick={() => {
+                if (mode === 'i2v') return;
+                onKlingShotTypeChange?.(option);
+              }}
+              className={clsx(toggleButtonClass, activeToggleClass(option === klingShotType))}
+            >
+              {option}
+            </Button>
+          ))}
+        </div>
+        {mode === 'i2v' ? (
+          <span className="text-[11px] text-text-muted">Shot type is locked to customize for image-to-video.</span>
+        ) : null}
+      </label>
+      {showVoiceControls ? (
+        <label className={fieldClass}>
+          <span className={labelClass}>Voice IDs (CSV)</span>
+          <input
+            type="text"
+            placeholder="voice_1, voice_2"
+            value={voiceIdsValue}
+            onChange={(event) => onVoiceIdsChange?.(event.currentTarget.value)}
+            className={inputClass}
+          />
+          <span className="text-[11px] text-text-muted">Voice control pricing: $0.392/s</span>
+          {voiceControlActive ? (
+            <span className="text-[11px] text-text-muted">Audio locked on while voice control is enabled.</span>
+          ) : null}
+        </label>
+      ) : null}
+    </>
+  );
+
+  if (isCompact) {
+    return (
+      <div className="space-y-3">
+        <span className={labelClass}>Kling v3 controls</span>
+        <div className="grid gap-3 md:grid-cols-2">{body}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <span className={labelClass}>Kling v3 controls</span>
+      <div className="space-y-2 rounded-input border border-border bg-surface p-3">{body}</div>
+    </div>
+  );
+}
+
+export function SettingsSeedanceAdvancedControls({
+  cameraFixed,
+  layout,
+  onCameraFixedChange,
+  onSafetyCheckerChange,
+  onSeedChange,
+  safetyChecker,
+  seedValue,
+}: SettingsSeedanceAdvancedControlsProps) {
+  const isCompact = layout === 'compact';
+  const labelClass = isCompact
+    ? 'text-[11px] font-semibold uppercase tracking-micro text-text-muted'
+    : 'text-[12px] uppercase tracking-micro text-text-muted';
+  const fieldClass = isCompact
+    ? 'flex flex-col gap-1.5 text-sm text-text-secondary'
+    : 'flex flex-col gap-2 text-sm text-text-secondary';
+  const inputClass = isCompact
+    ? 'h-10 rounded-input border border-border bg-surface px-3 text-sm text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+    : 'rounded-input border border-border bg-surface px-3 py-2 text-sm text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+
+  const body = (
+    <>
+      <label className={fieldClass}>
+        <span className={labelClass}>Seed</span>
+        <input
+          type="number"
+          placeholder="-1 for random"
+          value={seedValue}
+          onChange={(event) => onSeedChange?.(event.currentTarget.value)}
+          className={inputClass}
+        />
+        <span className="text-[11px] text-text-muted">Use -1 for random.</span>
+      </label>
+      <label className={fieldClass}>
+        <span className={labelClass}>Camera fixed</span>
+        <div className="flex flex-wrap gap-2">
+          {[true, false].map((option) => (
+            <Button
+              key={option ? 'camera-on' : 'camera-off'}
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => onCameraFixedChange?.(option)}
+              className={clsx(toggleButtonClass, activeToggleClass(option === cameraFixed))}
+            >
+              {option ? 'On' : 'Off'}
+            </Button>
+          ))}
+        </div>
+      </label>
+      <label className={fieldClass}>
+        <span className={labelClass}>Safety checker</span>
+        <div className="flex flex-wrap gap-2">
+          {[true, false].map((option) => (
+            <Button
+              key={option ? 'safety-on' : 'safety-off'}
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => onSafetyCheckerChange?.(option)}
+              className={clsx(toggleButtonClass, activeToggleClass(option === safetyChecker))}
+            >
+              {option ? 'On' : 'Off'}
+            </Button>
+          ))}
+        </div>
+      </label>
+    </>
+  );
+
+  if (isCompact) {
+    return (
+      <div className="space-y-3">
+        <span className={labelClass}>Seedance advanced</span>
+        <div className="grid gap-3 md:grid-cols-3">{body}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <span className={labelClass}>Seedance advanced</span>
+      <div className="space-y-3 rounded-input border border-border bg-surface p-3">{body}</div>
+    </div>
+  );
+}

--- a/tests/settings-controls-architecture.test.ts
+++ b/tests/settings-controls-architecture.test.ts
@@ -9,6 +9,7 @@ const partsPath = join(root, 'frontend/components/settings-controls/settings-con
 const durationPath = join(root, 'frontend/components/settings-controls/settings-control-duration.ts');
 const copyPath = join(root, 'frontend/components/settings-controls/settings-control-copy.ts');
 const genericFieldsPath = join(root, 'frontend/components/settings-controls/settings-control-generic-fields.tsx');
+const engineAdvancedPath = join(root, 'frontend/components/settings-controls/settings-control-engine-advanced.tsx');
 const typesPath = join(root, 'frontend/components/settings-controls/settings-control-types.ts');
 const stateHookPath = join(root, 'frontend/components/settings-controls/useSettingsControlState.ts');
 
@@ -17,6 +18,7 @@ const partsSource = readFileSync(partsPath, 'utf8');
 const durationSource = readFileSync(durationPath, 'utf8');
 const copySource = readFileSync(copyPath, 'utf8');
 const genericFieldsSource = readFileSync(genericFieldsPath, 'utf8');
+const engineAdvancedSource = readFileSync(engineAdvancedPath, 'utf8');
 const typesSource = readFileSync(typesPath, 'utf8');
 const stateHookSource = readFileSync(stateHookPath, 'utf8');
 
@@ -25,6 +27,7 @@ test('settings controls delegates reusable control parts and duration helpers', 
   assert.ok(existsSync(durationPath), 'settings duration helpers should live in a focused module');
   assert.ok(existsSync(copyPath), 'settings controls copy should live in a focused module');
   assert.ok(existsSync(genericFieldsPath), 'generic advanced fields should live in a focused module');
+  assert.ok(existsSync(engineAdvancedPath), 'engine-specific advanced controls should live in a focused module');
   assert.ok(existsSync(typesPath), 'settings controls props contract should live in a focused module');
   assert.ok(existsSync(stateHookPath), 'settings control derived state should live in a focused hook');
 
@@ -32,6 +35,7 @@ test('settings controls delegates reusable control parts and duration helpers', 
   assert.match(controlsSource, /from '@\/components\/settings-controls\/settings-control-duration'/);
   assert.match(controlsSource, /from '@\/components\/settings-controls\/settings-control-copy'/);
   assert.match(controlsSource, /from '@\/components\/settings-controls\/settings-control-generic-fields'/);
+  assert.match(controlsSource, /from '@\/components\/settings-controls\/settings-control-engine-advanced'/);
   assert.match(controlsSource, /from '@\/components\/settings-controls\/settings-control-types'/);
   assert.match(controlsSource, /from '@\/components\/settings-controls\/useSettingsControlState'/);
 });
@@ -45,6 +49,8 @@ test('settings controls does not regain extracted ownership', () => {
   assert.doesNotMatch(controlsSource, /function mergeControlsCopy\(/, 'copy merging belongs in settings-control-copy.ts');
   assert.doesNotMatch(controlsSource, /function renderGenericAdvancedField/, 'generic field rendering belongs in settings-control-generic-fields.tsx');
   assert.doesNotMatch(controlsSource, /<select[\s\S]*field\.values/, 'generic enum field rendering belongs in settings-control-generic-fields.tsx');
+  assert.doesNotMatch(controlsSource, /Voice IDs \(CSV\)/, 'Kling voice controls belong in settings-control-engine-advanced.tsx');
+  assert.doesNotMatch(controlsSource, /Camera fixed/, 'Seedance engine controls belong in settings-control-engine-advanced.tsx');
   assert.doesNotMatch(controlsSource, /interface Props/, 'settings controls prop contract belongs in settings-control-types.ts');
   assert.doesNotMatch(controlsSource, /EngineInputField/, 'advanced field prop typing belongs in settings-control-types.ts');
   assert.doesNotMatch(controlsSource, /useEffect\(/, 'derived option syncing belongs in useSettingsControlState');
@@ -52,7 +58,7 @@ test('settings controls does not regain extracted ownership', () => {
   assert.doesNotMatch(controlsSource, /const resolutionOptions =/, 'resolution option derivation belongs in useSettingsControlState');
 
   const lineCount = controlsSource.split('\n').length;
-  assert.ok(lineCount <= 950, `SettingsControls should stay below 950 lines after state hook extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 760, `SettingsControls should stay below 760 lines after engine advanced extraction, got ${lineCount}`);
 });
 
 test('settings control helper modules expose the expected contract', () => {
@@ -66,6 +72,10 @@ test('settings control helper modules expose the expected contract', () => {
   assert.match(genericFieldsSource, /export function SettingsGenericAdvancedFields/);
   assert.match(genericFieldsSource, /field\.type === 'enum'/);
   assert.match(genericFieldsSource, /field\.type === 'number'/);
+  assert.match(engineAdvancedSource, /export function SettingsKlingV3Controls/);
+  assert.match(engineAdvancedSource, /export function SettingsSeedanceAdvancedControls/);
+  assert.match(engineAdvancedSource, /Voice IDs \(CSV\)/);
+  assert.match(engineAdvancedSource, /Camera fixed/);
   assert.match(typesSource, /export interface SettingsControlsProps/);
   assert.match(typesSource, /EngineInputField/);
   assert.match(stateHookSource, /export function useSettingsControlState/);


### PR DESCRIPTION
## Summary
- move Kling v3 and Seedance advanced engine controls into a focused settings-control module
- remove duplicated engine-specific JSX from SettingsControls full and advanced variants
- tighten the settings controls architecture contract around the new module

## Checks
- ./node_modules/.bin/tsx --tsconfig frontend/tsconfig.json --test tests/settings-controls-architecture.test.ts tests/dark-mode-theme.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- frontend/components/SettingsControls.tsx frontend/components/settings-controls/settings-control-engine-advanced.tsx tests/settings-controls-architecture.test.ts