### PR TITLE
Split admin insights chart surfaces

### DIFF
--- a/frontend/app/(core)/admin/insights/_components/InsightsChartSurfaces.tsx
+++ b/frontend/app/(core)/admin/insights/_components/InsightsChartSurfaces.tsx
@@ -1,0 +1,136 @@
+import type { CSSProperties, ReactNode } from 'react';
+import { buildChartTicks } from '../_lib/insights-helpers';
+import type { ChartPoint, ChartTheme } from '../_lib/insights-types';
+import { formatCompactNumber } from '../_lib/insights-formatters';
+
+export function ComparisonChart({
+  currentPoints,
+  previousPoints,
+  theme,
+  ariaLabel = 'comparison chart',
+  axisFormatter = formatCompactNumber,
+  tooltipFormatter = formatCompactNumber,
+}: {
+  currentPoints: ChartPoint[];
+  previousPoints: ChartPoint[];
+  theme: ChartTheme;
+  ariaLabel?: string;
+  axisFormatter?: (value: number) => string;
+  tooltipFormatter?: (value: number) => string;
+}) {
+  const values = [...currentPoints.map((point) => point.value), ...previousPoints.map((point) => point.value)];
+
+  if (!values.length || values.every((value) => value <= 0)) {
+    return <EmptyStateCard>No data available for this range.</EmptyStateCard>;
+  }
+
+  const width = 820;
+  const height = 268;
+  const padding = { top: 18, right: 16, bottom: 34, left: 52 };
+  const chartWidth = width - padding.left - padding.right;
+  const chartHeight = height - padding.top - padding.bottom;
+  const maxValue = Math.max(...values);
+  const ticks = buildChartTicks(maxValue);
+  const maxTick = ticks[ticks.length - 1] || 1;
+  const totalPoints = Math.max(currentPoints.length, previousPoints.length);
+  const step = chartWidth / Math.max(1, totalPoints);
+  const barWidth = Math.max(6, step * 0.56);
+  const labelEvery = Math.max(1, Math.ceil(totalPoints / 7));
+
+  const previousLinePoints = Array.from({ length: totalPoints }, (_, index) => {
+    const value = previousPoints[index]?.value ?? 0;
+    return {
+      x: padding.left + step * index + step / 2,
+      y: padding.top + chartHeight - (value / maxTick) * chartHeight,
+    };
+  });
+
+  const previousPath = previousLinePoints
+    .map((point, index) => `${index === 0 ? 'M' : 'L'} ${point.x.toFixed(2)} ${point.y.toFixed(2)}`)
+    .join(' ');
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} role="img" aria-label={ariaLabel} className="h-64 w-full">
+      {ticks.map((tick) => {
+        const y = padding.top + chartHeight - (tick / maxTick) * chartHeight;
+        return (
+          <g key={`tick-${tick}`}>
+            <line x1={padding.left} x2={width - padding.right} y1={y} y2={y} stroke="var(--hairline)" />
+            <text x={padding.left - 10} y={y + 4} textAnchor="end" fontSize="10" fill="var(--text-muted)">
+              {axisFormatter(tick)}
+            </text>
+          </g>
+        );
+      })}
+
+      <line
+        x1={padding.left}
+        x2={width - padding.right}
+        y1={padding.top + chartHeight}
+        y2={padding.top + chartHeight}
+        stroke="var(--border)"
+      />
+
+      {previousLinePoints.length > 1 ? (
+        <path d={previousPath} fill="none" stroke={theme.line} strokeWidth="2" strokeDasharray="5 5" />
+      ) : null}
+
+      {previousLinePoints.map((point, index) => (
+        <circle key={`previous-${index}`} cx={point.x} cy={point.y} r="2.5" fill={theme.line} />
+      ))}
+
+      {currentPoints.map((point, index) => {
+        const xCenter = padding.left + step * index + step / 2;
+        const barHeight = (point.value / maxTick) * chartHeight;
+        const x = xCenter - barWidth / 2;
+        const y = padding.top + chartHeight - barHeight;
+        const previousValue = previousPoints[index]?.value ?? 0;
+        const showLabel = index === 0 || index === currentPoints.length - 1 || index % labelEvery === 0;
+
+        return (
+          <g key={`${point.label}-${index}`}>
+            <title>{`${point.label} | Current: ${tooltipFormatter(point.value)} | Previous: ${tooltipFormatter(previousValue)}`}</title>
+            <rect x={x} y={y} width={barWidth} height={Math.max(1, barHeight)} rx={4} fill={theme.bar} />
+            {showLabel ? (
+              <text x={xCenter} y={height - 12} textAnchor="middle" fontSize="10" fill="var(--text-muted)">
+                {point.label}
+              </text>
+            ) : null}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+export function ShareBar({
+  value,
+  label,
+  accent,
+}: {
+  value: number;
+  label: string;
+  accent: string;
+}) {
+  const style: CSSProperties = {
+    width: `${Math.min(100, Math.max(0, value * 100))}%`,
+    backgroundColor: accent,
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-2.5 w-full overflow-hidden rounded-full bg-hairline">
+        <div className="h-2.5 rounded-full" style={style} />
+      </div>
+      <span className="shrink-0 text-xs text-text-secondary">{label}</span>
+    </div>
+  );
+}
+
+export function EmptyStateCard({ children }: { children: ReactNode }) {
+  return (
+    <div className="rounded-2xl border border-dashed border-hairline bg-bg/40 px-4 py-5 text-sm text-text-secondary">
+      {children}
+    </div>
+  );
+}

--- a/frontend/app/(core)/admin/insights/_components/InsightsPanels.tsx
+++ b/frontend/app/(core)/admin/insights/_components/InsightsPanels.tsx
@@ -1,11 +1,8 @@
 import Link from 'next/link';
-import type { CSSProperties, ReactNode } from 'react';
 import type { AdminMetrics, MetricsRangeLabel } from '@/lib/admin/types';
 import { METRIC_RANGE_OPTIONS } from '@/server/admin-metrics';
 import { type AdminStatColumn, AdminStatTable } from '@/components/admin-system/surfaces/AdminStatTable';
 import type {
-  ChartPoint,
-  ChartTheme,
   FocusMetric,
   FunnelStep,
   LedgerRow,
@@ -15,10 +12,6 @@ import type {
   SmallStat,
 } from '../_lib/insights-types';
 import {
-  buildChartTicks,
-} from '../_lib/insights-helpers';
-import {
-  formatCompactNumber,
   formatCurrency,
   formatDay,
   formatFullDate,
@@ -29,6 +22,7 @@ import {
   toneValueClass,
 } from '../_lib/insights-formatters';
 import { buildInsightsHref, FOCUS_OPTIONS } from '../_lib/insights-navigation';
+import { EmptyStateCard, ShareBar } from './InsightsChartSurfaces';
 
 export function InsightsControls({
   current,
@@ -288,106 +282,6 @@ export function RevenueBoardTable({ rows }: { rows: RevenueBoardRow[] }) {
         bodyClassName="divide-y divide-hairline"
       />
     </div>
-  );
-}
-
-export function ComparisonChart({
-  currentPoints,
-  previousPoints,
-  theme,
-  ariaLabel = 'comparison chart',
-  axisFormatter = formatCompactNumber,
-  tooltipFormatter = formatCompactNumber,
-}: {
-  currentPoints: ChartPoint[];
-  previousPoints: ChartPoint[];
-  theme: ChartTheme;
-  ariaLabel?: string;
-  axisFormatter?: (value: number) => string;
-  tooltipFormatter?: (value: number) => string;
-}) {
-  const values = [...currentPoints.map((point) => point.value), ...previousPoints.map((point) => point.value)];
-
-  if (!values.length || values.every((value) => value <= 0)) {
-    return <EmptyStateCard>No data available for this range.</EmptyStateCard>;
-  }
-
-  const width = 820;
-  const height = 268;
-  const padding = { top: 18, right: 16, bottom: 34, left: 52 };
-  const chartWidth = width - padding.left - padding.right;
-  const chartHeight = height - padding.top - padding.bottom;
-  const maxValue = Math.max(...values);
-  const ticks = buildChartTicks(maxValue);
-  const maxTick = ticks[ticks.length - 1] || 1;
-  const totalPoints = Math.max(currentPoints.length, previousPoints.length);
-  const step = chartWidth / Math.max(1, totalPoints);
-  const barWidth = Math.max(6, step * 0.56);
-  const labelEvery = Math.max(1, Math.ceil(totalPoints / 7));
-
-  const previousLinePoints = Array.from({ length: totalPoints }, (_, index) => {
-    const value = previousPoints[index]?.value ?? 0;
-    return {
-      x: padding.left + step * index + step / 2,
-      y: padding.top + chartHeight - (value / maxTick) * chartHeight,
-    };
-  });
-
-  const previousPath = previousLinePoints
-    .map((point, index) => `${index === 0 ? 'M' : 'L'} ${point.x.toFixed(2)} ${point.y.toFixed(2)}`)
-    .join(' ');
-
-  return (
-    <svg viewBox={`0 0 ${width} ${height}`} role="img" aria-label={ariaLabel} className="h-64 w-full">
-      {ticks.map((tick) => {
-        const y = padding.top + chartHeight - (tick / maxTick) * chartHeight;
-        return (
-          <g key={`tick-${tick}`}>
-            <line x1={padding.left} x2={width - padding.right} y1={y} y2={y} stroke="var(--hairline)" />
-            <text x={padding.left - 10} y={y + 4} textAnchor="end" fontSize="10" fill="var(--text-muted)">
-              {axisFormatter(tick)}
-            </text>
-          </g>
-        );
-      })}
-
-      <line
-        x1={padding.left}
-        x2={width - padding.right}
-        y1={padding.top + chartHeight}
-        y2={padding.top + chartHeight}
-        stroke="var(--border)"
-      />
-
-      {previousLinePoints.length > 1 ? (
-        <path d={previousPath} fill="none" stroke={theme.line} strokeWidth="2" strokeDasharray="5 5" />
-      ) : null}
-
-      {previousLinePoints.map((point, index) => (
-        <circle key={`previous-${index}`} cx={point.x} cy={point.y} r="2.5" fill={theme.line} />
-      ))}
-
-      {currentPoints.map((point, index) => {
-        const xCenter = padding.left + step * index + step / 2;
-        const barHeight = (point.value / maxTick) * chartHeight;
-        const x = xCenter - barWidth / 2;
-        const y = padding.top + chartHeight - barHeight;
-        const previousValue = previousPoints[index]?.value ?? 0;
-        const showLabel = index === 0 || index === currentPoints.length - 1 || index % labelEvery === 0;
-
-        return (
-          <g key={`${point.label}-${index}`}>
-            <title>{`${point.label} | Current: ${tooltipFormatter(point.value)} | Previous: ${tooltipFormatter(previousValue)}`}</title>
-            <rect x={x} y={y} width={barWidth} height={Math.max(1, barHeight)} rx={4} fill={theme.bar} />
-            {showLabel ? (
-              <text x={xCenter} y={height - 12} textAnchor="middle" fontSize="10" fill="var(--text-muted)">
-                {point.label}
-              </text>
-            ) : null}
-          </g>
-        );
-      })}
-    </svg>
   );
 }
 
@@ -758,38 +652,6 @@ export function MonthlyRollupTable({
         <p className="mt-1 text-sm text-text-secondary">Six derniers mois, gardés séparés des lignes journalières.</p>
       </div>
       <AdminStatTable columns={columns} rows={rows} getRowKey={(row) => row.month} empty={null} className="rounded-none border-0" headerClassName="bg-surface" bodyClassName="divide-y divide-hairline" />
-    </div>
-  );
-}
-
-export function ShareBar({
-  value,
-  label,
-  accent,
-}: {
-  value: number;
-  label: string;
-  accent: string;
-}) {
-  const style: CSSProperties = {
-    width: `${Math.min(100, Math.max(0, value * 100))}%`,
-    backgroundColor: accent,
-  };
-
-  return (
-    <div className="flex items-center gap-2">
-      <div className="h-2.5 w-full overflow-hidden rounded-full bg-hairline">
-        <div className="h-2.5 rounded-full" style={style} />
-      </div>
-      <span className="shrink-0 text-xs text-text-secondary">{label}</span>
-    </div>
-  );
-}
-
-export function EmptyStateCard({ children }: { children: ReactNode }) {
-  return (
-    <div className="rounded-2xl border border-dashed border-hairline bg-bg/40 px-4 py-5 text-sm text-text-secondary">
-      {children}
     </div>
   );
 }

--- a/frontend/app/(core)/admin/insights/page.tsx
+++ b/frontend/app/(core)/admin/insights/page.tsx
@@ -23,7 +23,6 @@ import {
 import { describeRange, resolveFocusParam } from './_lib/insights-navigation';
 import {
   BehaviorGrid,
-  ComparisonChart,
   DailyLedgerTable,
   EngineMixTable,
   FunnelRows,
@@ -39,6 +38,7 @@ import {
   TopSpendersTable,
   WindowPulseGrid,
 } from './_components/InsightsPanels';
+import { ComparisonChart } from './_components/InsightsChartSurfaces';
 
 export default async function AdminInsightsPage(props: PageProps) {
   const searchParams = await props.searchParams;

--- a/tests/admin-insights-architecture.test.ts
+++ b/tests/admin-insights-architecture.test.ts
@@ -8,6 +8,7 @@ const formattersPath = 'frontend/app/(core)/admin/insights/_lib/insights-formatt
 const navigationPath = 'frontend/app/(core)/admin/insights/_lib/insights-navigation.ts';
 const typesPath = 'frontend/app/(core)/admin/insights/_lib/insights-types.ts';
 const panelsPath = 'frontend/app/(core)/admin/insights/_components/InsightsPanels.tsx';
+const chartSurfacesPath = 'frontend/app/(core)/admin/insights/_components/InsightsChartSurfaces.tsx';
 
 test('admin insights page stays a route orchestrator', () => {
   assert.equal(existsSync(pagePath), true);
@@ -16,6 +17,7 @@ test('admin insights page stays a route orchestrator', () => {
   assert.equal(existsSync(navigationPath), true);
   assert.equal(existsSync(typesPath), true);
   assert.equal(existsSync(panelsPath), true);
+  assert.equal(existsSync(chartSurfacesPath), true);
 
   const pageSource = readFileSync(pagePath, 'utf8');
   const pageLines = pageSource.split('\n').length;
@@ -25,6 +27,7 @@ test('admin insights page stays a route orchestrator', () => {
   assert.match(pageSource, /from '\.\/_lib\/insights-helpers';/);
   assert.match(pageSource, /from '\.\/_lib\/insights-navigation';/);
   assert.match(pageSource, /from '\.\/_components\/InsightsPanels';/);
+  assert.match(pageSource, /from '\.\/_components\/InsightsChartSurfaces';/);
   assert.match(pageSource, /fetchAdminMetrics\(/);
   assert.match(pageSource, /fetchAdminMetricsComparison\(/);
   assert.match(pageSource, /requireAdmin\(\)/);
@@ -68,11 +71,22 @@ test('admin insights panels own route-local JSX surfaces', () => {
   const panelsSource = readFileSync(panelsPath, 'utf8');
 
   assert.ok(statSync(panelsPath).size > 0);
-  assert.match(panelsSource, /export function ComparisonChart/);
   assert.match(panelsSource, /export function RevenueBoardTable/);
   assert.match(panelsSource, /export function HealthPanel/);
   assert.match(panelsSource, /export function InsightsControls/);
   assert.match(panelsSource, /export function DailyLedgerTable/);
   assert.match(panelsSource, /from '\.\.\/_lib\/insights-formatters';/);
   assert.match(panelsSource, /from '\.\.\/_lib\/insights-navigation';/);
+  assert.match(panelsSource, /from '\.\/InsightsChartSurfaces';/);
+  assert.doesNotMatch(panelsSource, /buildChartTicks/);
+  assert.doesNotMatch(panelsSource, /export function ComparisonChart/);
+});
+
+test('admin insights chart surfaces own chart primitives', () => {
+  const chartSurfacesSource = readFileSync(chartSurfacesPath, 'utf8');
+
+  assert.match(chartSurfacesSource, /export function ComparisonChart/);
+  assert.match(chartSurfacesSource, /export function ShareBar/);
+  assert.match(chartSurfacesSource, /export function EmptyStateCard/);
+  assert.match(chartSurfacesSource, /buildChartTicks/);
 });


### PR DESCRIPTION
## Summary
- move the admin insights comparison SVG chart into its own route-local component file
- move shared chart primitives used by the panels into the chart surfaces module
- update architecture tests so panels do not own chart math/rendering

## Checks
- ./node_modules/.bin/tsx --tsconfig frontend/tsconfig.json --test tests/admin-insights-architecture.test.ts
- ./node_modules/.bin/tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check -- touched files