### PR TITLE
Split image generation failure persistence

### DIFF
--- a/frontend/src/server/images/execute-image-generation.ts
+++ b/frontend/src/server/images/execute-image-generation.ts
@@ -1,4 +1,3 @@
-import { ApiError, ValidationError } from '@fal-ai/client';
 import { randomUUID } from 'crypto';
 import { listFalEngines } from '@/config/falEngines';
 import type {
@@ -7,7 +6,7 @@ import type {
   ImageGenerationResponse,
 } from '@/types/image-generation';
 import { getFalClient } from '@/lib/fal-client';
-import { isDatabaseConfigured, query } from '@/lib/db';
+import { isDatabaseConfigured } from '@/lib/db';
 import { ensureBillingSchema } from '@/lib/schema';
 import { computePricingSnapshot, getPlatformFeeCents } from '@/lib/pricing';
 import type { PricingSnapshot } from '@/types/engines';
@@ -53,6 +52,7 @@ import {
 import { ImageGenerationExecutionError } from './image-generation-error';
 import { createAtomicInitialImageJob } from './image-initial-job';
 import { persistCompletedImageGeneration } from './image-generation-completion';
+import { persistFailedImageGeneration } from './image-generation-failure';
 import {
   buildCharacterReferencePrompt,
   extractImages,
@@ -61,7 +61,6 @@ import {
 } from './image-provider-payload';
 import {
   buildReceiptSnapshot,
-  recordRefundReceipt,
   type PendingReceipt,
 } from './image-generation-receipts';
 import { buildDefaultSettingsSnapshot } from './image-generation-settings-snapshot';
@@ -746,98 +745,31 @@ export async function executeImageGeneration({
     } satisfies ImageGenerationResponse;
   } catch (error) {
     console.error('[images] Fal generation failed', error);
-    const providerStatus = error instanceof ApiError && typeof error.status === 'number' ? error.status : null;
-    const providerBody = error instanceof ApiError ? error.body : null;
-    const providerErrors =
-      error instanceof ValidationError
-        ? error.fieldErrors
-            .map((entry) => {
-              const loc = Array.isArray(entry.loc) ? entry.loc.filter((part) => part !== 'body') : [];
-              const path = loc.length ? loc.join('.') : null;
-              const msg = typeof entry.msg === 'string' ? entry.msg.trim() : '';
-              if (!msg) return null;
-              return path ? `${path}: ${msg}` : msg;
-            })
-            .filter((entry): entry is string => Boolean(entry))
-        : [];
-    const messageBase = error instanceof Error && error.message ? error.message : 'Fal request failed';
-    const message =
-      providerErrors.length > 0
-        ? providerErrors.slice(0, 3).join(' · ')
-        : providerStatus === 422 && messageBase === 'Unprocessable Entity'
-          ? 'Fal rejected the input (422). Check that your reference image URLs are reachable and valid image files.'
-          : messageBase;
-
-    try {
-      await query(
-        `UPDATE app_jobs
-         SET status = 'failed',
-             progress = 0,
-             message = $2,
-             provider_job_id = COALESCE($3, provider_job_id),
-             provisional = FALSE,
-             updated_at = NOW(),
-             payment_status = 'refunded_wallet'
-         WHERE job_id = $1`,
-        [jobId, message, providerJobId ?? null]
-      );
-    } catch (updateError) {
-      console.warn('[images] failed to update failed job', updateError);
-    }
-
-    try {
-      const hosts = combinedImageUrls
-        .map((url) => {
-          try {
-            return new URL(url).host;
-          } catch {
-            return null;
-          }
-        })
-        .filter((host): host is string => Boolean(host));
-      const uniqueHosts = Array.from(new Set(hosts));
-
-      await query(
-        `INSERT INTO fal_queue_log (job_id, provider, provider_job_id, engine_id, status, payload)
-         VALUES ($1,$2,$3,$4,$5,$6::jsonb)`,
-        [
-          jobId,
-          providerMode,
-          providerJobId ?? null,
-          engine.id,
-          'failed',
-          JSON.stringify({
-            request: {
-              mode,
-              numImages,
-              resolution,
-              ...(characterReferences.length ? { characterReferenceCount: characterReferences.length } : {}),
-              ...(resolvedAspectRatio ? { aspect_ratio: resolvedAspectRatio } : {}),
-              ...(normalizedSeed != null ? { seed: normalizedSeed } : {}),
-              ...(outputFormat ? { output_format: outputFormat } : {}),
-              ...(quality ? { quality } : {}),
-              ...(maskUrl ? { mask_url: maskUrl } : {}),
-              ...(enableWebSearch ? { enable_web_search: true } : {}),
-              ...(thinkingLevel ? { thinking_level: thinkingLevel } : {}),
-              ...(limitGenerations ? { limit_generations: true } : {}),
-              referenceImageCount: combinedImageUrls.length,
-              referenceImageHosts: uniqueHosts,
-              falModelId: modeConfig.falModelId,
-            },
-            error: {
-              status: providerStatus,
-              message,
-              body: providerBody,
-            },
-            pricing: { totalCents: pricing.totalCents, currency: pricing.currency },
-          }),
-        ]
-      );
-    } catch (logError) {
-      console.warn('[images] failed to record fal queue log', logError);
-    }
-
-    await recordRefundReceipt(pendingReceipt, refundDescription, priceOnlyReceipts);
+    const { message, providerBody, providerStatus } = await persistFailedImageGeneration({
+      characterReferenceCount: characterReferences.length,
+      enableWebSearch,
+      engineId: engine.id,
+      error,
+      falModelId: modeConfig.falModelId,
+      jobId,
+      limitGenerations,
+      maskUrl,
+      mode,
+      normalizedSeed,
+      numImages,
+      outputFormat,
+      pendingReceipt,
+      priceOnlyReceipts,
+      pricing,
+      providerJobId: providerJobId ?? null,
+      providerMode,
+      quality,
+      referenceImageUrls: combinedImageUrls,
+      refundDescription,
+      resolvedAspectRatio,
+      resolution,
+      thinkingLevel,
+    });
 
     fail(mode, 'fal_error', message, 502, { providerStatus, providerBody }, {
       engineId: engineEntry.id,

--- a/frontend/src/server/images/image-generation-failure.ts
+++ b/frontend/src/server/images/image-generation-failure.ts
@@ -1,0 +1,152 @@
+import { ApiError, ValidationError } from '@fal-ai/client';
+import { query } from '@/lib/db';
+import type { PricingSnapshot } from '@/types/engines';
+import type { ImageGenerationMode } from '@/types/image-generation';
+import { recordRefundReceipt, type PendingReceipt } from './image-generation-receipts';
+
+export async function persistFailedImageGeneration(params: {
+  characterReferenceCount: number;
+  enableWebSearch: boolean;
+  engineId: string;
+  error: unknown;
+  falModelId: string;
+  jobId: string;
+  limitGenerations: boolean;
+  maskUrl: string | null;
+  mode: ImageGenerationMode;
+  normalizedSeed: number | null;
+  numImages: number;
+  outputFormat: string | null;
+  pendingReceipt: PendingReceipt;
+  priceOnlyReceipts: boolean;
+  pricing: PricingSnapshot;
+  providerJobId: string | null;
+  providerMode: string;
+  quality: string | null;
+  referenceImageUrls: string[];
+  refundDescription: string;
+  resolvedAspectRatio: string | null;
+  resolution: string;
+  thinkingLevel: string | null;
+}) {
+  const {
+    characterReferenceCount,
+    enableWebSearch,
+    engineId,
+    error,
+    falModelId,
+    jobId,
+    limitGenerations,
+    maskUrl,
+    mode,
+    normalizedSeed,
+    numImages,
+    outputFormat,
+    pendingReceipt,
+    priceOnlyReceipts,
+    pricing,
+    providerJobId,
+    providerMode,
+    quality,
+    referenceImageUrls,
+    refundDescription,
+    resolvedAspectRatio,
+    resolution,
+    thinkingLevel,
+  } = params;
+
+  const providerStatus = error instanceof ApiError && typeof error.status === 'number' ? error.status : null;
+  const providerBody = error instanceof ApiError ? error.body : null;
+  const providerErrors =
+    error instanceof ValidationError
+      ? error.fieldErrors
+          .map((entry) => {
+            const loc = Array.isArray(entry.loc) ? entry.loc.filter((part) => part !== 'body') : [];
+            const path = loc.length ? loc.join('.') : null;
+            const msg = typeof entry.msg === 'string' ? entry.msg.trim() : '';
+            if (!msg) return null;
+            return path ? `${path}: ${msg}` : msg;
+          })
+          .filter((entry): entry is string => Boolean(entry))
+      : [];
+  const messageBase = error instanceof Error && error.message ? error.message : 'Fal request failed';
+  const message =
+    providerErrors.length > 0
+      ? providerErrors.slice(0, 3).join(' · ')
+      : providerStatus === 422 && messageBase === 'Unprocessable Entity'
+        ? 'Fal rejected the input (422). Check that your reference image URLs are reachable and valid image files.'
+        : messageBase;
+
+  try {
+    await query(
+      `UPDATE app_jobs
+       SET status = 'failed',
+           progress = 0,
+           message = $2,
+           provider_job_id = COALESCE($3, provider_job_id),
+           provisional = FALSE,
+           updated_at = NOW(),
+           payment_status = 'refunded_wallet'
+       WHERE job_id = $1`,
+      [jobId, message, providerJobId ?? null]
+    );
+  } catch (updateError) {
+    console.warn('[images] failed to update failed job', updateError);
+  }
+
+  try {
+    const hosts = referenceImageUrls
+      .map((url) => {
+        try {
+          return new URL(url).host;
+        } catch {
+          return null;
+        }
+      })
+      .filter((host): host is string => Boolean(host));
+    const uniqueHosts = Array.from(new Set(hosts));
+
+    await query(
+      `INSERT INTO fal_queue_log (job_id, provider, provider_job_id, engine_id, status, payload)
+       VALUES ($1,$2,$3,$4,$5,$6::jsonb)`,
+      [
+        jobId,
+        providerMode,
+        providerJobId ?? null,
+        engineId,
+        'failed',
+        JSON.stringify({
+          request: {
+            mode,
+            numImages,
+            resolution,
+            ...(characterReferenceCount ? { characterReferenceCount } : {}),
+            ...(resolvedAspectRatio ? { aspect_ratio: resolvedAspectRatio } : {}),
+            ...(normalizedSeed != null ? { seed: normalizedSeed } : {}),
+            ...(outputFormat ? { output_format: outputFormat } : {}),
+            ...(quality ? { quality } : {}),
+            ...(maskUrl ? { mask_url: maskUrl } : {}),
+            ...(enableWebSearch ? { enable_web_search: true } : {}),
+            ...(thinkingLevel ? { thinking_level: thinkingLevel } : {}),
+            ...(limitGenerations ? { limit_generations: true } : {}),
+            referenceImageCount: referenceImageUrls.length,
+            referenceImageHosts: uniqueHosts,
+            falModelId,
+          },
+          error: {
+            status: providerStatus,
+            message,
+            body: providerBody,
+          },
+          pricing: { totalCents: pricing.totalCents, currency: pricing.currency },
+        }),
+      ]
+    );
+  } catch (logError) {
+    console.warn('[images] failed to record fal queue log', logError);
+  }
+
+  await recordRefundReceipt(pendingReceipt, refundDescription, priceOnlyReceipts);
+
+  return { message, providerBody, providerStatus };
+}

--- a/tests/image-generation-server-architecture.test.ts
+++ b/tests/image-generation-server-architecture.test.ts
@@ -11,6 +11,7 @@ const initialJobPath = join(root, 'frontend/src/server/images/image-initial-job.
 const errorPath = join(root, 'frontend/src/server/images/image-generation-error.ts');
 const providerPayloadPath = join(root, 'frontend/src/server/images/image-provider-payload.ts');
 const completionPath = join(root, 'frontend/src/server/images/image-generation-completion.ts');
+const failurePath = join(root, 'frontend/src/server/images/image-generation-failure.ts');
 const receiptsPath = join(root, 'frontend/src/server/images/image-generation-receipts.ts');
 const settingsSnapshotPath = join(root, 'frontend/src/server/images/image-generation-settings-snapshot.ts');
 
@@ -21,6 +22,7 @@ const initialJobSource = readFileSync(initialJobPath, 'utf8');
 const errorSource = readFileSync(errorPath, 'utf8');
 const providerPayloadSource = readFileSync(providerPayloadPath, 'utf8');
 const completionSource = readFileSync(completionPath, 'utf8');
+const failureSource = readFileSync(failurePath, 'utf8');
 const receiptsSource = readFileSync(receiptsPath, 'utf8');
 const settingsSnapshotSource = readFileSync(settingsSnapshotPath, 'utf8');
 
@@ -31,6 +33,7 @@ test('image generation executor delegates focused server helpers', () => {
   assert.ok(existsSync(errorPath), 'image generation execution error should live in a focused module');
   assert.ok(existsSync(providerPayloadPath), 'provider payload parsing should live in a focused module');
   assert.ok(existsSync(completionPath), 'image generation completion persistence should live in a focused module');
+  assert.ok(existsSync(failurePath), 'image generation failure persistence should live in a focused module');
   assert.ok(existsSync(receiptsPath), 'image generation receipt helpers should live in a focused module');
   assert.ok(existsSync(settingsSnapshotPath), 'image settings snapshot helpers should live in a focused module');
   assert.match(executorSource, /from '\.\/existing-image-job-response'/);
@@ -39,6 +42,7 @@ test('image generation executor delegates focused server helpers', () => {
   assert.match(executorSource, /from '\.\/image-generation-error'/);
   assert.match(executorSource, /from '\.\/image-provider-payload'/);
   assert.match(executorSource, /from '\.\/image-generation-completion'/);
+  assert.match(executorSource, /from '\.\/image-generation-failure'/);
   assert.match(executorSource, /from '\.\/image-generation-receipts'/);
   assert.match(executorSource, /from '\.\/image-generation-settings-snapshot'/);
   assert.match(executorSource, /export \{ buildResponseFromExistingJob \} from '\.\/existing-image-job-response'/);
@@ -68,9 +72,13 @@ test('image generation executor does not regain extracted server ownership', () 
   assert.doesNotMatch(executorSource, /upsertLegacyJobOutputs/, 'completed output persistence belongs in image-generation-completion.ts');
   assert.doesNotMatch(executorSource, /ensureReusableAsset/, 'reusable character asset persistence belongs in image-generation-completion.ts');
   assert.doesNotMatch(executorSource, /status = 'completed'/, 'completed job update belongs in image-generation-completion.ts');
+  assert.doesNotMatch(executorSource, /ApiError/, 'provider failure classification belongs in image-generation-failure.ts');
+  assert.doesNotMatch(executorSource, /ValidationError/, 'provider validation error parsing belongs in image-generation-failure.ts');
+  assert.doesNotMatch(executorSource, /status = 'failed'/, 'failed job update belongs in image-generation-failure.ts');
+  assert.doesNotMatch(executorSource, /referenceImageHosts/, 'failed provider log metadata belongs in image-generation-failure.ts');
 
   const lineCount = executorSource.split('\n').length;
-  assert.ok(lineCount <= 860, `image generation executor should stay below 860 lines after completion extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 790, `image generation executor should stay below 790 lines after failure extraction, got ${lineCount}`);
 });
 
 test('existing image job response module exposes the expected contract', () => {
@@ -99,6 +107,11 @@ test('existing image job response module exposes the expected contract', () => {
   assert.match(completionSource, /upsertLegacyJobOutputs/);
   assert.match(completionSource, /ensureReusableAsset/);
   assert.match(completionSource, /status = 'completed'/);
+  assert.match(failureSource, /export async function persistFailedImageGeneration/);
+  assert.match(failureSource, /ApiError/);
+  assert.match(failureSource, /ValidationError/);
+  assert.match(failureSource, /recordRefundReceipt/);
+  assert.match(failureSource, /status = 'failed'/);
   assert.match(receiptsSource, /export type PendingReceipt/);
   assert.match(receiptsSource, /export function buildReceiptSnapshot/);
   assert.match(receiptsSource, /export async function recordRefundReceipt/);


### PR DESCRIPTION
## Summary
- move provider failure classification, failed job persistence, failed Fal log, and refund receipt writes into a focused server helper
- keep execute-image-generation centered on validation, provider execution, and response shaping
- tighten the image generation architecture contract and line budget again

## Checks
- ./node_modules/.bin/tsx --tsconfig frontend/tsconfig.json --test tests/image-generation-server-architecture.test.ts tests/image-generation-route.test.ts tests/generate-initial-video-job-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- frontend/src/server/images/execute-image-generation.ts frontend/src/server/images/image-generation-failure.ts tests/image-generation-server-architecture.test.ts