### PR TITLE
Split admin insights formatting helpers

### DIFF
--- a/frontend/app/(core)/admin/insights/_components/InsightsPanels.tsx
+++ b/frontend/app/(core)/admin/insights/_components/InsightsPanels.tsx
@@ -16,8 +16,8 @@ import type {
 } from '../_lib/insights-types';
 import {
   buildChartTicks,
-  buildInsightsHref,
-  FOCUS_OPTIONS,
+} from '../_lib/insights-helpers';
+import {
   formatCompactNumber,
   formatCurrency,
   formatDay,
@@ -27,7 +27,8 @@ import {
   formatPercent,
   toneBadgeClass,
   toneValueClass,
-} from '../_lib/insights-helpers';
+} from '../_lib/insights-formatters';
+import { buildInsightsHref, FOCUS_OPTIONS } from '../_lib/insights-navigation';
 
 export function InsightsControls({
   current,

--- a/frontend/app/(core)/admin/insights/_lib/insights-formatters.ts
+++ b/frontend/app/(core)/admin/insights/_lib/insights-formatters.ts
@@ -1,0 +1,159 @@
+import type { DeltaSnapshot, SmallStat } from './insights-types';
+
+const dayFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
+const monthFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', year: 'numeric' });
+const fullDateFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+const currencyFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
+const preciseCurrencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+const numberFormatter = new Intl.NumberFormat('en-US');
+const compactNumberFormatter = new Intl.NumberFormat('en-US', { notation: 'compact', maximumFractionDigits: 1 });
+const percentFormatter = new Intl.NumberFormat('en-US', { style: 'percent', maximumFractionDigits: 1 });
+
+export function toneBadgeClass(tone: SmallStat['tone']) {
+  if (tone === 'success') {
+    return 'bg-success-bg text-success';
+  }
+  if (tone === 'warning') {
+    return 'bg-error-bg text-error';
+  }
+  return 'bg-surface-hover text-text-secondary';
+}
+
+export function toneValueClass(tone: SmallStat['tone']) {
+  if (tone === 'success') {
+    return 'text-success';
+  }
+  if (tone === 'warning') {
+    return 'text-error';
+  }
+  return 'text-text-primary';
+}
+
+export function formatDeltaLabel(delta: DeltaSnapshot) {
+  if (delta.current === 0 && delta.previous === 0) {
+    return 'Flat';
+  }
+  if (delta.previous === 0) {
+    return delta.current > 0 ? 'New' : 'Flat';
+  }
+  if (delta.absoluteChange === 0) {
+    return 'Flat';
+  }
+  return formatSignedPercent(delta.ratioChange ?? 0);
+}
+
+export function formatNarrativeDelta(delta: DeltaSnapshot) {
+  if (delta.current === 0 && delta.previous === 0) {
+    return 'flat';
+  }
+  if (delta.previous === 0) {
+    return delta.current > 0 ? 'up from a zero base' : 'flat';
+  }
+  if (delta.absoluteChange === 0) {
+    return 'flat';
+  }
+  return formatSignedPercent(delta.ratioChange ?? 0);
+}
+
+export function resolveDeltaTone(delta: DeltaSnapshot, positiveIsGood = true): SmallStat['tone'] {
+  if (delta.current === 0 && delta.previous === 0) {
+    return 'default';
+  }
+  if (delta.previous === 0) {
+    return delta.current > 0 ? (positiveIsGood ? 'success' : 'warning') : 'default';
+  }
+  if (delta.absoluteChange === 0) {
+    return 'default';
+  }
+  const improved = positiveIsGood ? delta.absoluteChange > 0 : delta.absoluteChange < 0;
+  return improved ? 'success' : 'warning';
+}
+
+export function formatCurrency(amount: number, options?: { precise?: boolean }) {
+  if (options?.precise) {
+    return preciseCurrencyFormatter.format(amount);
+  }
+  return currencyFormatter.format(amount);
+}
+
+export function formatSignedCurrency(amount: number) {
+  if (!Number.isFinite(amount)) {
+    return '$0';
+  }
+  if (amount === 0) {
+    return '$0';
+  }
+  const absolute = formatCurrency(Math.abs(amount));
+  return `${amount > 0 ? '+' : '-'}${absolute}`;
+}
+
+export function formatAverageTicket(totals: { amountUsd: number; count: number }) {
+  return formatCurrency(totals.amountUsd / totals.count, { precise: true });
+}
+
+export function formatNumber(value: number) {
+  return numberFormatter.format(value);
+}
+
+export function formatCompactNumber(value: number) {
+  if (!Number.isFinite(value)) return '0';
+  if (Math.abs(value) >= 1000) return compactNumberFormatter.format(value);
+  if (Number.isInteger(value)) return numberFormatter.format(value);
+  return value.toFixed(1);
+}
+
+export function formatAxisCurrency(value: number) {
+  const absolute = Math.abs(value);
+  if (absolute >= 1000) {
+    return `$${(value / 1000).toFixed(absolute >= 10000 ? 0 : 1)}k`;
+  }
+  if (absolute >= 10) {
+    return `$${Math.round(value)}`;
+  }
+  return `$${value.toFixed(1)}`;
+}
+
+export function formatPercent(value: number) {
+  if (!Number.isFinite(value)) {
+    return '0%';
+  }
+  return percentFormatter.format(value);
+}
+
+export function formatSignedPercent(value: number) {
+  if (!Number.isFinite(value)) {
+    return '0%';
+  }
+  const sign = value > 0 ? '+' : value < 0 ? '-' : '';
+  return `${sign}${percentFormatter.format(Math.abs(value))}`;
+}
+
+export function formatDay(value: string) {
+  return dayFormatter.format(new Date(value));
+}
+
+export function formatMonth(value: string) {
+  return monthFormatter.format(new Date(value));
+}
+
+export function formatFullDate(value: string | null) {
+  if (!value) return '—';
+  return fullDateFormatter.format(new Date(value));
+}
+
+export function formatDays(value: number | null) {
+  if (value == null || Number.isNaN(value)) return '—';
+  return `${value.toFixed(1)} days`;
+}
+
+export function formatAverage(value: number) {
+  if (!Number.isFinite(value)) {
+    return '0.0';
+  }
+  return value.toFixed(1);
+}

--- a/frontend/app/(core)/admin/insights/_lib/insights-helpers.ts
+++ b/frontend/app/(core)/admin/insights/_lib/insights-helpers.ts
@@ -4,7 +4,6 @@ import type {
   AdminMetrics,
   AdminMetricsComparison,
   AmountSeriesPoint,
-  MetricsRangeLabel,
   TimeSeriesPoint,
 } from '@/lib/admin/types';
 import type {
@@ -19,20 +18,21 @@ import type {
   RevenueBoardRow,
   SmallStat,
 } from './insights-types';
-
-const dayFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
-const monthFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', year: 'numeric' });
-const fullDateFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-const currencyFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
-const preciseCurrencyFormatter = new Intl.NumberFormat('en-US', {
-  style: 'currency',
-  currency: 'USD',
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
-const numberFormatter = new Intl.NumberFormat('en-US');
-const compactNumberFormatter = new Intl.NumberFormat('en-US', { notation: 'compact', maximumFractionDigits: 1 });
-const percentFormatter = new Intl.NumberFormat('en-US', { style: 'percent', maximumFractionDigits: 1 });
+import {
+  formatAverage,
+  formatAverageTicket,
+  formatAxisCurrency,
+  formatCurrency,
+  formatDay,
+  formatDays,
+  formatDeltaLabel,
+  formatNarrativeDelta,
+  formatNumber,
+  formatPercent,
+  formatSignedCurrency,
+  resolveDeltaTone,
+} from './insights-formatters';
+import { buildInsightsHref, describeRange, FOCUS_OPTIONS } from './insights-navigation';
 
 export const CHART_THEMES: Record<FocusMetric, ChartTheme> = {
   signups: {
@@ -52,41 +52,6 @@ export const CHART_THEMES: Record<FocusMetric, ChartTheme> = {
     line: '#94A3B8',
   },
 };
-
-export const FOCUS_OPTIONS: Array<{ key: FocusMetric; label: string }> = [
-  { key: 'signups', label: 'Signups' },
-  { key: 'active', label: 'Active' },
-  { key: 'topups', label: 'Top-ups' },
-  { key: 'charges', label: 'Charges' },
-];
-
-export function toneBadgeClass(tone: SmallStat['tone']) {
-  if (tone === 'success') {
-    return 'bg-success-bg text-success';
-  }
-  if (tone === 'warning') {
-    return 'bg-error-bg text-error';
-  }
-  return 'bg-surface-hover text-text-secondary';
-}
-
-export function toneValueClass(tone: SmallStat['tone']) {
-  if (tone === 'success') {
-    return 'text-success';
-  }
-  if (tone === 'warning') {
-    return 'text-error';
-  }
-  return 'text-text-primary';
-}
-
-export function resolveFocusParam(value: string | string[] | undefined): FocusMetric {
-  const resolved = Array.isArray(value) ? value[value.length - 1] : value;
-  if (resolved === 'active' || resolved === 'topups' || resolved === 'charges') {
-    return resolved;
-  }
-  return 'signups';
-}
 
 export function buildExecutiveMetrics(
   metrics: AdminMetrics,
@@ -731,46 +696,6 @@ export function compareValues(current: number, previous: number): DeltaSnapshot 
   };
 }
 
-export function formatDeltaLabel(delta: DeltaSnapshot) {
-  if (delta.current === 0 && delta.previous === 0) {
-    return 'Flat';
-  }
-  if (delta.previous === 0) {
-    return delta.current > 0 ? 'New' : 'Flat';
-  }
-  if (delta.absoluteChange === 0) {
-    return 'Flat';
-  }
-  return formatSignedPercent(delta.ratioChange ?? 0);
-}
-
-export function formatNarrativeDelta(delta: DeltaSnapshot) {
-  if (delta.current === 0 && delta.previous === 0) {
-    return 'flat';
-  }
-  if (delta.previous === 0) {
-    return delta.current > 0 ? 'up from a zero base' : 'flat';
-  }
-  if (delta.absoluteChange === 0) {
-    return 'flat';
-  }
-  return formatSignedPercent(delta.ratioChange ?? 0);
-}
-
-export function resolveDeltaTone(delta: DeltaSnapshot, positiveIsGood = true): SmallStat['tone'] {
-  if (delta.current === 0 && delta.previous === 0) {
-    return 'default';
-  }
-  if (delta.previous === 0) {
-    return delta.current > 0 ? (positiveIsGood ? 'success' : 'warning') : 'default';
-  }
-  if (delta.absoluteChange === 0) {
-    return 'default';
-  }
-  const improved = positiveIsGood ? delta.absoluteChange > 0 : delta.absoluteChange < 0;
-  return improved ? 'success' : 'warning';
-}
-
 export function sumTimeSeries(points: TimeSeriesPoint[]): number {
   return points.reduce((sum, point) => sum + point.value, 0);
 }
@@ -822,117 +747,4 @@ export function buildChartTicks(maxValue: number): number[] {
   const tickCount = Math.max(2, Math.round(niceMax / step));
 
   return Array.from({ length: tickCount + 1 }, (_, index) => Number((index * step).toFixed(4)));
-}
-
-export function buildInsightsHref({
-  range,
-  excludeAdmin,
-  focus,
-}: {
-  range: MetricsRangeLabel;
-  excludeAdmin: boolean;
-  focus: FocusMetric;
-}) {
-  const params = new URLSearchParams();
-  params.set('range', range);
-  params.set('excludeAdmin', excludeAdmin ? '1' : '0');
-  params.set('focus', focus);
-  return `/admin/insights?${params.toString()}`;
-}
-
-export function describeRange(label: MetricsRangeLabel) {
-  switch (label) {
-    case '24h':
-      return '24 hours';
-    case '7d':
-      return '7 days';
-    case '90d':
-      return '90 days';
-    default:
-      return '30 days';
-  }
-}
-
-export function formatCurrency(amount: number, options?: { precise?: boolean }) {
-  if (options?.precise) {
-    return preciseCurrencyFormatter.format(amount);
-  }
-  return currencyFormatter.format(amount);
-}
-
-export function formatSignedCurrency(amount: number) {
-  if (!Number.isFinite(amount)) {
-    return '$0';
-  }
-  if (amount === 0) {
-    return '$0';
-  }
-  const absolute = formatCurrency(Math.abs(amount));
-  return `${amount > 0 ? '+' : '-'}${absolute}`;
-}
-
-export function formatAverageTicket(totals: { amountUsd: number; count: number }) {
-  return formatCurrency(totals.amountUsd / totals.count, { precise: true });
-}
-
-export function formatNumber(value: number) {
-  return numberFormatter.format(value);
-}
-
-export function formatCompactNumber(value: number) {
-  if (!Number.isFinite(value)) return '0';
-  if (Math.abs(value) >= 1000) return compactNumberFormatter.format(value);
-  if (Number.isInteger(value)) return numberFormatter.format(value);
-  return value.toFixed(1);
-}
-
-export function formatAxisCurrency(value: number) {
-  const absolute = Math.abs(value);
-  if (absolute >= 1000) {
-    return `$${(value / 1000).toFixed(absolute >= 10000 ? 0 : 1)}k`;
-  }
-  if (absolute >= 10) {
-    return `$${Math.round(value)}`;
-  }
-  return `$${value.toFixed(1)}`;
-}
-
-export function formatPercent(value: number) {
-  if (!Number.isFinite(value)) {
-    return '0%';
-  }
-  return percentFormatter.format(value);
-}
-
-export function formatSignedPercent(value: number) {
-  if (!Number.isFinite(value)) {
-    return '0%';
-  }
-  const sign = value > 0 ? '+' : value < 0 ? '-' : '';
-  return `${sign}${percentFormatter.format(Math.abs(value))}`;
-}
-
-export function formatDay(value: string) {
-  return dayFormatter.format(new Date(value));
-}
-
-export function formatMonth(value: string) {
-  return monthFormatter.format(new Date(value));
-}
-
-export function formatFullDate(value: string | null) {
-  if (!value) return '—';
-  return fullDateFormatter.format(new Date(value));
-}
-
-export function formatDays(value: number | null) {
-  if (value == null || Number.isNaN(value)) return '—';
-  return `${value.toFixed(1)} days`;
-}
-
-export function formatAverage(value: number) {
-  if (!Number.isFinite(value)) {
-    return '0.0';
-  }
-  return value.toFixed(1);
 }

--- a/frontend/app/(core)/admin/insights/_lib/insights-navigation.ts
+++ b/frontend/app/(core)/admin/insights/_lib/insights-navigation.ts
@@ -1,0 +1,46 @@
+import type { MetricsRangeLabel } from '@/lib/admin/types';
+import type { FocusMetric } from './insights-types';
+
+export const FOCUS_OPTIONS: Array<{ key: FocusMetric; label: string }> = [
+  { key: 'signups', label: 'Signups' },
+  { key: 'active', label: 'Active' },
+  { key: 'topups', label: 'Top-ups' },
+  { key: 'charges', label: 'Charges' },
+];
+
+export function resolveFocusParam(value: string | string[] | undefined): FocusMetric {
+  const resolved = Array.isArray(value) ? value[value.length - 1] : value;
+  if (resolved === 'active' || resolved === 'topups' || resolved === 'charges') {
+    return resolved;
+  }
+  return 'signups';
+}
+
+export function buildInsightsHref({
+  range,
+  excludeAdmin,
+  focus,
+}: {
+  range: MetricsRangeLabel;
+  excludeAdmin: boolean;
+  focus: FocusMetric;
+}) {
+  const params = new URLSearchParams();
+  params.set('range', range);
+  params.set('excludeAdmin', excludeAdmin ? '1' : '0');
+  params.set('focus', focus);
+  return `/admin/insights?${params.toString()}`;
+}
+
+export function describeRange(label: MetricsRangeLabel) {
+  switch (label) {
+    case '24h':
+      return '24 hours';
+    case '7d':
+      return '7 days';
+    case '90d':
+      return '90 days';
+    default:
+      return '30 days';
+  }
+}

--- a/frontend/app/(core)/admin/insights/page.tsx
+++ b/frontend/app/(core)/admin/insights/page.tsx
@@ -19,9 +19,8 @@ import {
   buildQuickInsights,
   buildRecentLedgerRows,
   buildRevenueBoardRows,
-  describeRange,
-  resolveFocusParam,
 } from './_lib/insights-helpers';
+import { describeRange, resolveFocusParam } from './_lib/insights-navigation';
 import {
   BehaviorGrid,
   ComparisonChart,

--- a/tests/admin-insights-architecture.test.ts
+++ b/tests/admin-insights-architecture.test.ts
@@ -4,12 +4,16 @@ import test from 'node:test';
 
 const pagePath = 'frontend/app/(core)/admin/insights/page.tsx';
 const helpersPath = 'frontend/app/(core)/admin/insights/_lib/insights-helpers.ts';
+const formattersPath = 'frontend/app/(core)/admin/insights/_lib/insights-formatters.ts';
+const navigationPath = 'frontend/app/(core)/admin/insights/_lib/insights-navigation.ts';
 const typesPath = 'frontend/app/(core)/admin/insights/_lib/insights-types.ts';
 const panelsPath = 'frontend/app/(core)/admin/insights/_components/InsightsPanels.tsx';
 
 test('admin insights page stays a route orchestrator', () => {
   assert.equal(existsSync(pagePath), true);
   assert.equal(existsSync(helpersPath), true);
+  assert.equal(existsSync(formattersPath), true);
+  assert.equal(existsSync(navigationPath), true);
   assert.equal(existsSync(typesPath), true);
   assert.equal(existsSync(panelsPath), true);
 
@@ -19,6 +23,7 @@ test('admin insights page stays a route orchestrator', () => {
   assert.ok(pageLines < 260, `expected admin insights page to stay under 260 lines, got ${pageLines}`);
   assert.match(pageSource, /from '\.\/_lib\/insights-types';/);
   assert.match(pageSource, /from '\.\/_lib\/insights-helpers';/);
+  assert.match(pageSource, /from '\.\/_lib\/insights-navigation';/);
   assert.match(pageSource, /from '\.\/_components\/InsightsPanels';/);
   assert.match(pageSource, /fetchAdminMetrics\(/);
   assert.match(pageSource, /fetchAdminMetricsComparison\(/);
@@ -30,15 +35,33 @@ test('admin insights page stays a route orchestrator', () => {
   assert.doesNotMatch(pageSource, /new Intl\./);
 });
 
-test('admin insights helpers own data shaping and formatting', () => {
+test('admin insights helpers own data shaping', () => {
   const helpersSource = readFileSync(helpersPath, 'utf8');
 
   assert.match(helpersSource, /export function buildExecutiveMetrics/);
   assert.match(helpersSource, /export function buildFocusMetricData/);
   assert.match(helpersSource, /export function buildRevenueBoardRows/);
   assert.match(helpersSource, /export function buildMonthlyRows/);
-  assert.match(helpersSource, /export function describeRange/);
-  assert.match(helpersSource, /const currencyFormatter = new Intl\.NumberFormat/);
+  assert.match(helpersSource, /from '\.\/insights-formatters';/);
+  assert.match(helpersSource, /from '\.\/insights-navigation';/);
+  assert.doesNotMatch(helpersSource, /const currencyFormatter = new Intl\.NumberFormat/);
+  assert.doesNotMatch(helpersSource, /export function buildInsightsHref/);
+  assert.doesNotMatch(helpersSource, /export function resolveFocusParam/);
+});
+
+test('admin insights formatting and navigation helpers stay split', () => {
+  const formattersSource = readFileSync(formattersPath, 'utf8');
+  const navigationSource = readFileSync(navigationPath, 'utf8');
+
+  assert.match(formattersSource, /const currencyFormatter = new Intl\.NumberFormat/);
+  assert.match(formattersSource, /export function formatCurrency/);
+  assert.match(formattersSource, /export function formatCompactNumber/);
+  assert.match(formattersSource, /export function toneBadgeClass/);
+  assert.match(formattersSource, /export function resolveDeltaTone/);
+  assert.match(navigationSource, /export const FOCUS_OPTIONS/);
+  assert.match(navigationSource, /export function buildInsightsHref/);
+  assert.match(navigationSource, /export function resolveFocusParam/);
+  assert.match(navigationSource, /export function describeRange/);
 });
 
 test('admin insights panels own route-local JSX surfaces', () => {
@@ -50,4 +73,6 @@ test('admin insights panels own route-local JSX surfaces', () => {
   assert.match(panelsSource, /export function HealthPanel/);
   assert.match(panelsSource, /export function InsightsControls/);
   assert.match(panelsSource, /export function DailyLedgerTable/);
+  assert.match(panelsSource, /from '\.\.\/_lib\/insights-formatters';/);
+  assert.match(panelsSource, /from '\.\.\/_lib\/insights-navigation';/);
 });


### PR DESCRIPTION
## Summary
- split admin insights presentation formatting into a dedicated route helper
- move focus URL/query helpers into a navigation helper
- update admin insights architecture tests to lock the split

## Checks
- ./node_modules/.bin/tsx --tsconfig frontend/tsconfig.json --test tests/admin-insights-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- touched files