### PR TITLE
Split gallery surface components

### DIFF
--- a/frontend/components/GalleryRail.tsx
+++ b/frontend/components/GalleryRail.tsx
@@ -2,27 +2,39 @@
 /* eslint-disable @next/next/no-img-element */
 
 import clsx from 'clsx';
-import { createPortal } from 'react-dom';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { EngineCaps } from '@/types/engines';
 import type { Job } from '@/types/jobs';
 import type { GroupSummary } from '@/types/groups';
-import type { VideoGroup, ResultProvider } from '@/types/video-groups';
+import type { VideoGroup } from '@/types/video-groups';
 import { saveImageToLibrary, useEngines, useInfiniteJobs } from '@/lib/api';
 import { groupJobsIntoSummaries } from '@/lib/job-groups';
-import { GroupedJobCard, type GroupedJobAction } from '@/components/GroupedJobCard';
+import type { GroupedJobAction } from '@/components/GroupedJobCard';
 import { normalizeGroupSummaries, normalizeGroupSummary } from '@/lib/normalize-group-summary';
 import { useI18n } from '@/lib/i18n/I18nProvider';
 import { GroupViewerModal } from '@/components/groups/GroupViewerModal';
 import { adaptGroupSummary } from '@/lib/video-group-adapter';
-import { Button, ButtonLink } from '@/components/ui/Button';
 import { suggestDownloadFilename, triggerAppDownload } from '@/lib/download';
 import { copyTextToClipboard } from '@/lib/clipboard';
-import { countResolvedVisualSlots, mergeImageProgressGroup } from '@/lib/group-progress';
 import { isExpiredRefundedFailedGalleryItem } from '@/lib/gallery-retention';
 import { PRIMARY_VIDEO_READY_EVENT } from '@/lib/video-warmup-events';
-
-type GalleryVariant = 'desktop' | 'mobile';
+import { GalleryRailCards } from './GalleryRailCards';
+import { GalleryRailSnackbar, type SnackbarState } from './GalleryRailSnackbar';
+import { GalleryRailCuratedBanner, GalleryRailErrorBanner, GalleryRailHeader } from './GalleryRailStatus';
+import {
+  DEFAULT_GALLERY_COPY,
+  DEFAULT_GROUP_PROVIDER,
+  INITIAL_EAGER_PREVIEW_COUNT,
+  filterGalleryFeedJobs,
+  resolveAspectRatioLabel,
+  resolveBackgroundWarmPreviewLimit,
+  resolveDisplayedActiveGroup,
+  resolveMediaUrl,
+  type GalleryCopy,
+  type GalleryFeedType,
+  type GalleryVariant,
+} from './gallery-rail-utils';
+import { useGalleryRailScrollbar } from './useGalleryRailScrollbar';
 
 export interface GalleryFeedState {
   visibleGroups: GroupSummary[];
@@ -32,7 +44,7 @@ export interface GalleryFeedState {
 export interface GalleryRailProps {
   engine: EngineCaps;
   engineRegistry?: EngineCaps[];
-  feedType?: 'video' | 'image';
+  feedType?: GalleryFeedType;
   activeGroups?: GroupSummary[];
   onOpenGroup?: (group: GroupSummary) => void;
   onGroupAction?: (group: GroupSummary, action: GroupedJobAction, options?: { autoPlayPreview?: boolean }) => void;
@@ -41,82 +53,8 @@ export interface GalleryRailProps {
   variant?: GalleryVariant;
 }
 
-interface SnackbarAction {
-  label: string;
-  onClick: () => void;
-  variant?: 'primary' | 'ghost';
-}
-
-interface SnackbarState {
-  message: string;
-  actions?: SnackbarAction[];
-  duration?: number;
-}
-
-const DEFAULT_GALLERY_COPY = {
-  title: 'Latest renders',
-  viewAll: 'View all',
-  curated: 'Starter samples curated by the MaxVideo team are shown until you generate your own videos.',
-  error: 'Failed to load latest renders. Please retry.',
-  retry: 'Retry',
-  imageCta: 'Generate images',
-  snackbar: {
-    samples: 'Sample clips cannot be removed.',
-    removed: 'Removed from gallery.',
-    failed: 'Unable to remove from gallery.',
-    saved: 'Saved to library.',
-    saveFailed: 'Unable to save to library.',
-    copied: 'Link copied.',
-    copyFailed: 'Unable to copy link.',
-    noMedia: 'No media available.',
-  },
-} as const;
-
-type GalleryCopy = typeof DEFAULT_GALLERY_COPY;
-const DEFAULT_GROUP_PROVIDER: ResultProvider = 'fal';
-const INITIAL_EAGER_PREVIEW_COUNT = 0;
-const DESKTOP_BACKGROUND_WARM_PREVIEW_LIMIT = 2;
 const BACKGROUND_WARM_START_DELAY_MS = 200;
 const BACKGROUND_WARM_STEP_DELAY_MS = 900;
-
-type NavigatorWithConnection = Navigator & {
-  connection?: {
-    effectiveType?: string;
-    saveData?: boolean;
-  };
-};
-
-function resolveBackgroundWarmPreviewLimit(variant: GalleryVariant): number {
-  if (variant !== 'desktop') return 0;
-  if (typeof navigator === 'undefined') return DESKTOP_BACKGROUND_WARM_PREVIEW_LIMIT;
-  const connection = (navigator as NavigatorWithConnection).connection;
-  if (connection?.saveData) return 0;
-  const effectiveType = connection?.effectiveType;
-  if (effectiveType === 'slow-2g' || effectiveType === '2g') return 1;
-  if (effectiveType === '3g') return 1;
-  return DESKTOP_BACKGROUND_WARM_PREVIEW_LIMIT;
-}
-
-function resolveDisplayedActiveGroup(
-  feedType: 'video' | 'image',
-  activeGroup: GroupSummary,
-  historicalGroup?: GroupSummary
-): GroupSummary {
-  if (!historicalGroup) return activeGroup;
-  if (feedType !== 'image') return historicalGroup;
-
-  const expectedCount = Math.max(1, Math.min(4, activeGroup.count || historicalGroup.count || 1));
-  const resolvedCount = countResolvedVisualSlots(historicalGroup);
-  if (resolvedCount >= expectedCount) {
-    return historicalGroup;
-  }
-
-  if (resolvedCount > 0) {
-    return mergeImageProgressGroup(activeGroup, historicalGroup);
-  }
-
-  return activeGroup;
-}
 
 export function GalleryRail({
   engine,
@@ -149,8 +87,7 @@ export function GalleryRail({
   }, [feedType]);
 
   const surfaceSafeJobs = useMemo(() => {
-    if (feedType !== 'video') return jobs;
-    return jobs.filter((job) => job.surface !== 'audio');
+    return filterGalleryFeedJobs(feedType, jobs);
   }, [feedType, jobs]);
   const filteredJobs = useMemo(() => {
     if (!jobFilter) return surfaceSafeJobs;
@@ -270,17 +207,25 @@ export function GalleryRail({
 
   const lastPage = data?.[data.length - 1];
   const hasMore = Boolean(lastPage?.nextCursor);
-  const sentinelRef = useRef<HTMLDivElement>(null);
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const [snackbar, setSnackbar] = useState<SnackbarState | null>(null);
-  const [railProgress, setRailProgress] = useState(0);
-  const [showRail, setShowRail] = useState(false);
-  const [railTrackHeight, setRailTrackHeight] = useState(200);
-  const railTrackRef = useRef<HTMLDivElement>(null);
-  const railDragPointerId = useRef<number | null>(null);
   const isDesktopVariant = variant === 'desktop';
-  const railThumbHeight = 24;
-  const railTrackOffset = 12;
+  const isInitialLoading = hasMounted && isLoading && filteredJobs.length === 0;
+  const isFetchingMore = hasMounted && isValidating && filteredJobs.length > 0;
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const [snackbar, setSnackbar] = useState<SnackbarState | null>(null);
+  const {
+    handleRailPointerDown,
+    handleRailPointerMove,
+    handleRailPointerUp,
+    railThumbHeight,
+    railThumbOffset,
+    railTrackHeight,
+    railTrackRef,
+    scrollContainerRef,
+    showRail,
+  } = useGalleryRailScrollbar({
+    isDesktopVariant,
+    refreshKey: `${isFetchingMore}:${isInitialLoading}:${renderedGroups.length}`,
+  });
 
   useEffect(() => {
     setHasMounted(true);
@@ -296,66 +241,6 @@ export function GalleryRail({
 
   const closeSnackbar = useCallback(() => setSnackbar(null), []);
   const closeViewer = useCallback(() => setViewerGroup(null), []);
-
-  const resolveAspectRatioLabel = useCallback((group: GroupSummary) => {
-    const ratio = group.hero.aspectRatio ?? group.previews.find((preview) => preview.aspectRatio)?.aspectRatio ?? null;
-    if (!ratio) return null;
-    if (ratio.toLowerCase() === 'auto') return 'Auto';
-    return ratio;
-  }, []);
-
-  const resolveImageOriginalUrl = useCallback((group: GroupSummary) => {
-    const resolveFromMember = (member = group.hero) => {
-      const job = member.job;
-      if (!job || !Array.isArray(job.renderIds) || !job.renderIds.length) {
-        return null;
-      }
-      const renderIds = job.renderIds.filter((value): value is string => typeof value === 'string' && /^https?:\/\//i.test(value));
-      if (!renderIds.length) {
-        return null;
-      }
-      if (typeof job.heroRenderId === 'string' && /^https?:\/\//i.test(job.heroRenderId)) {
-        return job.heroRenderId;
-      }
-      const match = member.id.match(/-image-(\d+)$/);
-      if (match) {
-        const index = Number(match[1]) - 1;
-        if (Number.isInteger(index) && index >= 0 && index < renderIds.length) {
-          return renderIds[index];
-        }
-      }
-      return renderIds[0] ?? null;
-    };
-
-    return (
-      resolveFromMember(group.hero) ??
-      group.members.map((member) => resolveFromMember(member)).find((value): value is string => typeof value === 'string' && value.length > 0) ??
-      group.hero.thumbUrl ??
-      group.previews.find((preview) => preview.thumbUrl)?.thumbUrl ??
-      null
-    );
-  }, []);
-
-  const resolveMediaUrl = useCallback(
-    (group: GroupSummary, preferImage: boolean) => {
-      if (preferImage) {
-        return (
-          resolveImageOriginalUrl(group) ??
-          group.hero.videoUrl ??
-          group.previews.find((preview) => preview.videoUrl)?.videoUrl ??
-          null
-        );
-      }
-      return (
-        group.hero.videoUrl ??
-        group.previews.find((preview) => preview.videoUrl)?.videoUrl ??
-        group.hero.thumbUrl ??
-        group.previews.find((preview) => preview.thumbUrl)?.thumbUrl ??
-        null
-      );
-    },
-    [resolveImageOriginalUrl]
-  );
 
   const handleCardOpen = useCallback(
     (group: GroupSummary) => {
@@ -395,7 +280,7 @@ export function GalleryRail({
       }
       triggerAppDownload(candidateUrl, suggestDownloadFilename(candidateUrl, feedType === 'image' ? 'gallery-image' : 'gallery-video'));
     },
-    [copy.snackbar.noMedia, feedType, resolveMediaUrl, summaryIndex]
+    [copy.snackbar.noMedia, feedType, summaryIndex]
   );
 
   const handleCardCopy = useCallback(
@@ -410,7 +295,7 @@ export function GalleryRail({
         setSnackbar({ message: copied ? copy.snackbar.copied : copy.snackbar.copyFailed, duration: copied ? 2000 : 2400 });
       });
     },
-    [copy.snackbar.copied, copy.snackbar.copyFailed, copy.snackbar.noMedia, feedType, resolveMediaUrl, summaryIndex]
+    [copy.snackbar.copied, copy.snackbar.copyFailed, copy.snackbar.noMedia, feedType, summaryIndex]
   );
 
   const handleCardSaveImage = useCallback(
@@ -429,7 +314,7 @@ export function GalleryRail({
         .then(() => setSnackbar({ message: copy.snackbar.saved, duration: 2000 }))
         .catch(() => setSnackbar({ message: copy.snackbar.saveFailed, duration: 2400 }));
     },
-    [copy.snackbar.noMedia, copy.snackbar.saveFailed, copy.snackbar.saved, resolveMediaUrl, summaryIndex]
+    [copy.snackbar.noMedia, copy.snackbar.saveFailed, copy.snackbar.saved, summaryIndex]
   );
 
   const handleCardAction = useCallback(
@@ -485,63 +370,6 @@ export function GalleryRail({
     void mutate();
   }, [mutate]);
 
-  const updateRailFromPointer = useCallback(
-    (clientY: number) => {
-      const track = railTrackRef.current;
-      const scroller = scrollContainerRef.current;
-      if (!track || !scroller) return;
-      const maxScroll = scroller.scrollHeight - scroller.clientHeight;
-      if (maxScroll <= 0) return;
-      const rect = track.getBoundingClientRect();
-      const trackRange = Math.max(1, railTrackHeight - railThumbHeight);
-      const offset = clientY - rect.top - railThumbHeight / 2;
-      const clamped = Math.min(Math.max(offset, 0), trackRange);
-      scroller.scrollTop = (clamped / trackRange) * maxScroll;
-    },
-    [railThumbHeight, railTrackHeight]
-  );
-
-  const handleRailPointerDown = useCallback(
-    (event: React.PointerEvent<HTMLDivElement>) => {
-      if (event.button !== 0) return;
-      railDragPointerId.current = event.pointerId;
-      event.currentTarget.setPointerCapture(event.pointerId);
-      updateRailFromPointer(event.clientY);
-      event.preventDefault();
-    },
-    [updateRailFromPointer]
-  );
-
-  const handleRailPointerMove = useCallback(
-    (event: React.PointerEvent<HTMLDivElement>) => {
-      if (railDragPointerId.current !== event.pointerId) return;
-      updateRailFromPointer(event.clientY);
-      event.preventDefault();
-    },
-    [updateRailFromPointer]
-  );
-
-  const handleRailPointerUp = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
-    if (railDragPointerId.current !== event.pointerId) return;
-    railDragPointerId.current = null;
-    event.currentTarget.releasePointerCapture(event.pointerId);
-  }, []);
-
-  const updateRailProgress = useCallback(() => {
-    const element = scrollContainerRef.current;
-    if (!element) return;
-    const maxScroll = element.scrollHeight - element.clientHeight;
-    if (!isDesktopVariant || maxScroll <= 4) {
-      setShowRail(false);
-      setRailProgress(0);
-      return;
-    }
-    const nextTrackHeight = Math.max(120, element.clientHeight - railTrackOffset * 2);
-    setRailTrackHeight((prev) => (prev === nextTrackHeight ? prev : nextTrackHeight));
-    setShowRail(true);
-    setRailProgress(element.scrollTop / maxScroll);
-  }, [isDesktopVariant, railTrackOffset]);
-
   useEffect(() => {
     onFeedStateChange?.({ visibleGroups: renderedGroups, sampleOnly });
   }, [onFeedStateChange, renderedGroups, sampleOnly]);
@@ -571,112 +399,22 @@ export function GalleryRail({
 
     observer.observe(element);
     return () => observer.disconnect();
-  }, [hasMore, isDesktopVariant, loadMore]);
-
-  useEffect(() => {
-    const element = scrollContainerRef.current;
-    if (!element) return undefined;
-
-    updateRailProgress();
-
-    const handleScroll = () => updateRailProgress();
-    element.addEventListener('scroll', handleScroll, { passive: true });
-
-    let resizeObserver: ResizeObserver | null = null;
-    if (typeof ResizeObserver !== 'undefined') {
-      resizeObserver = new ResizeObserver(() => updateRailProgress());
-      resizeObserver.observe(element);
-    }
-
-    window.addEventListener('resize', updateRailProgress);
-
-    return () => {
-      element.removeEventListener('scroll', handleScroll);
-      resizeObserver?.disconnect();
-      window.removeEventListener('resize', updateRailProgress);
-    };
-  }, [updateRailProgress]);
-
-  const isInitialLoading = hasMounted && isLoading && filteredJobs.length === 0;
-  const isFetchingMore = hasMounted && isValidating && filteredJobs.length > 0;
-  const railThumbOffset = railProgress * (railTrackHeight - railThumbHeight);
-
-  useEffect(() => {
-    updateRailProgress();
-  }, [isFetchingMore, isInitialLoading, renderedGroups.length, updateRailProgress]);
+  }, [hasMore, isDesktopVariant, loadMore, scrollContainerRef]);
 
   const cards = (
-    <>
-      {renderedGroups.map((group, index) => {
-        const engineId = group.hero.engineId;
-        const engineEntry = engineId ? engineMap.get(engineId) ?? null : null;
-        return (
-          <GroupedJobCard
-            key={group.id}
-            group={group}
-            engine={engineEntry ?? undefined}
-            onOpen={handleCardOpen}
-            onAction={handleCardAction}
-            allowRemove={false}
-            metaLabel={feedType === 'image' ? resolveAspectRatioLabel(group) : undefined}
-            menuVariant={feedType === 'video' ? 'gallery' : 'gallery-image'}
-            openLabel={feedType === 'video' ? 'Preview' : undefined}
-            showOpenOverlay={false}
-            eagerPreview={feedType === 'video' && index < backgroundWarmCount}
-            warmOnVisible={false}
-          />
-        );
-      })}
-      {(isInitialLoading || isFetchingMore) &&
-        Array.from({ length: isInitialLoading ? 4 : 2 }).map((_, index) => (
-          <div key={`rail-skeleton-${index}`} className="rounded-card border border-border bg-surface-glass-60 p-0" aria-hidden>
-            <div className="relative overflow-hidden rounded-card">
-              <div className="relative" style={{ aspectRatio: '16 / 9' }}>
-                <div className="skeleton absolute inset-0" />
-              </div>
-            </div>
-            <div className="border-t border-border bg-surface-glass-70 px-3 py-2">
-              <div className="h-3 w-24 rounded-full bg-skeleton" />
-            </div>
-          </div>
-        ))}
-      <div ref={sentinelRef} className="h-1 w-full" aria-hidden />
-    </>
+    <GalleryRailCards
+      backgroundWarmCount={backgroundWarmCount}
+      engineMap={engineMap}
+      feedType={feedType}
+      groups={renderedGroups}
+      isFetchingMore={isFetchingMore}
+      isInitialLoading={isInitialLoading}
+      onCardAction={handleCardAction}
+      onCardOpen={handleCardOpen}
+      resolveAspectRatioLabel={resolveAspectRatioLabel}
+      sentinelRef={sentinelRef}
+    />
   );
-
-  const header = (
-    <header className="flex flex-wrap items-center justify-between gap-2">
-      <h2 className="text-[12px] font-semibold uppercase tracking-micro text-text-muted">{copy.title}</h2>
-      <ButtonLink
-        href="/jobs"
-        prefetch={false}
-        variant="ghost"
-        size="sm"
-        className="rounded-input border border-transparent px-3 py-1 text-[12px] font-medium text-text-muted hover:text-text-secondary"
-      >
-        {copy.viewAll}
-      </ButtonLink>
-    </header>
-  );
-
-  const curatedBanner = hasMounted && hasCuratedJobs ? (
-    <div className="rounded-card border border-hairline bg-surface-glass-80 px-3 py-2 text-[12px] text-text-secondary">{copy.curated}</div>
-  ) : null;
-
-  const errorBanner = hasMounted && error ? (
-    <div className="flex flex-wrap items-center justify-between gap-4 rounded-card border border-warning-border bg-warning-bg px-3 py-2 text-[12px] text-warning">
-      <span role="alert">{copy.error}</span>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={retry}
-        className="rounded-input border-warning-border bg-surface-glass-70 px-3 py-1 text-[11px] font-semibold uppercase tracking-micro text-warning hover:bg-surface"
-      >
-        {copy.retry}
-      </Button>
-    </div>
-  ) : null;
 
   const body = (
     <div className={clsx('relative', isDesktopVariant ? 'flex-1 min-h-0' : '')}>
@@ -712,11 +450,11 @@ export function GalleryRail({
 
   const content = (
     <>
-      {header}
-      {curatedBanner}
-      {errorBanner}
+      <GalleryRailHeader title={copy.title} viewAll={copy.viewAll} />
+      <GalleryRailCuratedBanner copy={copy.curated} show={hasMounted && hasCuratedJobs} />
+      <GalleryRailErrorBanner copy={copy.error} retryLabel={copy.retry} show={hasMounted && Boolean(error)} onRetry={retry} />
       {body}
-      <Snackbar state={snackbar} onClose={closeSnackbar} />
+      <GalleryRailSnackbar state={snackbar} onClose={closeSnackbar} />
     </>
   );
 
@@ -733,60 +471,5 @@ export function GalleryRail({
       )}
       {viewerGroup ? <GroupViewerModal group={viewerGroup} onClose={closeViewer} /> : null}
     </>
-  );
-}
-function Snackbar({ state, onClose }: { state: SnackbarState | null; onClose: () => void }) {
-  useEffect(() => {
-    if (!state?.duration) return undefined;
-    const timeout = window.setTimeout(onClose, state.duration);
-    return () => window.clearTimeout(timeout);
-  }, [state, onClose]);
-
-  useEffect(() => {
-    if (!state) return undefined;
-    const handleKey = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        onClose();
-      }
-    };
-    document.addEventListener('keydown', handleKey);
-    return () => document.removeEventListener('keydown', handleKey);
-  }, [state, onClose]);
-
-  if (!state) return null;
-
-  const actions = state.actions ?? [];
-
-  return createPortal(
-    <div className="fixed inset-x-0 bottom-6 z-[9998] flex justify-center px-4">
-      <div className="inline-flex max-w-xl flex-wrap items-center gap-4 rounded-card border border-surface-on-media-15 bg-surface-on-media-dark-80 px-4 py-3 text-[13px] text-on-inverse shadow-lg backdrop-blur">
-        <span>{state.message}</span>
-        {actions.length > 0 && (
-          <div className="flex flex-wrap gap-2">
-            {actions.map((action) => (
-              <Button
-                key={action.label}
-                type="button"
-                onClick={() => {
-                  onClose();
-                  action.onClick();
-                }}
-                variant="outline"
-                size="sm"
-                className={clsx(
-                  'rounded-full px-3 py-1.5 text-[12px] font-semibold uppercase tracking-micro',
-                  action.variant === 'primary'
-                    ? 'border-transparent bg-brand text-on-brand hover:bg-brandHover'
-                    : 'border border-surface-on-media-30 bg-transparent text-on-inverse hover:bg-surface-on-media-10'
-                )}
-              >
-                {action.label}
-              </Button>
-            ))}
-          </div>
-        )}
-      </div>
-    </div>,
-    document.body
   );
 }

--- a/frontend/components/GalleryRailCards.tsx
+++ b/frontend/components/GalleryRailCards.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import type { Ref } from 'react';
+import type { EngineCaps } from '@/types/engines';
+import type { GroupSummary } from '@/types/groups';
+import { GroupedJobCard, type GroupedJobAction } from '@/components/GroupedJobCard';
+import type { GalleryFeedType } from './gallery-rail-utils';
+
+interface GalleryRailCardsProps {
+  backgroundWarmCount: number;
+  engineMap: ReadonlyMap<string, EngineCaps>;
+  feedType: GalleryFeedType;
+  groups: GroupSummary[];
+  isFetchingMore: boolean;
+  isInitialLoading: boolean;
+  onCardAction: (group: GroupSummary, action: GroupedJobAction) => void;
+  onCardOpen: (group: GroupSummary) => void;
+  resolveAspectRatioLabel: (group: GroupSummary) => string | null;
+  sentinelRef: Ref<HTMLDivElement>;
+}
+
+export function GalleryRailCards({
+  backgroundWarmCount,
+  engineMap,
+  feedType,
+  groups,
+  isFetchingMore,
+  isInitialLoading,
+  onCardAction,
+  onCardOpen,
+  resolveAspectRatioLabel,
+  sentinelRef,
+}: GalleryRailCardsProps) {
+  return (
+    <>
+      {groups.map((group, index) => {
+        const engineId = group.hero.engineId;
+        const engineEntry = engineId ? engineMap.get(engineId) ?? null : null;
+        return (
+          <GroupedJobCard
+            key={group.id}
+            group={group}
+            engine={engineEntry ?? undefined}
+            onOpen={onCardOpen}
+            onAction={onCardAction}
+            allowRemove={false}
+            metaLabel={feedType === 'image' ? resolveAspectRatioLabel(group) : undefined}
+            menuVariant={feedType === 'video' ? 'gallery' : 'gallery-image'}
+            openLabel={feedType === 'video' ? 'Preview' : undefined}
+            showOpenOverlay={false}
+            eagerPreview={feedType === 'video' && index < backgroundWarmCount}
+            warmOnVisible={false}
+          />
+        );
+      })}
+      {(isInitialLoading || isFetchingMore) &&
+        Array.from({ length: isInitialLoading ? 4 : 2 }).map((_, index) => (
+          <div key={`rail-skeleton-${index}`} className="rounded-card border border-border bg-surface-glass-60 p-0" aria-hidden>
+            <div className="relative overflow-hidden rounded-card">
+              <div className="relative" style={{ aspectRatio: '16 / 9' }}>
+                <div className="skeleton absolute inset-0" />
+              </div>
+            </div>
+            <div className="border-t border-border bg-surface-glass-70 px-3 py-2">
+              <div className="h-3 w-24 rounded-full bg-skeleton" />
+            </div>
+          </div>
+        ))}
+      <div ref={sentinelRef} className="h-1 w-full" aria-hidden />
+    </>
+  );
+}

--- a/frontend/components/GalleryRailSnackbar.tsx
+++ b/frontend/components/GalleryRailSnackbar.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import clsx from 'clsx';
+import { createPortal } from 'react-dom';
+import { useEffect } from 'react';
+import { Button } from '@/components/ui/Button';
+
+interface SnackbarAction {
+  label: string;
+  onClick: () => void;
+  variant?: 'primary' | 'ghost';
+}
+
+export interface SnackbarState {
+  message: string;
+  actions?: SnackbarAction[];
+  duration?: number;
+}
+
+export function GalleryRailSnackbar({ state, onClose }: { state: SnackbarState | null; onClose: () => void }) {
+  useEffect(() => {
+    if (!state?.duration) return undefined;
+    const timeout = window.setTimeout(onClose, state.duration);
+    return () => window.clearTimeout(timeout);
+  }, [state, onClose]);
+
+  useEffect(() => {
+    if (!state) return undefined;
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [state, onClose]);
+
+  if (!state) return null;
+
+  const actions = state.actions ?? [];
+
+  return createPortal(
+    <div className="fixed inset-x-0 bottom-6 z-[9998] flex justify-center px-4">
+      <div className="inline-flex max-w-xl flex-wrap items-center gap-4 rounded-card border border-surface-on-media-15 bg-surface-on-media-dark-80 px-4 py-3 text-[13px] text-on-inverse shadow-lg backdrop-blur">
+        <span>{state.message}</span>
+        {actions.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {actions.map((action) => (
+              <Button
+                key={action.label}
+                type="button"
+                onClick={() => {
+                  onClose();
+                  action.onClick();
+                }}
+                variant="outline"
+                size="sm"
+                className={clsx(
+                  'rounded-full px-3 py-1.5 text-[12px] font-semibold uppercase tracking-micro',
+                  action.variant === 'primary'
+                    ? 'border-transparent bg-brand text-on-brand hover:bg-brandHover'
+                    : 'border border-surface-on-media-30 bg-transparent text-on-inverse hover:bg-surface-on-media-10'
+                )}
+              >
+                {action.label}
+              </Button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/frontend/components/GalleryRailStatus.tsx
+++ b/frontend/components/GalleryRailStatus.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { Button, ButtonLink } from '@/components/ui/Button';
+
+export function GalleryRailHeader({ title, viewAll }: { title: string; viewAll: string }) {
+  return (
+    <header className="flex flex-wrap items-center justify-between gap-2">
+      <h2 className="text-[12px] font-semibold uppercase tracking-micro text-text-muted">{title}</h2>
+      <ButtonLink
+        href="/jobs"
+        prefetch={false}
+        variant="ghost"
+        size="sm"
+        className="rounded-input border border-transparent px-3 py-1 text-[12px] font-medium text-text-muted hover:text-text-secondary"
+      >
+        {viewAll}
+      </ButtonLink>
+    </header>
+  );
+}
+
+export function GalleryRailCuratedBanner({ copy, show }: { copy: string; show: boolean }) {
+  if (!show) return null;
+  return (
+    <div className="rounded-card border border-hairline bg-surface-glass-80 px-3 py-2 text-[12px] text-text-secondary">
+      {copy}
+    </div>
+  );
+}
+
+export function GalleryRailErrorBanner({
+  copy,
+  retryLabel,
+  show,
+  onRetry,
+}: {
+  copy: string;
+  retryLabel: string;
+  show: boolean;
+  onRetry: () => void;
+}) {
+  if (!show) return null;
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-4 rounded-card border border-warning-border bg-warning-bg px-3 py-2 text-[12px] text-warning">
+      <span role="alert">{copy}</span>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onRetry}
+        className="rounded-input border-warning-border bg-surface-glass-70 px-3 py-1 text-[11px] font-semibold uppercase tracking-micro text-warning hover:bg-surface"
+      >
+        {retryLabel}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/components/GroupedJobCard.tsx
+++ b/frontend/components/GroupedJobCard.tsx
@@ -3,206 +3,21 @@
 /* eslint-disable @next/next/no-img-element */
 import clsx from 'clsx';
 import { ChevronDown, Maximize2, Plus } from 'lucide-react';
-import Image from 'next/image';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { EngineCaps } from '@/types/engines';
 import type { GroupSummary } from '@/types/groups';
 import { Card } from '@/components/ui/Card';
 import { EngineIcon } from '@/components/ui/EngineIcon';
 import { AudioEqualizerBadge } from '@/components/ui/AudioEqualizerBadge';
-import { AudioWaveformThumb } from '@/components/ui/AudioWaveformThumb';
-import { ProcessingOverlay } from '@/components/groups/ProcessingOverlay';
 import { Button, ButtonLink } from '@/components/ui/Button';
 import { CURRENCY_LOCALE } from '@/lib/intl';
-import { isPlaceholderMediaUrl } from '@/lib/media';
+import { GroupedJobCardMenu } from './GroupedJobCardMenu';
+import { shouldWarmVisiblePreview } from './GroupedJobCardMedia';
+import { GroupedJobCardPreviewGrid } from './GroupedJobCardPreviewGrid';
+import type { GroupedJobAction, GroupedJobMenuVariant } from './grouped-job-card-types';
 
-export type GroupedJobAction =
-  | 'open'
-  | 'view'
-  | 'download'
-  | 'copy'
-  | 'continue'
-  | 'refine'
-  | 'branch'
-  | 'compare'
-  | 'remove'
-  | 'save-image'
-  | 'save-to-library';
-
-const GROUPED_JOB_THUMB_SIZES = '(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 320px';
-
-type NavigatorWithConnection = Navigator & {
-  connection?: {
-    effectiveType?: string;
-    saveData?: boolean;
-  };
-};
-
-function shouldWarmVisiblePreview(): boolean {
-  if (typeof navigator === 'undefined') return true;
-  const connection = (navigator as NavigatorWithConnection).connection;
-  if (connection?.saveData) return false;
-  const effectiveType = connection?.effectiveType;
-  return effectiveType !== 'slow-2g' && effectiveType !== '2g';
-}
-
-function ThumbImage({ src, alt, className }: { src: string; alt: string; className?: string }) {
-  const baseClass = clsx('h-full w-full pointer-events-none', className);
-  if (src.startsWith('data:')) {
-    return <img src={src} alt={alt} className={baseClass} />;
-  }
-  return <Image src={src} alt={alt} fill className={baseClass} sizes={GROUPED_JOB_THUMB_SIZES} />;
-}
-
-export function GroupPreviewMedia({
-  preview,
-  audioUrl,
-  audioLabel,
-  shouldPlay,
-  shouldWarm,
-  fit = 'contain',
-}: {
-  preview: GroupSummary['previews'][number] | undefined;
-  audioUrl?: string | null;
-  audioLabel?: string | null;
-  shouldPlay: boolean;
-  shouldWarm: boolean;
-  fit?: 'contain' | 'cover';
-}) {
-  const displayVideoUrl = preview?.previewVideoUrl ?? preview?.videoUrl ?? null;
-  const hasOptimizedPreview = Boolean(preview?.previewVideoUrl);
-  const hasVideo = Boolean(displayVideoUrl);
-  const hasAudioOnly = Boolean(audioUrl) && !hasVideo;
-  const thumbSrc = preview?.thumbUrl && !isPlaceholderMediaUrl(preview.thumbUrl) ? preview.thumbUrl : null;
-  const videoRef = useRef<HTMLVideoElement | null>(null);
-  const videoReadyRef = useRef(false);
-  const [videoReady, setVideoReady] = useState(false);
-
-  useEffect(() => {
-    if (!hasVideo) return;
-    videoReadyRef.current = false;
-    setVideoReady(false);
-  }, [hasVideo, displayVideoUrl]);
-
-  const markVideoReady = useCallback(() => {
-    if (videoReadyRef.current) return;
-    videoReadyRef.current = true;
-    setVideoReady(true);
-  }, []);
-
-  const playPreviewVideo = useCallback(() => {
-    const element = videoRef.current;
-    if (!element) return;
-    element.preload = 'auto';
-    if (
-      element.networkState === HTMLMediaElement.NETWORK_EMPTY ||
-      (element.networkState === HTMLMediaElement.NETWORK_IDLE && element.readyState < HTMLMediaElement.HAVE_CURRENT_DATA)
-    ) {
-      element.load();
-    }
-    if (element.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
-      return;
-    }
-    const playPromise = element.play();
-    if (playPromise) {
-      playPromise.catch(() => {
-        /* ignore autoplay rejection */
-      });
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!hasVideo) return;
-    const element = videoRef.current;
-    if (!element) return;
-    if (shouldPlay) {
-      playPreviewVideo();
-    } else {
-      element.pause();
-      if (
-        shouldWarm &&
-        hasOptimizedPreview &&
-        (element.networkState === HTMLMediaElement.NETWORK_EMPTY ||
-          (element.networkState === HTMLMediaElement.NETWORK_IDLE && element.readyState < HTMLMediaElement.HAVE_CURRENT_DATA))
-      ) {
-        element.preload = 'auto';
-        element.load();
-      }
-    }
-  }, [hasVideo, hasOptimizedPreview, playPreviewVideo, displayVideoUrl, shouldPlay, shouldWarm]);
-
-  const handleCanPlay = () => {
-    markVideoReady();
-    if (shouldPlay) {
-      playPreviewVideo();
-    }
-  };
-
-  const handleLoadedData = () => {
-    markVideoReady();
-    if (shouldPlay) {
-      playPreviewVideo();
-    }
-  };
-
-  if (hasVideo && displayVideoUrl) {
-    const poster = thumbSrc ?? undefined;
-    return (
-      <div className="relative h-full w-full overflow-hidden rounded-[inherit]">
-        {thumbSrc ? (
-          <ThumbImage
-            src={thumbSrc}
-            alt=""
-            className={clsx(
-              'absolute inset-0 transition-opacity duration-150 ease-out',
-              fit === 'cover' ? 'object-cover scale-[1.06] transform-gpu' : 'object-contain',
-              shouldPlay && videoReady ? 'opacity-0' : 'opacity-100'
-            )}
-          />
-        ) : null}
-        <video
-          ref={videoRef}
-          src={displayVideoUrl}
-          poster={poster}
-          className={clsx(
-            'absolute inset-0 h-full w-full pointer-events-none transition-opacity duration-150 ease-out',
-            fit === 'cover' ? 'object-cover scale-[1.06] transform-gpu' : 'object-contain',
-            videoReady ? 'opacity-100' : 'opacity-0'
-          )}
-          muted
-          playsInline
-          autoPlay={shouldPlay}
-          loop
-          preload={shouldPlay || (shouldWarm && hasOptimizedPreview) ? 'auto' : 'none'}
-          onLoadedData={handleLoadedData}
-          onCanPlay={handleCanPlay}
-        />
-      </div>
-    );
-  }
-  if (hasAudioOnly) {
-    return (
-      <AudioWaveformThumb
-        seed={audioUrl ?? preview?.id ?? 'audio-preview'}
-        thumbSrc={thumbSrc}
-        label={audioLabel}
-        active={shouldPlay}
-      />
-    );
-  }
-  if (thumbSrc) {
-    return (
-      <div className="relative h-full w-full overflow-hidden rounded-[inherit]">
-        <ThumbImage
-          src={thumbSrc}
-          alt=""
-          className={fit === 'cover' ? 'object-cover scale-[1.06] transform-gpu' : 'object-contain'}
-        />
-      </div>
-    );
-  }
-  return null;
-}
+export type { GroupedJobAction } from './grouped-job-card-types';
+export { GroupPreviewMedia } from './GroupedJobCardMedia';
 
 export interface GroupedJobCardProps {
   group: GroupSummary;
@@ -211,7 +26,7 @@ export interface GroupedJobCardProps {
   onAction?: (group: GroupSummary, action: GroupedJobAction) => void;
   metaLabel?: string | null;
   actionMenu?: boolean;
-  menuVariant?: 'full' | 'compact' | 'gallery' | 'gallery-image';
+  menuVariant?: GroupedJobMenuVariant;
   allowRemove?: boolean;
   isImageGroup?: boolean;
   savingToLibrary?: boolean;
@@ -318,9 +133,6 @@ export function GroupedJobCard({
   }, [previewCount]);
   const showMenu = Boolean(onAction) && actionMenu;
   const isCurated = Boolean(hero.job?.curated);
-  const showAdvancedMenuActions = menuVariant === 'full';
-  const showGalleryActions = menuVariant === 'gallery';
-  const showGalleryImageActions = menuVariant === 'gallery-image';
   const showCompactMenuButton = menuVariant === 'compact';
 
   const handleAction = (action: GroupedJobAction) => {
@@ -396,66 +208,15 @@ export function GroupedJobCard({
         }}
       >
         <div className="relative w-full" style={{ aspectRatio: '16 / 9' }}>
-          <div
-            className={clsx(
-              'absolute inset-0 grid bg-placeholder',
-              previewGridClass,
-              isSinglePreview ? 'p-0' : 'gap-1 p-1'
-            )}
-          >
-            {Array.from({ length: previewCount }).map((_, index) => {
-              const preview = previews[index];
-              const member = preview ? group.members.find((entry) => entry.id === preview.id) : undefined;
-              const memberStatus = member?.status ?? 'completed';
-              const memberAudioUrl = member?.audioUrl ?? member?.job?.audioUrl ?? null;
-              const previewThumb = preview?.thumbUrl && !isPlaceholderMediaUrl(preview.thumbUrl) ? preview.thumbUrl : null;
-              const previewHasMedia = Boolean(preview?.previewVideoUrl || preview?.videoUrl || previewThumb || memberAudioUrl);
-              const isCompleted =
-                memberStatus === 'completed' ||
-                (previewHasMedia && memberStatus !== 'pending' && memberStatus !== 'failed');
-              const previewKey = preview?.id ? `${preview.id}-${index}` : `preview-${index}`;
-              return (
-                <div
-                  key={previewKey}
-                  className={clsx(
-                    'relative flex items-center justify-center overflow-hidden bg-[var(--surface-2)]',
-                    isSinglePreview ? 'rounded-none' : 'rounded-card'
-                  )}
-                >
-                  <div className="absolute inset-0">
-                    {isCompleted ? (
-                      <GroupPreviewMedia
-                        preview={preview}
-                        audioUrl={memberAudioUrl}
-                        audioLabel={preview?.previewVideoUrl || preview?.videoUrl ? null : 'Audio'}
-                        shouldPlay={hovered}
-                        shouldWarm={isPreviewWarm || hovered}
-                      />
-                    ) : previewThumb ? (
-                      <Image
-                        src={previewThumb}
-                        alt=""
-                        fill
-                        className="pointer-events-none object-contain"
-                        sizes={GROUPED_JOB_THUMB_SIZES}
-                      />
-                    ) : null}
-                  </div>
-                  <div className="pointer-events-none block" style={{ width: '100%', aspectRatio: '16 / 9' }} aria-hidden />
-                  {!isCompleted && member ? (
-                    <ProcessingOverlay
-                      className="absolute inset-0"
-                      state={memberStatus === 'failed' ? 'error' : 'pending'}
-                      message={member.message}
-                      tone="light"
-                      tileIndex={index + 1}
-                      tileCount={previewCount}
-                    />
-                  ) : null}
-                </div>
-              );
-            })}
-          </div>
+          <GroupedJobCardPreviewGrid
+            group={group}
+            hovered={hovered}
+            isPreviewWarm={isPreviewWarm}
+            isSinglePreview={isSinglePreview}
+            previewCount={previewCount}
+            previewGridClass={previewGridClass}
+            previews={previews}
+          />
         </div>
         {heroHasAudio ? <AudioEqualizerBadge tone="light" size="sm" label="Audio available" /> : null}
         {group.count > 1 ? (
@@ -564,177 +325,23 @@ export function GroupedJobCard({
         </div>
       </div>
 
-      {showMenu && menuOpen && (
-        <div
-          ref={menuRef}
-          className="absolute right-3 top-12 z-40 w-48 rounded-card border border-border bg-surface p-2 text-sm text-text-secondary shadow-card"
-        >
-          {showGalleryActions ? (
-            <>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => handleAction('open')}
-                className="w-full justify-between rounded-input px-2 py-1.5 text-left"
-              >
-                <span>Preview</span>
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={handleRemake}
-                disabled={!onOpen}
-                className={clsx(
-                  'mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left',
-                  onOpen ? '' : 'cursor-not-allowed opacity-60'
-                )}
-              >
-                <span>Remake</span>
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => handleAction('download')}
-                className="mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left"
-              >
-                <span>Download</span>
-              </Button>
-            </>
-          ) : showGalleryImageActions ? (
-            <>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => handleAction('open')}
-                className="w-full justify-between rounded-input px-2 py-1.5 text-left"
-              >
-                <span>Open</span>
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => handleAction('save-image')}
-                className="mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left"
-              >
-                <span>Add to Library</span>
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => handleAction('download')}
-                className="mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left"
-              >
-                <span>Download</span>
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => handleAction('copy')}
-                className="mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left"
-              >
-                <span>Copy link</span>
-              </Button>
-            </>
-          ) : (
-            <>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => handleAction('open')}
-                className="w-full justify-between rounded-input px-2 py-1.5 text-left"
-              >
-                <span>{openLabel}</span>
-                <span className="text-[11px] text-text-muted">↵</span>
-              </Button>
-              {recreateHref ? (
-                <ButtonLink
-                  href={recreateHref}
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setMenuOpen(false)}
-                  className="mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left"
-                >
-                  <span>{recreateLabel}</span>
-                </ButtonLink>
-              ) : null}
-              {showAdvancedMenuActions ? (
-                <>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => handleAction('continue')}
-                    className="mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left"
-                  >
-                    <span>Continue (Hero)</span>
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => handleAction('refine')}
-                    className="mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left"
-                  >
-                    <span>Refine (Hero)</span>
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => handleAction('branch')}
-                    className="mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left"
-                  >
-                    <span>Branch</span>
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => handleAction('compare')}
-                    className="mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left"
-                  >
-                    <span>Compare</span>
-                  </Button>
-                </>
-              ) : null}
-            </>
-          )}
-          {isImageGroup && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => handleAction('save-image')}
-              className={clsx(
-                'mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left',
-                savingToLibrary ? 'opacity-60' : ''
-              )}
-              disabled={savingToLibrary}
-            >
-              <span>{savingToLibrary ? 'Saving…' : 'Add to Library'}</span>
-            </Button>
-          )}
-          {allowRemove && group.count <= 1 && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => handleAction('remove')}
-              className="mt-2 w-full justify-between rounded-input px-2 py-1.5 text-left text-error hover:bg-error-bg"
-            >
-              <span>Remove</span>
-            </Button>
-          )}
-        </div>
-      )}
+      {showMenu && menuOpen ? (
+        <GroupedJobCardMenu
+          allowRemove={allowRemove}
+          closeMenu={() => setMenuOpen(false)}
+          group={group}
+          handleAction={handleAction}
+          handleRemake={handleRemake}
+          isImageGroup={isImageGroup}
+          menuRef={menuRef}
+          menuVariant={menuVariant}
+          onOpen={onOpen}
+          openLabel={openLabel}
+          recreateHref={recreateHref}
+          recreateLabel={recreateLabel}
+          savingToLibrary={savingToLibrary}
+        />
+      ) : null}
     </Card>
   );
 }

--- a/frontend/components/GroupedJobCardMedia.tsx
+++ b/frontend/components/GroupedJobCardMedia.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+/* eslint-disable @next/next/no-img-element */
+import clsx from 'clsx';
+import Image from 'next/image';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { GroupSummary } from '@/types/groups';
+import { AudioWaveformThumb } from '@/components/ui/AudioWaveformThumb';
+import { isPlaceholderMediaUrl } from '@/lib/media';
+
+export const GROUPED_JOB_THUMB_SIZES = '(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 320px';
+
+type NavigatorWithConnection = Navigator & {
+  connection?: {
+    effectiveType?: string;
+    saveData?: boolean;
+  };
+};
+
+export function shouldWarmVisiblePreview(): boolean {
+  if (typeof navigator === 'undefined') return true;
+  const connection = (navigator as NavigatorWithConnection).connection;
+  if (connection?.saveData) return false;
+  const effectiveType = connection?.effectiveType;
+  return effectiveType !== 'slow-2g' && effectiveType !== '2g';
+}
+
+function ThumbImage({ src, alt, className }: { src: string; alt: string; className?: string }) {
+  const baseClass = clsx('h-full w-full pointer-events-none', className);
+  if (src.startsWith('data:')) {
+    return <img src={src} alt={alt} className={baseClass} />;
+  }
+  return <Image src={src} alt={alt} fill className={baseClass} sizes={GROUPED_JOB_THUMB_SIZES} />;
+}
+
+export function GroupPreviewMedia({
+  preview,
+  audioUrl,
+  audioLabel,
+  shouldPlay,
+  shouldWarm,
+  fit = 'contain',
+}: {
+  preview: GroupSummary['previews'][number] | undefined;
+  audioUrl?: string | null;
+  audioLabel?: string | null;
+  shouldPlay: boolean;
+  shouldWarm: boolean;
+  fit?: 'contain' | 'cover';
+}) {
+  const displayVideoUrl = preview?.previewVideoUrl ?? preview?.videoUrl ?? null;
+  const hasOptimizedPreview = Boolean(preview?.previewVideoUrl);
+  const hasVideo = Boolean(displayVideoUrl);
+  const hasAudioOnly = Boolean(audioUrl) && !hasVideo;
+  const thumbSrc = preview?.thumbUrl && !isPlaceholderMediaUrl(preview.thumbUrl) ? preview.thumbUrl : null;
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const videoReadyRef = useRef(false);
+  const [videoReady, setVideoReady] = useState(false);
+
+  useEffect(() => {
+    if (!hasVideo) return;
+    videoReadyRef.current = false;
+    setVideoReady(false);
+  }, [hasVideo, displayVideoUrl]);
+
+  const markVideoReady = useCallback(() => {
+    if (videoReadyRef.current) return;
+    videoReadyRef.current = true;
+    setVideoReady(true);
+  }, []);
+
+  const playPreviewVideo = useCallback(() => {
+    const element = videoRef.current;
+    if (!element) return;
+    element.preload = 'auto';
+    if (
+      element.networkState === HTMLMediaElement.NETWORK_EMPTY ||
+      (element.networkState === HTMLMediaElement.NETWORK_IDLE && element.readyState < HTMLMediaElement.HAVE_CURRENT_DATA)
+    ) {
+      element.load();
+    }
+    if (element.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) {
+      return;
+    }
+    const playPromise = element.play();
+    if (playPromise) {
+      playPromise.catch(() => {
+        /* ignore autoplay rejection */
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!hasVideo) return;
+    const element = videoRef.current;
+    if (!element) return;
+    if (shouldPlay) {
+      playPreviewVideo();
+    } else {
+      element.pause();
+      if (
+        shouldWarm &&
+        hasOptimizedPreview &&
+        (element.networkState === HTMLMediaElement.NETWORK_EMPTY ||
+          (element.networkState === HTMLMediaElement.NETWORK_IDLE && element.readyState < HTMLMediaElement.HAVE_CURRENT_DATA))
+      ) {
+        element.preload = 'auto';
+        element.load();
+      }
+    }
+  }, [hasVideo, hasOptimizedPreview, playPreviewVideo, displayVideoUrl, shouldPlay, shouldWarm]);
+
+  const handleCanPlay = () => {
+    markVideoReady();
+    if (shouldPlay) {
+      playPreviewVideo();
+    }
+  };
+
+  const handleLoadedData = () => {
+    markVideoReady();
+    if (shouldPlay) {
+      playPreviewVideo();
+    }
+  };
+
+  if (hasVideo && displayVideoUrl) {
+    const poster = thumbSrc ?? undefined;
+    return (
+      <div className="relative h-full w-full overflow-hidden rounded-[inherit]">
+        {thumbSrc ? (
+          <ThumbImage
+            src={thumbSrc}
+            alt=""
+            className={clsx(
+              'absolute inset-0 transition-opacity duration-150 ease-out',
+              fit === 'cover' ? 'object-cover scale-[1.06] transform-gpu' : 'object-contain',
+              shouldPlay && videoReady ? 'opacity-0' : 'opacity-100'
+            )}
+          />
+        ) : null}
+        <video
+          ref={videoRef}
+          src={displayVideoUrl}
+          poster={poster}
+          className={clsx(
+            'absolute inset-0 h-full w-full pointer-events-none transition-opacity duration-150 ease-out',
+            fit === 'cover' ? 'object-cover scale-[1.06] transform-gpu' : 'object-contain',
+            videoReady ? 'opacity-100' : 'opacity-0'
+          )}
+          muted
+          playsInline
+          autoPlay={shouldPlay}
+          loop
+          preload={shouldPlay || (shouldWarm && hasOptimizedPreview) ? 'auto' : 'none'}
+          onLoadedData={handleLoadedData}
+          onCanPlay={handleCanPlay}
+        />
+      </div>
+    );
+  }
+  if (hasAudioOnly) {
+    return (
+      <AudioWaveformThumb
+        seed={audioUrl ?? preview?.id ?? 'audio-preview'}
+        thumbSrc={thumbSrc}
+        label={audioLabel}
+        active={shouldPlay}
+      />
+    );
+  }
+  if (thumbSrc) {
+    return (
+      <div className="relative h-full w-full overflow-hidden rounded-[inherit]">
+        <ThumbImage
+          src={thumbSrc}
+          alt=""
+          className={fit === 'cover' ? 'object-cover scale-[1.06] transform-gpu' : 'object-contain'}
+        />
+      </div>
+    );
+  }
+  return null;
+}

--- a/frontend/components/GroupedJobCardMenu.tsx
+++ b/frontend/components/GroupedJobCardMenu.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import clsx from 'clsx';
+import type { Ref } from 'react';
+import type { GroupSummary } from '@/types/groups';
+import { Button, ButtonLink } from '@/components/ui/Button';
+import type { GroupedJobAction, GroupedJobMenuVariant } from './grouped-job-card-types';
+
+interface GroupedJobCardMenuProps {
+  allowRemove: boolean;
+  closeMenu: () => void;
+  group: GroupSummary;
+  handleAction: (action: GroupedJobAction) => void;
+  handleRemake: () => void;
+  isImageGroup: boolean;
+  menuRef: Ref<HTMLDivElement>;
+  menuVariant: GroupedJobMenuVariant;
+  onOpen?: (group: GroupSummary) => void;
+  openLabel: string;
+  recreateHref?: string;
+  recreateLabel: string;
+  savingToLibrary: boolean;
+}
+
+export function GroupedJobCardMenu({
+  allowRemove,
+  closeMenu,
+  group,
+  handleAction,
+  handleRemake,
+  isImageGroup,
+  menuRef,
+  menuVariant,
+  onOpen,
+  openLabel,
+  recreateHref,
+  recreateLabel,
+  savingToLibrary,
+}: GroupedJobCardMenuProps) {
+  const showAdvancedMenuActions = menuVariant === 'full';
+  const showGalleryActions = menuVariant === 'gallery';
+  const showGalleryImageActions = menuVariant === 'gallery-image';
+
+  return (
+    <div
+      ref={menuRef}
+      className="absolute right-3 top-12 z-40 w-48 rounded-card border border-border bg-surface p-2 text-sm text-text-secondary shadow-card"
+    >
+      {showGalleryActions ? (
+        <>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => handleAction('open')}
+            className="w-full justify-between rounded-input px-2 py-1.5 text-left"
+          >
+            <span>Preview</span>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={handleRemake}
+            disabled={!onOpen}
+            className={clsx(
+              'mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left',
+              onOpen ? '' : 'cursor-not-allowed opacity-60'
+            )}
+          >
+            <span>Remake</span>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => handleAction('download')}
+            className="mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left"
+          >
+            <span>Download</span>
+          </Button>
+        </>
+      ) : showGalleryImageActions ? (
+        <>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => handleAction('open')}
+            className="w-full justify-between rounded-input px-2 py-1.5 text-left"
+          >
+            <span>Open</span>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => handleAction('save-image')}
+            className="mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left"
+          >
+            <span>Add to Library</span>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => handleAction('download')}
+            className="mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left"
+          >
+            <span>Download</span>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => handleAction('copy')}
+            className="mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left"
+          >
+            <span>Copy link</span>
+          </Button>
+        </>
+      ) : (
+        <>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => handleAction('open')}
+            className="w-full justify-between rounded-input px-2 py-1.5 text-left"
+          >
+            <span>{openLabel}</span>
+            <span className="text-[11px] text-text-muted">↵</span>
+          </Button>
+          {recreateHref ? (
+            <ButtonLink
+              href={recreateHref}
+              variant="ghost"
+              size="sm"
+              onClick={closeMenu}
+              className="mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left"
+            >
+              <span>{recreateLabel}</span>
+            </ButtonLink>
+          ) : null}
+          {showAdvancedMenuActions ? (
+            <>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => handleAction('continue')}
+                className="mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left"
+              >
+                <span>Continue (Hero)</span>
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => handleAction('refine')}
+                className="mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left"
+              >
+                <span>Refine (Hero)</span>
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => handleAction('branch')}
+                className="mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left"
+              >
+                <span>Branch</span>
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => handleAction('compare')}
+                className="mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left"
+              >
+                <span>Compare</span>
+              </Button>
+            </>
+          ) : null}
+        </>
+      )}
+      {isImageGroup && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => handleAction('save-image')}
+          className={clsx('mt-1 w-full justify-between rounded-input px-2 py-1.5 text-left', savingToLibrary ? 'opacity-60' : '')}
+          disabled={savingToLibrary}
+        >
+          <span>{savingToLibrary ? 'Saving…' : 'Add to Library'}</span>
+        </Button>
+      )}
+      {allowRemove && group.count <= 1 && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => handleAction('remove')}
+          className="mt-2 w-full justify-between rounded-input px-2 py-1.5 text-left text-error hover:bg-error-bg"
+        >
+          <span>Remove</span>
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/GroupedJobCardPreviewGrid.tsx
+++ b/frontend/components/GroupedJobCardPreviewGrid.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import clsx from 'clsx';
+import Image from 'next/image';
+import type { GroupSummary } from '@/types/groups';
+import { ProcessingOverlay } from '@/components/groups/ProcessingOverlay';
+import { isPlaceholderMediaUrl } from '@/lib/media';
+import { GROUPED_JOB_THUMB_SIZES, GroupPreviewMedia } from './GroupedJobCardMedia';
+
+interface GroupedJobCardPreviewGridProps {
+  group: GroupSummary;
+  hovered: boolean;
+  isPreviewWarm: boolean;
+  isSinglePreview: boolean;
+  previewCount: number;
+  previewGridClass: string;
+  previews: GroupSummary['previews'];
+}
+
+export function GroupedJobCardPreviewGrid({
+  group,
+  hovered,
+  isPreviewWarm,
+  isSinglePreview,
+  previewCount,
+  previewGridClass,
+  previews,
+}: GroupedJobCardPreviewGridProps) {
+  return (
+    <div
+      className={clsx(
+        'absolute inset-0 grid bg-placeholder',
+        previewGridClass,
+        isSinglePreview ? 'p-0' : 'gap-1 p-1'
+      )}
+    >
+      {Array.from({ length: previewCount }).map((_, index) => {
+        const preview = previews[index];
+        const member = preview ? group.members.find((entry) => entry.id === preview.id) : undefined;
+        const memberStatus = member?.status ?? 'completed';
+        const memberAudioUrl = member?.audioUrl ?? member?.job?.audioUrl ?? null;
+        const previewThumb = preview?.thumbUrl && !isPlaceholderMediaUrl(preview.thumbUrl) ? preview.thumbUrl : null;
+        const previewHasMedia = Boolean(preview?.previewVideoUrl || preview?.videoUrl || previewThumb || memberAudioUrl);
+        const isCompleted =
+          memberStatus === 'completed' || (previewHasMedia && memberStatus !== 'pending' && memberStatus !== 'failed');
+        const previewKey = preview?.id ? `${preview.id}-${index}` : `preview-${index}`;
+
+        return (
+          <div
+            key={previewKey}
+            className={clsx(
+              'relative flex items-center justify-center overflow-hidden bg-[var(--surface-2)]',
+              isSinglePreview ? 'rounded-none' : 'rounded-card'
+            )}
+          >
+            <div className="absolute inset-0">
+              {isCompleted ? (
+                <GroupPreviewMedia
+                  preview={preview}
+                  audioUrl={memberAudioUrl}
+                  audioLabel={preview?.previewVideoUrl || preview?.videoUrl ? null : 'Audio'}
+                  shouldPlay={hovered}
+                  shouldWarm={isPreviewWarm || hovered}
+                />
+              ) : previewThumb ? (
+                <Image
+                  src={previewThumb}
+                  alt=""
+                  fill
+                  className="pointer-events-none object-contain"
+                  sizes={GROUPED_JOB_THUMB_SIZES}
+                />
+              ) : null}
+            </div>
+            <div className="pointer-events-none block" style={{ width: '100%', aspectRatio: '16 / 9' }} aria-hidden />
+            {!isCompleted && member ? (
+              <ProcessingOverlay
+                className="absolute inset-0"
+                state={memberStatus === 'failed' ? 'error' : 'pending'}
+                message={member.message}
+                tone="light"
+                tileIndex={index + 1}
+                tileCount={previewCount}
+              />
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/components/gallery-rail-utils.ts
+++ b/frontend/components/gallery-rail-utils.ts
@@ -1,0 +1,133 @@
+import type { Job } from '@/types/jobs';
+import type { GroupSummary } from '@/types/groups';
+import type { ResultProvider } from '@/types/video-groups';
+import { countResolvedVisualSlots, mergeImageProgressGroup } from '@/lib/group-progress';
+
+export type GalleryVariant = 'desktop' | 'mobile';
+export type GalleryFeedType = 'video' | 'image';
+
+export const DEFAULT_GALLERY_COPY = {
+  title: 'Latest renders',
+  viewAll: 'View all',
+  curated: 'Starter samples curated by the MaxVideo team are shown until you generate your own videos.',
+  error: 'Failed to load latest renders. Please retry.',
+  retry: 'Retry',
+  imageCta: 'Generate images',
+  snackbar: {
+    samples: 'Sample clips cannot be removed.',
+    removed: 'Removed from gallery.',
+    failed: 'Unable to remove from gallery.',
+    saved: 'Saved to library.',
+    saveFailed: 'Unable to save to library.',
+    copied: 'Link copied.',
+    copyFailed: 'Unable to copy link.',
+    noMedia: 'No media available.',
+  },
+} as const;
+
+export type GalleryCopy = typeof DEFAULT_GALLERY_COPY;
+
+export const DEFAULT_GROUP_PROVIDER: ResultProvider = 'fal';
+export const INITIAL_EAGER_PREVIEW_COUNT = 0;
+const DESKTOP_BACKGROUND_WARM_PREVIEW_LIMIT = 2;
+
+type NavigatorWithConnection = Navigator & {
+  connection?: {
+    effectiveType?: string;
+    saveData?: boolean;
+  };
+};
+
+export function resolveBackgroundWarmPreviewLimit(variant: GalleryVariant): number {
+  if (variant !== 'desktop') return 0;
+  if (typeof navigator === 'undefined') return DESKTOP_BACKGROUND_WARM_PREVIEW_LIMIT;
+  const connection = (navigator as NavigatorWithConnection).connection;
+  if (connection?.saveData) return 0;
+  const effectiveType = connection?.effectiveType;
+  if (effectiveType === 'slow-2g' || effectiveType === '2g') return 1;
+  if (effectiveType === '3g') return 1;
+  return DESKTOP_BACKGROUND_WARM_PREVIEW_LIMIT;
+}
+
+export function resolveDisplayedActiveGroup(
+  feedType: GalleryFeedType,
+  activeGroup: GroupSummary,
+  historicalGroup?: GroupSummary
+): GroupSummary {
+  if (!historicalGroup) return activeGroup;
+  if (feedType !== 'image') return historicalGroup;
+
+  const expectedCount = Math.max(1, Math.min(4, activeGroup.count || historicalGroup.count || 1));
+  const resolvedCount = countResolvedVisualSlots(historicalGroup);
+  if (resolvedCount >= expectedCount) {
+    return historicalGroup;
+  }
+
+  if (resolvedCount > 0) {
+    return mergeImageProgressGroup(activeGroup, historicalGroup);
+  }
+
+  return activeGroup;
+}
+
+export function resolveAspectRatioLabel(group: GroupSummary): string | null {
+  const ratio = group.hero.aspectRatio ?? group.previews.find((preview) => preview.aspectRatio)?.aspectRatio ?? null;
+  if (!ratio) return null;
+  if (ratio.toLowerCase() === 'auto') return 'Auto';
+  return ratio;
+}
+
+export function resolveImageOriginalUrl(group: GroupSummary): string | null {
+  const resolveFromMember = (member = group.hero) => {
+    const job = member.job;
+    if (!job || !Array.isArray(job.renderIds) || !job.renderIds.length) {
+      return null;
+    }
+    const renderIds = job.renderIds.filter((value): value is string => typeof value === 'string' && /^https?:\/\//i.test(value));
+    if (!renderIds.length) {
+      return null;
+    }
+    if (typeof job.heroRenderId === 'string' && /^https?:\/\//i.test(job.heroRenderId)) {
+      return job.heroRenderId;
+    }
+    const match = member.id.match(/-image-(\d+)$/);
+    if (match) {
+      const index = Number(match[1]) - 1;
+      if (Number.isInteger(index) && index >= 0 && index < renderIds.length) {
+        return renderIds[index];
+      }
+    }
+    return renderIds[0] ?? null;
+  };
+
+  return (
+    resolveFromMember(group.hero) ??
+    group.members.map((member) => resolveFromMember(member)).find((value): value is string => typeof value === 'string' && value.length > 0) ??
+    group.hero.thumbUrl ??
+    group.previews.find((preview) => preview.thumbUrl)?.thumbUrl ??
+    null
+  );
+}
+
+export function resolveMediaUrl(group: GroupSummary, preferImage: boolean): string | null {
+  if (preferImage) {
+    return (
+      resolveImageOriginalUrl(group) ??
+      group.hero.videoUrl ??
+      group.previews.find((preview) => preview.videoUrl)?.videoUrl ??
+      null
+    );
+  }
+  return (
+    group.hero.videoUrl ??
+    group.previews.find((preview) => preview.videoUrl)?.videoUrl ??
+    group.hero.thumbUrl ??
+    group.previews.find((preview) => preview.thumbUrl)?.thumbUrl ??
+    null
+  );
+}
+
+export function filterGalleryFeedJobs(feedType: GalleryFeedType, jobs: Job[]): Job[] {
+  if (feedType !== 'video') return jobs;
+  return jobs.filter((job) => job.surface !== 'audio');
+}

--- a/frontend/components/grouped-job-card-types.ts
+++ b/frontend/components/grouped-job-card-types.ts
@@ -1,0 +1,14 @@
+export type GroupedJobAction =
+  | 'open'
+  | 'view'
+  | 'download'
+  | 'copy'
+  | 'continue'
+  | 'refine'
+  | 'branch'
+  | 'compare'
+  | 'remove'
+  | 'save-image'
+  | 'save-to-library';
+
+export type GroupedJobMenuVariant = 'full' | 'compact' | 'gallery' | 'gallery-image';

--- a/frontend/components/useGalleryRailScrollbar.ts
+++ b/frontend/components/useGalleryRailScrollbar.ts
@@ -1,0 +1,119 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { PointerEvent } from 'react';
+
+const RAIL_THUMB_HEIGHT = 24;
+const RAIL_TRACK_OFFSET = 12;
+
+export function useGalleryRailScrollbar({
+  isDesktopVariant,
+  refreshKey,
+}: {
+  isDesktopVariant: boolean;
+  refreshKey: number | string;
+}) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const railTrackRef = useRef<HTMLDivElement>(null);
+  const railDragPointerId = useRef<number | null>(null);
+  const [railProgress, setRailProgress] = useState(0);
+  const [showRail, setShowRail] = useState(false);
+  const [railTrackHeight, setRailTrackHeight] = useState(200);
+
+  const updateRailFromPointer = useCallback(
+    (clientY: number) => {
+      const track = railTrackRef.current;
+      const scroller = scrollContainerRef.current;
+      if (!track || !scroller) return;
+      const maxScroll = scroller.scrollHeight - scroller.clientHeight;
+      if (maxScroll <= 0) return;
+      const rect = track.getBoundingClientRect();
+      const trackRange = Math.max(1, railTrackHeight - RAIL_THUMB_HEIGHT);
+      const offset = clientY - rect.top - RAIL_THUMB_HEIGHT / 2;
+      const clamped = Math.min(Math.max(offset, 0), trackRange);
+      scroller.scrollTop = (clamped / trackRange) * maxScroll;
+    },
+    [railTrackHeight]
+  );
+
+  const handleRailPointerDown = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0) return;
+      railDragPointerId.current = event.pointerId;
+      event.currentTarget.setPointerCapture(event.pointerId);
+      updateRailFromPointer(event.clientY);
+      event.preventDefault();
+    },
+    [updateRailFromPointer]
+  );
+
+  const handleRailPointerMove = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (railDragPointerId.current !== event.pointerId) return;
+      updateRailFromPointer(event.clientY);
+      event.preventDefault();
+    },
+    [updateRailFromPointer]
+  );
+
+  const handleRailPointerUp = useCallback((event: PointerEvent<HTMLDivElement>) => {
+    if (railDragPointerId.current !== event.pointerId) return;
+    railDragPointerId.current = null;
+    event.currentTarget.releasePointerCapture(event.pointerId);
+  }, []);
+
+  const updateRailProgress = useCallback(() => {
+    const element = scrollContainerRef.current;
+    if (!element) return;
+    const maxScroll = element.scrollHeight - element.clientHeight;
+    if (!isDesktopVariant || maxScroll <= 4) {
+      setShowRail(false);
+      setRailProgress(0);
+      return;
+    }
+    const nextTrackHeight = Math.max(120, element.clientHeight - RAIL_TRACK_OFFSET * 2);
+    setRailTrackHeight((prev) => (prev === nextTrackHeight ? prev : nextTrackHeight));
+    setShowRail(true);
+    setRailProgress(element.scrollTop / maxScroll);
+  }, [isDesktopVariant]);
+
+  useEffect(() => {
+    const element = scrollContainerRef.current;
+    if (!element) return undefined;
+
+    updateRailProgress();
+
+    const handleScroll = () => updateRailProgress();
+    element.addEventListener('scroll', handleScroll, { passive: true });
+
+    let resizeObserver: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(() => updateRailProgress());
+      resizeObserver.observe(element);
+    }
+
+    window.addEventListener('resize', updateRailProgress);
+
+    return () => {
+      element.removeEventListener('scroll', handleScroll);
+      resizeObserver?.disconnect();
+      window.removeEventListener('resize', updateRailProgress);
+    };
+  }, [updateRailProgress]);
+
+  useEffect(() => {
+    updateRailProgress();
+  }, [refreshKey, updateRailProgress]);
+
+  return {
+    handleRailPointerDown,
+    handleRailPointerMove,
+    handleRailPointerUp,
+    railThumbHeight: RAIL_THUMB_HEIGHT,
+    railThumbOffset: railProgress * (railTrackHeight - RAIL_THUMB_HEIGHT),
+    railTrackHeight,
+    railTrackRef,
+    scrollContainerRef,
+    showRail,
+  };
+}

--- a/tests/gallery-surfaces-architecture.test.ts
+++ b/tests/gallery-surfaces-architecture.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+const root = process.cwd();
+
+function readSource(relativePath: string) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+function countLines(source: string) {
+  return source.split(/\r?\n/).length;
+}
+
+test('gallery rail delegates cards, snackbar, status blocks, scrollbar, and pure helpers', () => {
+  const railSource = readSource('frontend/components/GalleryRail.tsx');
+
+  assert.ok(countLines(railSource) <= 500, `GalleryRail.tsx should stay under 500 lines, found ${countLines(railSource)}`);
+  assert.match(railSource, /GalleryRailCards/);
+  assert.match(railSource, /GalleryRailSnackbar/);
+  assert.match(railSource, /GalleryRailHeader/);
+  assert.match(railSource, /useGalleryRailScrollbar/);
+  assert.match(railSource, /from '\.\/gallery-rail-utils';/);
+  assert.doesNotMatch(railSource, /function resolveBackgroundWarmPreviewLimit/);
+  assert.doesNotMatch(railSource, /function Snackbar/);
+  assert.doesNotMatch(railSource, /createPortal/);
+});
+
+test('grouped job card delegates media, preview grid, menu, and action types', () => {
+  const cardSource = readSource('frontend/components/GroupedJobCard.tsx');
+  const mediaSource = readSource('frontend/components/GroupedJobCardMedia.tsx');
+  const gridSource = readSource('frontend/components/GroupedJobCardPreviewGrid.tsx');
+  const menuSource = readSource('frontend/components/GroupedJobCardMenu.tsx');
+  const typesSource = readSource('frontend/components/grouped-job-card-types.ts');
+
+  assert.ok(countLines(cardSource) <= 500, `GroupedJobCard.tsx should stay under 500 lines, found ${countLines(cardSource)}`);
+  assert.match(cardSource, /GroupedJobCardPreviewGrid/);
+  assert.match(cardSource, /GroupedJobCardMenu/);
+  assert.match(cardSource, /shouldWarmVisiblePreview/);
+  assert.match(mediaSource, /export function GroupPreviewMedia/);
+  assert.match(gridSource, /export function GroupedJobCardPreviewGrid/);
+  assert.match(menuSource, /export function GroupedJobCardMenu/);
+  assert.match(typesSource, /export type GroupedJobAction/);
+  assert.doesNotMatch(cardSource, /export function GroupPreviewMedia/);
+  assert.doesNotMatch(cardSource, /const GROUPED_JOB_THUMB_SIZES/);
+});

--- a/tests/media-library-contract.test.ts
+++ b/tests/media-library-contract.test.ts
@@ -292,6 +292,10 @@ test('history cards use thumbnails and explicit card actions', () => {
     path.join(process.cwd(), 'frontend/components/GroupedJobCard.tsx'),
     'utf8'
   );
+  const mediaSource = fs.readFileSync(
+    path.join(process.cwd(), 'frontend/components/GroupedJobCardMedia.tsx'),
+    'utf8'
+  );
   const jobsSource = fs.readFileSync(
     path.join(process.cwd(), 'frontend/app/(core)/jobs/_hooks/useJobsPageController.ts'),
     'utf8'
@@ -301,8 +305,8 @@ test('history cards use thumbnails and explicit card actions', () => {
     'utf8'
   );
 
-  assert.match(cardSource, /const\s+thumbSrc\s*=\s*preview\?\.thumbUrl/);
-  assert.match(cardSource, /src=\{thumbSrc\}/);
+  assert.match(mediaSource, /const\s+thumbSrc\s*=\s*preview\?\.thumbUrl/);
+  assert.match(mediaSource, /src=\{thumbSrc\}/);
   assert.match(cardSource, /openLabel\?:\s*string/);
   assert.match(cardSource, /actionMenuLabel\?:\s*string/);
   assert.match(cardSource, /aria-label=\{actionMenuLabel\}/);
@@ -317,6 +321,10 @@ test('history cards use thumbnails and explicit card actions', () => {
 test('history can save renders to library from cards and job details', () => {
   const cardSource = fs.readFileSync(
     path.join(process.cwd(), 'frontend/components/GroupedJobCard.tsx'),
+    'utf8'
+  );
+  const cardTypesSource = fs.readFileSync(
+    path.join(process.cwd(), 'frontend/components/grouped-job-card-types.ts'),
     'utf8'
   );
   const jobsSource = fs.readFileSync(
@@ -336,7 +344,7 @@ test('history can save renders to library from cards and job details', () => {
     'utf8'
   );
 
-  assert.match(cardSource, /\|\s*'save-to-library'/);
+  assert.match(cardTypesSource, /\|\s*'save-to-library'/);
   assert.match(cardSource, /showLibraryCta\?:\s*boolean/);
   assert.match(cardSource, /<Plus\s+className=/);
   assert.match(cardSource, /handleAction\('save-to-library'\)/);

--- a/tests/workspace-gallery-rail-contract.test.ts
+++ b/tests/workspace-gallery-rail-contract.test.ts
@@ -8,18 +8,26 @@ test('workspace video rail opens renders in the composite preview, not the group
     path.join(process.cwd(), 'frontend/components/GalleryRail.tsx'),
     'utf8'
   );
+  const railCardsSource = fs.readFileSync(
+    path.join(process.cwd(), 'frontend/components/GalleryRailCards.tsx'),
+    'utf8'
+  );
   const cardSource = fs.readFileSync(
     path.join(process.cwd(), 'frontend/components/GroupedJobCard.tsx'),
+    'utf8'
+  );
+  const cardMenuSource = fs.readFileSync(
+    path.join(process.cwd(), 'frontend/components/GroupedJobCardMenu.tsx'),
     'utf8'
   );
 
   assert.match(cardSource, /showOpenOverlay\?:\s*boolean/);
   assert.match(cardSource, /showOpenOverlay\s*&&\s*onOpen/);
-  assert.match(cardSource, /onClick=\{\(\)\s*=>\s*handleAction\('open'\)\}/);
-  assert.doesNotMatch(cardSource, /showGalleryActions[\s\S]*onClick=\{\(\)\s*=>\s*handleAction\('view'\)\}/);
+  assert.match(cardMenuSource, /onClick=\{\(\)\s*=>\s*handleAction\('open'\)\}/);
+  assert.doesNotMatch(cardMenuSource, /showGalleryActions[\s\S]*onClick=\{\(\)\s*=>\s*handleAction\('view'\)\}/);
 
-  assert.match(railSource, /openLabel=\{feedType === 'video' \? 'Preview' : undefined\}/);
-  assert.match(railSource, /showOpenOverlay=\{false\}/);
+  assert.match(railCardsSource, /openLabel=\{feedType === 'video' \? 'Preview' : undefined\}/);
+  assert.match(railCardsSource, /showOpenOverlay=\{false\}/);
   assert.match(railSource, /onGroupAction\(original,\s*'open',\s*\{\s*autoPlayPreview:\s*true\s*\}\)/);
 });
 


### PR DESCRIPTION
## Summary
- split GalleryRail cards, snackbar, status blocks, scrollbar, and pure helper logic into focused modules
- split GroupedJobCard media playback, preview grid, menu, and action types into focused modules
- add architecture guards so GalleryRail and GroupedJobCard stay under the 500-line threshold

## Verification
- node --test tests/gallery-surfaces-architecture.test.ts tests/workspace-gallery-rail-contract.test.ts
- npx tsx --tsconfig frontend/tsconfig.json --test tests/media-library-contract.test.ts
- pnpm --dir frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- npm run test:validate
- npm run architecture:audit -- --min-lines 500
- git diff --check