### PR TITLE
Split examples route sections

### DIFF
--- a/frontend/app/(localized)/[locale]/(marketing)/examples/_components/examples-engine-filter-nav.tsx
+++ b/frontend/app/(localized)/[locale]/(marketing)/examples/_components/examples-engine-filter-nav.tsx
@@ -1,0 +1,79 @@
+import clsx from 'clsx';
+import Link from 'next/link';
+import {
+  getEngineAccentOutlineStyle,
+  type EngineFilterOption,
+} from '../_lib/examples-route-utils';
+
+type ExamplesEngineFilterNavProps = {
+  browseByModelLabel: string;
+  engineFilterAllLabel: string;
+  engineFilterOptions: EngineFilterOption[];
+  getEngineFilterHref: (engineId: string | null) => string;
+  selectedEngine: string | null;
+};
+
+export function ExamplesEngineFilterNav({
+  browseByModelLabel,
+  engineFilterAllLabel,
+  engineFilterOptions,
+  getEngineFilterHref,
+  selectedEngine,
+}: ExamplesEngineFilterNavProps) {
+  if (!engineFilterOptions.length) {
+    return null;
+  }
+
+  return (
+    <div className="sticky top-16 z-[35] -mt-px border-b border-hairline bg-surface">
+      <div className="container-page max-w-6xl">
+        <nav
+          aria-label={browseByModelLabel}
+          className="flex flex-col gap-2 py-2 lg:flex-row lg:items-center lg:gap-4 lg:py-2"
+        >
+          <span className="shrink-0 pl-1 text-[11px] font-semibold uppercase tracking-micro text-text-muted">
+            {browseByModelLabel}
+          </span>
+
+          <div className="min-w-0 flex-1">
+            <div className="grid grid-cols-[repeat(auto-fit,minmax(5.75rem,1fr))] gap-1 rounded-xl bg-surface-2/70 p-1 sm:grid-cols-[repeat(auto-fit,minmax(6.5rem,1fr))] lg:grid-flow-col lg:auto-cols-fr lg:grid-cols-none">
+              <Link
+                href={getEngineFilterHref(null)}
+                scroll={false}
+                prefetch={false}
+                className={clsx(
+                  'flex h-9 items-center justify-center whitespace-nowrap rounded-lg px-1.5 text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:h-10 sm:px-3 sm:text-sm',
+                  selectedEngine
+                    ? 'text-text-secondary hover:bg-surface hover:text-text-primary'
+                    : 'bg-surface text-text-primary shadow-sm ring-1 ring-black/5'
+                )}
+              >
+                {engineFilterAllLabel}
+              </Link>
+              {engineFilterOptions.map((engine) => {
+                const isActive = selectedEngine === engine.id;
+                return (
+                  <Link
+                    key={engine.id}
+                    href={getEngineFilterHref(engine.id)}
+                    scroll={false}
+                    prefetch={false}
+                    className={clsx(
+                      'flex h-9 items-center justify-center whitespace-nowrap rounded-lg px-1.5 text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:h-10 sm:px-3 sm:text-sm',
+                      isActive
+                        ? 'bg-surface text-text-primary shadow-sm ring-1 ring-black/5'
+                        : 'text-text-secondary hover:bg-surface hover:text-text-primary'
+                    )}
+                    style={isActive ? getEngineAccentOutlineStyle(engine.brandId) : undefined}
+                  >
+                    {engine.label}
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        </nav>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/(localized)/[locale]/(marketing)/examples/_components/examples-jsonld-scripts.tsx
+++ b/frontend/app/(localized)/[locale]/(marketing)/examples/_components/examples-jsonld-scripts.tsx
@@ -1,0 +1,39 @@
+import { serializeJsonLd } from '../_lib/examples-route-utils';
+
+type ExamplesJsonLdScriptsProps = {
+  breadcrumbJsonLd: unknown;
+  faqJsonLd: unknown;
+  itemListJson: unknown;
+};
+
+export function ExamplesJsonLdScripts({
+  breadcrumbJsonLd,
+  faqJsonLd,
+  itemListJson,
+}: ExamplesJsonLdScriptsProps) {
+  return (
+    <>
+      {breadcrumbJsonLd ? (
+        <script
+          type="application/ld+json"
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }}
+        />
+      ) : null}
+      {itemListJson ? (
+        <script
+          type="application/ld+json"
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(itemListJson) }}
+        />
+      ) : null}
+      {faqJsonLd ? (
+        <script
+          type="application/ld+json"
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(faqJsonLd) }}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/frontend/app/(localized)/[locale]/(marketing)/examples/_components/examples-route-sections.tsx
+++ b/frontend/app/(localized)/[locale]/(marketing)/examples/_components/examples-route-sections.tsx
@@ -1,0 +1,45 @@
+import Link from 'next/link';
+import type { AppLocale } from '@/i18n/locales';
+
+type ExamplesIntroHeroProps = {
+  heroLead: string;
+  heroSubtitle: string;
+  heroTitle: string;
+};
+
+type ExamplesNextStepsSectionProps = {
+  locale: AppLocale;
+  nextStepLinks: Array<{
+    href: string;
+    label: string;
+  }>;
+};
+
+export function ExamplesIntroHero({ heroLead, heroSubtitle, heroTitle }: ExamplesIntroHeroProps) {
+  return (
+    <section className="halo-hero stack-gap-sm text-center sm:stack-gap-md">
+      <header className="mx-auto max-w-3xl stack-gap-sm text-center">
+        <h1 className="text-3xl font-semibold text-text-primary sm:text-5xl">{heroTitle}</h1>
+        <p className="text-base leading-relaxed text-text-secondary">{heroSubtitle}</p>
+        <p className="mx-auto max-w-2xl text-sm leading-relaxed text-text-secondary/90">{heroLead}</p>
+      </header>
+    </section>
+  );
+}
+
+export function ExamplesNextStepsSection({ locale, nextStepLinks }: ExamplesNextStepsSectionProps) {
+  return (
+    <section className="rounded-[16px] border border-hairline bg-surface/80 px-5 py-5 shadow-card">
+      <h2 className="text-lg font-semibold text-text-primary">
+        {locale === 'fr' ? 'Aller plus loin' : locale === 'es' ? 'Siguientes pasos' : 'Next steps'}
+      </h2>
+      <div className="mt-3 flex flex-wrap gap-3 text-sm">
+        {nextStepLinks.map((item) => (
+          <Link key={item.label} href={item.href} className="font-semibold text-brand hover:text-brandHover">
+            {item.label}
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/(localized)/[locale]/(marketing)/examples/page.tsx
+++ b/frontend/app/(localized)/[locale]/(marketing)/examples/page.tsx
@@ -12,10 +12,7 @@ import { buildSeoMetadata } from '@/lib/seo/metadata';
 import { getBreadcrumbLabels } from '@/lib/seo/breadcrumbs';
 import { buildOptimizedPosterUrl } from '@/lib/media-helpers';
 import { resolveExampleCanonicalSlug } from '@/lib/examples-links';
-import {
-  getExampleModelLanding,
-  getHubExamplesFaq,
-} from '@/lib/examples/modelLanding';
+import { getExampleModelLanding, getHubExamplesFaq } from '@/lib/examples/modelLanding';
 import { pickFirstPlayableVideo } from '@/lib/examples/heroVideo';
 import {
   ALLOWED_QUERY_KEYS,
@@ -42,7 +39,6 @@ import {
   formatModelSlugLabel,
   formatPromptExcerpt,
   getAspectRatioStyle,
-  getEngineAccentOutlineStyle,
   getPlaceholderPoster,
   getSort,
   getVideoMimeType,
@@ -53,14 +49,14 @@ import {
   resolveEngineLabel,
   resolveEngineLinkId,
   resolveFilterDescriptor,
-  serializeJsonLd,
   toAbsoluteUrl,
   type EngineFilterOption,
 } from './_lib/examples-route-utils';
-import {
-  getExampleFamilyDescriptor,
-} from '@/lib/model-families';
+import { getExampleFamilyDescriptor } from '@/lib/model-families';
+import { ExamplesEngineFilterNav } from './_components/examples-engine-filter-nav';
+import { ExamplesJsonLdScripts } from './_components/examples-jsonld-scripts';
 import { ExamplesMainVideoFeature } from './_components/examples-main-video-feature';
+import { ExamplesIntroHero, ExamplesNextStepsSection } from './_components/examples-route-sections';
 import {
   buildExamplesNextStepLinks,
   getExamplesBrowseByModelLabel,
@@ -594,59 +590,13 @@ export default async function ExamplesPage(props: ExamplesPageProps) {
 
   return (
     <>
-      {engineFilterOptions.length ? (
-        <div className="sticky top-16 z-[35] -mt-px border-b border-hairline bg-surface">
-          <div className="container-page max-w-6xl">
-            <nav
-              aria-label={browseByModelLabel}
-              className="flex flex-col gap-2 py-2 lg:flex-row lg:items-center lg:gap-4 lg:py-2"
-            >
-              <span className="shrink-0 pl-1 text-[11px] font-semibold uppercase tracking-micro text-text-muted">
-                {browseByModelLabel}
-              </span>
-
-              <div className="min-w-0 flex-1">
-                <div className="grid grid-cols-[repeat(auto-fit,minmax(5.75rem,1fr))] gap-1 rounded-xl bg-surface-2/70 p-1 sm:grid-cols-[repeat(auto-fit,minmax(6.5rem,1fr))] lg:grid-flow-col lg:auto-cols-fr lg:grid-cols-none">
-                  <Link
-                    href={buildEngineFilterHref(null)}
-                    scroll={false}
-                    prefetch={false}
-                    className={clsx(
-                      'flex h-9 items-center justify-center whitespace-nowrap rounded-lg px-1.5 text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:h-10 sm:px-3 sm:text-sm',
-                      selectedEngine
-                        ? 'text-text-secondary hover:bg-surface hover:text-text-primary'
-                        : 'bg-surface text-text-primary shadow-sm ring-1 ring-black/5'
-                    )}
-                  >
-                    {engineFilterAllLabel}
-                  </Link>
-                  {engineFilterOptions.map((engine) => {
-                    const isActive = selectedEngine === engine.id;
-                    const activeAccentStyle = isActive ? getEngineAccentOutlineStyle(engine.brandId) : undefined;
-                    return (
-                      <Link
-                        key={engine.id}
-                        href={buildEngineFilterHref(engine.id)}
-                        scroll={false}
-                        prefetch={false}
-                        className={clsx(
-                          'flex h-9 items-center justify-center whitespace-nowrap rounded-lg px-1.5 text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:h-10 sm:px-3 sm:text-sm',
-                          isActive
-                            ? 'bg-surface text-text-primary shadow-sm ring-1 ring-black/5'
-                            : 'text-text-secondary hover:bg-surface hover:text-text-primary'
-                        )}
-                        style={activeAccentStyle}
-                      >
-                        {engine.label}
-                      </Link>
-                    );
-                  })}
-                </div>
-              </div>
-            </nav>
-          </div>
-        </div>
-      ) : null}
+      <ExamplesEngineFilterNav
+        browseByModelLabel={browseByModelLabel}
+        engineFilterAllLabel={engineFilterAllLabel}
+        engineFilterOptions={engineFilterOptions}
+        getEngineFilterHref={buildEngineFilterHref}
+        selectedEngine={selectedEngine}
+      />
 
       <main
         className={clsx(
@@ -655,13 +605,7 @@ export default async function ExamplesPage(props: ExamplesPageProps) {
         )}
       >
         <div className="stack-gap-lg">
-          <section className="halo-hero stack-gap-sm text-center sm:stack-gap-md">
-            <header className="mx-auto max-w-3xl stack-gap-sm text-center">
-              <h1 className="text-3xl font-semibold text-text-primary sm:text-5xl">{heroTitle}</h1>
-              <p className="text-base leading-relaxed text-text-secondary">{heroSubtitle}</p>
-              <p className="mx-auto max-w-2xl text-sm leading-relaxed text-text-secondary/90">{heroLead}</p>
-            </header>
-          </section>
+          <ExamplesIntroHero heroLead={heroLead} heroSubtitle={heroSubtitle} heroTitle={heroTitle} />
 
           {mainVideo && mainVideoContentUrl ? (
             <ExamplesMainVideoFeature
@@ -814,22 +758,7 @@ export default async function ExamplesPage(props: ExamplesPageProps) {
             </section>
           )}
 
-          <section className="rounded-[16px] border border-hairline bg-surface/80 px-5 py-5 shadow-card">
-            <h2 className="text-lg font-semibold text-text-primary">
-              {locale === 'fr'
-                ? 'Aller plus loin'
-                : locale === 'es'
-                  ? 'Siguientes pasos'
-                  : 'Next steps'}
-            </h2>
-            <div className="mt-3 flex flex-wrap gap-3 text-sm">
-              {nextStepLinks.map((item) => (
-                <Link key={item.label} href={item.href} className="font-semibold text-brand hover:text-brandHover">
-                  {item.label}
-                </Link>
-              ))}
-            </div>
-          </section>
+          <ExamplesNextStepsSection locale={appLocale} nextStepLinks={nextStepLinks} />
 
           {faqBlock.items.length ? (
             <section className="rounded-[16px] border border-hairline bg-surface/80 px-5 py-5 shadow-card">
@@ -847,27 +776,11 @@ export default async function ExamplesPage(props: ExamplesPageProps) {
 
         </div>
 
-        {breadcrumbJsonLd ? (
-          <script
-            type="application/ld+json"
-            suppressHydrationWarning
-            dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }}
-          />
-        ) : null}
-        {itemListJson ? (
-          <script
-            type="application/ld+json"
-            suppressHydrationWarning
-            dangerouslySetInnerHTML={{ __html: serializeJsonLd(itemListJson) }}
-          />
-        ) : null}
-        {faqJsonLd ? (
-          <script
-            type="application/ld+json"
-            suppressHydrationWarning
-            dangerouslySetInnerHTML={{ __html: serializeJsonLd(faqJsonLd) }}
-          />
-        ) : null}
+        <ExamplesJsonLdScripts
+          breadcrumbJsonLd={breadcrumbJsonLd}
+          faqJsonLd={faqJsonLd}
+          itemListJson={itemListJson}
+        />
       </main>
     </>
   );

--- a/tests/examples-route-architecture.test.ts
+++ b/tests/examples-route-architecture.test.ts
@@ -8,19 +8,31 @@ const pagePath = join(root, 'frontend/app/(localized)/[locale]/(marketing)/examp
 const utilsPath = join(root, 'frontend/app/(localized)/[locale]/(marketing)/examples/_lib/examples-route-utils.ts');
 const copyPath = join(root, 'frontend/app/(localized)/[locale]/(marketing)/examples/_lib/examples-page-copy.ts');
 const mainVideoFeaturePath = join(root, 'frontend/app/(localized)/[locale]/(marketing)/examples/_components/examples-main-video-feature.tsx');
+const engineFilterNavPath = join(root, 'frontend/app/(localized)/[locale]/(marketing)/examples/_components/examples-engine-filter-nav.tsx');
+const jsonLdScriptsPath = join(root, 'frontend/app/(localized)/[locale]/(marketing)/examples/_components/examples-jsonld-scripts.tsx');
+const routeSectionsPath = join(root, 'frontend/app/(localized)/[locale]/(marketing)/examples/_components/examples-route-sections.tsx');
 
 const pageSource = readFileSync(pagePath, 'utf8');
 const utilsSource = readFileSync(utilsPath, 'utf8');
 const copySource = readFileSync(copyPath, 'utf8');
 const mainVideoFeatureSource = readFileSync(mainVideoFeaturePath, 'utf8');
+const engineFilterNavSource = readFileSync(engineFilterNavPath, 'utf8');
+const jsonLdScriptsSource = readFileSync(jsonLdScriptsPath, 'utf8');
+const routeSectionsSource = readFileSync(routeSectionsPath, 'utf8');
 
 test('examples route delegates URL, filter, and gallery helper logic', () => {
   assert.ok(existsSync(pagePath), 'examples route page should exist');
   assert.ok(existsSync(utilsPath), 'examples route helper module should exist');
   assert.ok(existsSync(copyPath), 'examples route copy helper module should exist');
   assert.ok(existsSync(mainVideoFeaturePath), 'examples main video feature should exist');
+  assert.ok(existsSync(engineFilterNavPath), 'examples engine filter nav should exist');
+  assert.ok(existsSync(jsonLdScriptsPath), 'examples JSON-LD scripts should exist');
+  assert.ok(existsSync(routeSectionsPath), 'examples route sections should exist');
 
   assert.match(pageSource, /from '\.\/_components\/examples-main-video-feature'/, 'route should import main video feature');
+  assert.match(pageSource, /from '\.\/_components\/examples-engine-filter-nav'/, 'route should import engine filter nav');
+  assert.match(pageSource, /from '\.\/_components\/examples-jsonld-scripts'/, 'route should import JSON-LD scripts');
+  assert.match(pageSource, /from '\.\/_components\/examples-route-sections'/, 'route should import route sections');
   assert.match(pageSource, /from '\.\/_lib\/examples-route-utils'/, 'route should import examples helpers');
   assert.match(pageSource, /from '\.\/_lib\/examples-page-copy'/, 'route should import examples copy helpers');
   assert.match(pageSource, /export async function generateMetadata/, 'route should keep metadata orchestration');
@@ -37,9 +49,13 @@ test('examples route delegates URL, filter, and gallery helper logic', () => {
   assert.doesNotMatch(pageSource, /ExamplesHeroVideo/, 'main video hero rendering belongs in ExamplesMainVideoFeature');
   assert.doesNotMatch(pageSource, /DeferredSourcePrompt/, 'main video prompt disclosure belongs in ExamplesMainVideoFeature');
   assert.doesNotMatch(pageSource, /mainVideoCopy\.openExample/, 'main video CTAs belong in ExamplesMainVideoFeature');
+  assert.doesNotMatch(pageSource, /sticky top-16 z-\[35\]/, 'engine filter nav markup belongs in ExamplesEngineFilterNav');
+  assert.doesNotMatch(pageSource, /dangerouslySetInnerHTML/, 'JSON-LD script rendering belongs in ExamplesJsonLdScripts');
+  assert.doesNotMatch(pageSource, /halo-hero stack-gap-sm/, 'intro hero markup belongs in ExamplesIntroHero');
+  assert.doesNotMatch(pageSource, /Aller plus loin/, 'next-step section markup belongs in ExamplesNextStepsSection');
 
   const lineCount = pageSource.split('\n').length;
-  assert.ok(lineCount <= 900, `examples page should stay below 900 lines after main video extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 790, `examples page should stay below 790 lines after route section extraction, got ${lineCount}`);
 });
 
 test('examples helper module exposes the route contract', () => {
@@ -113,4 +129,16 @@ test('examples main video feature owns the hero media card', () => {
   assert.match(mainVideoFeatureSource, /ExamplesHeroVideo/, 'main video feature should own hero video rendering');
   assert.match(mainVideoFeatureSource, /AudioEqualizerBadge/, 'main video feature should own audio badge rendering');
   assert.match(mainVideoFeatureSource, /DeferredSourcePrompt/, 'main video feature should own prompt disclosure');
+});
+
+test('examples route components own nav and JSON-LD rendering', () => {
+  assert.match(engineFilterNavSource, /export function ExamplesEngineFilterNav/, 'engine filter nav should be exported');
+  assert.match(engineFilterNavSource, /sticky top-16 z-\[35\]/, 'engine filter nav should own sticky filter markup');
+  assert.match(engineFilterNavSource, /getEngineAccentOutlineStyle/, 'engine filter nav should own active brand outline styling');
+  assert.match(jsonLdScriptsSource, /export function ExamplesJsonLdScripts/, 'JSON-LD scripts component should be exported');
+  assert.match(jsonLdScriptsSource, /dangerouslySetInnerHTML/, 'JSON-LD scripts component should own JSON-LD script rendering');
+  assert.match(jsonLdScriptsSource, /serializeJsonLd/, 'JSON-LD scripts component should serialize via route helper');
+  assert.match(routeSectionsSource, /export function ExamplesIntroHero/, 'intro hero section should be exported');
+  assert.match(routeSectionsSource, /export function ExamplesNextStepsSection/, 'next steps section should be exported');
+  assert.match(routeSectionsSource, /Aller plus loin/, 'next steps section should own localized heading fallback');
 });


### PR DESCRIPTION
## Summary
- move examples engine filter navigation into a focused route component
- move JSON-LD script rendering into a focused component
- move intro hero and next-step section markup out of the page orchestrator
- tighten the examples architecture contract around the extracted route sections

## Checks
- ./node_modules/.bin/tsx --tsconfig frontend/tsconfig.json --test tests/examples-route-architecture.test.ts tests/fr-seo-localization.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- frontend/app/(localized)/[locale]/(marketing)/examples/page.tsx frontend/app/(localized)/[locale]/(marketing)/examples/_components/examples-engine-filter-nav.tsx frontend/app/(localized)/[locale]/(marketing)/examples/_components/examples-jsonld-scripts.tsx frontend/app/(localized)/[locale]/(marketing)/examples/_components/examples-route-sections.tsx tests/examples-route-architecture.test.ts