### PR TITLE
Split image workspace composer surface

### DIFF
--- a/frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx
+++ b/frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx
@@ -9,25 +9,22 @@ import { usePathname, useSearchParams } from 'next/navigation';
 import { Plus } from 'lucide-react';
 import { GalleryRail } from '@/components/GalleryRail';
 import { Button } from '@/components/ui/Button';
-import { EngineSelect } from '@/components/ui/EngineSelect';
-import { Composer, type AssetFieldConfig, type ComposerAttachment } from '@/components/Composer';
-import { ImageSettingsBar } from '@/components/ImageSettingsBar';
-import { ImageAdvancedSettings } from '@/components/ImageAdvancedSettings';
+import type { AssetFieldConfig, ComposerAttachment } from '@/components/Composer';
 import { saveImageToLibrary } from '@/lib/api';
 import type { ImageGenerationMode } from '@/types/image-generation';
 import type { VideoGroup } from '@/types/video-groups';
 import type { MediaLightboxEntry } from '@/components/MediaLightbox';
-import { ImageCompositePreviewDock, type ImageCompositePreviewEntry } from '@/components/groups/ImageCompositePreviewDock';
+import type { ImageCompositePreviewEntry } from '@/components/groups/ImageCompositePreviewDock';
 import { buildVideoGroupFromImageRun } from '@/lib/image-groups';
 import { useI18n } from '@/lib/i18n/I18nProvider';
 import { FEATURES } from '@/content/feature-flags';
 import { clampRequestedImageCount } from '@/lib/image/inputSchema';
 import {
-  GPT_IMAGE_2_SIZE_CONSTRAINTS,
   parseGptImage2SizeKey,
 } from '@/lib/image/gptImage2';
 import { ImageAuthGateModal } from './_components/ImageAuthGateModal';
 import { ImageLibraryModal } from './_components/ImageLibraryModal';
+import { ImageWorkspaceComposerSurface } from './_components/ImageWorkspaceComposerSurface';
 import { useImageGallerySelection } from './_hooks/useImageGallerySelection';
 import { useImageGenerationRunner } from './_hooks/useImageGenerationRunner';
 import { useImageWorkspaceHistory } from './_hooks/useImageWorkspaceHistory';
@@ -528,235 +525,90 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
       <div className={clsx('flex w-full flex-1 min-w-0', isDesktopLayout ? 'flex-row' : 'flex-col')}>
         <div className="flex w-full flex-1 min-w-0 flex-col overflow-hidden">
           <main className="flex w-full flex-1 min-w-0 flex-col gap-[var(--stack-gap-lg)] p-4 sm:p-6">
-            <div className="stack-gap-lg">
-              <ImageCompositePreviewDock
-                entry={compositePreviewEntry}
-                selectedIndex={selectedPreviewImageIndex}
-                onSelectIndex={setSelectedPreviewImageIndex}
-                onOpenModal={previewEntry ? () => handleOpenHistoryEntry(previewEntry) : undefined}
-                onDownload={handleDownload}
-                onCopyLink={handleCopy}
-                onAddToLibrary={handleAddToLibrary}
-                onRemoveFromLibrary={handleRemoveFromLibrary}
-                isInLibrary={isInLibrary}
-                isSavingToLibrary={isSavingToLibrary}
-                isRemovingFromLibrary={isRemovingFromLibrary}
-                copiedUrl={copiedUrl}
-                showTitle={false}
-                engineSettings={
-                  <div className="flex min-w-0 flex-1 flex-wrap items-center gap-4">
-                  <EngineSelect
-                    engines={engineCapsList}
-                    engineId={selectedEngine.id}
-                    onEngineChange={(nextId) => setEngineId(nextId)}
-                    mode={mode}
-                    onModeChange={(nextMode) => setMode(nextMode as ImageGenerationMode)}
-                    modeOptions={['t2i', 'i2i']}
-                    modeLabelOverrides={{
-                      t2i: resolvedCopy.modeTabs.generate,
-                      i2i: resolvedCopy.modeTabs.edit,
-                    }}
-                    showModeSelect={false}
-                    modeLayout="stacked"
-                    showBillingNote={false}
-                    variant="bar"
-                    className="min-w-0 flex-1"
-                  />
-                  </div>
-                }
-              />
-
-              <form onSubmit={handleRun} className="space-y-4">
-                {inProgressMessage ? (
-                  <p
-                    role="status"
-                    aria-live="polite"
-                    className="rounded-card border border-success-border bg-success-bg px-3 py-2 text-sm text-success"
-                  >
-                    {inProgressMessage}
-                  </p>
-                ) : statusMessage ? (
-                  <p
-                    role="status"
-                    aria-live="polite"
-                    className="rounded-card border border-success-border bg-success-bg px-3 py-2 text-sm text-success"
-                  >
-                    {statusMessage}
-                  </p>
-                ) : null}
-
-                <Composer
-                  engine={selectedEngineCaps}
-                  prompt={prompt}
-                  onPromptChange={setPrompt}
-                  price={estimatedCostAmount}
-                  currency={estimatedCostCurrency}
-                  isLoading={false}
-                  error={composerError ?? undefined}
-                  promptField={{
-                    id: 'prompt',
-                    type: 'text',
-                    label: resolvedCopy.composer.promptLabel,
-                  }}
-                  promptRequired
-                  promptPlaceholder={resolvedCopy.composer.promptPlaceholder}
-                  promptPlaceholderWithAsset={
-                    resolvedCopy.composer.promptPlaceholderWithImage ?? resolvedCopy.composer.promptPlaceholder
-                  }
-                  assetFields={referenceAssetFields}
-                  assets={composerReferenceAssets}
-                  onAssetAdd={(_, file, slotIndex = 0) => {
-                    void handleReferenceFile(slotIndex, file);
-                  }}
-                  onAssetRemove={(_, index) => handleRemoveReferenceSlot(index)}
-                  onAssetUrlSelect={(_, url, slotIndex) => handleReferenceUrl(slotIndex, url, 'paste')}
-                  onOpenLibrary={(_, index) => openLibraryForSlot(index)}
-                  onNotice={setError}
-                  settingsBar={
-                    <ImageSettingsBar
-                      numImages={
-                        showNumImagesControl
-                          ? {
-                              value: numImages,
-                              options: imageCountOptions,
-                              onChange: setNumImagesPreset,
-                            }
-                          : undefined
-                      }
-                      aspectRatio={
-                        showAspectRatioControl
-                          ? {
-                              value: aspectRatio ?? String(aspectRatioSelectOptions[0]?.value ?? ''),
-                              options: aspectRatioSelectOptions,
-                              onChange: setAspectRatio,
-                            }
-                          : undefined
-                      }
-                      resolution={
-                        showResolutionControl
-                          ? {
-                              value: resolution ?? String(resolutionSelectOptions[0]?.value ?? ''),
-                              options: resolutionSelectOptions,
-                              onChange: setResolutionPreset,
-                              disabled: isResolutionLocked,
-                            }
-                          : undefined
-                      }
-                      quality={
-                        showQualityControl
-                          ? {
-                              value: quality ?? String(qualitySelectOptions[0]?.value ?? ''),
-                              options: qualitySelectOptions,
-                              onChange: setQuality,
-                            }
-                          : undefined
-                      }
-                      outputFormat={
-                        showOutputFormatControl
-                          ? {
-                              value: outputFormat ?? String(outputFormatSelectOptions[0]?.value ?? ''),
-                              options: outputFormatSelectOptions,
-                              onChange: setOutputFormat,
-                            }
-                          : undefined
-                      }
-                    />
-                  }
-                  onGenerate={() => {
-                    void handleRun();
-                  }}
-                  generateLabel={resolvedCopy.runButton.idle}
-                  generateLoadingLabel={resolvedCopy.runButton.running}
-                  afterAssets={
-                    canCollapseReferenceSlots ? (
-                      <div className="flex justify-center">
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          onClick={() => setAreReferenceSlotsExpanded((previous) => !previous)}
-                          className="rounded-full border-border text-[11px] text-text-secondary hover:text-text-primary"
-                        >
-                          {referenceToggleLabel}
-                        </Button>
-                      </div>
-                    ) : null
-                  }
-                  extraFields={
-                    <div className="space-y-6">
-                      <ImageAdvancedSettings
-                        title={advancedSettingsTitle}
-                        seed={
-                          showSeedControl
-                            ? {
-                                label: resolvedCopy.composer.seedLabel,
-                                placeholder: resolvedCopy.composer.seedPlaceholder,
-                                value: seed,
-                                onChange: setSeed,
-                              }
-                            : undefined
-                        }
-                        thinkingLevel={
-                          showThinkingLevelControl
-                            ? {
-                                label: resolvedCopy.composer.thinkingLevelLabel,
-                                value: thinkingLevel ?? String(thinkingLevelSelectOptions[0]?.value ?? ''),
-                                options: thinkingLevelSelectOptions,
-                                onChange: setThinkingLevel,
-                            }
-                            : undefined
-                        }
-                        customImageSize={
-                          showCustomImageSizeControl
-                            ? {
-                                widthLabel: resolvedCopy.composer.customWidthLabel,
-                                heightLabel: resolvedCopy.composer.customHeightLabel,
-                                widthValue: customImageWidth,
-                                heightValue: customImageHeight,
-                                min: 16,
-                                max: GPT_IMAGE_2_SIZE_CONSTRAINTS.maxEdge,
-                                step: GPT_IMAGE_2_SIZE_CONSTRAINTS.multipleOf,
-                                onWidthChange: setCustomImageWidth,
-                                onHeightChange: setCustomImageHeight,
-                              }
-                            : undefined
-                        }
-                        maskUrl={
-                          maskUrlField
-                            ? {
-                                label: resolvedCopy.composer.maskUrlLabel,
-                                placeholder: resolvedCopy.composer.maskUrlPlaceholder,
-                                value: maskUrl,
-                                onChange: setMaskUrl,
-                              }
-                            : undefined
-                        }
-                        enableWebSearch={
-                          showEnableWebSearchControl
-                            ? {
-                                label: resolvedCopy.composer.enableWebSearchLabel,
-                                value: enableWebSearch,
-                                options: booleanSelectOptions,
-                                onChange: setEnableWebSearch,
-                              }
-                            : undefined
-                        }
-                        limitGenerations={
-                          showLimitGenerationsControl
-                            ? {
-                                label: resolvedCopy.composer.limitGenerationsLabel,
-                                value: limitGenerations,
-                                options: booleanSelectOptions,
-                                onChange: setLimitGenerations,
-                              }
-                            : undefined
-                        }
-                      />
-                    </div>
-                  }
-                />
-              </form>
-            </div>
+            <ImageWorkspaceComposerSurface
+              advancedSettingsTitle={advancedSettingsTitle}
+              aspectRatio={aspectRatio}
+              aspectRatioSelectOptions={aspectRatioSelectOptions}
+              booleanSelectOptions={booleanSelectOptions}
+              canCollapseReferenceSlots={canCollapseReferenceSlots}
+              composerError={composerError}
+              composerReferenceAssets={composerReferenceAssets}
+              compositePreviewEntry={compositePreviewEntry}
+              copiedUrl={copiedUrl}
+              currency={estimatedCostCurrency}
+              customImageHeight={customImageHeight}
+              customImageWidth={customImageWidth}
+              enableWebSearch={enableWebSearch}
+              engineCapsList={engineCapsList}
+              estimatedCostAmount={estimatedCostAmount}
+              handleAddToLibrary={handleAddToLibrary}
+              handleCopy={handleCopy}
+              handleDownload={handleDownload}
+              handleOpenHistoryEntry={handleOpenHistoryEntry}
+              handleReferenceFile={handleReferenceFile}
+              handleReferenceUrl={handleReferenceUrl}
+              handleRemoveFromLibrary={handleRemoveFromLibrary}
+              handleRemoveReferenceSlot={handleRemoveReferenceSlot}
+              handleRun={handleRun}
+              imageCountOptions={imageCountOptions}
+              inProgressMessage={inProgressMessage}
+              isInLibrary={isInLibrary}
+              isRemovingFromLibrary={isRemovingFromLibrary}
+              isResolutionLocked={isResolutionLocked}
+              isSavingToLibrary={isSavingToLibrary}
+              limitGenerations={limitGenerations}
+              maskUrl={maskUrl}
+              mode={mode}
+              numImages={numImages}
+              openLibraryForSlot={openLibraryForSlot}
+              outputFormat={outputFormat}
+              outputFormatSelectOptions={outputFormatSelectOptions}
+              previewEntry={previewEntry}
+              prompt={prompt}
+              quality={quality}
+              qualitySelectOptions={qualitySelectOptions}
+              referenceAssetFields={referenceAssetFields}
+              referenceToggleLabel={referenceToggleLabel}
+              resolution={resolution}
+              resolutionSelectOptions={resolutionSelectOptions}
+              resolvedCopy={resolvedCopy}
+              seed={seed}
+              selectedEngineCaps={selectedEngineCaps}
+              selectedEngineId={selectedEngine.id}
+              selectedPreviewImageIndex={selectedPreviewImageIndex}
+              setAreReferenceSlotsExpanded={setAreReferenceSlotsExpanded}
+              setAspectRatio={setAspectRatio}
+              setCustomImageHeight={setCustomImageHeight}
+              setCustomImageWidth={setCustomImageWidth}
+              setEnableWebSearch={setEnableWebSearch}
+              setEngineId={setEngineId}
+              setError={setError}
+              setLimitGenerations={setLimitGenerations}
+              setMaskUrl={setMaskUrl}
+              setMode={setMode}
+              setNumImagesPreset={setNumImagesPreset}
+              setOutputFormat={setOutputFormat}
+              setPrompt={setPrompt}
+              setQuality={setQuality}
+              setResolutionPreset={setResolutionPreset}
+              setSeed={setSeed}
+              setSelectedPreviewImageIndex={setSelectedPreviewImageIndex}
+              setThinkingLevel={setThinkingLevel}
+              showAspectRatioControl={showAspectRatioControl}
+              showCustomImageSizeControl={showCustomImageSizeControl}
+              showEnableWebSearchControl={showEnableWebSearchControl}
+              showLimitGenerationsControl={showLimitGenerationsControl}
+              showMaskUrlControl={Boolean(maskUrlField)}
+              showNumImagesControl={showNumImagesControl}
+              showOutputFormatControl={showOutputFormatControl}
+              showQualityControl={showQualityControl}
+              showResolutionControl={showResolutionControl}
+              showSeedControl={showSeedControl}
+              showThinkingLevelControl={showThinkingLevelControl}
+              statusMessage={statusMessage}
+              thinkingLevel={thinkingLevel}
+              thinkingLevelSelectOptions={thinkingLevelSelectOptions}
+            />
           </main>
         </div>
         {isDesktopLayout ? (

--- a/frontend/app/(core)/(workspace)/app/image/_components/ImageWorkspaceComposerSurface.tsx
+++ b/frontend/app/(core)/(workspace)/app/image/_components/ImageWorkspaceComposerSurface.tsx
@@ -1,0 +1,422 @@
+'use client';
+
+import type { Dispatch, FormEvent, SetStateAction } from 'react';
+import type { EngineCaps } from '@/types/engines';
+import type { ImageGenerationMode } from '@/types/image-generation';
+import { Composer, type AssetFieldConfig, type ComposerAttachment } from '@/components/Composer';
+import { ImageAdvancedSettings } from '@/components/ImageAdvancedSettings';
+import { ImageSettingsBar } from '@/components/ImageSettingsBar';
+import { EngineSelect } from '@/components/ui/EngineSelect';
+import { Button } from '@/components/ui/Button';
+import { ImageCompositePreviewDock, type ImageCompositePreviewEntry } from '@/components/groups/ImageCompositePreviewDock';
+import { GPT_IMAGE_2_SIZE_CONSTRAINTS } from '@/lib/image/gptImage2';
+import type { ImageWorkspaceCopy } from '../_lib/image-workspace-copy';
+import type { HistoryEntry } from '../_lib/image-workspace-types';
+
+type ControlOption = {
+  value: string | number | boolean;
+  label: string;
+  disabled?: boolean;
+};
+
+interface ImageWorkspaceComposerSurfaceProps {
+  advancedSettingsTitle: string;
+  aspectRatio: string | null;
+  aspectRatioSelectOptions: ControlOption[];
+  booleanSelectOptions: ControlOption[];
+  canCollapseReferenceSlots: boolean;
+  composerError: string | null;
+  composerReferenceAssets: Record<string, (ComposerAttachment | null)[]>;
+  compositePreviewEntry: ImageCompositePreviewEntry | null;
+  copiedUrl: string | null;
+  currency: string;
+  customImageHeight: string;
+  customImageWidth: string;
+  enableWebSearch: boolean;
+  engineCapsList: EngineCaps[];
+  estimatedCostAmount: number;
+  handleAddToLibrary: (url: string) => void;
+  handleCopy: (url: string) => void;
+  handleDownload: (url: string) => void;
+  handleOpenHistoryEntry: (entry: HistoryEntry) => void;
+  handleReferenceFile: (slotIndex: number, file: File) => Promise<void> | void;
+  handleReferenceUrl: (slotIndex: number, url: string, source: 'paste' | 'library') => void;
+  handleRemoveFromLibrary: () => void;
+  handleRemoveReferenceSlot: (index: number) => void;
+  handleRun: (event?: FormEvent<HTMLFormElement> | null) => Promise<void> | void;
+  imageCountOptions: ControlOption[];
+  inProgressMessage: string | null;
+  isInLibrary: boolean;
+  isRemovingFromLibrary: boolean;
+  isResolutionLocked: boolean;
+  isSavingToLibrary: boolean;
+  limitGenerations: boolean;
+  maskUrl: string;
+  mode: ImageGenerationMode;
+  numImages: number;
+  openLibraryForSlot: (slotIndex: number) => void;
+  outputFormat: string | null;
+  outputFormatSelectOptions: ControlOption[];
+  previewEntry: HistoryEntry | undefined;
+  prompt: string;
+  quality: string | null;
+  qualitySelectOptions: ControlOption[];
+  referenceAssetFields: AssetFieldConfig[];
+  referenceToggleLabel: string;
+  resolution: string | null;
+  resolutionSelectOptions: ControlOption[];
+  resolvedCopy: ImageWorkspaceCopy;
+  seed: string;
+  selectedEngineCaps: EngineCaps;
+  selectedEngineId: string;
+  selectedPreviewImageIndex: number;
+  setAreReferenceSlotsExpanded: Dispatch<SetStateAction<boolean>>;
+  setAspectRatio: (value: string | null) => void;
+  setCustomImageHeight: (value: string) => void;
+  setCustomImageWidth: (value: string) => void;
+  setEnableWebSearch: (value: boolean) => void;
+  setEngineId: (value: string) => void;
+  setError: (value: string | null) => void;
+  setLimitGenerations: (value: boolean) => void;
+  setMaskUrl: (value: string) => void;
+  setMode: (value: ImageGenerationMode) => void;
+  setNumImagesPreset: (value: number) => void;
+  setOutputFormat: (value: string | null) => void;
+  setPrompt: (value: string) => void;
+  setQuality: (value: string | null) => void;
+  setResolutionPreset: (value: string) => void;
+  setSeed: (value: string) => void;
+  setSelectedPreviewImageIndex: (value: number) => void;
+  setThinkingLevel: (value: string | null) => void;
+  showAspectRatioControl: boolean;
+  showCustomImageSizeControl: boolean;
+  showEnableWebSearchControl: boolean;
+  showLimitGenerationsControl: boolean;
+  showMaskUrlControl: boolean;
+  showNumImagesControl: boolean;
+  showOutputFormatControl: boolean;
+  showQualityControl: boolean;
+  showResolutionControl: boolean;
+  showSeedControl: boolean;
+  showThinkingLevelControl: boolean;
+  statusMessage: string | null;
+  thinkingLevel: string | null;
+  thinkingLevelSelectOptions: ControlOption[];
+}
+
+export function ImageWorkspaceComposerSurface({
+  advancedSettingsTitle,
+  aspectRatio,
+  aspectRatioSelectOptions,
+  booleanSelectOptions,
+  canCollapseReferenceSlots,
+  composerError,
+  composerReferenceAssets,
+  compositePreviewEntry,
+  copiedUrl,
+  currency,
+  customImageHeight,
+  customImageWidth,
+  enableWebSearch,
+  engineCapsList,
+  estimatedCostAmount,
+  handleAddToLibrary,
+  handleCopy,
+  handleDownload,
+  handleOpenHistoryEntry,
+  handleReferenceFile,
+  handleReferenceUrl,
+  handleRemoveFromLibrary,
+  handleRemoveReferenceSlot,
+  handleRun,
+  imageCountOptions,
+  inProgressMessage,
+  isInLibrary,
+  isRemovingFromLibrary,
+  isResolutionLocked,
+  isSavingToLibrary,
+  limitGenerations,
+  maskUrl,
+  mode,
+  numImages,
+  openLibraryForSlot,
+  outputFormat,
+  outputFormatSelectOptions,
+  previewEntry,
+  prompt,
+  quality,
+  qualitySelectOptions,
+  referenceAssetFields,
+  referenceToggleLabel,
+  resolution,
+  resolutionSelectOptions,
+  resolvedCopy,
+  seed,
+  selectedEngineCaps,
+  selectedEngineId,
+  selectedPreviewImageIndex,
+  setAreReferenceSlotsExpanded,
+  setAspectRatio,
+  setCustomImageHeight,
+  setCustomImageWidth,
+  setEnableWebSearch,
+  setEngineId,
+  setError,
+  setLimitGenerations,
+  setMaskUrl,
+  setMode,
+  setNumImagesPreset,
+  setOutputFormat,
+  setPrompt,
+  setQuality,
+  setResolutionPreset,
+  setSeed,
+  setSelectedPreviewImageIndex,
+  setThinkingLevel,
+  showAspectRatioControl,
+  showCustomImageSizeControl,
+  showEnableWebSearchControl,
+  showLimitGenerationsControl,
+  showMaskUrlControl,
+  showNumImagesControl,
+  showOutputFormatControl,
+  showQualityControl,
+  showResolutionControl,
+  showSeedControl,
+  showThinkingLevelControl,
+  statusMessage,
+  thinkingLevel,
+  thinkingLevelSelectOptions,
+}: ImageWorkspaceComposerSurfaceProps) {
+  return (
+    <div className="stack-gap-lg">
+      <ImageCompositePreviewDock
+        entry={compositePreviewEntry}
+        selectedIndex={selectedPreviewImageIndex}
+        onSelectIndex={setSelectedPreviewImageIndex}
+        onOpenModal={previewEntry ? () => handleOpenHistoryEntry(previewEntry) : undefined}
+        onDownload={handleDownload}
+        onCopyLink={handleCopy}
+        onAddToLibrary={handleAddToLibrary}
+        onRemoveFromLibrary={handleRemoveFromLibrary}
+        isInLibrary={isInLibrary}
+        isSavingToLibrary={isSavingToLibrary}
+        isRemovingFromLibrary={isRemovingFromLibrary}
+        copiedUrl={copiedUrl}
+        showTitle={false}
+        engineSettings={
+          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-4">
+            <EngineSelect
+              engines={engineCapsList}
+              engineId={selectedEngineId}
+              onEngineChange={setEngineId}
+              mode={mode}
+              onModeChange={(nextMode) => setMode(nextMode as ImageGenerationMode)}
+              modeOptions={['t2i', 'i2i']}
+              modeLabelOverrides={{
+                t2i: resolvedCopy.modeTabs.generate,
+                i2i: resolvedCopy.modeTabs.edit,
+              }}
+              showModeSelect={false}
+              modeLayout="stacked"
+              showBillingNote={false}
+              variant="bar"
+              className="min-w-0 flex-1"
+            />
+          </div>
+        }
+      />
+
+      <form onSubmit={handleRun} className="space-y-4">
+        {inProgressMessage ? (
+          <p
+            role="status"
+            aria-live="polite"
+            className="rounded-card border border-success-border bg-success-bg px-3 py-2 text-sm text-success"
+          >
+            {inProgressMessage}
+          </p>
+        ) : statusMessage ? (
+          <p
+            role="status"
+            aria-live="polite"
+            className="rounded-card border border-success-border bg-success-bg px-3 py-2 text-sm text-success"
+          >
+            {statusMessage}
+          </p>
+        ) : null}
+
+        <Composer
+          engine={selectedEngineCaps}
+          prompt={prompt}
+          onPromptChange={setPrompt}
+          price={estimatedCostAmount}
+          currency={currency}
+          isLoading={false}
+          error={composerError ?? undefined}
+          promptField={{
+            id: 'prompt',
+            type: 'text',
+            label: resolvedCopy.composer.promptLabel,
+          }}
+          promptRequired
+          promptPlaceholder={resolvedCopy.composer.promptPlaceholder}
+          promptPlaceholderWithAsset={
+            resolvedCopy.composer.promptPlaceholderWithImage ?? resolvedCopy.composer.promptPlaceholder
+          }
+          assetFields={referenceAssetFields}
+          assets={composerReferenceAssets}
+          onAssetAdd={(_, file, slotIndex = 0) => {
+            void handleReferenceFile(slotIndex, file);
+          }}
+          onAssetRemove={(_, index) => handleRemoveReferenceSlot(index)}
+          onAssetUrlSelect={(_, url, slotIndex) => handleReferenceUrl(slotIndex, url, 'paste')}
+          onOpenLibrary={(_, index) => openLibraryForSlot(index)}
+          onNotice={setError}
+          settingsBar={
+            <ImageSettingsBar
+              numImages={
+                showNumImagesControl
+                  ? {
+                      value: numImages,
+                      options: imageCountOptions,
+                      onChange: setNumImagesPreset,
+                    }
+                  : undefined
+              }
+              aspectRatio={
+                showAspectRatioControl
+                  ? {
+                      value: aspectRatio ?? String(aspectRatioSelectOptions[0]?.value ?? ''),
+                      options: aspectRatioSelectOptions,
+                      onChange: setAspectRatio,
+                    }
+                  : undefined
+              }
+              resolution={
+                showResolutionControl
+                  ? {
+                      value: resolution ?? String(resolutionSelectOptions[0]?.value ?? ''),
+                      options: resolutionSelectOptions,
+                      onChange: setResolutionPreset,
+                      disabled: isResolutionLocked,
+                    }
+                  : undefined
+              }
+              quality={
+                showQualityControl
+                  ? {
+                      value: quality ?? String(qualitySelectOptions[0]?.value ?? ''),
+                      options: qualitySelectOptions,
+                      onChange: setQuality,
+                    }
+                  : undefined
+              }
+              outputFormat={
+                showOutputFormatControl
+                  ? {
+                      value: outputFormat ?? String(outputFormatSelectOptions[0]?.value ?? ''),
+                      options: outputFormatSelectOptions,
+                      onChange: setOutputFormat,
+                    }
+                  : undefined
+              }
+            />
+          }
+          onGenerate={() => {
+            void handleRun();
+          }}
+          generateLabel={resolvedCopy.runButton.idle}
+          generateLoadingLabel={resolvedCopy.runButton.running}
+          afterAssets={
+            canCollapseReferenceSlots ? (
+              <div className="flex justify-center">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setAreReferenceSlotsExpanded((previous) => !previous)}
+                  className="rounded-full border-border text-[11px] text-text-secondary hover:text-text-primary"
+                >
+                  {referenceToggleLabel}
+                </Button>
+              </div>
+            ) : null
+          }
+          extraFields={
+            <div className="space-y-6">
+              <ImageAdvancedSettings
+                title={advancedSettingsTitle}
+                seed={
+                  showSeedControl
+                    ? {
+                        label: resolvedCopy.composer.seedLabel,
+                        placeholder: resolvedCopy.composer.seedPlaceholder,
+                        value: seed,
+                        onChange: setSeed,
+                      }
+                    : undefined
+                }
+                thinkingLevel={
+                  showThinkingLevelControl
+                    ? {
+                        label: resolvedCopy.composer.thinkingLevelLabel,
+                        value: thinkingLevel ?? String(thinkingLevelSelectOptions[0]?.value ?? ''),
+                        options: thinkingLevelSelectOptions,
+                        onChange: setThinkingLevel,
+                      }
+                    : undefined
+                }
+                customImageSize={
+                  showCustomImageSizeControl
+                    ? {
+                        widthLabel: resolvedCopy.composer.customWidthLabel,
+                        heightLabel: resolvedCopy.composer.customHeightLabel,
+                        widthValue: customImageWidth,
+                        heightValue: customImageHeight,
+                        min: 16,
+                        max: GPT_IMAGE_2_SIZE_CONSTRAINTS.maxEdge,
+                        step: GPT_IMAGE_2_SIZE_CONSTRAINTS.multipleOf,
+                        onWidthChange: setCustomImageWidth,
+                        onHeightChange: setCustomImageHeight,
+                      }
+                    : undefined
+                }
+                maskUrl={
+                  showMaskUrlControl
+                    ? {
+                        label: resolvedCopy.composer.maskUrlLabel,
+                        placeholder: resolvedCopy.composer.maskUrlPlaceholder,
+                        value: maskUrl,
+                        onChange: setMaskUrl,
+                      }
+                    : undefined
+                }
+                enableWebSearch={
+                  showEnableWebSearchControl
+                    ? {
+                        label: resolvedCopy.composer.enableWebSearchLabel,
+                        value: enableWebSearch,
+                        options: booleanSelectOptions,
+                        onChange: setEnableWebSearch,
+                      }
+                    : undefined
+                }
+                limitGenerations={
+                  showLimitGenerationsControl
+                    ? {
+                        label: resolvedCopy.composer.limitGenerationsLabel,
+                        value: limitGenerations,
+                        options: booleanSelectOptions,
+                        onChange: setLimitGenerations,
+                      }
+                    : undefined
+                }
+              />
+            </div>
+          }
+        />
+      </form>
+    </div>
+  );
+}

--- a/tests/image-workspace-split-contract.test.ts
+++ b/tests/image-workspace-split-contract.test.ts
@@ -10,10 +10,12 @@ const composerPersistenceHookPath = path.join(imageDir, '_hooks/useImageComposer
 const queryHydrationHookPath = path.join(imageDir, '_hooks/useImageWorkspaceQueryHydration.ts');
 const generationRunnerHookPath = path.join(imageDir, '_hooks/useImageGenerationRunner.ts');
 const gallerySelectionHookPath = path.join(imageDir, '_hooks/useImageGallerySelection.ts');
+const composerSurfacePath = path.join(imageDir, '_components/ImageWorkspaceComposerSurface.tsx');
 
 const splitFiles = [
   '_components/ImageAuthGateModal.tsx',
   '_components/ImageLibraryModal.tsx',
+  '_components/ImageWorkspaceComposerSurface.tsx',
   '_hooks/useImageComposerPersistence.ts',
   '_hooks/useImageWorkspaceHistory.ts',
   '_hooks/useImageWorkspacePricing.ts',
@@ -39,6 +41,7 @@ test('image workspace foundations are split from the route orchestrator', () => 
   const queryHydrationHookSource = readFileSync(queryHydrationHookPath, 'utf8');
   const generationRunnerHookSource = readFileSync(generationRunnerHookPath, 'utf8');
   const gallerySelectionHookSource = readFileSync(gallerySelectionHookPath, 'utf8');
+  const composerSurfaceSource = readFileSync(composerSurfacePath, 'utf8');
 
   for (const file of splitFiles) {
     statSync(path.join(imageDir, file));
@@ -46,6 +49,7 @@ test('image workspace foundations are split from the route orchestrator', () => 
 
   assert.match(source, /from '\.\/_components\/ImageLibraryModal'/);
   assert.match(source, /from '\.\/_components\/ImageAuthGateModal'/);
+  assert.match(source, /from '\.\/_components\/ImageWorkspaceComposerSurface'/);
   assert.match(source, /from '\.\/_hooks\/useImageComposerPersistence'/);
   assert.match(source, /from '\.\/_hooks\/useImageWorkspaceHistory'/);
   assert.match(source, /from '\.\/_hooks\/useImageWorkspacePricing'/);
@@ -78,6 +82,18 @@ test('image workspace foundations are split from the route orchestrator', () => 
   assert.doesNotMatch(source, /const previewUrls =/, 'fallback gallery image derivation belongs in useImageGallerySelection');
   assert.doesNotMatch(source, /findImageEngine/, 'gallery engine default selection belongs in useImageGallerySelection');
   assert.doesNotMatch(source, /authFetch/, 'gallery API snapshot lookup belongs in useImageGallerySelection');
+  assert.doesNotMatch(source, /<Composer\b/, 'composer JSX belongs in ImageWorkspaceComposerSurface');
+  assert.doesNotMatch(source, /<ImageCompositePreviewDock\b/, 'preview dock JSX belongs in ImageWorkspaceComposerSurface');
+  assert.doesNotMatch(source, /<ImageSettingsBar\b/, 'settings bar JSX belongs in ImageWorkspaceComposerSurface');
+  assert.doesNotMatch(source, /<ImageAdvancedSettings\b/, 'advanced settings JSX belongs in ImageWorkspaceComposerSurface');
+  assert.doesNotMatch(source, /<EngineSelect\b/, 'image engine selector JSX belongs in ImageWorkspaceComposerSurface');
+
+  assert.match(composerSurfaceSource, /export function ImageWorkspaceComposerSurface/);
+  assert.match(composerSurfaceSource, /<ImageCompositePreviewDock\b/);
+  assert.match(composerSurfaceSource, /<Composer\b/);
+  assert.match(composerSurfaceSource, /<ImageSettingsBar\b/);
+  assert.match(composerSurfaceSource, /<ImageAdvancedSettings\b/);
+  assert.match(composerSurfaceSource, /<EngineSelect\b/);
 
   assert.match(composerPersistenceHookSource, /export function useImageComposerPersistence/);
   assert.match(composerPersistenceHookSource, /parsePersistedImageComposerState/);
@@ -101,5 +117,5 @@ test('image workspace foundations are split from the route orchestrator', () => 
   assert.match(gallerySelectionHookSource, /const previewUrls =/);
 
   const lineCount = source.split('\n').length;
-  assert.ok(lineCount <= 830, `ImageWorkspace should stay below 830 lines after gallery selection extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 700, `ImageWorkspace should stay below 700 lines after composer surface extraction, got ${lineCount}`);
 });


### PR DESCRIPTION
## Summary
- move ImageWorkspace preview dock, Composer, settings bar, and advanced settings into a focused composer surface component
- keep ImageWorkspace focused on hooks, state wiring, and route-level layout
- tighten the image workspace architecture contract and line budget

## Checks
- ./node_modules/.bin/tsx --tsconfig frontend/tsconfig.json --test tests/image-workspace-split-contract.test.ts tests/image-settings-fields-hook-contract.test.ts tests/image-reference-slots-hook-contract.test.ts tests/image-preview-actions-hook-contract.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx frontend/app/(core)/(workspace)/app/image/_components/ImageWorkspaceComposerSurface.tsx tests/image-workspace-split-contract.test.ts