### PR TITLE
Split image generation completion persistence

### DIFF
--- a/frontend/src/server/images/execute-image-generation.ts
+++ b/frontend/src/server/images/execute-image-generation.ts
@@ -19,11 +19,8 @@ import {
   createSignedDownloadUrl,
   extractStorageKeyFromUrl,
   isStorageConfigured,
-  recordUserAsset,
 } from '@/server/storage';
 import { createImageThumbnailBatch } from '@/server/image-thumbnails';
-import { buildStoredImageRenderEntries, resolveHeroThumbFromRenders } from '@/lib/image-renders';
-import { ensureReusableAsset, upsertLegacyJobOutputs } from '@/server/media-library';
 import {
   formatSupportedImageFormatsLabel,
   getSupportedImageFormats,
@@ -54,7 +51,8 @@ import {
   type StoredAssetInfo,
 } from './image-reference-normalization';
 import { ImageGenerationExecutionError } from './image-generation-error';
-import { createAtomicInitialImageJob, PLACEHOLDER_THUMB } from './image-initial-job';
+import { createAtomicInitialImageJob } from './image-initial-job';
+import { persistCompletedImageGeneration } from './image-generation-completion';
 import {
   buildCharacterReferencePrompt,
   extractImages,
@@ -693,150 +691,41 @@ export async function executeImageGeneration({
       ...image,
       thumbUrl: thumbUrls[index] ?? null,
     }));
-    const storedRenderEntries = buildStoredImageRenderEntries(normalizedImagesWithThumbs);
-    const hero = normalizedImagesWithThumbs[0]?.url ?? null;
-    const heroThumb = resolveHeroThumbFromRenders(normalizedImagesWithThumbs) ?? hero;
     const description =
       (result.data && typeof result.data === 'object' && (result.data as { description?: string }).description) || null;
-    const renderIdsJson = JSON.stringify(storedRenderEntries);
     const providerRequestId = providerJobId ?? parseRequestId(result.data) ?? result.requestId ?? null;
     providerJobId = providerRequestId ?? undefined;
 
-    if (jobSurface === 'character') {
-      await Promise.all(
-        normalizedImagesWithThumbs.map(async (image, index) => {
-          try {
-            await recordUserAsset({
-              assetId: `${jobId}:character:${index + 1}`,
-              userId,
-              url: image.url,
-              mime: image.mimeType ?? 'image/png',
-              width: image.width ?? null,
-              height: image.height ?? null,
-              size: null,
-              source: 'character',
-              metadata: {
-                jobId,
-                thumbUrl: image.thumbUrl ?? null,
-                engineId: engine.id,
-                engineLabel: engine.label,
-                surface: jobSurface,
-                billingProductKey,
-                resultIndex: index,
-              },
-            });
-          } catch (assetError) {
-            console.warn('[images] failed to persist character asset', { jobId, index }, assetError);
-          }
-        })
-      );
-    }
-
-    await query(
-      `UPDATE app_jobs
-       SET thumb_url = $2,
-           video_url = $3,
-           status = 'completed',
-           progress = 100,
-           provider_job_id = COALESCE($4, provider_job_id),
-           final_price_cents = $5,
-           pricing_snapshot = $6::jsonb,
-           cost_breakdown_usd = $7::jsonb,
-           currency = $8,
-           vendor_account_id = $9,
-           payment_status = 'paid_wallet',
-           visibility = $10,
-           indexable = $11,
-           message = $12,
-           render_ids = $13::jsonb,
-           hero_render_id = $14,
-           provisional = FALSE,
-           updated_at = NOW()
-       WHERE job_id = $1`,
-      [
-        jobId,
-        heroThumb ?? PLACEHOLDER_THUMB,
-        null,
-        providerJobId ?? null,
-        pricing.totalCents,
-        pricingSnapshotJson,
-        costBreakdownJson,
-        pricing.currency,
-        vendorAccountId,
-        visibility,
-        indexable,
-        description,
-        renderIdsJson,
-        hero,
-      ]
-    );
-
-    await upsertLegacyJobOutputs({
-      job_id: jobId,
-      user_id: userId,
-      surface: jobSurface,
-      video_url: null,
-      audio_url: null,
-      thumb_url: heroThumb ?? PLACEHOLDER_THUMB,
-      preview_frame: heroThumb ?? PLACEHOLDER_THUMB,
-      render_ids: storedRenderEntries,
-      duration_sec: 1,
-      status: 'completed',
-    }).catch((outputError) => {
-      console.warn('[images] failed to persist job outputs', { jobId }, outputError);
+    const { heroThumb } = await persistCompletedImageGeneration({
+      billingProductKey,
+      characterReferenceCount: characterReferences.length,
+      costBreakdownJson,
+      description,
+      enableWebSearch,
+      engineId: engine.id,
+      engineLabel: engine.label,
+      images: normalizedImagesWithThumbs,
+      indexable,
+      jobId,
+      jobSurface,
+      limitGenerations,
+      maskUrl,
+      mode,
+      normalizedSeed,
+      numImages,
+      outputFormat,
+      pricing,
+      pricingSnapshotJson,
+      providerJobId: providerJobId ?? null,
+      providerMode,
+      quality,
+      resolvedAspectRatio,
+      resolution,
+      thinkingLevel,
+      userId,
+      vendorAccountId,
+      visibility,
     });
-
-    if (jobSurface === 'character') {
-      await Promise.allSettled(
-        normalizedImagesWithThumbs.map((image, index) =>
-          ensureReusableAsset({
-            userId,
-            url: image.url,
-            kind: 'image',
-            source: 'character',
-            sourceJobId: jobId,
-            sourceOutputId: `${jobId}:image:${index}`,
-            mimeType: image.mimeType ?? 'image/png',
-            width: image.width ?? null,
-            height: image.height ?? null,
-            thumbUrl: image.thumbUrl ?? null,
-          })
-        )
-      );
-    }
-
-    try {
-      await query(
-        `INSERT INTO fal_queue_log (job_id, provider, provider_job_id, engine_id, status, payload)
-         VALUES ($1,$2,$3,$4,$5,$6::jsonb)`,
-        [
-          jobId,
-          providerMode,
-          providerJobId ?? null,
-          engine.id,
-          'completed',
-          JSON.stringify({
-            request: {
-              mode,
-              numImages,
-              resolution,
-              ...(characterReferences.length ? { characterReferenceCount: characterReferences.length } : {}),
-              ...(resolvedAspectRatio ? { aspect_ratio: resolvedAspectRatio } : {}),
-              ...(normalizedSeed != null ? { seed: normalizedSeed } : {}),
-              ...(outputFormat ? { output_format: outputFormat } : {}),
-              ...(quality ? { quality } : {}),
-              ...(maskUrl ? { mask_url: maskUrl } : {}),
-              ...(enableWebSearch ? { enable_web_search: true } : {}),
-              ...(thinkingLevel ? { thinking_level: thinkingLevel } : {}),
-              ...(limitGenerations ? { limit_generations: true } : {}),
-            },
-            pricing: { totalCents: pricing.totalCents, currency: pricing.currency },
-          }),
-        ]
-      );
-    } catch (error) {
-      console.warn('[images] failed to record fal queue log', error);
-    }
 
     return {
       ok: true,

--- a/frontend/src/server/images/image-generation-completion.ts
+++ b/frontend/src/server/images/image-generation-completion.ts
@@ -1,0 +1,217 @@
+import { query } from '@/lib/db';
+import { buildStoredImageRenderEntries, resolveHeroThumbFromRenders } from '@/lib/image-renders';
+import { ensureReusableAsset, upsertLegacyJobOutputs } from '@/server/media-library';
+import { recordUserAsset } from '@/server/storage';
+import type { BillingProductKey, JobSurface } from '@/types/billing';
+import type { PricingSnapshot } from '@/types/engines';
+import type { GeneratedImage, ImageGenerationMode } from '@/types/image-generation';
+import { PLACEHOLDER_THUMB } from './image-initial-job';
+
+type CompletedImage = GeneratedImage & {
+  thumbUrl?: string | null;
+};
+
+export async function persistCompletedImageGeneration(params: {
+  billingProductKey: BillingProductKey | null;
+  characterReferenceCount: number;
+  costBreakdownJson: string | null;
+  description: string | null;
+  enableWebSearch: boolean;
+  engineId: string;
+  engineLabel: string;
+  images: CompletedImage[];
+  indexable: boolean;
+  jobId: string;
+  jobSurface: JobSurface;
+  limitGenerations: boolean;
+  maskUrl: string | null;
+  mode: ImageGenerationMode;
+  normalizedSeed: number | null;
+  numImages: number;
+  outputFormat: string | null;
+  pricing: PricingSnapshot;
+  pricingSnapshotJson: string;
+  providerJobId: string | null;
+  providerMode: string;
+  quality: string | null;
+  resolvedAspectRatio: string | null;
+  resolution: string;
+  thinkingLevel: string | null;
+  userId: string;
+  vendorAccountId: string | null;
+  visibility: 'public' | 'private';
+}) {
+  const {
+    billingProductKey,
+    characterReferenceCount,
+    costBreakdownJson,
+    description,
+    enableWebSearch,
+    engineId,
+    engineLabel,
+    images,
+    indexable,
+    jobId,
+    jobSurface,
+    limitGenerations,
+    maskUrl,
+    mode,
+    normalizedSeed,
+    numImages,
+    outputFormat,
+    pricing,
+    pricingSnapshotJson,
+    providerJobId,
+    providerMode,
+    quality,
+    resolvedAspectRatio,
+    resolution,
+    thinkingLevel,
+    userId,
+    vendorAccountId,
+    visibility,
+  } = params;
+
+  const storedRenderEntries = buildStoredImageRenderEntries(images);
+  const hero = images[0]?.url ?? null;
+  const heroThumb = resolveHeroThumbFromRenders(images) ?? hero;
+  const renderIdsJson = JSON.stringify(storedRenderEntries);
+
+  if (jobSurface === 'character') {
+    await Promise.all(
+      images.map(async (image, index) => {
+        try {
+          await recordUserAsset({
+            assetId: `${jobId}:character:${index + 1}`,
+            userId,
+            url: image.url,
+            mime: image.mimeType ?? 'image/png',
+            width: image.width ?? null,
+            height: image.height ?? null,
+            size: null,
+            source: 'character',
+            metadata: {
+              jobId,
+              thumbUrl: image.thumbUrl ?? null,
+              engineId,
+              engineLabel,
+              surface: jobSurface,
+              billingProductKey,
+              resultIndex: index,
+            },
+          });
+        } catch (assetError) {
+          console.warn('[images] failed to persist character asset', { jobId, index }, assetError);
+        }
+      })
+    );
+  }
+
+  await query(
+    `UPDATE app_jobs
+     SET thumb_url = $2,
+         video_url = $3,
+         status = 'completed',
+         progress = 100,
+         provider_job_id = COALESCE($4, provider_job_id),
+         final_price_cents = $5,
+         pricing_snapshot = $6::jsonb,
+         cost_breakdown_usd = $7::jsonb,
+         currency = $8,
+         vendor_account_id = $9,
+         payment_status = 'paid_wallet',
+         visibility = $10,
+         indexable = $11,
+         message = $12,
+         render_ids = $13::jsonb,
+         hero_render_id = $14,
+         provisional = FALSE,
+         updated_at = NOW()
+     WHERE job_id = $1`,
+    [
+      jobId,
+      heroThumb ?? PLACEHOLDER_THUMB,
+      null,
+      providerJobId ?? null,
+      pricing.totalCents,
+      pricingSnapshotJson,
+      costBreakdownJson,
+      pricing.currency,
+      vendorAccountId,
+      visibility,
+      indexable,
+      description,
+      renderIdsJson,
+      hero,
+    ]
+  );
+
+  await upsertLegacyJobOutputs({
+    job_id: jobId,
+    user_id: userId,
+    surface: jobSurface,
+    video_url: null,
+    audio_url: null,
+    thumb_url: heroThumb ?? PLACEHOLDER_THUMB,
+    preview_frame: heroThumb ?? PLACEHOLDER_THUMB,
+    render_ids: storedRenderEntries,
+    duration_sec: 1,
+    status: 'completed',
+  }).catch((outputError) => {
+    console.warn('[images] failed to persist job outputs', { jobId }, outputError);
+  });
+
+  if (jobSurface === 'character') {
+    await Promise.allSettled(
+      images.map((image, index) =>
+        ensureReusableAsset({
+          userId,
+          url: image.url,
+          kind: 'image',
+          source: 'character',
+          sourceJobId: jobId,
+          sourceOutputId: `${jobId}:image:${index}`,
+          mimeType: image.mimeType ?? 'image/png',
+          width: image.width ?? null,
+          height: image.height ?? null,
+          thumbUrl: image.thumbUrl ?? null,
+        })
+      )
+    );
+  }
+
+  try {
+    await query(
+      `INSERT INTO fal_queue_log (job_id, provider, provider_job_id, engine_id, status, payload)
+       VALUES ($1,$2,$3,$4,$5,$6::jsonb)`,
+      [
+        jobId,
+        providerMode,
+        providerJobId ?? null,
+        engineId,
+        'completed',
+        JSON.stringify({
+          request: {
+            mode,
+            numImages,
+            resolution,
+            ...(characterReferenceCount ? { characterReferenceCount } : {}),
+            ...(resolvedAspectRatio ? { aspect_ratio: resolvedAspectRatio } : {}),
+            ...(normalizedSeed != null ? { seed: normalizedSeed } : {}),
+            ...(outputFormat ? { output_format: outputFormat } : {}),
+            ...(quality ? { quality } : {}),
+            ...(maskUrl ? { mask_url: maskUrl } : {}),
+            ...(enableWebSearch ? { enable_web_search: true } : {}),
+            ...(thinkingLevel ? { thinking_level: thinkingLevel } : {}),
+            ...(limitGenerations ? { limit_generations: true } : {}),
+          },
+          pricing: { totalCents: pricing.totalCents, currency: pricing.currency },
+        }),
+      ]
+    );
+  } catch (error) {
+    console.warn('[images] failed to record fal queue log', error);
+  }
+
+  return { hero, heroThumb, renderIdsJson, storedRenderEntries };
+}

--- a/tests/image-generation-server-architecture.test.ts
+++ b/tests/image-generation-server-architecture.test.ts
@@ -10,6 +10,7 @@ const referenceNormalizationPath = join(root, 'frontend/src/server/images/image-
 const initialJobPath = join(root, 'frontend/src/server/images/image-initial-job.ts');
 const errorPath = join(root, 'frontend/src/server/images/image-generation-error.ts');
 const providerPayloadPath = join(root, 'frontend/src/server/images/image-provider-payload.ts');
+const completionPath = join(root, 'frontend/src/server/images/image-generation-completion.ts');
 const receiptsPath = join(root, 'frontend/src/server/images/image-generation-receipts.ts');
 const settingsSnapshotPath = join(root, 'frontend/src/server/images/image-generation-settings-snapshot.ts');
 
@@ -19,6 +20,7 @@ const referenceNormalizationSource = readFileSync(referenceNormalizationPath, 'u
 const initialJobSource = readFileSync(initialJobPath, 'utf8');
 const errorSource = readFileSync(errorPath, 'utf8');
 const providerPayloadSource = readFileSync(providerPayloadPath, 'utf8');
+const completionSource = readFileSync(completionPath, 'utf8');
 const receiptsSource = readFileSync(receiptsPath, 'utf8');
 const settingsSnapshotSource = readFileSync(settingsSnapshotPath, 'utf8');
 
@@ -28,6 +30,7 @@ test('image generation executor delegates focused server helpers', () => {
   assert.ok(existsSync(initialJobPath), 'atomic initial image job creation should live in a focused module');
   assert.ok(existsSync(errorPath), 'image generation execution error should live in a focused module');
   assert.ok(existsSync(providerPayloadPath), 'provider payload parsing should live in a focused module');
+  assert.ok(existsSync(completionPath), 'image generation completion persistence should live in a focused module');
   assert.ok(existsSync(receiptsPath), 'image generation receipt helpers should live in a focused module');
   assert.ok(existsSync(settingsSnapshotPath), 'image settings snapshot helpers should live in a focused module');
   assert.match(executorSource, /from '\.\/existing-image-job-response'/);
@@ -35,6 +38,7 @@ test('image generation executor delegates focused server helpers', () => {
   assert.match(executorSource, /from '\.\/image-initial-job'/);
   assert.match(executorSource, /from '\.\/image-generation-error'/);
   assert.match(executorSource, /from '\.\/image-provider-payload'/);
+  assert.match(executorSource, /from '\.\/image-generation-completion'/);
   assert.match(executorSource, /from '\.\/image-generation-receipts'/);
   assert.match(executorSource, /from '\.\/image-generation-settings-snapshot'/);
   assert.match(executorSource, /export \{ buildResponseFromExistingJob \} from '\.\/existing-image-job-response'/);
@@ -60,9 +64,13 @@ test('image generation executor does not regain extracted server ownership', () 
   assert.doesNotMatch(executorSource, /function buildReceiptSnapshot\(/, 'receipt snapshots belong in image-generation-receipts.ts');
   assert.doesNotMatch(executorSource, /async function recordRefundReceipt\(/, 'refund receipt writes belong in image-generation-receipts.ts');
   assert.doesNotMatch(executorSource, /function buildDefaultSettingsSnapshot\(/, 'default settings snapshots belong in image-generation-settings-snapshot.ts');
+  assert.doesNotMatch(executorSource, /recordUserAsset/, 'completed character asset persistence belongs in image-generation-completion.ts');
+  assert.doesNotMatch(executorSource, /upsertLegacyJobOutputs/, 'completed output persistence belongs in image-generation-completion.ts');
+  assert.doesNotMatch(executorSource, /ensureReusableAsset/, 'reusable character asset persistence belongs in image-generation-completion.ts');
+  assert.doesNotMatch(executorSource, /status = 'completed'/, 'completed job update belongs in image-generation-completion.ts');
 
   const lineCount = executorSource.split('\n').length;
-  assert.ok(lineCount <= 970, `image generation executor should stay below 970 lines after receipt and settings extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 860, `image generation executor should stay below 860 lines after completion extraction, got ${lineCount}`);
 });
 
 test('existing image job response module exposes the expected contract', () => {
@@ -86,6 +94,11 @@ test('existing image job response module exposes the expected contract', () => {
   assert.match(providerPayloadSource, /export function buildCharacterReferencePrompt/);
   assert.match(providerPayloadSource, /export function extractImages/);
   assert.match(providerPayloadSource, /export function parseRequestId/);
+  assert.match(completionSource, /export async function persistCompletedImageGeneration/);
+  assert.match(completionSource, /recordUserAsset/);
+  assert.match(completionSource, /upsertLegacyJobOutputs/);
+  assert.match(completionSource, /ensureReusableAsset/);
+  assert.match(completionSource, /status = 'completed'/);
   assert.match(receiptsSource, /export type PendingReceipt/);
   assert.match(receiptsSource, /export function buildReceiptSnapshot/);
   assert.match(receiptsSource, /export async function recordRefundReceipt/);


### PR DESCRIPTION
## Summary
- move completed image generation persistence into a focused server helper
- keep execute-image-generation focused on request validation and provider execution
- update the image generation architecture contract and line budget

## Checks
- ./node_modules/.bin/tsx --tsconfig frontend/tsconfig.json --test tests/image-generation-server-architecture.test.ts tests/image-generation-route.test.ts tests/generate-initial-video-job-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- frontend/src/server/images/execute-image-generation.ts frontend/src/server/images/image-generation-completion.ts tests/image-generation-server-architecture.test.ts