### PR TITLE
Split pricing page hero

### DIFF
--- a/frontend/app/(localized)/[locale]/(marketing)/pricing/_components/PricingHeroSection.tsx
+++ b/frontend/app/(localized)/[locale]/(marketing)/pricing/_components/PricingHeroSection.tsx
@@ -1,0 +1,92 @@
+import { Link } from '@/i18n/navigation';
+import { MarketingHeroImage } from '@/components/marketing/MarketingHeroImage';
+
+type PricingHeroLink = {
+  after?: string;
+  before?: string;
+  label?: string;
+};
+
+type PricingHeroSectionProps = {
+  compareBlogHref: string;
+  heroAccentLine: string | null;
+  heroBodyLines: string[];
+  heroEyebrow: string;
+  heroHeadline: string;
+  heroLink: PricingHeroLink | null;
+};
+
+function isNoSubscriptionCopy(line: string) {
+  const normalized = line.toLowerCase();
+  return (
+    normalized.includes('no subscription') ||
+    normalized.includes('lock-in') ||
+    normalized.includes('abonnement') ||
+    normalized.includes('engagement') ||
+    normalized.includes('suscripción') ||
+    normalized.includes('permanencia')
+  );
+}
+
+export function PricingHeroSection({
+  compareBlogHref,
+  heroAccentLine,
+  heroBodyLines,
+  heroEyebrow,
+  heroHeadline,
+  heroLink,
+}: PricingHeroSectionProps) {
+  return (
+    <header className="relative min-h-[520px] overflow-hidden border-b border-hairline bg-bg">
+      <MarketingHeroImage
+        src="/assets/pricing/pricing-hero-reference.webp"
+        darkSrc="/assets/pricing/pricing-hero-reference-dark.webp"
+        className="opacity-55 dark:opacity-70"
+      />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_38%,rgba(255,255,255,0.93)_0%,rgba(255,255,255,0.76)_34%,rgba(247,249,253,0.36)_68%,rgba(247,249,253,0.08)_100%)] dark:bg-[radial-gradient(circle_at_50%_38%,rgba(3,7,18,0.24)_0%,rgba(3,7,18,0.16)_42%,rgba(3,7,18,0.05)_76%,rgba(3,7,18,0.00)_100%)]" />
+      <div className="absolute inset-x-0 bottom-0 h-28 bg-gradient-to-t from-bg to-transparent" />
+      <div className="container-page relative flex min-h-[520px] max-w-[1220px] items-center justify-center pb-24 pt-14 text-center">
+        <div className="mx-auto flex max-w-[760px] flex-col items-center gap-4">
+          <span className="inline-flex items-center rounded-pill border border-hairline bg-white/72 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.24em] text-[#356BE8] shadow-sm backdrop-blur dark:bg-white/10">
+            {heroEyebrow}
+          </span>
+          <h1 className="text-4xl font-semibold leading-[1.04] tracking-tight text-text-primary sm:text-6xl">
+            {heroHeadline}
+            {heroAccentLine ? (
+              <>
+                <br />
+                <span className="text-text-secondary">{heroAccentLine}</span>
+              </>
+            ) : null}
+          </h1>
+          <div className="flex flex-col items-center gap-3 text-base leading-7 text-text-secondary">
+            {heroBodyLines.map((line) =>
+              isNoSubscriptionCopy(line) ? (
+                <p
+                  key={line}
+                  className="rounded-[14px] border border-hairline bg-white/76 px-5 py-3 text-lg font-semibold tracking-tight text-text-primary shadow-card backdrop-blur sm:text-xl dark:bg-white/10"
+                >
+                  {line}
+                </p>
+              ) : (
+                <p key={line}>{line}</p>
+              )
+            )}
+          </div>
+          {heroLink ? (
+            <p className="text-sm leading-6 text-text-secondary">
+              {heroLink.before}
+              <Link
+                href={compareBlogHref}
+                className="font-semibold text-text-primary underline decoration-text-muted/30 underline-offset-4 hover:decoration-text-primary"
+              >
+                {heroLink.label ?? 'AI video comparison'}
+              </Link>
+              {heroLink.after}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/frontend/app/(localized)/[locale]/(marketing)/pricing/_components/PricingJsonLdScripts.tsx
+++ b/frontend/app/(localized)/[locale]/(marketing)/pricing/_components/PricingJsonLdScripts.tsx
@@ -1,0 +1,25 @@
+type PricingJsonLdScriptsProps = {
+  breadcrumbJsonLd: object;
+  serviceSchema: object;
+};
+
+const serializeJsonLd = (data: object) => JSON.stringify(data).replace(/</g, '\\u003c');
+
+export function PricingJsonLdScripts({ breadcrumbJsonLd, serviceSchema }: PricingJsonLdScriptsProps) {
+  return (
+    <>
+      <script
+        id="pricing-breadcrumb-jsonld"
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }}
+      />
+      <script
+        id="pricing-service-jsonld"
+        type="application/ld+json"
+        suppressHydrationWarning
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(serviceSchema) }}
+      />
+    </>
+  );
+}

--- a/frontend/app/(localized)/[locale]/(marketing)/pricing/page.tsx
+++ b/frontend/app/(localized)/[locale]/(marketing)/pricing/page.tsx
@@ -37,7 +37,8 @@ import { applyEnginePricingOverride } from '@/lib/pricing-definition';
 import { TextLink } from '@/components/ui/TextLink';
 import { localizePathFromEnglish } from '@/lib/i18n/paths';
 import { LazyPriceEstimator } from '@/components/marketing/LazyPriceEstimator';
-import { MarketingHeroImage } from '@/components/marketing/MarketingHeroImage';
+import { PricingHeroSection } from './_components/PricingHeroSection';
+import { PricingJsonLdScripts } from './_components/PricingJsonLdScripts';
 
 const PRICING_SLUG_MAP = buildSlugMap('pricing');
 
@@ -231,8 +232,6 @@ const DEFAULT_PRICE_FACTORS: Record<AppLocale, { title: string; points: string[]
     ],
   },
 };
-
-const serializeJsonLd = (data: object) => JSON.stringify(data).replace(/</g, '\\u003c');
 
 const EXAMPLE_CARD_VISUALS: Array<{ Icon: LucideIcon; accentClass: string; chartClass: string }> = [
   { Icon: Film, accentClass: 'bg-surface-3 text-text-secondary', chartClass: 'text-text-muted' },
@@ -537,71 +536,16 @@ export default async function PricingPage(props: { params: Promise<{ locale: App
         ? 'Abre el workspace para ver el precio exacto antes de crear el video.'
         : 'Open the workspace to see the exact price before you create a video.');
   const refundFeatureIcons: LucideIcon[] = [ShieldCheck, WalletCards, CheckCircle2];
-  const isNoSubscriptionCopy = (line: string) => {
-    const normalized = line.toLowerCase();
-    return (
-      normalized.includes('no subscription') ||
-      normalized.includes('lock-in') ||
-      normalized.includes('abonnement') ||
-      normalized.includes('engagement') ||
-      normalized.includes('suscripción') ||
-      normalized.includes('permanencia')
-    );
-  };
-
   return (
     <main className="bg-bg">
-      <header className="relative min-h-[520px] overflow-hidden border-b border-hairline bg-bg">
-        <MarketingHeroImage
-          src="/assets/pricing/pricing-hero-reference.webp"
-          darkSrc="/assets/pricing/pricing-hero-reference-dark.webp"
-          className="opacity-55 dark:opacity-70"
-        />
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_38%,rgba(255,255,255,0.93)_0%,rgba(255,255,255,0.76)_34%,rgba(247,249,253,0.36)_68%,rgba(247,249,253,0.08)_100%)] dark:bg-[radial-gradient(circle_at_50%_38%,rgba(3,7,18,0.24)_0%,rgba(3,7,18,0.16)_42%,rgba(3,7,18,0.05)_76%,rgba(3,7,18,0.00)_100%)]" />
-        <div className="absolute inset-x-0 bottom-0 h-28 bg-gradient-to-t from-bg to-transparent" />
-        <div className="container-page relative flex min-h-[520px] max-w-[1220px] items-center justify-center pb-24 pt-14 text-center">
-          <div className="mx-auto flex max-w-[760px] flex-col items-center gap-4">
-            <span className="inline-flex items-center rounded-pill border border-hairline bg-white/72 px-4 py-1.5 text-[11px] font-semibold uppercase tracking-[0.24em] text-[#356BE8] shadow-sm backdrop-blur dark:bg-white/10">
-              {heroEyebrow}
-            </span>
-            <h1 className="text-4xl font-semibold leading-[1.04] tracking-tight text-text-primary sm:text-6xl">
-              {heroHeadline}
-              {heroAccentLine ? (
-                <>
-                  <br />
-                  <span className="text-text-secondary">{heroAccentLine}</span>
-                </>
-              ) : null}
-            </h1>
-            <div className="flex flex-col items-center gap-3 text-base leading-7 text-text-secondary">
-              {heroBodyLines.map((line) =>
-                isNoSubscriptionCopy(line) ? (
-                  <p
-                    key={line}
-                    className="rounded-[14px] border border-hairline bg-white/76 px-5 py-3 text-lg font-semibold tracking-tight text-text-primary shadow-card backdrop-blur sm:text-xl dark:bg-white/10"
-                  >
-                    {line}
-                  </p>
-                ) : (
-                  <p key={line}>{line}</p>
-                )
-              )}
-            </div>
-            {heroLink ? (
-              <p className="text-sm leading-6 text-text-secondary">
-                {heroLink.before}
-                <Link
-                  href={compareBlogHref}
-                  className="font-semibold text-text-primary underline decoration-text-muted/30 underline-offset-4 hover:decoration-text-primary"
-                >
-                  {heroLink.label ?? 'AI video comparison'}
-                </Link>
-                {heroLink.after}
-              </p>
-            ) : null}
-          </div>
-        </div>
-      </header>
+      <PricingHeroSection
+        compareBlogHref={compareBlogHref}
+        heroAccentLine={heroAccentLine}
+        heroBodyLines={heroBodyLines}
+        heroEyebrow={heroEyebrow}
+        heroHeadline={heroHeadline}
+        heroLink={heroLink}
+      />
 
       <div className="container-page relative z-10 -mt-14 max-w-[1220px] pb-14">
         <div className="stack-gap-lg">
@@ -822,18 +766,7 @@ export default async function PricingPage(props: { params: Promise<{ locale: App
         </div>
       </div>
 
-      <script
-        id="pricing-breadcrumb-jsonld"
-        type="application/ld+json"
-        suppressHydrationWarning
-        dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }}
-      />
-      <script
-        id="pricing-service-jsonld"
-        type="application/ld+json"
-        suppressHydrationWarning
-        dangerouslySetInnerHTML={{ __html: serializeJsonLd(serviceSchema) }}
-      />
+      <PricingJsonLdScripts breadcrumbJsonLd={breadcrumbJsonLd} serviceSchema={serviceSchema} />
       <FAQSchema questions={faqJsonLdEntries} />
     </main>
   );

--- a/tests/dark-mode-theme.test.ts
+++ b/tests/dark-mode-theme.test.ts
@@ -12,7 +12,10 @@ const heroShowcaseSource = readFileSync('frontend/components/marketing/home/Hero
 const navSource = readFileSync('frontend/components/marketing/MarketingNav.tsx', 'utf8');
 const buttonSource = readFileSync('frontend/components/ui/Button.tsx', 'utf8');
 const toolsHubSource = readFileSync('frontend/src/components/tools/ToolsMarketingHubPage.tsx', 'utf8');
-const pricingPageSource = readFileSync('frontend/app/(localized)/[locale]/(marketing)/pricing/page.tsx', 'utf8');
+const pricingPageSource = [
+  readFileSync('frontend/app/(localized)/[locale]/(marketing)/pricing/page.tsx', 'utf8'),
+  readFileSync('frontend/app/(localized)/[locale]/(marketing)/pricing/_components/PricingHeroSection.tsx', 'utf8'),
+].join('\n');
 const blogPageSource = readFileSync('frontend/app/(localized)/[locale]/(marketing)/blog/page.tsx', 'utf8');
 const comparePageSource = readFileSync('frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/page.tsx', 'utf8');
 

--- a/tests/pricing-page-architecture.test.ts
+++ b/tests/pricing-page-architecture.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const root = process.cwd();
+const pagePath = join(root, 'frontend/app/(localized)/[locale]/(marketing)/pricing/page.tsx');
+const heroPath = join(root, 'frontend/app/(localized)/[locale]/(marketing)/pricing/_components/PricingHeroSection.tsx');
+const jsonLdPath = join(root, 'frontend/app/(localized)/[locale]/(marketing)/pricing/_components/PricingJsonLdScripts.tsx');
+
+const pageSource = readFileSync(pagePath, 'utf8');
+const heroSource = readFileSync(heroPath, 'utf8');
+const jsonLdSource = readFileSync(jsonLdPath, 'utf8');
+
+test('pricing page delegates hero and JSON-LD rendering', () => {
+  assert.ok(existsSync(heroPath), 'pricing hero should live in a route-local component');
+  assert.ok(existsSync(jsonLdPath), 'pricing JSON-LD scripts should live in a route-local component');
+  assert.match(pageSource, /from '\.\/_components\/PricingHeroSection'/);
+  assert.match(pageSource, /from '\.\/_components\/PricingJsonLdScripts'/);
+  assert.match(pageSource, /export default async function PricingPage/);
+});
+
+test('pricing page does not regain extracted rendering ownership', () => {
+  assert.doesNotMatch(pageSource, /MarketingHeroImage/, 'hero image rendering belongs in PricingHeroSection');
+  assert.doesNotMatch(pageSource, /pricing-breadcrumb-jsonld/, 'schema script tags belong in PricingJsonLdScripts');
+  assert.doesNotMatch(pageSource, /function isNoSubscriptionCopy/, 'hero copy treatment belongs in PricingHeroSection');
+
+  const lineCount = pageSource.split('\n').length;
+  assert.ok(lineCount <= 790, `pricing page should stay below 790 lines after hero extraction, got ${lineCount}`);
+});
+
+test('pricing route components expose the expected contract', () => {
+  assert.match(heroSource, /export function PricingHeroSection/);
+  assert.match(heroSource, /MarketingHeroImage/);
+  assert.match(heroSource, /pricing-hero-reference-dark\.webp/);
+  assert.match(jsonLdSource, /export function PricingJsonLdScripts/);
+  assert.match(jsonLdSource, /pricing-breadcrumb-jsonld/);
+  assert.match(jsonLdSource, /serializeJsonLd/);
+});


### PR DESCRIPTION
## Summary
- move the pricing hero into a route-local component
- move pricing JSON-LD script rendering into a focused component
- add a pricing page architecture contract and update dark-mode coverage to follow the extracted hero

## Checks
- ./node_modules/.bin/tsx --tsconfig frontend/tsconfig.json --test tests/pricing-page-architecture.test.ts tests/dark-mode-theme.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false (frontend)
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- frontend/app/(localized)/[locale]/(marketing)/pricing/page.tsx frontend/app/(localized)/[locale]/(marketing)/pricing/_components/PricingHeroSection.tsx frontend/app/(localized)/[locale]/(marketing)/pricing/_components/PricingJsonLdScripts.tsx tests/pricing-page-architecture.test.ts tests/dark-mode-theme.test.ts