### PR TITLE
Split angle output persistence

### DIFF
--- a/frontend/src/server/tools/angle-output-persistence.ts
+++ b/frontend/src/server/tools/angle-output-persistence.ts
@@ -1,0 +1,117 @@
+import { isStorageConfigured, recordUserAsset, uploadImageToStorage } from '@/server/storage';
+import type { AngleToolEngineId, AngleToolOutput } from '@/types/tools-angle';
+
+async function persistAngleOutput(params: {
+  output: AngleToolOutput;
+  outputIndex: number;
+  userId: string;
+  jobId: string;
+  providerJobId?: string | null;
+  engineId: AngleToolEngineId;
+  engineLabel: string;
+}): Promise<AngleToolOutput> {
+  const { output, outputIndex, userId, jobId, providerJobId, engineId, engineLabel } = params;
+  if (!isStorageConfigured() || !output.url) {
+    return output;
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 12_000);
+    let response: Response;
+    try {
+      response = await fetch(output.url, { signal: controller.signal });
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (!response.ok) {
+      throw new Error(`fetch failed (${response.status})`);
+    }
+
+    const mimeHeader = response.headers.get('content-type') ?? '';
+    const mime =
+      typeof output.mimeType === 'string' && output.mimeType.startsWith('image/')
+        ? output.mimeType
+        : mimeHeader.startsWith('image/')
+          ? mimeHeader
+          : 'image/png';
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (!buffer.length) {
+      throw new Error('empty image');
+    }
+
+    const upload = await uploadImageToStorage({
+      data: buffer,
+      mime,
+      userId,
+      prefix: 'angle',
+      fileName: `angle-${engineId}-${outputIndex + 1}.${mime.split('/')[1] || 'png'}`,
+    });
+
+    const assetId = await recordUserAsset({
+      userId,
+      url: upload.url,
+      mime: upload.mime,
+      width: upload.width ?? output.width ?? null,
+      height: upload.height ?? output.height ?? null,
+      size: upload.size,
+      source: 'angle',
+      metadata: {
+        originUrl: output.url,
+        jobId,
+        providerJobId: providerJobId ?? null,
+        tool: 'angle',
+        label: 'angle',
+        engineId,
+        engineLabel,
+        outputIndex,
+      },
+    });
+
+    return {
+      ...output,
+      url: upload.url,
+      width: upload.width ?? output.width ?? null,
+      height: upload.height ?? output.height ?? null,
+      mimeType: upload.mime,
+      originUrl: output.url,
+      assetId,
+      source: 'angle',
+      persisted: true,
+    };
+  } catch (error) {
+    console.warn('[tools/angle] failed to persist output', {
+      engineId,
+      jobId,
+      outputIndex,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return output;
+  }
+}
+
+export async function persistAngleOutputs(params: {
+  outputs: AngleToolOutput[];
+  userId: string;
+  jobId: string;
+  providerJobId?: string | null;
+  engineId: AngleToolEngineId;
+  engineLabel: string;
+}): Promise<AngleToolOutput[]> {
+  const { outputs, userId, jobId, providerJobId, engineId, engineLabel } = params;
+  return Promise.all(
+    outputs.map((output, index) =>
+      persistAngleOutput({
+        output,
+        outputIndex: index,
+        userId,
+        jobId,
+        providerJobId,
+        engineId,
+        engineLabel,
+      })
+    )
+  );
+}

--- a/frontend/src/server/tools/angle.ts
+++ b/frontend/src/server/tools/angle.ts
@@ -10,7 +10,6 @@ import { getPlatformFeeCents } from '@/lib/pricing';
 import { getUserPreferredCurrency, type Currency } from '@/lib/currency';
 import { reserveWalletChargeInExecutor } from '@/lib/wallet';
 import { receiptsPriceOnlyEnabled } from '@/lib/env';
-import { isStorageConfigured, recordUserAsset, uploadImageToStorage } from '@/server/storage';
 import { createImageThumbnailBatch } from '@/server/image-thumbnails';
 import { buildStoredImageRenderEntries, resolveHeroThumbFromRenders } from '@/lib/image-renders';
 import { ensureReusableAsset, upsertLegacyJobOutputs } from '@/server/media-library';
@@ -39,6 +38,7 @@ import {
   parseAngleRequestId,
   toAngleValidationMessage,
 } from './angle-request-utils';
+import { persistAngleOutputs } from './angle-output-persistence';
 
 const TOOL_EVENT_NAME = 'tool_angle_generate';
 const PLACEHOLDER_THUMB = '/assets/frames/thumb-1x1.svg';
@@ -303,121 +303,6 @@ async function insertToolEvent(params: {
   } catch (error) {
     console.warn('[tools/angle] failed to persist event log', error);
   }
-}
-
-async function persistAngleOutput(params: {
-  output: AngleToolOutput;
-  outputIndex: number;
-  userId: string;
-  jobId: string;
-  providerJobId?: string | null;
-  engineId: AngleToolEngineId;
-  engineLabel: string;
-}): Promise<AngleToolOutput> {
-  const { output, outputIndex, userId, jobId, providerJobId, engineId, engineLabel } = params;
-  if (!isStorageConfigured() || !output.url) {
-    return output;
-  }
-
-  try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 12_000);
-    let response: Response;
-    try {
-      response = await fetch(output.url, { signal: controller.signal });
-    } finally {
-      clearTimeout(timeout);
-    }
-
-    if (!response.ok) {
-      throw new Error(`fetch failed (${response.status})`);
-    }
-
-    const mimeHeader = response.headers.get('content-type') ?? '';
-    const mime =
-      typeof output.mimeType === 'string' && output.mimeType.startsWith('image/')
-        ? output.mimeType
-        : mimeHeader.startsWith('image/')
-          ? mimeHeader
-          : 'image/png';
-
-    const buffer = Buffer.from(await response.arrayBuffer());
-    if (!buffer.length) {
-      throw new Error('empty image');
-    }
-
-    const upload = await uploadImageToStorage({
-      data: buffer,
-      mime,
-      userId,
-      prefix: 'angle',
-      fileName: `angle-${engineId}-${outputIndex + 1}.${mime.split('/')[1] || 'png'}`,
-    });
-
-    const assetId = await recordUserAsset({
-      userId,
-      url: upload.url,
-      mime: upload.mime,
-      width: upload.width ?? output.width ?? null,
-      height: upload.height ?? output.height ?? null,
-      size: upload.size,
-      source: 'angle',
-      metadata: {
-        originUrl: output.url,
-        jobId,
-        providerJobId: providerJobId ?? null,
-        tool: 'angle',
-        label: 'angle',
-        engineId,
-        engineLabel,
-        outputIndex,
-      },
-    });
-
-    return {
-      ...output,
-      url: upload.url,
-      width: upload.width ?? output.width ?? null,
-      height: upload.height ?? output.height ?? null,
-      mimeType: upload.mime,
-      originUrl: output.url,
-      assetId,
-      source: 'angle',
-      persisted: true,
-    };
-  } catch (error) {
-    console.warn('[tools/angle] failed to persist output', {
-      engineId,
-      jobId,
-      outputIndex,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return output;
-  }
-}
-
-async function persistAngleOutputs(params: {
-  outputs: AngleToolOutput[];
-  userId: string;
-  jobId: string;
-  providerJobId?: string | null;
-  engineId: AngleToolEngineId;
-  engineLabel: string;
-}): Promise<AngleToolOutput[]> {
-  const { outputs, userId, jobId, providerJobId, engineId, engineLabel } = params;
-  return Promise.all(
-    outputs.map((output, index) =>
-      persistAngleOutput({
-        output,
-        outputIndex: index,
-        userId,
-        jobId,
-        providerJobId,
-        engineId,
-        engineLabel,
-      })
-    )
-  );
 }
 
 export async function runAngleTool(input: RunAngleToolInput): Promise<AngleToolResponse> {

--- a/tests/angle-server-architecture.test.ts
+++ b/tests/angle-server-architecture.test.ts
@@ -6,9 +6,11 @@ import test from 'node:test';
 const root = process.cwd();
 const serverPath = join(root, 'frontend/src/server/tools/angle.ts');
 const requestUtilsPath = join(root, 'frontend/src/server/tools/angle-request-utils.ts');
+const outputPersistencePath = join(root, 'frontend/src/server/tools/angle-output-persistence.ts');
 
 const serverSource = readFileSync(serverPath, 'utf8');
 const requestUtilsSource = readFileSync(requestUtilsPath, 'utf8');
+const outputPersistenceSource = readFileSync(outputPersistencePath, 'utf8');
 
 test('angle server delegates request and provider normalization helpers', () => {
   assert.ok(existsSync(requestUtilsPath), 'angle request helpers should live in a server-local utility module');
@@ -40,7 +42,36 @@ test('angle server delegates request and provider normalization helpers', () => 
   assert.doesNotMatch(serverSource, /normalizeMediaUrl/, 'Fal output URL normalization belongs in angle-request-utils.ts');
 
   const lineCount = serverSource.split('\n').length;
-  assert.ok(lineCount <= 820, `angle server orchestrator should stay below 820 lines after helper extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 700, `angle server orchestrator should stay below 700 lines after helper extraction, got ${lineCount}`);
+});
+
+test('angle server delegates output persistence to a focused helper', () => {
+  assert.ok(existsSync(outputPersistencePath), 'angle output persistence should live in a server-local helper module');
+  assert.match(
+    serverSource,
+    /from '\.\/angle-output-persistence'/,
+    'angle server orchestration should import output persistence helpers'
+  );
+  assert.doesNotMatch(
+    serverSource,
+    /async function persistAngleOutput/,
+    'single-output persistence should not live in the route-level orchestrator'
+  );
+  assert.match(
+    outputPersistenceSource,
+    /export async function persistAngleOutputs/,
+    'angle output persistence helper should export the batch persistence contract'
+  );
+  assert.match(
+    outputPersistenceSource,
+    /recordUserAsset/,
+    'angle output persistence helper should own media-library asset recording'
+  );
+  assert.match(
+    outputPersistenceSource,
+    /uploadImageToStorage/,
+    'angle output persistence helper should own storage upload details'
+  );
 });
 
 test('angle request utils expose the expected pure helper contract', () => {


### PR DESCRIPTION
## Summary
- move Angle output storage and media-library persistence into a focused server helper
- keep the Angle server module focused on orchestration
- tighten the Angle architecture contract around persistence ownership

## Checks
- ./node_modules/.bin/tsx --tsconfig frontend/tsconfig.json --test tests/angle-server-architecture.test.ts tests/angle-atomic.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- frontend/src/server/tools/angle.ts frontend/src/server/tools/angle-output-persistence.ts tests/angle-server-architecture.test.ts