### PR TITLE
Split audio workspace composer surface

### DIFF
--- a/frontend/app/(core)/(workspace)/app/audio/AudioWorkspace.tsx
+++ b/frontend/app/(core)/(workspace)/app/audio/AudioWorkspace.tsx
@@ -3,17 +3,12 @@
 import deepmerge from 'deepmerge';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import {
-  AudioLines,
-} from 'lucide-react';
 
 import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { authFetch } from '@/lib/authFetch';
 import { useI18n } from '@/lib/i18n/I18nProvider';
 import type { Job } from '@/types/jobs';
 import { ButtonLink } from '@/components/ui/Button';
-import { Textarea } from '@/components/ui/Input';
-import { UIIcon } from '@/components/ui/UIIcon';
 import {
   AUDIO_INTENSITY_VALUES,
   AUDIO_LANGUAGE_VALUES,
@@ -44,12 +39,8 @@ import {
   type AudioVoiceProfile,
 } from '@/lib/audio-generation';
 import AudioLatestRendersRail from './AudioLatestRendersRail';
-import { AudioGenerationDock } from './_components/audio-generation-dock';
 import { AudioGeneratedVideoPickerModal } from './_components/audio-generated-video-picker';
-import { AudioOptionsSection } from './_components/audio-options-section';
-import { AudioSourceVideoSection } from './_components/audio-source-video-section';
-import { AudioVoiceSection } from './_components/audio-voice-section';
-import { AudioModePicker } from './_components/audio-workspace-controls';
+import { AudioWorkspaceComposerSurface } from './_components/audio-workspace-composer-surface';
 import { useAudioActiveJobPolling } from './_hooks/useAudioActiveJobPolling';
 import { useAudioGenerationRunner } from './_hooks/useAudioGenerationRunner';
 import { useAudioGeneratedVideos } from './_hooks/useAudioGeneratedVideos';
@@ -629,147 +620,75 @@ export default function AudioWorkspace() {
   return (
     <div className="flex flex-1 min-w-0 flex-col bg-bg xl:flex-row">
       <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-        <main className="min-h-0 flex-1 overflow-y-auto px-4 py-5 lg:px-7 lg:py-6">
-          <div className="mx-auto flex w-full max-w-[980px] flex-col gap-4 pb-28">
-            {notice ? (
-              <div role="status" aria-live="polite" className="rounded-[10px] border border-warning-border bg-warning-bg px-4 py-2 text-sm text-warning shadow-card">
-                {notice}
-              </div>
-            ) : null}
-
-            <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-              <div className="flex items-start gap-4">
-                <span className="mt-1 flex h-9 w-9 items-center justify-center rounded-[9px] border border-hairline bg-surface text-brand shadow-sm">
-                  <UIIcon icon={AudioLines} size={20} strokeWidth={1.9} />
-                </span>
-                <div>
-                  <p className="text-xs font-semibold uppercase tracking-micro text-text-muted">{copy.hero.eyebrow}</p>
-                  <h1 className="mt-1 text-2xl font-semibold tracking-normal text-text-primary md:text-3xl">{copy.hero.title}</h1>
-                  <p className="mt-1 max-w-2xl text-sm text-text-secondary">{copy.hero.body}</p>
-                </div>
-              </div>
-            </div>
-
-            <section className="rounded-[12px] border border-hairline bg-surface p-4 shadow-card">
-              <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-                <h2 className="text-sm font-semibold text-text-primary">{copy.controls.chooseType}</h2>
-              </div>
-              <div className="mt-3">
-                <AudioModePicker value={pack} options={modeOptions} onChange={handlePackChange} />
-              </div>
-            </section>
-
-            {(sourceVideoRequired || sourceVideo) ? (
-              <AudioSourceVideoSection
-                copy={copy}
-                inputRef={sourceInputRef}
-                isUploading={isUploadingSource}
-                onClear={handleClearSourceVideo}
-                onFileSelect={handleSourceFileSelect}
-                onOpenGeneratedPicker={() => setGeneratedPickerOpen(true)}
-                required={sourceVideoRequired}
-                sourceVideo={sourceVideo}
-              />
-            ) : null}
-
-            <section className="rounded-[12px] border border-hairline bg-surface shadow-card">
-              <label className="block p-4">
-                <div className="mb-3 flex items-center justify-between gap-3">
-                  <span className="text-base font-semibold text-text-primary">{composerLabel}</span>
-                  <span className="shrink-0 text-xs text-text-muted">{composerValue.length} / {composerMaxLength}</span>
-                </div>
-                <Textarea
-                  rows={9}
-                  value={composerValue}
-                  onChange={(event) => {
-                    if (composerIsScript) {
-                      setScript(event.target.value);
-                    } else {
-                      setPrompt(event.target.value);
-                    }
-                  }}
-                  placeholder={composerPlaceholder}
-                  className="min-h-[260px] resize-y bg-bg pr-4 text-base leading-7"
-                  maxLength={composerMaxLength}
-                />
-                {pack === 'voice_only' && script.trim().length ? (
-                  <p className="mt-2 text-xs text-text-secondary">
-                    {formatCopy(copy.controls.estimatedDuration, { seconds: estimatedDurationSec ?? '-' })}
-                  </p>
-                ) : null}
-              </label>
-            </section>
-
-            <section className="grid gap-4 lg:grid-cols-2">
-              {showVoiceFields ? (
-                <AudioVoiceSection
-                  copy={copy}
-                  inputRef={voiceInputRef}
-                  isUploading={isUploadingVoice}
-                  onClear={() => setVoiceSample(null)}
-                  onFileSelect={handleVoiceFileSelect}
-                  voiceSample={voiceSample}
-                />
-              ) : null}
-
-              <AudioOptionsSection
-                copy={copy}
-                durationOptions={durationOptions}
-                exportAudioFile={exportAudioFile}
-                intensity={intensity}
-                intensityOptions={intensityOptions}
-                language={language}
-                languageOptions={languageOptions}
-                manualDurationSec={manualDurationSec}
-                mood={mood}
-                moodOptions={moodOptions}
-                musicEnabled={musicEnabled}
-                onExportAudioFileChange={setExportAudioFile}
-                onIntensityChange={setIntensity}
-                onLanguageChange={setLanguage}
-                onManualDurationChange={setManualDurationSec}
-                onMoodChange={setMood}
-                onMusicEnabledChange={setMusicEnabled}
-                onVoiceDeliveryChange={setVoiceDelivery}
-                onVoiceGenderChange={setVoiceGender}
-                onVoiceProfileChange={setVoiceProfile}
-                pack={pack}
-                showExportToggle={showExportToggle}
-                showIntensity={showIntensity}
-                showManualDuration={showManualDuration}
-                showMood={showMood}
-                showMusicToggle={showMusicToggle}
-                showVoiceFields={showVoiceFields}
-                showVoiceGender={showVoiceGender}
-                voiceDelivery={voiceDelivery}
-                voiceDeliveryOptions={voiceDeliveryOptions}
-                voiceGender={voiceGender}
-                voiceGenderOptions={voiceGenderOptions}
-                voiceProfile={voiceProfile}
-                voiceProfileOptions={voiceProfileOptions}
-              />
-            </section>
-
-            <div className="xl:hidden">
-              <AudioLatestRendersRail
-                activeJobId={activeJob?.jobId ?? result?.jobId ?? null}
-                onSelectJob={handleSelectLatestJob}
-                variant="mobile"
-              />
-            </div>
-          </div>
-
-          <AudioGenerationDock
-            activeProgress={activeProgress}
-            canGenerate={canGenerate}
-            copy={copy}
-            durationLabel={dockDurationLabel}
-            generationHint={generationHint}
-            isGenerating={isGenerating}
-            onGenerate={handleGenerate}
-            priceLabel={dockPriceLabel}
-          />
-        </main>
+        <AudioWorkspaceComposerSurface
+          activeJobId={activeJob?.jobId ?? null}
+          activeProgress={activeProgress}
+          canGenerate={canGenerate}
+          composerIsScript={composerIsScript}
+          composerLabel={composerLabel}
+          composerMaxLength={composerMaxLength}
+          composerPlaceholder={composerPlaceholder}
+          composerValue={composerValue}
+          copy={copy}
+          dockDurationLabel={dockDurationLabel}
+          dockPriceLabel={dockPriceLabel}
+          durationOptions={durationOptions}
+          estimatedDurationSec={estimatedDurationSec}
+          exportAudioFile={exportAudioFile}
+          generationHint={generationHint}
+          handleGenerate={handleGenerate}
+          handlePackChange={handlePackChange}
+          handleSelectLatestJob={handleSelectLatestJob}
+          intensity={intensity}
+          intensityOptions={intensityOptions}
+          isGenerating={isGenerating}
+          isUploadingSource={isUploadingSource}
+          isUploadingVoice={isUploadingVoice}
+          language={language}
+          languageOptions={languageOptions}
+          manualDurationSec={manualDurationSec}
+          modeOptions={modeOptions}
+          mood={mood}
+          moodOptions={moodOptions}
+          musicEnabled={musicEnabled}
+          notice={notice}
+          onClearSourceVideo={handleClearSourceVideo}
+          onOpenGeneratedPicker={() => setGeneratedPickerOpen(true)}
+          onSourceFileSelect={handleSourceFileSelect}
+          onVoiceFileSelect={handleVoiceFileSelect}
+          pack={pack}
+          resultJobId={result?.jobId ?? null}
+          setExportAudioFile={setExportAudioFile}
+          setIntensity={setIntensity}
+          setLanguage={setLanguage}
+          setManualDurationSec={setManualDurationSec}
+          setMood={setMood}
+          setMusicEnabled={setMusicEnabled}
+          setPrompt={setPrompt}
+          setScript={setScript}
+          setVoiceDelivery={setVoiceDelivery}
+          setVoiceGender={setVoiceGender}
+          setVoiceProfile={setVoiceProfile}
+          setVoiceSample={setVoiceSample}
+          showExportToggle={showExportToggle}
+          showIntensity={showIntensity}
+          showManualDuration={showManualDuration}
+          showMood={showMood}
+          showMusicToggle={showMusicToggle}
+          showVoiceFields={showVoiceFields}
+          showVoiceGender={showVoiceGender}
+          sourceInputRef={sourceInputRef}
+          sourceVideo={sourceVideo}
+          sourceVideoRequired={sourceVideoRequired}
+          voiceDelivery={voiceDelivery}
+          voiceDeliveryOptions={voiceDeliveryOptions}
+          voiceGender={voiceGender}
+          voiceGenderOptions={voiceGenderOptions}
+          voiceInputRef={voiceInputRef}
+          voiceProfile={voiceProfile}
+          voiceProfileOptions={voiceProfileOptions}
+          voiceSample={voiceSample}
+        />
       </div>
 
       <aside className="hidden h-[calc(100vh-var(--header-height))] w-full max-w-[332px] shrink-0 flex-col border-l border-hairline bg-surface-2 px-4 pb-6 pt-6 xl:flex">

--- a/frontend/app/(core)/(workspace)/app/audio/_components/audio-source-video-section.tsx
+++ b/frontend/app/(core)/(workspace)/app/audio/_components/audio-source-video-section.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { RefObject } from 'react';
+import type { Ref, RefObject } from 'react';
 import { CheckCircle2, FileVideo, Upload, Video } from 'lucide-react';
 
 import { Button } from '@/components/ui/Button';
@@ -20,7 +20,7 @@ export function AudioSourceVideoSection({
   sourceVideo,
 }: {
   copy: AudioWorkspaceCopy;
-  inputRef: RefObject<HTMLInputElement>;
+  inputRef: RefObject<HTMLInputElement | null>;
   isUploading: boolean;
   onClear: () => void;
   onFileSelect: (fileList: FileList | null) => void | Promise<void>;
@@ -73,7 +73,7 @@ export function AudioSourceVideoSection({
         </div>
       </div>
       <input
-        ref={inputRef}
+        ref={inputRef as Ref<HTMLInputElement>}
         type="file"
         accept="video/*"
         className="sr-only"

--- a/frontend/app/(core)/(workspace)/app/audio/_components/audio-voice-section.tsx
+++ b/frontend/app/(core)/(workspace)/app/audio/_components/audio-voice-section.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { RefObject } from 'react';
+import type { Ref, RefObject } from 'react';
 import { AudioLines, Play, Upload } from 'lucide-react';
 
 import { Button } from '@/components/ui/Button';
@@ -16,7 +16,7 @@ export function AudioVoiceSection({
   voiceSample,
 }: {
   copy: AudioWorkspaceCopy;
-  inputRef: RefObject<HTMLInputElement>;
+  inputRef: RefObject<HTMLInputElement | null>;
   isUploading: boolean;
   onClear: () => void;
   onFileSelect: (fileList: FileList | null) => void | Promise<void>;
@@ -67,7 +67,7 @@ export function AudioVoiceSection({
             {isUploading ? copy.source.uploading : copy.controls.uploadVoiceSample}
           </Button>
           <input
-            ref={inputRef}
+            ref={inputRef as Ref<HTMLInputElement>}
             type="file"
             accept="audio/*"
             className="sr-only"

--- a/frontend/app/(core)/(workspace)/app/audio/_components/audio-workspace-composer-surface.tsx
+++ b/frontend/app/(core)/(workspace)/app/audio/_components/audio-workspace-composer-surface.tsx
@@ -1,0 +1,310 @@
+'use client';
+
+import type { RefObject } from 'react';
+import { AudioLines } from 'lucide-react';
+import { Textarea } from '@/components/ui/Input';
+import { UIIcon } from '@/components/ui/UIIcon';
+import {
+  type AudioIntensity,
+  type AudioLanguage,
+  type AudioMood,
+  type AudioPackId,
+  type AudioVoiceDelivery,
+  type AudioVoiceGender,
+  type AudioVoiceProfile,
+} from '@/lib/audio-generation';
+import AudioLatestRendersRail from '../AudioLatestRendersRail';
+import type { AudioWorkspaceCopy } from '../copy';
+import type { SourceVideoState } from '../_lib/audio-workspace-types';
+import { formatCopy } from '../_lib/audio-workspace-helpers';
+import { AudioGenerationDock } from './audio-generation-dock';
+import { AudioOptionsSection } from './audio-options-section';
+import { AudioSourceVideoSection } from './audio-source-video-section';
+import { AudioVoiceSection } from './audio-voice-section';
+import { AudioModePicker } from './audio-workspace-controls';
+
+type AudioOption = {
+  value: string | number | boolean;
+  label: string;
+  disabled?: boolean;
+};
+
+interface AudioWorkspaceComposerSurfaceProps {
+  activeJobId: string | null;
+  activeProgress: number | null;
+  canGenerate: boolean;
+  composerIsScript: boolean;
+  composerLabel: string;
+  composerMaxLength: number;
+  composerPlaceholder: string;
+  composerValue: string;
+  copy: AudioWorkspaceCopy;
+  dockDurationLabel: string;
+  dockPriceLabel: string;
+  durationOptions: AudioOption[];
+  estimatedDurationSec: number | null;
+  exportAudioFile: boolean;
+  generationHint: string;
+  handleGenerate: () => void;
+  handlePackChange: (nextPack: AudioPackId) => void;
+  handleSelectLatestJob: (jobId: string) => void;
+  intensity: AudioIntensity;
+  intensityOptions: AudioOption[];
+  isGenerating: boolean;
+  isUploadingSource: boolean;
+  isUploadingVoice: boolean;
+  language: AudioLanguage;
+  languageOptions: AudioOption[];
+  manualDurationSec: number;
+  modeOptions: Array<{ id: AudioPackId; label: string; description: string }>;
+  mood: AudioMood;
+  moodOptions: AudioOption[];
+  musicEnabled: boolean;
+  notice: string | null;
+  onClearSourceVideo: () => void;
+  onOpenGeneratedPicker: () => void;
+  onSourceFileSelect: (fileList: FileList | null) => void | Promise<void>;
+  onVoiceFileSelect: (fileList: FileList | null) => void | Promise<void>;
+  pack: AudioPackId;
+  resultJobId: string | null;
+  setExportAudioFile: (value: boolean) => void;
+  setIntensity: (value: AudioIntensity) => void;
+  setLanguage: (value: AudioLanguage) => void;
+  setManualDurationSec: (value: number) => void;
+  setMood: (value: AudioMood) => void;
+  setMusicEnabled: (value: boolean) => void;
+  setPrompt: (value: string) => void;
+  setScript: (value: string) => void;
+  setVoiceDelivery: (value: AudioVoiceDelivery) => void;
+  setVoiceGender: (value: AudioVoiceGender) => void;
+  setVoiceProfile: (value: AudioVoiceProfile) => void;
+  setVoiceSample: (value: { url: string; name: string } | null) => void;
+  showExportToggle: boolean;
+  showIntensity: boolean;
+  showManualDuration: boolean;
+  showMood: boolean;
+  showMusicToggle: boolean;
+  showVoiceFields: boolean;
+  showVoiceGender: boolean;
+  sourceInputRef: RefObject<HTMLInputElement | null>;
+  sourceVideo: SourceVideoState | null;
+  sourceVideoRequired: boolean;
+  voiceDelivery: AudioVoiceDelivery;
+  voiceDeliveryOptions: AudioOption[];
+  voiceGender: AudioVoiceGender;
+  voiceGenderOptions: AudioOption[];
+  voiceInputRef: RefObject<HTMLInputElement | null>;
+  voiceProfile: AudioVoiceProfile;
+  voiceProfileOptions: AudioOption[];
+  voiceSample: { url: string; name: string } | null;
+}
+
+export function AudioWorkspaceComposerSurface({
+  activeJobId,
+  activeProgress,
+  canGenerate,
+  composerIsScript,
+  composerLabel,
+  composerMaxLength,
+  composerPlaceholder,
+  composerValue,
+  copy,
+  dockDurationLabel,
+  dockPriceLabel,
+  durationOptions,
+  estimatedDurationSec,
+  exportAudioFile,
+  generationHint,
+  handleGenerate,
+  handlePackChange,
+  handleSelectLatestJob,
+  intensity,
+  intensityOptions,
+  isGenerating,
+  isUploadingSource,
+  isUploadingVoice,
+  language,
+  languageOptions,
+  manualDurationSec,
+  modeOptions,
+  mood,
+  moodOptions,
+  musicEnabled,
+  notice,
+  onClearSourceVideo,
+  onOpenGeneratedPicker,
+  onSourceFileSelect,
+  onVoiceFileSelect,
+  pack,
+  resultJobId,
+  setExportAudioFile,
+  setIntensity,
+  setLanguage,
+  setManualDurationSec,
+  setMood,
+  setMusicEnabled,
+  setPrompt,
+  setScript,
+  setVoiceDelivery,
+  setVoiceGender,
+  setVoiceProfile,
+  setVoiceSample,
+  showExportToggle,
+  showIntensity,
+  showManualDuration,
+  showMood,
+  showMusicToggle,
+  showVoiceFields,
+  showVoiceGender,
+  sourceInputRef,
+  sourceVideo,
+  sourceVideoRequired,
+  voiceDelivery,
+  voiceDeliveryOptions,
+  voiceGender,
+  voiceGenderOptions,
+  voiceInputRef,
+  voiceProfile,
+  voiceProfileOptions,
+  voiceSample,
+}: AudioWorkspaceComposerSurfaceProps) {
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto px-4 py-5 lg:px-7 lg:py-6">
+      <div className="mx-auto flex w-full max-w-[980px] flex-col gap-4 pb-28">
+        {notice ? (
+          <div role="status" aria-live="polite" className="rounded-[10px] border border-warning-border bg-warning-bg px-4 py-2 text-sm text-warning shadow-card">
+            {notice}
+          </div>
+        ) : null}
+
+        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+          <div className="flex items-start gap-4">
+            <span className="mt-1 flex h-9 w-9 items-center justify-center rounded-[9px] border border-hairline bg-surface text-brand shadow-sm">
+              <UIIcon icon={AudioLines} size={20} strokeWidth={1.9} />
+            </span>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-micro text-text-muted">{copy.hero.eyebrow}</p>
+              <h1 className="mt-1 text-2xl font-semibold tracking-normal text-text-primary md:text-3xl">{copy.hero.title}</h1>
+              <p className="mt-1 max-w-2xl text-sm text-text-secondary">{copy.hero.body}</p>
+            </div>
+          </div>
+        </div>
+
+        <section className="rounded-[12px] border border-hairline bg-surface p-4 shadow-card">
+          <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+            <h2 className="text-sm font-semibold text-text-primary">{copy.controls.chooseType}</h2>
+          </div>
+          <div className="mt-3">
+            <AudioModePicker value={pack} options={modeOptions} onChange={handlePackChange} />
+          </div>
+        </section>
+
+        {(sourceVideoRequired || sourceVideo) ? (
+          <AudioSourceVideoSection
+            copy={copy}
+            inputRef={sourceInputRef}
+            isUploading={isUploadingSource}
+            onClear={onClearSourceVideo}
+            onFileSelect={onSourceFileSelect}
+            onOpenGeneratedPicker={onOpenGeneratedPicker}
+            required={sourceVideoRequired}
+            sourceVideo={sourceVideo}
+          />
+        ) : null}
+
+        <section className="rounded-[12px] border border-hairline bg-surface shadow-card">
+          <label className="block p-4">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <span className="text-base font-semibold text-text-primary">{composerLabel}</span>
+              <span className="shrink-0 text-xs text-text-muted">{composerValue.length} / {composerMaxLength}</span>
+            </div>
+            <Textarea
+              rows={9}
+              value={composerValue}
+              onChange={(event) => {
+                if (composerIsScript) {
+                  setScript(event.target.value);
+                } else {
+                  setPrompt(event.target.value);
+                }
+              }}
+              placeholder={composerPlaceholder}
+              className="min-h-[260px] resize-y bg-bg pr-4 text-base leading-7"
+              maxLength={composerMaxLength}
+            />
+            {pack === 'voice_only' && composerValue.trim().length ? (
+              <p className="mt-2 text-xs text-text-secondary">
+                {formatCopy(copy.controls.estimatedDuration, { seconds: estimatedDurationSec ?? '-' })}
+              </p>
+            ) : null}
+          </label>
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-2">
+          {showVoiceFields ? (
+            <AudioVoiceSection
+              copy={copy}
+              inputRef={voiceInputRef}
+              isUploading={isUploadingVoice}
+              onClear={() => setVoiceSample(null)}
+              onFileSelect={onVoiceFileSelect}
+              voiceSample={voiceSample}
+            />
+          ) : null}
+
+          <AudioOptionsSection
+            copy={copy}
+            durationOptions={durationOptions}
+            exportAudioFile={exportAudioFile}
+            intensity={intensity}
+            intensityOptions={intensityOptions}
+            language={language}
+            languageOptions={languageOptions}
+            manualDurationSec={manualDurationSec}
+            mood={mood}
+            moodOptions={moodOptions}
+            musicEnabled={musicEnabled}
+            onExportAudioFileChange={setExportAudioFile}
+            onIntensityChange={setIntensity}
+            onLanguageChange={setLanguage}
+            onManualDurationChange={setManualDurationSec}
+            onMoodChange={setMood}
+            onMusicEnabledChange={setMusicEnabled}
+            onVoiceDeliveryChange={setVoiceDelivery}
+            onVoiceGenderChange={setVoiceGender}
+            onVoiceProfileChange={setVoiceProfile}
+            pack={pack}
+            showExportToggle={showExportToggle}
+            showIntensity={showIntensity}
+            showManualDuration={showManualDuration}
+            showMood={showMood}
+            showMusicToggle={showMusicToggle}
+            showVoiceFields={showVoiceFields}
+            showVoiceGender={showVoiceGender}
+            voiceDelivery={voiceDelivery}
+            voiceDeliveryOptions={voiceDeliveryOptions}
+            voiceGender={voiceGender}
+            voiceGenderOptions={voiceGenderOptions}
+            voiceProfile={voiceProfile}
+            voiceProfileOptions={voiceProfileOptions}
+          />
+        </section>
+
+        <div className="xl:hidden">
+          <AudioLatestRendersRail activeJobId={activeJobId ?? resultJobId} onSelectJob={handleSelectLatestJob} variant="mobile" />
+        </div>
+      </div>
+
+      <AudioGenerationDock
+        activeProgress={activeProgress}
+        canGenerate={canGenerate}
+        copy={copy}
+        durationLabel={dockDurationLabel}
+        generationHint={generationHint}
+        isGenerating={isGenerating}
+        onGenerate={handleGenerate}
+        priceLabel={dockPriceLabel}
+      />
+    </main>
+  );
+}

--- a/tests/audio-workspace-architecture.test.ts
+++ b/tests/audio-workspace-architecture.test.ts
@@ -7,6 +7,7 @@ const root = process.cwd();
 const audioDir = join(root, 'frontend/app/(core)/(workspace)/app/audio');
 const workspacePath = join(audioDir, 'AudioWorkspace.tsx');
 const controlsPath = join(audioDir, '_components/audio-workspace-controls.tsx');
+const composerSurfacePath = join(audioDir, '_components/audio-workspace-composer-surface.tsx');
 const generatedPickerPath = join(audioDir, '_components/audio-generated-video-picker.tsx');
 const optionsSectionPath = join(audioDir, '_components/audio-options-section.tsx');
 const sourceVideoSectionPath = join(audioDir, '_components/audio-source-video-section.tsx');
@@ -19,9 +20,11 @@ const generatedVideosHookPath = join(audioDir, '_hooks/useAudioGeneratedVideos.t
 const generationRunnerHookPath = join(audioDir, '_hooks/useAudioGenerationRunner.ts');
 
 const workspaceSource = readFileSync(workspacePath, 'utf8');
+const composerSurfaceSource = readFileSync(composerSurfacePath, 'utf8');
 
 test('audio workspace delegates local controls, helpers, and contracts', () => {
   assert.ok(existsSync(controlsPath), 'audio control components should live in a route-local component module');
+  assert.ok(existsSync(composerSurfacePath), 'audio composer surface should live in a route-local component module');
   assert.ok(existsSync(generatedPickerPath), 'generated video picker should live in a route-local component module');
   assert.ok(existsSync(optionsSectionPath), 'audio options section should live in a route-local component module');
   assert.ok(existsSync(sourceVideoSectionPath), 'source video section should live in a route-local component module');
@@ -33,12 +36,13 @@ test('audio workspace delegates local controls, helpers, and contracts', () => {
   assert.ok(existsSync(generatedVideosHookPath), 'generated video loading should live in a route-local hook');
   assert.ok(existsSync(generationRunnerHookPath), 'audio generation runner should live in a route-local hook');
 
-  assert.match(workspaceSource, /from '\.\/_components\/audio-workspace-controls'/);
+  assert.match(workspaceSource, /from '\.\/_components\/audio-workspace-composer-surface'/);
   assert.match(workspaceSource, /from '\.\/_components\/audio-generated-video-picker'/);
-  assert.match(workspaceSource, /from '\.\/_components\/audio-options-section'/);
-  assert.match(workspaceSource, /from '\.\/_components\/audio-source-video-section'/);
-  assert.match(workspaceSource, /from '\.\/_components\/audio-generation-dock'/);
-  assert.match(workspaceSource, /from '\.\/_components\/audio-voice-section'/);
+  assert.match(composerSurfaceSource, /from '\.\/audio-workspace-controls'/);
+  assert.match(composerSurfaceSource, /from '\.\/audio-options-section'/);
+  assert.match(composerSurfaceSource, /from '\.\/audio-source-video-section'/);
+  assert.match(composerSurfaceSource, /from '\.\/audio-generation-dock'/);
+  assert.match(composerSurfaceSource, /from '\.\/audio-voice-section'/);
   assert.match(workspaceSource, /from '\.\/_hooks\/useAudioActiveJobPolling'/);
   assert.match(workspaceSource, /from '\.\/_hooks\/useAudioGeneratedVideos'/);
   assert.match(workspaceSource, /from '\.\/_hooks\/useAudioGenerationRunner'/);
@@ -66,9 +70,14 @@ test('audio workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /<AudioSelectControl/, 'audio option selectors belong in audio-options-section.tsx');
   assert.doesNotMatch(workspaceSource, /copy\.controls\.providerStack/, 'provider stack UI belongs in audio-options-section.tsx');
   assert.doesNotMatch(workspaceSource, /SlidersHorizontal/, 'advanced options UI belongs in audio-options-section.tsx');
+  assert.doesNotMatch(workspaceSource, /<AudioModePicker/, 'audio mode picker composition belongs in audio-workspace-composer-surface.tsx');
+  assert.doesNotMatch(workspaceSource, /<AudioGenerationDock/, 'audio generation dock composition belongs in audio-workspace-composer-surface.tsx');
+  assert.doesNotMatch(workspaceSource, /<AudioVoiceSection/, 'voice section composition belongs in audio-workspace-composer-surface.tsx');
+  assert.doesNotMatch(workspaceSource, /copy\.hero\.title/, 'audio hero UI belongs in audio-workspace-composer-surface.tsx');
+  assert.doesNotMatch(workspaceSource, /copy\.controls\.estimatedDuration/, 'script composer UI belongs in audio-workspace-composer-surface.tsx');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 800, `AudioWorkspace should stay below 800 lines after options section extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 720, `AudioWorkspace should stay below 720 lines after composer surface extraction, got ${lineCount}`);
 });
 
 test('audio helper modules expose the expected workspace contract', () => {
@@ -97,6 +106,10 @@ test('audio helper modules expose the expected workspace contract', () => {
     /export function AudioGeneratedVideoPickerModal/,
     'AudioGeneratedVideoPickerModal should be exported'
   );
+  assert.match(composerSurfaceSource, /export function AudioWorkspaceComposerSurface/, 'AudioWorkspaceComposerSurface should be exported');
+  assert.match(composerSurfaceSource, /AudioModePicker/, 'composer surface should own mode picker composition');
+  assert.match(composerSurfaceSource, /AudioGenerationDock/, 'composer surface should own generation dock composition');
+  assert.match(composerSurfaceSource, /AudioLatestRendersRail/, 'composer surface should own mobile latest renders rail');
   assert.match(optionsSectionSource, /export function AudioOptionsSection/, 'AudioOptionsSection should be exported');
   assert.match(optionsSectionSource, /AudioSelectControl/, 'audio options section should own select controls');
   assert.match(optionsSectionSource, /resolveProviderLabel/, 'audio options section should own provider stack rendering');


### PR DESCRIPTION
## Summary
- move AudioWorkspace authenticated composer UI into a focused composer surface component
- keep restore, polling, generation, and state orchestration in AudioWorkspace
- update audio architecture contract and line budget

## Checks
- ./node_modules/.bin/tsx --tsconfig frontend/tsconfig.json --test tests/audio-workspace-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- frontend/app/(core)/(workspace)/app/audio/AudioWorkspace.tsx frontend/app/(core)/(workspace)/app/audio/_components/audio-workspace-composer-surface.tsx frontend/app/(core)/(workspace)/app/audio/_components/audio-source-video-section.tsx frontend/app/(core)/(workspace)/app/audio/_components/audio-voice-section.tsx tests/audio-workspace-architecture.test.ts