### PR TITLE
[codex] Split settings advanced panel

### DIFF
--- a/frontend/components/SettingsControls.tsx
+++ b/frontend/components/SettingsControls.tsx
@@ -5,12 +5,8 @@ import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { formatResolutionLabel } from '@/lib/resolution-labels';
 import { matchesDurationOptionValue } from '@/components/settings-controls/settings-control-duration';
-import {
-  SettingsKlingV3Controls,
-  SettingsSeedanceAdvancedControls,
-} from '@/components/settings-controls/settings-control-engine-advanced';
-import { SettingsGenericAdvancedFields } from '@/components/settings-controls/settings-control-generic-fields';
-import { FieldGroup, RangeWithInput } from '@/components/settings-controls/settings-control-parts';
+import { SettingsAdvancedPanel } from '@/components/settings-controls/SettingsAdvancedPanel';
+import { FieldGroup } from '@/components/settings-controls/settings-control-parts';
 import type { SettingsControlsProps } from '@/components/settings-controls/settings-control-types';
 import { useSettingsControlState } from '@/components/settings-controls/useSettingsControlState';
 
@@ -68,40 +64,7 @@ export function SettingsControls({
   variant = 'full',
 }: SettingsControlsProps) {
   const showCore = variant !== 'advanced';
-  const {
-    advancedHasContent,
-    aspectOptions,
-    audioNotice,
-    canToggleAudio,
-    controlsCopy,
-    durationMaxSeconds,
-    durationOptionsContainerRef,
-    durationRange,
-    durationSliderRef,
-    effectiveCfgScale,
-    enumeratedDurationOptions,
-    frameOptions,
-    frameOptionsContainerRef,
-    guidance,
-    hasGenericAdvancedFields,
-    initInfluence,
-    isAdvancedOpen,
-    isLtxFastLong,
-    promptStrength,
-    resolutionLocked,
-    resolutionOptions,
-    resolvedDurationManagedLabel,
-    seed,
-    setGuidance,
-    setInitInfluence,
-    setInternalCfgScale,
-    setIsAdvancedOpen,
-    setPromptStrength,
-    setSeed,
-    showAspectControl,
-    showAudioToggle,
-    showResolutionControl,
-  } = useSettingsControlState({
+  const controlState = useSettingsControlState({
     advancedFields,
     audioControlDisabled,
     audioControlNote,
@@ -128,219 +91,60 @@ export function SettingsControls({
     showSafetyCheckerControl,
     showSeedanceControls,
   });
+  const {
+    aspectOptions,
+    audioNotice,
+    canToggleAudio,
+    controlsCopy,
+    durationMaxSeconds,
+    durationOptionsContainerRef,
+    durationRange,
+    durationSliderRef,
+    enumeratedDurationOptions,
+    frameOptions,
+    frameOptionsContainerRef,
+    isLtxFastLong,
+    resolutionLocked,
+    resolutionOptions,
+    resolvedDurationManagedLabel,
+    showAspectControl,
+    showAudioToggle,
+    showResolutionControl,
+  } = controlState;
+
+  const advancedPanelProps = {
+    advancedFieldValues,
+    advancedFields,
+    cameraFixed,
+    engine,
+    klingShotType,
+    loopEnabled,
+    mode,
+    onAdvancedFieldChange,
+    onCameraFixedChange,
+    onCfgScaleChange,
+    onKlingShotTypeChange,
+    onLoopChange,
+    onSafetyCheckerChange,
+    onSeedChange,
+    onSeedLockedChange,
+    onVoiceIdsChange,
+    safetyChecker,
+    seedLocked,
+    seedValue,
+    showExtendControl,
+    showKlingV3Controls,
+    showKlingV3VoiceControls,
+    showLoopControl,
+    showSafetyCheckerControl,
+    showSeedanceControls,
+    state: controlState,
+    voiceControlActive,
+    voiceIdsValue,
+  };
 
   if (variant === 'advanced') {
-    if (!advancedHasContent) return null;
-
-    return (
-      <div className="space-y-3">
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          className="min-h-0 h-auto w-full justify-between px-0 py-0 text-left font-normal"
-          onClick={() => setIsAdvancedOpen((prev) => !prev)}
-          aria-expanded={isAdvancedOpen}
-        >
-          <span className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">
-            {controlsCopy.advancedTitle}
-          </span>
-          <svg
-            className={clsx('h-4 w-4 text-text-muted transition-transform', isAdvancedOpen ? 'rotate-180' : 'rotate-0')}
-            viewBox="0 0 20 20"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            aria-hidden="true"
-          >
-            <path d="M5 8l5 5 5-5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-        </Button>
-        {isAdvancedOpen ? (
-          <div className="space-y-4 rounded-input border border-border bg-surface-glass-60 p-3">
-            {showLoopControl && typeof loopEnabled === 'boolean' && onLoopChange ? (
-              <div className="grid gap-3 md:grid-cols-3">
-                <label className="flex flex-col gap-1.5">
-                  <span className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">{controlsCopy.loop.label}</span>
-                  <div className="flex flex-wrap gap-2">
-                    {[true, false].map((option) => (
-                      <Button
-                        key={option ? 'loop-on' : 'loop-off'}
-                        type="button"
-                        size="sm"
-                        variant="outline"
-                        onClick={() => onLoopChange(option)}
-                        className={clsx(
-                          'min-h-0 h-auto px-2.5 py-1 text-[12px]',
-                          option === loopEnabled
-                            ? 'border-brand bg-brand text-on-brand'
-                            : 'border-hairline bg-surface text-text-secondary hover:border-text-muted hover:bg-surface-2'
-                        )}
-                      >
-                        {option ? controlsCopy.loop.on : controlsCopy.loop.off}
-                      </Button>
-                    ))}
-                  </div>
-                </label>
-              </div>
-            ) : null}
-
-            {!showSeedanceControls ? (
-              <div className="grid gap-3 md:grid-cols-3 md:items-end">
-                <label className="flex flex-col gap-1.5 text-sm text-text-secondary">
-                  <span className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">{controlsCopy.seed.label}</span>
-                  <input
-                    type="number"
-                    placeholder={controlsCopy.seed.placeholder}
-                    value={onSeedChange ? seedValue : seed}
-                    onChange={(e) => {
-                      setSeed(e.currentTarget.value);
-                      onSeedChange?.(e.currentTarget.value);
-                    }}
-                    className="h-10 rounded-input border border-border bg-surface px-3 text-sm text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  />
-                </label>
-                <label className="inline-flex min-h-[40px] items-center gap-2 text-[13px] text-text-secondary">
-                  <input
-                    type="checkbox"
-                    checked={Boolean(seedLocked)}
-                    onChange={(e) => onSeedLockedChange?.(e.currentTarget.checked)}
-                  />
-                  <span>{controlsCopy.seed.lock}</span>
-                </label>
-                {showSafetyCheckerControl ? (
-                  <label className="flex flex-col gap-1.5 text-sm text-text-secondary">
-                    <span className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">Safety checker</span>
-                    <div className="flex flex-wrap gap-2">
-                      {[true, false].map((option) => (
-                        <Button
-                          key={option ? 'generic-safety-on' : 'generic-safety-off'}
-                          type="button"
-                          size="sm"
-                          variant="outline"
-                          onClick={() => onSafetyCheckerChange?.(option)}
-                          className={clsx(
-                            'min-h-0 h-auto px-3 py-1.5 text-[13px]',
-                            option === safetyChecker
-                              ? 'border-brand bg-brand text-on-brand'
-                              : 'border-hairline bg-surface text-text-secondary hover:border-text-muted hover:bg-surface-2'
-                          )}
-                        >
-                          {option ? 'On' : 'Off'}
-                        </Button>
-                      ))}
-                    </div>
-                  </label>
-                ) : null}
-              </div>
-            ) : null}
-
-            {engine.params.promptStrength ? (
-              <div className="space-y-2">
-                <span className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">{controlsCopy.promptStrength}</span>
-                <RangeWithInput
-                  value={promptStrength ?? engine.params.promptStrength.default ?? 0.5}
-                  min={engine.params.promptStrength.min ?? 0}
-                  max={engine.params.promptStrength.max ?? 1}
-                  step={engine.params.promptStrength.step ?? 0.05}
-                  onChange={(value) => setPromptStrength(value)}
-                />
-              </div>
-            ) : null}
-
-            {engine.params.guidance ? (
-              <div className="space-y-2">
-                <span className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">{controlsCopy.guidance}</span>
-                <RangeWithInput
-                  value={guidance ?? engine.params.guidance.default ?? 0.5}
-                  min={engine.params.guidance.min ?? 0}
-                  max={engine.params.guidance.max ?? 1}
-                  step={engine.params.guidance.step ?? 0.05}
-                  onChange={(value) => setGuidance(value)}
-                />
-              </div>
-            ) : null}
-
-            {mode === 'i2v' && engine.params.initInfluence ? (
-              <div className="space-y-2">
-                <span className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">{controlsCopy.inputInfluence}</span>
-                <RangeWithInput
-                  value={initInfluence ?? engine.params.initInfluence.default ?? 0.5}
-                  min={engine.params.initInfluence.min ?? 0}
-                  max={engine.params.initInfluence.max ?? 1}
-                  step={engine.params.initInfluence.step ?? 0.05}
-                  onChange={(value) => setInitInfluence(value)}
-                />
-              </div>
-            ) : null}
-
-            {showExtendControl && engine.extend ? (
-              <div className="space-y-2">
-                <span className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">{controlsCopy.extend.label}</span>
-                <div className="flex flex-wrap items-center gap-2 text-[13px] text-text-secondary">
-                  <span>{controlsCopy.extend.action}</span>
-                  <input type="number" min={1} max={30} defaultValue={5} className="h-10 w-20 rounded-input border border-border bg-surface px-2 text-right focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" />
-                  <span>{controlsCopy.extend.unit}</span>
-                </div>
-              </div>
-            ) : null}
-
-            {engine.keyframes ? <div className="text-[12px] text-text-muted">{controlsCopy.keyframes}</div> : null}
-
-            {hasGenericAdvancedFields ? (
-              <SettingsGenericAdvancedFields
-                fields={advancedFields}
-                values={advancedFieldValues}
-                onChange={onAdvancedFieldChange}
-              />
-            ) : null}
-
-            {showKlingV3Controls ? (
-              <SettingsKlingV3Controls
-                klingShotType={klingShotType}
-                layout="compact"
-                mode={mode}
-                onKlingShotTypeChange={onKlingShotTypeChange}
-                onVoiceIdsChange={onVoiceIdsChange}
-                showVoiceControls={showKlingV3VoiceControls}
-                voiceControlActive={voiceControlActive}
-                voiceIdsValue={voiceIdsValue}
-              />
-            ) : null}
-
-            {showSeedanceControls ? (
-              <SettingsSeedanceAdvancedControls
-                cameraFixed={cameraFixed}
-                layout="compact"
-                onCameraFixedChange={onCameraFixedChange}
-                onSafetyCheckerChange={onSafetyCheckerChange}
-                onSeedChange={onSeedChange}
-                safetyChecker={safetyChecker}
-                seedValue={seedValue}
-              />
-            ) : null}
-
-            {engine.params.cfg_scale ? (
-              <div className="space-y-2">
-                <span className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">{controlsCopy.cfgScale}</span>
-                <RangeWithInput
-                  value={effectiveCfgScale}
-                  min={engine.params.cfg_scale.min ?? 0}
-                  max={engine.params.cfg_scale.max ?? 1}
-                  step={engine.params.cfg_scale.step ?? 0.01}
-                  onChange={(value) => {
-                    if (onCfgScaleChange) {
-                      onCfgScaleChange(value);
-                    } else {
-                      setInternalCfgScale(value);
-                    }
-                  }}
-                />
-              </div>
-            ) : null}
-          </div>
-        ) : null}
-      </div>
-    );
+    return <SettingsAdvancedPanel {...advancedPanelProps} panelVariant="standalone" />;
   }
 
   return (
@@ -602,157 +406,7 @@ export function SettingsControls({
           )}
         </>
       )}
-      <div className="rounded-input border border-border bg-surface">
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          className="min-h-0 h-auto w-full justify-between px-3 py-2 text-left font-normal"
-          onClick={() => setIsAdvancedOpen((prev) => !prev)}
-          aria-expanded={isAdvancedOpen}
-        >
-          <span className="text-[12px] font-semibold uppercase tracking-micro text-text-muted">
-            {controlsCopy.advancedTitle}
-          </span>
-          <svg
-            className={clsx('h-4 w-4 text-text-muted transition-transform', isAdvancedOpen ? 'rotate-180' : 'rotate-0')}
-            viewBox="0 0 20 20"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            aria-hidden="true"
-          >
-            <path d="M5 8l5 5 5-5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-        </Button>
-        {isAdvancedOpen && (
-          <div className="stack-gap-sm border-t border-border px-3 pb-3 pt-2">
-            {!showSeedanceControls && (
-              <>
-                <label className="flex flex-col gap-2 text-sm text-text-secondary">
-                  <span className="text-[12px] uppercase tracking-micro text-text-muted">{controlsCopy.seed.label}</span>
-                  <input
-                    type="number"
-                    placeholder={controlsCopy.seed.placeholder}
-                    value={seed}
-                    onChange={(e) => setSeed(e.currentTarget.value)}
-                    className="rounded-input border border-border bg-surface px-3 py-2 text-sm text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  />
-                </label>
-                <label className="inline-flex items-center gap-2 text-[13px] text-text-secondary">
-                  <input
-                    type="checkbox"
-                    checked={Boolean(seedLocked)}
-                    onChange={(e) => onSeedLockedChange?.(e.currentTarget.checked)}
-                  />
-                  <span>{controlsCopy.seed.lock}</span>
-                </label>
-              </>
-            )}
-
-            {engine.params.promptStrength && (
-              <div className="space-y-2">
-                <span className="text-[12px] uppercase tracking-micro text-text-muted">{controlsCopy.promptStrength}</span>
-                <RangeWithInput
-                  value={promptStrength ?? engine.params.promptStrength.default ?? 0.5}
-                  min={engine.params.promptStrength.min ?? 0}
-                  max={engine.params.promptStrength.max ?? 1}
-                  step={engine.params.promptStrength.step ?? 0.05}
-                  onChange={(value) => setPromptStrength(value)}
-                />
-              </div>
-            )}
-
-            {engine.params.guidance && (
-              <div className="space-y-2">
-                <span className="text-[12px] uppercase tracking-micro text-text-muted">{controlsCopy.guidance}</span>
-                <RangeWithInput
-                  value={guidance ?? engine.params.guidance.default ?? 0.5}
-                  min={engine.params.guidance.min ?? 0}
-                  max={engine.params.guidance.max ?? 1}
-                  step={engine.params.guidance.step ?? 0.05}
-                  onChange={(value) => setGuidance(value)}
-                />
-              </div>
-            )}
-
-            {mode === 'i2v' && engine.params.initInfluence && (
-              <div className="space-y-2">
-                <h4 className="text-[12px] font-semibold uppercase tracking-micro text-text-muted">
-                  {controlsCopy.inputInfluence}
-                </h4>
-                <RangeWithInput
-                  value={initInfluence ?? engine.params.initInfluence.default ?? 0.5}
-                  min={engine.params.initInfluence.min ?? 0}
-                  max={engine.params.initInfluence.max ?? 1}
-                  step={engine.params.initInfluence.step ?? 0.05}
-                  onChange={(value) => setInitInfluence(value)}
-                />
-              </div>
-            )}
-
-            {showExtendControl && engine.extend && (
-              <div className="space-y-2">
-                <h4 className="text-[12px] font-semibold uppercase tracking-micro text-text-muted">
-                  {controlsCopy.extend.label}
-                </h4>
-                <div className="flex items-center gap-2 text-[13px]">
-                  <span>{controlsCopy.extend.action}</span>
-                  <input type="number" min={1} max={30} defaultValue={5} className="w-20 rounded-input border border-border bg-surface px-2 py-1 text-right focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" />
-                  <span>{controlsCopy.extend.unit}</span>
-                </div>
-              </div>
-            )}
-
-            {engine.keyframes && (
-              <div className="text-[12px] text-text-muted">{controlsCopy.keyframes}</div>
-            )}
-
-            {showKlingV3Controls && (
-              <SettingsKlingV3Controls
-                klingShotType={klingShotType}
-                layout="panel"
-                mode={mode}
-                onKlingShotTypeChange={onKlingShotTypeChange}
-                onVoiceIdsChange={onVoiceIdsChange}
-                showVoiceControls={showKlingV3VoiceControls}
-                voiceControlActive={voiceControlActive}
-                voiceIdsValue={voiceIdsValue}
-              />
-            )}
-
-            {showSeedanceControls && (
-              <SettingsSeedanceAdvancedControls
-                cameraFixed={cameraFixed}
-                layout="panel"
-                onCameraFixedChange={onCameraFixedChange}
-                onSafetyCheckerChange={onSafetyCheckerChange}
-                onSeedChange={onSeedChange}
-                safetyChecker={safetyChecker}
-                seedValue={seedValue}
-              />
-            )}
-
-            {engine.params.cfg_scale && (
-              <div className="space-y-2">
-                <span className="text-[12px] uppercase tracking-micro text-text-muted">{controlsCopy.cfgScale}</span>
-                <RangeWithInput
-                  value={effectiveCfgScale}
-                  min={engine.params.cfg_scale.min ?? 0}
-                  max={engine.params.cfg_scale.max ?? 1}
-                  step={engine.params.cfg_scale.step ?? 0.01}
-                  onChange={(value) => {
-                    if (onCfgScaleChange) {
-                      onCfgScaleChange(value);
-                    } else {
-                      setInternalCfgScale(value);
-                    }
-                  }}
-                />
-              </div>
-            )}
-          </div>
-        )}
-      </div>
+      <SettingsAdvancedPanel {...advancedPanelProps} panelVariant="embedded" />
     </Card>
   );
 }

--- a/frontend/components/settings-controls/SettingsAdvancedPanel.tsx
+++ b/frontend/components/settings-controls/SettingsAdvancedPanel.tsx
@@ -1,0 +1,469 @@
+'use client';
+
+import clsx from 'clsx';
+import { Button } from '@/components/ui/Button';
+import {
+  SettingsKlingV3Controls,
+  SettingsSeedanceAdvancedControls,
+} from '@/components/settings-controls/settings-control-engine-advanced';
+import { SettingsGenericAdvancedFields } from '@/components/settings-controls/settings-control-generic-fields';
+import { RangeWithInput } from '@/components/settings-controls/settings-control-parts';
+import type { SettingsControlsProps } from '@/components/settings-controls/settings-control-types';
+import type { useSettingsControlState } from '@/components/settings-controls/useSettingsControlState';
+
+type SettingsControlState = ReturnType<typeof useSettingsControlState>;
+
+type SettingsAdvancedPanelProps = Pick<
+  SettingsControlsProps,
+  | 'advancedFieldValues'
+  | 'advancedFields'
+  | 'cameraFixed'
+  | 'engine'
+  | 'klingShotType'
+  | 'loopEnabled'
+  | 'mode'
+  | 'onAdvancedFieldChange'
+  | 'onCameraFixedChange'
+  | 'onCfgScaleChange'
+  | 'onKlingShotTypeChange'
+  | 'onLoopChange'
+  | 'onSafetyCheckerChange'
+  | 'onSeedChange'
+  | 'onSeedLockedChange'
+  | 'onVoiceIdsChange'
+  | 'safetyChecker'
+  | 'seedLocked'
+  | 'seedValue'
+  | 'showExtendControl'
+  | 'showKlingV3Controls'
+  | 'showKlingV3VoiceControls'
+  | 'showLoopControl'
+  | 'showSafetyCheckerControl'
+  | 'showSeedanceControls'
+  | 'voiceControlActive'
+  | 'voiceIdsValue'
+> & {
+  panelVariant: 'standalone' | 'embedded';
+  state: SettingsControlState;
+};
+
+function AdvancedToggle({
+  className,
+  isOpen,
+  label,
+  onClick,
+  titleClassName,
+}: {
+  className: string;
+  isOpen: boolean;
+  label: string;
+  onClick: () => void;
+  titleClassName: string;
+}) {
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="ghost"
+      className={className}
+      onClick={onClick}
+      aria-expanded={isOpen}
+    >
+      <span className={titleClassName}>{label}</span>
+      <svg
+        className={clsx('h-4 w-4 text-text-muted transition-transform', isOpen ? 'rotate-180' : 'rotate-0')}
+        viewBox="0 0 20 20"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <path d="M5 8l5 5 5-5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    </Button>
+  );
+}
+
+function LoopModeControl({
+  copy,
+  loopEnabled,
+  onLoopChange,
+}: {
+  copy: SettingsControlState['controlsCopy']['loop'];
+  loopEnabled: boolean;
+  onLoopChange: (value: boolean) => void;
+}) {
+  return (
+    <div className="grid gap-3 md:grid-cols-3">
+      <label className="flex flex-col gap-1.5">
+        <span className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">{copy.label}</span>
+        <div className="flex flex-wrap gap-2">
+          {[true, false].map((option) => (
+            <Button
+              key={option ? 'loop-on' : 'loop-off'}
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => onLoopChange(option)}
+              className={clsx(
+                'min-h-0 h-auto px-2.5 py-1 text-[12px]',
+                option === loopEnabled
+                  ? 'border-brand bg-brand text-on-brand'
+                  : 'border-hairline bg-surface text-text-secondary hover:border-text-muted hover:bg-surface-2'
+              )}
+            >
+              {option ? copy.on : copy.off}
+            </Button>
+          ))}
+        </div>
+      </label>
+    </div>
+  );
+}
+
+function StandaloneSeedControls({
+  safetyChecker,
+  seedLocked,
+  seedValue,
+  showSafetyCheckerControl,
+  state,
+  onSafetyCheckerChange,
+  onSeedChange,
+  onSeedLockedChange,
+}: Pick<
+  SettingsAdvancedPanelProps,
+  | 'onSafetyCheckerChange'
+  | 'onSeedChange'
+  | 'onSeedLockedChange'
+  | 'safetyChecker'
+  | 'seedLocked'
+  | 'seedValue'
+  | 'showSafetyCheckerControl'
+> & {
+  state: SettingsControlState;
+}) {
+  const { controlsCopy, seed, setSeed } = state;
+
+  return (
+    <div className="grid gap-3 md:grid-cols-3 md:items-end">
+      <label className="flex flex-col gap-1.5 text-sm text-text-secondary">
+        <span className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">{controlsCopy.seed.label}</span>
+        <input
+          type="number"
+          placeholder={controlsCopy.seed.placeholder}
+          value={onSeedChange ? seedValue : seed}
+          onChange={(event) => {
+            setSeed(event.currentTarget.value);
+            onSeedChange?.(event.currentTarget.value);
+          }}
+          className="h-10 rounded-input border border-border bg-surface px-3 text-sm text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+      </label>
+      <label className="inline-flex min-h-[40px] items-center gap-2 text-[13px] text-text-secondary">
+        <input
+          type="checkbox"
+          checked={Boolean(seedLocked)}
+          onChange={(event) => onSeedLockedChange?.(event.currentTarget.checked)}
+        />
+        <span>{controlsCopy.seed.lock}</span>
+      </label>
+      {showSafetyCheckerControl ? (
+        <label className="flex flex-col gap-1.5 text-sm text-text-secondary">
+          <span className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">Safety checker</span>
+          <div className="flex flex-wrap gap-2">
+            {[true, false].map((option) => (
+              <Button
+                key={option ? 'generic-safety-on' : 'generic-safety-off'}
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => onSafetyCheckerChange?.(option)}
+                className={clsx(
+                  'min-h-0 h-auto px-3 py-1.5 text-[13px]',
+                  option === safetyChecker
+                    ? 'border-brand bg-brand text-on-brand'
+                    : 'border-hairline bg-surface text-text-secondary hover:border-text-muted hover:bg-surface-2'
+                )}
+              >
+                {option ? 'On' : 'Off'}
+              </Button>
+            ))}
+          </div>
+        </label>
+      ) : null}
+    </div>
+  );
+}
+
+function EmbeddedSeedControls({
+  seedLocked,
+  state,
+  onSeedLockedChange,
+}: Pick<SettingsAdvancedPanelProps, 'onSeedLockedChange' | 'seedLocked'> & {
+  state: SettingsControlState;
+}) {
+  const { controlsCopy, seed, setSeed } = state;
+
+  return (
+    <>
+      <label className="flex flex-col gap-2 text-sm text-text-secondary">
+        <span className="text-[12px] uppercase tracking-micro text-text-muted">{controlsCopy.seed.label}</span>
+        <input
+          type="number"
+          placeholder={controlsCopy.seed.placeholder}
+          value={seed}
+          onChange={(event) => setSeed(event.currentTarget.value)}
+          className="rounded-input border border-border bg-surface px-3 py-2 text-sm text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+      </label>
+      <label className="inline-flex items-center gap-2 text-[13px] text-text-secondary">
+        <input
+          type="checkbox"
+          checked={Boolean(seedLocked)}
+          onChange={(event) => onSeedLockedChange?.(event.currentTarget.checked)}
+        />
+        <span>{controlsCopy.seed.lock}</span>
+      </label>
+    </>
+  );
+}
+
+function AdvancedRangeFields({
+  labelClassName,
+  state,
+  props,
+}: {
+  labelClassName: string;
+  state: SettingsControlState;
+  props: SettingsAdvancedPanelProps;
+}) {
+  const { controlsCopy, effectiveCfgScale, guidance, initInfluence, promptStrength } = state;
+  const { engine, mode, onCfgScaleChange } = props;
+
+  return (
+    <>
+      {engine.params.promptStrength ? (
+        <div className="space-y-2">
+          <span className={labelClassName}>{controlsCopy.promptStrength}</span>
+          <RangeWithInput
+            value={promptStrength ?? engine.params.promptStrength.default ?? 0.5}
+            min={engine.params.promptStrength.min ?? 0}
+            max={engine.params.promptStrength.max ?? 1}
+            step={engine.params.promptStrength.step ?? 0.05}
+            onChange={(value) => state.setPromptStrength(value)}
+          />
+        </div>
+      ) : null}
+
+      {engine.params.guidance ? (
+        <div className="space-y-2">
+          <span className={labelClassName}>{controlsCopy.guidance}</span>
+          <RangeWithInput
+            value={guidance ?? engine.params.guidance.default ?? 0.5}
+            min={engine.params.guidance.min ?? 0}
+            max={engine.params.guidance.max ?? 1}
+            step={engine.params.guidance.step ?? 0.05}
+            onChange={(value) => state.setGuidance(value)}
+          />
+        </div>
+      ) : null}
+
+      {mode === 'i2v' && engine.params.initInfluence ? (
+        <div className="space-y-2">
+          <span className={labelClassName}>{controlsCopy.inputInfluence}</span>
+          <RangeWithInput
+            value={initInfluence ?? engine.params.initInfluence.default ?? 0.5}
+            min={engine.params.initInfluence.min ?? 0}
+            max={engine.params.initInfluence.max ?? 1}
+            step={engine.params.initInfluence.step ?? 0.05}
+            onChange={(value) => state.setInitInfluence(value)}
+          />
+        </div>
+      ) : null}
+
+      {engine.params.cfg_scale ? (
+        <div className="space-y-2">
+          <span className={labelClassName}>{controlsCopy.cfgScale}</span>
+          <RangeWithInput
+            value={effectiveCfgScale}
+            min={engine.params.cfg_scale.min ?? 0}
+            max={engine.params.cfg_scale.max ?? 1}
+            step={engine.params.cfg_scale.step ?? 0.01}
+            onChange={(value) => {
+              if (onCfgScaleChange) {
+                onCfgScaleChange(value);
+              } else {
+                state.setInternalCfgScale(value);
+              }
+            }}
+          />
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function ExtendAndKeyframeControls({
+  labelClassName,
+  props,
+  state,
+}: {
+  labelClassName: string;
+  props: SettingsAdvancedPanelProps;
+  state: SettingsControlState;
+}) {
+  const { controlsCopy } = state;
+  const { engine, showExtendControl } = props;
+
+  return (
+    <>
+      {showExtendControl && engine.extend ? (
+        <div className="space-y-2">
+          <span className={labelClassName}>{controlsCopy.extend.label}</span>
+          <div className="flex flex-wrap items-center gap-2 text-[13px] text-text-secondary">
+            <span>{controlsCopy.extend.action}</span>
+            <input
+              type="number"
+              min={1}
+              max={30}
+              defaultValue={5}
+              className="h-10 w-20 rounded-input border border-border bg-surface px-2 text-right focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            />
+            <span>{controlsCopy.extend.unit}</span>
+          </div>
+        </div>
+      ) : null}
+
+      {engine.keyframes ? <div className="text-[12px] text-text-muted">{controlsCopy.keyframes}</div> : null}
+    </>
+  );
+}
+
+function EngineAdvancedControls({
+  layout,
+  props,
+}: {
+  layout: 'compact' | 'panel';
+  props: SettingsAdvancedPanelProps;
+}) {
+  const {
+    cameraFixed,
+    klingShotType,
+    mode,
+    onCameraFixedChange,
+    onKlingShotTypeChange,
+    onSafetyCheckerChange,
+    onSeedChange,
+    onVoiceIdsChange,
+    safetyChecker,
+    seedValue,
+    showKlingV3Controls,
+    showKlingV3VoiceControls,
+    showSeedanceControls,
+    voiceControlActive,
+    voiceIdsValue,
+  } = props;
+
+  return (
+    <>
+      {showKlingV3Controls ? (
+        <SettingsKlingV3Controls
+          klingShotType={klingShotType ?? 'customize'}
+          layout={layout}
+          mode={mode}
+          onKlingShotTypeChange={onKlingShotTypeChange}
+          onVoiceIdsChange={onVoiceIdsChange}
+          showVoiceControls={showKlingV3VoiceControls ?? true}
+          voiceControlActive={voiceControlActive ?? false}
+          voiceIdsValue={voiceIdsValue ?? ''}
+        />
+      ) : null}
+
+      {showSeedanceControls ? (
+        <SettingsSeedanceAdvancedControls
+          cameraFixed={cameraFixed ?? false}
+          layout={layout}
+          onCameraFixedChange={onCameraFixedChange}
+          onSafetyCheckerChange={onSafetyCheckerChange}
+          onSeedChange={onSeedChange}
+          safetyChecker={safetyChecker ?? true}
+          seedValue={seedValue ?? ''}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function AdvancedContent(props: SettingsAdvancedPanelProps) {
+  const { panelVariant, showLoopControl, loopEnabled, onLoopChange, showSeedanceControls, state } = props;
+  const labelClassName =
+    panelVariant === 'standalone'
+      ? 'text-[11px] font-semibold uppercase tracking-micro text-text-muted'
+      : 'text-[12px] uppercase tracking-micro text-text-muted';
+
+  return (
+    <>
+      {panelVariant === 'standalone' && showLoopControl && typeof loopEnabled === 'boolean' && onLoopChange ? (
+        <LoopModeControl copy={state.controlsCopy.loop} loopEnabled={loopEnabled} onLoopChange={onLoopChange} />
+      ) : null}
+
+      {!showSeedanceControls && panelVariant === 'standalone' ? <StandaloneSeedControls {...props} /> : null}
+      {!showSeedanceControls && panelVariant === 'embedded' ? <EmbeddedSeedControls {...props} /> : null}
+
+      <AdvancedRangeFields labelClassName={labelClassName} state={state} props={props} />
+      <ExtendAndKeyframeControls labelClassName={labelClassName} state={state} props={props} />
+
+      {panelVariant === 'standalone' && state.hasGenericAdvancedFields ? (
+        <SettingsGenericAdvancedFields
+          fields={props.advancedFields ?? []}
+          values={props.advancedFieldValues ?? {}}
+          onChange={props.onAdvancedFieldChange}
+        />
+      ) : null}
+
+      <EngineAdvancedControls layout={panelVariant === 'standalone' ? 'compact' : 'panel'} props={props} />
+    </>
+  );
+}
+
+export function SettingsAdvancedPanel(props: SettingsAdvancedPanelProps) {
+  const { panelVariant, state } = props;
+  const { advancedHasContent, controlsCopy, isAdvancedOpen, setIsAdvancedOpen } = state;
+
+  if (panelVariant === 'standalone') {
+    if (!advancedHasContent) return null;
+
+    return (
+      <div className="space-y-3">
+        <AdvancedToggle
+          className="min-h-0 h-auto w-full justify-between px-0 py-0 text-left font-normal"
+          isOpen={isAdvancedOpen}
+          label={controlsCopy.advancedTitle}
+          onClick={() => setIsAdvancedOpen((prev) => !prev)}
+          titleClassName="text-[11px] font-semibold uppercase tracking-micro text-text-muted"
+        />
+        {isAdvancedOpen ? (
+          <div className="space-y-4 rounded-input border border-border bg-surface-glass-60 p-3">
+            <AdvancedContent {...props} />
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-input border border-border bg-surface">
+      <AdvancedToggle
+        className="min-h-0 h-auto w-full justify-between px-3 py-2 text-left font-normal"
+        isOpen={isAdvancedOpen}
+        label={controlsCopy.advancedTitle}
+        onClick={() => setIsAdvancedOpen((prev) => !prev)}
+        titleClassName="text-[12px] font-semibold uppercase tracking-micro text-text-muted"
+      />
+      {isAdvancedOpen ? (
+        <div className="stack-gap-sm border-t border-border px-3 pb-3 pt-2">
+          <AdvancedContent {...props} />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/tests/settings-controls-architecture.test.ts
+++ b/tests/settings-controls-architecture.test.ts
@@ -10,6 +10,7 @@ const durationPath = join(root, 'frontend/components/settings-controls/settings-
 const copyPath = join(root, 'frontend/components/settings-controls/settings-control-copy.ts');
 const genericFieldsPath = join(root, 'frontend/components/settings-controls/settings-control-generic-fields.tsx');
 const engineAdvancedPath = join(root, 'frontend/components/settings-controls/settings-control-engine-advanced.tsx');
+const advancedPanelPath = join(root, 'frontend/components/settings-controls/SettingsAdvancedPanel.tsx');
 const typesPath = join(root, 'frontend/components/settings-controls/settings-control-types.ts');
 const stateHookPath = join(root, 'frontend/components/settings-controls/useSettingsControlState.ts');
 
@@ -19,6 +20,7 @@ const durationSource = readFileSync(durationPath, 'utf8');
 const copySource = readFileSync(copyPath, 'utf8');
 const genericFieldsSource = readFileSync(genericFieldsPath, 'utf8');
 const engineAdvancedSource = readFileSync(engineAdvancedPath, 'utf8');
+const advancedPanelSource = readFileSync(advancedPanelPath, 'utf8');
 const typesSource = readFileSync(typesPath, 'utf8');
 const stateHookSource = readFileSync(stateHookPath, 'utf8');
 
@@ -28,16 +30,19 @@ test('settings controls delegates reusable control parts and duration helpers', 
   assert.ok(existsSync(copyPath), 'settings controls copy should live in a focused module');
   assert.ok(existsSync(genericFieldsPath), 'generic advanced fields should live in a focused module');
   assert.ok(existsSync(engineAdvancedPath), 'engine-specific advanced controls should live in a focused module');
+  assert.ok(existsSync(advancedPanelPath), 'advanced panel rendering should live in a focused module');
   assert.ok(existsSync(typesPath), 'settings controls props contract should live in a focused module');
   assert.ok(existsSync(stateHookPath), 'settings control derived state should live in a focused hook');
 
   assert.match(controlsSource, /from '@\/components\/settings-controls\/settings-control-parts'/);
   assert.match(controlsSource, /from '@\/components\/settings-controls\/settings-control-duration'/);
   assert.match(controlsSource, /from '@\/components\/settings-controls\/settings-control-copy'/);
-  assert.match(controlsSource, /from '@\/components\/settings-controls\/settings-control-generic-fields'/);
-  assert.match(controlsSource, /from '@\/components\/settings-controls\/settings-control-engine-advanced'/);
+  assert.match(controlsSource, /from '@\/components\/settings-controls\/SettingsAdvancedPanel'/);
   assert.match(controlsSource, /from '@\/components\/settings-controls\/settings-control-types'/);
   assert.match(controlsSource, /from '@\/components\/settings-controls\/useSettingsControlState'/);
+  assert.match(advancedPanelSource, /from '@\/components\/settings-controls\/settings-control-generic-fields'/);
+  assert.match(advancedPanelSource, /from '@\/components\/settings-controls\/settings-control-engine-advanced'/);
+  assert.match(advancedPanelSource, /from '@\/components\/settings-controls\/settings-control-parts'/);
 });
 
 test('settings controls does not regain extracted ownership', () => {
@@ -51,6 +56,9 @@ test('settings controls does not regain extracted ownership', () => {
   assert.doesNotMatch(controlsSource, /<select[\s\S]*field\.values/, 'generic enum field rendering belongs in settings-control-generic-fields.tsx');
   assert.doesNotMatch(controlsSource, /Voice IDs \(CSV\)/, 'Kling voice controls belong in settings-control-engine-advanced.tsx');
   assert.doesNotMatch(controlsSource, /Camera fixed/, 'Seedance engine controls belong in settings-control-engine-advanced.tsx');
+  assert.doesNotMatch(controlsSource, /SettingsGenericAdvancedFields/, 'generic advanced field composition belongs in SettingsAdvancedPanel.tsx');
+  assert.doesNotMatch(controlsSource, /SettingsKlingV3Controls/, 'engine-specific advanced composition belongs in SettingsAdvancedPanel.tsx');
+  assert.doesNotMatch(controlsSource, /RangeWithInput/, 'advanced range rendering belongs in SettingsAdvancedPanel.tsx');
   assert.doesNotMatch(controlsSource, /interface Props/, 'settings controls prop contract belongs in settings-control-types.ts');
   assert.doesNotMatch(controlsSource, /EngineInputField/, 'advanced field prop typing belongs in settings-control-types.ts');
   assert.doesNotMatch(controlsSource, /useEffect\(/, 'derived option syncing belongs in useSettingsControlState');
@@ -58,7 +66,9 @@ test('settings controls does not regain extracted ownership', () => {
   assert.doesNotMatch(controlsSource, /const resolutionOptions =/, 'resolution option derivation belongs in useSettingsControlState');
 
   const lineCount = controlsSource.split('\n').length;
-  assert.ok(lineCount <= 760, `SettingsControls should stay below 760 lines after engine advanced extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 500, `SettingsControls should stay below 500 lines after panel extraction, got ${lineCount}`);
+  const advancedPanelLineCount = advancedPanelSource.split('\n').length;
+  assert.ok(advancedPanelLineCount <= 500, `SettingsAdvancedPanel should stay below 500 lines, got ${advancedPanelLineCount}`);
 });
 
 test('settings control helper modules expose the expected contract', () => {
@@ -76,6 +86,10 @@ test('settings control helper modules expose the expected contract', () => {
   assert.match(engineAdvancedSource, /export function SettingsSeedanceAdvancedControls/);
   assert.match(engineAdvancedSource, /Voice IDs \(CSV\)/);
   assert.match(engineAdvancedSource, /Camera fixed/);
+  assert.match(advancedPanelSource, /export function SettingsAdvancedPanel/);
+  assert.match(advancedPanelSource, /SettingsGenericAdvancedFields/);
+  assert.match(advancedPanelSource, /SettingsKlingV3Controls/);
+  assert.match(advancedPanelSource, /RangeWithInput/);
   assert.match(typesSource, /export interface SettingsControlsProps/);
   assert.match(typesSource, /EngineInputField/);
   assert.match(stateHookSource, /export function useSettingsControlState/);


### PR DESCRIPTION
## Summary
- Split advanced settings rendering out of `SettingsControls.tsx` into `SettingsAdvancedPanel.tsx`.
- Kept `SettingsControls.tsx` as the route-level/control orchestrator for core settings.
- Tightened the settings architecture contract so advanced panel composition stays extracted.
- Integrated latest `origin/main` before opening the PR, including the parallel wallet checkout commit `e1024c4f`.

## Validation
- `pnpm --dir frontend exec tsc --noEmit --pretty false`
- `node --test tests/settings-controls-architecture.test.ts`
- `npm --prefix frontend run lint`
- `npm run lint:exposure`
- `npm run architecture:audit -- --min-lines 500`
- `npm run test:validate` (729/729)
- `git diff --check`