### PR TITLE
[codex] Split tools workspace panels

### DIFF
--- a/frontend/src/components/tools/AngleWorkspace.tsx
+++ b/frontend/src/components/tools/AngleWorkspace.tsx
@@ -16,11 +16,10 @@ import {
   type ClipboardEvent as ReactClipboardEvent,
   type DragEvent as ReactDragEvent,
 } from 'react';
-import { ArrowLeft, Loader2, WandSparkles } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
 import { HeaderBar } from '@/components/HeaderBar';
 import { AppSidebar } from '@/components/AppSidebar';
-import { Button, ButtonLink } from '@/components/ui/Button';
-import { Card } from '@/components/ui/Card';
+import { ButtonLink } from '@/components/ui/Button';
 import { saveImageToLibrary, useInfiniteJobs } from '@/lib/api';
 import { authFetch } from '@/lib/authFetch';
 import { useI18n } from '@/lib/i18n/I18nProvider';
@@ -29,12 +28,10 @@ import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { FEATURES } from '@/content/feature-flags';
 import type { AngleToolEngineId, AngleToolNumericParams, AngleToolResponse } from '@/types/tools-angle';
 import { AngleAuthGateModal } from './angle/_components/angle-auth-gate-modal';
-import { AngleCameraControls } from './angle/_components/angle-camera-controls';
+import { AngleGenerationSettingsPanel } from './angle/_components/angle-generation-settings-panel';
 import { AngleImageLibraryModal } from './angle/_components/angle-image-library-modal';
-import { AngleOrbitSelector } from './angle/_components/angle-orbit-selector';
 import { AngleOutputPanel } from './angle/_components/angle-output-panel';
 import { AngleRecentJobModal } from './angle/_components/angle-recent-job-modal';
-import { AngleSourceImagePanel } from './angle/_components/angle-source-image-panel';
 import { useAngleGenerationRunner } from './angle/_hooks/useAngleGenerationRunner';
 import { DEFAULT_ANGLE_COPY, type AngleCopy } from './angle/_lib/angle-workspace-copy';
 import {
@@ -44,7 +41,6 @@ import {
   collectAnglePreviewImages,
   DEFAULT_ENGINE_ID,
   ENGINES,
-  formatUsdCompact,
   getAngleBillingProductKey,
   isAuthRequiredError,
   parsePersistedAngleToolState,
@@ -487,93 +483,34 @@ export default function AngleToolPage() {
             </div>
 
             <div className="grid gap-6 xl:grid-cols-[minmax(0,1.2fr)_minmax(340px,0.8fr)]">
-              <Card className="border border-border bg-surface p-5">
-                <div className="space-y-5">
-                  <div className="grid gap-4 xl:grid-cols-[minmax(0,0.95fr)_minmax(320px,1.05fr)]">
-                    <div className="space-y-4">
-                      <div>
-                        <p className="text-xs font-semibold uppercase tracking-micro text-text-muted">{copy.engine}</p>
-                        <label className="mt-2 block">
-                          <span className="sr-only">{copy.engineSelect}</span>
-                          <select
-                            value={engineId}
-                            onChange={(event) => setEngineId(event.target.value as AngleToolEngineId)}
-                            className="w-full rounded-input border border-border bg-bg px-3 py-2 text-sm text-text-primary"
-                          >
-                            {ENGINES.map((engine) => (
-                              <option key={engine.id} value={engine.id}>
-                                {copy.engines[engine.id].label}
-                              </option>
-                            ))}
-                          </select>
-                        </label>
-                        <p className="mt-2 text-xs text-text-muted">{selectedEngine ? copy.engines[selectedEngine.id].description : null}</p>
-                        {engineId === 'flux-multiple-angles' ? (
-                          <p className="mt-1 text-xs text-text-muted">
-                            {copy.engineHelpFlux}
-                          </p>
-                        ) : null}
-                        {engineId === 'qwen-multiple-angles' && params.tilt < 0 ? (
-                          <p className="mt-1 text-xs text-warning">{copy.engineHelpQwen}</p>
-                        ) : null}
-                      </div>
-
-                      <AngleSourceImagePanel
-                        copy={copy}
-                        fileInputRef={fileInputRef}
-                        onAuthRequired={openAuthGate}
-                        onFileSelect={handleFileSelect}
-                        onLibraryOpen={() => setLibraryModalOpen(true)}
-                        onRemoveSource={handleRemoveSource}
-                        onSourceDragActiveChange={setSourceDragActive}
-                        onSourceDrop={handleSourceDrop}
-                        onSourcePaste={handleSourcePaste}
-                        onUploadRequest={handleUploadRequest}
-                        sourceDragActive={sourceDragActive}
-                        sourceImage={sourceImage}
-                        uploading={uploading}
-                        userPresent={Boolean(user)}
-                      />
-                    </div>
-
-                    <AngleOrbitSelector
-                      params={params}
-                      onParamsChange={setParams}
-                      generateBestAngles={generateBestAngles}
-                      onGenerateBestAnglesChange={setGenerateBestAngles}
-                      supportsMultiOutput={Boolean(selectedEngine?.supportsMultiOutput)}
-                      sourceImage={sourceImage}
-                      copy={copy}
-                    />
-                  </div>
-
-                  <AngleCameraControls copy={copy} onParamsChange={setParams} params={params} />
-
-                  <div className="rounded-card border border-border bg-bg p-4">
-                    <p className="text-xs uppercase tracking-micro text-text-muted">{copy.estimatedCost}</p>
-                    <p className="mt-2 text-2xl font-semibold leading-none text-text-primary">
-                      {formatUsdCompact(estimatedCostUsd)}
-                    </p>
-                  </div>
-
-                  <Button
-                    type="button"
-                    variant={user ? 'primary' : 'outline'}
-                    className="w-full gap-2"
-                    onClick={user ? handleGenerate : openAuthGate}
-                    disabled={generating || uploading || !sourceImage?.url}
-                  >
-                    {generating ? <Loader2 className="h-4 w-4 animate-spin" /> : <WandSparkles className="h-4 w-4" />}
-                    {generating ? copy.generating : user ? copy.generate : copy.generateLocked}
-                  </Button>
-
-                  {error ? (
-                    <p role="alert" className="text-sm text-error">
-                      {error}
-                    </p>
-                  ) : null}
-                </div>
-              </Card>
+              <AngleGenerationSettingsPanel
+                copy={copy}
+                engineId={engineId}
+                engines={ENGINES}
+                error={error}
+                estimatedCostUsd={estimatedCostUsd}
+                fileInputRef={fileInputRef}
+                generateBestAngles={generateBestAngles}
+                generating={generating}
+                onAuthRequired={openAuthGate}
+                onEngineIdChange={setEngineId}
+                onFileSelect={handleFileSelect}
+                onGenerate={handleGenerate}
+                onGenerateBestAnglesChange={setGenerateBestAngles}
+                onLibraryOpen={() => setLibraryModalOpen(true)}
+                onParamsChange={setParams}
+                onRemoveSource={handleRemoveSource}
+                onSourceDragActiveChange={setSourceDragActive}
+                onSourceDrop={handleSourceDrop}
+                onSourcePaste={handleSourcePaste}
+                onUploadRequest={handleUploadRequest}
+                params={params}
+                selectedEngine={selectedEngine}
+                sourceDragActive={sourceDragActive}
+                sourceImage={sourceImage}
+                uploading={uploading}
+                userPresent={Boolean(user)}
+              />
 
               <AngleOutputPanel
                 copy={copy}

--- a/frontend/src/components/tools/UpscaleWorkspace.tsx
+++ b/frontend/src/components/tools/UpscaleWorkspace.tsx
@@ -6,14 +6,12 @@ import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import {
   ArrowLeft,
-  RefreshCw,
 } from 'lucide-react';
 import { AppSidebar } from '@/components/AppSidebar';
 import type { GroupedJobAction } from '@/components/GroupedJobCard';
 import { HeaderBar } from '@/components/HeaderBar';
-import { Button, ButtonLink } from '@/components/ui/Button';
+import { ButtonLink } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
-import { AssetLibraryBrowser } from '@/components/library/AssetLibraryBrowser';
 import { authFetch } from '@/lib/authFetch';
 import { runUpscaleTool, saveAssetToLibrary } from '@/lib/api';
 import { suggestDownloadFilename, triggerAppDownload } from '@/lib/download';
@@ -37,6 +35,7 @@ import type { GroupSummary } from '@/types/groups';
 import type { Job } from '@/types/jobs';
 import { UpscaleRecipePanel, UpscaleSourcePanel } from './upscale/_components/UpscaleInputPanels';
 import { UpscaleHeroSummaryCard } from './upscale/_components/UpscaleHeroSummaryCard';
+import { UpscaleLibraryModal } from './upscale/_components/UpscaleLibraryModal';
 import { UpscalePreviewCard } from './upscale/_components/UpscalePreviewCard';
 import { UpscaleRecentRail } from './upscale/_components/UpscaleRecentRail';
 import { DEFAULT_UPSCALE_COPY } from './upscale/_lib/upscale-workspace-copy';
@@ -594,66 +593,20 @@ export default function UpscaleWorkspace() {
           </div>
         </main>
       </div>
-      {libraryModalOpen ? (
-        <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-overlay-bg px-3 py-4 backdrop-blur-sm">
-          <button
-            type="button"
-            className="absolute inset-0 cursor-default"
-            aria-label="Close library"
-            onClick={() => setLibraryModalOpen(false)}
-          />
-          <AssetLibraryBrowser
-            className="relative z-10 h-[88svh] max-w-[1180px]"
-            title={copy.libraryTitle}
-            subtitle={copy.libraryBody}
-            countLabel={copy.libraryCount.replace('{count}', String(visibleLibraryAssets.length))}
-            onClose={() => setLibraryModalOpen(false)}
-            closeLabel="Close"
-            assetType={mediaType}
-            assets={visibleLibraryAssets}
-            isLoading={libraryLoading}
-            error={libraryError}
-            source={librarySource}
-            availableSources={[...librarySourceOptions]}
-            sourceLabels={copy.libraryTabs}
-            onSourceChange={(nextSource) => {
-              if (nextSource === librarySource) return;
-              resetLibraryState(nextSource);
-            }}
-            searchPlaceholder={copy.librarySearch}
-            sourcesTitle={copy.librarySourcesTitle}
-            emptyLabel={mediaType === 'video' ? copy.libraryEmptyVideos : copy.libraryEmptyImages}
-            emptySearchLabel={copy.libraryEmptySearch}
-            headerActions={
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="rounded-full border-border bg-surface-2 px-3 text-sm text-text-secondary hover:bg-surface-3 hover:text-text-primary"
-                onClick={() => fetchLibraryAssets({ kind: mediaType, source: librarySource })}
-                disabled={libraryLoading}
-              >
-                <RefreshCw className={`h-4 w-4 ${libraryLoading ? 'animate-spin' : ''}`} />
-                {copy.libraryRefresh}
-              </Button>
-            }
-            renderAssetActions={(asset) => (
-              <Button
-                type="button"
-                variant="primary"
-                size="sm"
-                className="min-h-[34px] flex-1 rounded-full border-brand px-2.5 py-1 text-[11px] uppercase tracking-micro sm:min-h-[36px] sm:flex-none sm:px-3 sm:text-[12px]"
-                onClick={() => selectLibraryAsset(asset)}
-              >
-                {copy.libraryUse}
-              </Button>
-            )}
-            renderAssetMeta={(asset) =>
-              asset.source ? <span className="capitalize">{asset.source}</span> : null
-            }
-          />
-        </div>
-      ) : null}
+      <UpscaleLibraryModal
+        assets={visibleLibraryAssets}
+        copy={copy}
+        error={libraryError}
+        isLoading={libraryLoading}
+        mediaType={mediaType}
+        onClose={() => setLibraryModalOpen(false)}
+        onRefresh={fetchLibraryAssets}
+        onSelectAsset={selectLibraryAsset}
+        onSourceChange={resetLibraryState}
+        open={libraryModalOpen}
+        source={librarySource}
+        sourceOptions={librarySourceOptions}
+      />
     </div>
   );
 }

--- a/frontend/src/components/tools/angle/_components/angle-generation-settings-panel.tsx
+++ b/frontend/src/components/tools/angle/_components/angle-generation-settings-panel.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import {
+  type ChangeEvent,
+  type ClipboardEvent as ReactClipboardEvent,
+  type DragEvent as ReactDragEvent,
+  type Ref,
+} from 'react';
+import { Loader2, WandSparkles } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { Card } from '@/components/ui/Card';
+import type { AngleToolEngineDefinition, AngleToolEngineId, AngleToolNumericParams } from '@/types/tools-angle';
+import { AngleCameraControls } from './angle-camera-controls';
+import { AngleOrbitSelector } from './angle-orbit-selector';
+import { AngleSourceImagePanel } from './angle-source-image-panel';
+import type { AngleCopy } from '../_lib/angle-workspace-copy';
+import { formatUsdCompact } from '../_lib/angle-workspace-helpers';
+import type { UploadedImage } from '../_lib/angle-workspace-types';
+
+interface AngleGenerationSettingsPanelProps {
+  copy: AngleCopy;
+  engineId: AngleToolEngineId;
+  engines: readonly AngleToolEngineDefinition[];
+  error: string | null;
+  estimatedCostUsd: number;
+  fileInputRef: Ref<HTMLInputElement>;
+  generateBestAngles: boolean;
+  generating: boolean;
+  onAuthRequired: () => void;
+  onEngineIdChange: (engineId: AngleToolEngineId) => void;
+  onFileSelect: (event: ChangeEvent<HTMLInputElement>) => void;
+  onGenerate: () => void;
+  onGenerateBestAnglesChange: (enabled: boolean) => void;
+  onLibraryOpen: () => void;
+  onParamsChange: (params: AngleToolNumericParams) => void;
+  onRemoveSource: () => void;
+  onSourceDragActiveChange: (active: boolean) => void;
+  onSourceDrop: (event: ReactDragEvent<HTMLDivElement>) => void;
+  onSourcePaste: (event: ReactClipboardEvent<HTMLDivElement>) => void;
+  onUploadRequest: () => void;
+  params: AngleToolNumericParams;
+  selectedEngine?: AngleToolEngineDefinition;
+  sourceDragActive: boolean;
+  sourceImage: UploadedImage | null;
+  uploading: boolean;
+  userPresent: boolean;
+}
+
+export function AngleGenerationSettingsPanel({
+  copy,
+  engineId,
+  engines,
+  error,
+  estimatedCostUsd,
+  fileInputRef,
+  generateBestAngles,
+  generating,
+  onAuthRequired,
+  onEngineIdChange,
+  onFileSelect,
+  onGenerate,
+  onGenerateBestAnglesChange,
+  onLibraryOpen,
+  onParamsChange,
+  onRemoveSource,
+  onSourceDragActiveChange,
+  onSourceDrop,
+  onSourcePaste,
+  onUploadRequest,
+  params,
+  selectedEngine,
+  sourceDragActive,
+  sourceImage,
+  uploading,
+  userPresent,
+}: AngleGenerationSettingsPanelProps) {
+  return (
+    <Card className="border border-border bg-surface p-5">
+      <div className="space-y-5">
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,0.95fr)_minmax(320px,1.05fr)]">
+          <div className="space-y-4">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-micro text-text-muted">{copy.engine}</p>
+              <label className="mt-2 block">
+                <span className="sr-only">{copy.engineSelect}</span>
+                <select
+                  value={engineId}
+                  onChange={(event) => onEngineIdChange(event.target.value as AngleToolEngineId)}
+                  className="w-full rounded-input border border-border bg-bg px-3 py-2 text-sm text-text-primary"
+                >
+                  {engines.map((engine) => (
+                    <option key={engine.id} value={engine.id}>
+                      {copy.engines[engine.id].label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <p className="mt-2 text-xs text-text-muted">{selectedEngine ? copy.engines[selectedEngine.id].description : null}</p>
+              {engineId === 'flux-multiple-angles' ? (
+                <p className="mt-1 text-xs text-text-muted">{copy.engineHelpFlux}</p>
+              ) : null}
+              {engineId === 'qwen-multiple-angles' && params.tilt < 0 ? (
+                <p className="mt-1 text-xs text-warning">{copy.engineHelpQwen}</p>
+              ) : null}
+            </div>
+
+            <AngleSourceImagePanel
+              copy={copy}
+              fileInputRef={fileInputRef}
+              onAuthRequired={onAuthRequired}
+              onFileSelect={onFileSelect}
+              onLibraryOpen={onLibraryOpen}
+              onRemoveSource={onRemoveSource}
+              onSourceDragActiveChange={onSourceDragActiveChange}
+              onSourceDrop={onSourceDrop}
+              onSourcePaste={onSourcePaste}
+              onUploadRequest={onUploadRequest}
+              sourceDragActive={sourceDragActive}
+              sourceImage={sourceImage}
+              uploading={uploading}
+              userPresent={userPresent}
+            />
+          </div>
+
+          <AngleOrbitSelector
+            params={params}
+            onParamsChange={onParamsChange}
+            generateBestAngles={generateBestAngles}
+            onGenerateBestAnglesChange={onGenerateBestAnglesChange}
+            supportsMultiOutput={Boolean(selectedEngine?.supportsMultiOutput)}
+            sourceImage={sourceImage}
+            copy={copy}
+          />
+        </div>
+
+        <AngleCameraControls copy={copy} onParamsChange={onParamsChange} params={params} />
+
+        <div className="rounded-card border border-border bg-bg p-4">
+          <p className="text-xs uppercase tracking-micro text-text-muted">{copy.estimatedCost}</p>
+          <p className="mt-2 text-2xl font-semibold leading-none text-text-primary">
+            {formatUsdCompact(estimatedCostUsd)}
+          </p>
+        </div>
+
+        <Button
+          type="button"
+          variant={userPresent ? 'primary' : 'outline'}
+          className="w-full gap-2"
+          onClick={userPresent ? onGenerate : onAuthRequired}
+          disabled={generating || uploading || !sourceImage?.url}
+        >
+          {generating ? <Loader2 className="h-4 w-4 animate-spin" /> : <WandSparkles className="h-4 w-4" />}
+          {generating ? copy.generating : userPresent ? copy.generate : copy.generateLocked}
+        </Button>
+
+        {error ? (
+          <p role="alert" className="text-sm text-error">
+            {error}
+          </p>
+        ) : null}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/tools/upscale/_components/UpscaleLibraryModal.tsx
+++ b/frontend/src/components/tools/upscale/_components/UpscaleLibraryModal.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import {
+  AssetLibraryBrowser,
+  type AssetBrowserAsset,
+  type AssetLibrarySource,
+} from '@/components/library/AssetLibraryBrowser';
+import type { UpscaleMediaType } from '@/types/tools-upscale';
+
+type UpscaleLibraryModalCopy = {
+  libraryBody: string;
+  libraryCount: string;
+  libraryEmptyImages: string;
+  libraryEmptySearch: string;
+  libraryEmptyVideos: string;
+  libraryRefresh: string;
+  librarySearch: string;
+  librarySourcesTitle: string;
+  libraryTabs: Partial<Record<AssetLibrarySource, string>>;
+  libraryTitle: string;
+  libraryUse: string;
+};
+
+interface UpscaleLibraryModalProps {
+  assets: AssetBrowserAsset[];
+  copy: UpscaleLibraryModalCopy;
+  error: string | null;
+  isLoading: boolean;
+  mediaType: UpscaleMediaType;
+  onClose: () => void;
+  onRefresh: (options: { kind: UpscaleMediaType; source: AssetLibrarySource }) => void;
+  onSelectAsset: (asset: AssetBrowserAsset) => void;
+  onSourceChange: (source: AssetLibrarySource) => void;
+  open: boolean;
+  source: AssetLibrarySource;
+  sourceOptions: readonly AssetLibrarySource[];
+}
+
+export function UpscaleLibraryModal({
+  assets,
+  copy,
+  error,
+  isLoading,
+  mediaType,
+  onClose,
+  onRefresh,
+  onSelectAsset,
+  onSourceChange,
+  open,
+  source,
+  sourceOptions,
+}: UpscaleLibraryModalProps) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-overlay-bg px-3 py-4 backdrop-blur-sm">
+      <button type="button" className="absolute inset-0 cursor-default" aria-label="Close library" onClick={onClose} />
+      <AssetLibraryBrowser
+        className="relative z-10 h-[88svh] max-w-[1180px]"
+        title={copy.libraryTitle}
+        subtitle={copy.libraryBody}
+        countLabel={copy.libraryCount.replace('{count}', String(assets.length))}
+        onClose={onClose}
+        closeLabel="Close"
+        assetType={mediaType}
+        assets={assets}
+        isLoading={isLoading}
+        error={error}
+        source={source}
+        availableSources={[...sourceOptions]}
+        sourceLabels={copy.libraryTabs}
+        onSourceChange={(nextSource) => {
+          if (nextSource === source) return;
+          onSourceChange(nextSource);
+        }}
+        searchPlaceholder={copy.librarySearch}
+        sourcesTitle={copy.librarySourcesTitle}
+        emptyLabel={mediaType === 'video' ? copy.libraryEmptyVideos : copy.libraryEmptyImages}
+        emptySearchLabel={copy.libraryEmptySearch}
+        headerActions={
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="rounded-full border-border bg-surface-2 px-3 text-sm text-text-secondary hover:bg-surface-3 hover:text-text-primary"
+            onClick={() => onRefresh({ kind: mediaType, source })}
+            disabled={isLoading}
+          >
+            <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
+            {copy.libraryRefresh}
+          </Button>
+        }
+        renderAssetActions={(asset) => (
+          <Button
+            type="button"
+            variant="primary"
+            size="sm"
+            className="min-h-[34px] flex-1 rounded-full border-brand px-2.5 py-1 text-[11px] uppercase tracking-micro sm:min-h-[36px] sm:flex-none sm:px-3 sm:text-[12px]"
+            onClick={() => onSelectAsset(asset)}
+          >
+            {copy.libraryUse}
+          </Button>
+        )}
+        renderAssetMeta={(asset) => (asset.source ? <span className="capitalize">{asset.source}</span> : null)}
+      />
+    </div>
+  );
+}

--- a/tests/angle-workspace-architecture.test.ts
+++ b/tests/angle-workspace-architecture.test.ts
@@ -8,6 +8,7 @@ const workspacePath = join(root, 'frontend/src/components/tools/AngleWorkspace.t
 const componentsDir = join(root, 'frontend/src/components/tools/angle/_components');
 const libraryModalPath = join(componentsDir, 'angle-image-library-modal.tsx');
 const cameraControlsPath = join(componentsDir, 'angle-camera-controls.tsx');
+const generationSettingsPanelPath = join(componentsDir, 'angle-generation-settings-panel.tsx');
 const orbitSelectorPath = join(componentsDir, 'angle-orbit-selector.tsx');
 const outputMosaicPath = join(componentsDir, 'angle-output-mosaic.tsx');
 const outputPanelPath = join(componentsDir, 'angle-output-panel.tsx');
@@ -24,6 +25,7 @@ const workspaceSource = readFileSync(workspacePath, 'utf8');
 test('angle workspace delegates copy, local types, and helper logic', () => {
   assert.ok(existsSync(libraryModalPath), 'angle library modal should live in a colocated component module');
   assert.ok(existsSync(cameraControlsPath), 'angle camera controls should live in a colocated component module');
+  assert.ok(existsSync(generationSettingsPanelPath), 'angle generation settings panel should live in a colocated component module');
   assert.ok(existsSync(orbitSelectorPath), 'angle orbit selector should live in a colocated component module');
   assert.ok(existsSync(outputMosaicPath), 'angle output mosaic should live in a colocated component module');
   assert.ok(existsSync(outputPanelPath), 'angle output panel should live in a colocated component module');
@@ -36,12 +38,10 @@ test('angle workspace delegates copy, local types, and helper logic', () => {
   assert.ok(existsSync(helpersPath), 'angle workspace helper logic should live in a route-local helper module');
 
   assert.match(workspaceSource, /from '\.\/angle\/_components\/angle-image-library-modal'/, 'workspace should import angle library modal');
-  assert.match(workspaceSource, /from '\.\/angle\/_components\/angle-camera-controls'/, 'workspace should import angle camera controls');
-  assert.match(workspaceSource, /from '\.\/angle\/_components\/angle-orbit-selector'/, 'workspace should import angle orbit selector');
+  assert.match(workspaceSource, /from '\.\/angle\/_components\/angle-generation-settings-panel'/, 'workspace should import angle generation settings panel');
   assert.match(workspaceSource, /from '\.\/angle\/_components\/angle-output-panel'/, 'workspace should import angle output panel');
   assert.match(workspaceSource, /from '\.\/angle\/_components\/angle-recent-job-modal'/, 'workspace should import angle recent job modal');
   assert.match(workspaceSource, /from '\.\/angle\/_components\/angle-auth-gate-modal'/, 'workspace should import angle auth gate modal');
-  assert.match(workspaceSource, /from '\.\/angle\/_components\/angle-source-image-panel'/, 'workspace should import angle source image panel');
   assert.match(workspaceSource, /from '\.\/angle\/_hooks\/useAngleGenerationRunner'/, 'workspace should import angle generation runner');
   assert.match(workspaceSource, /from '\.\/angle\/_lib\/angle-workspace-copy'/, 'workspace should import angle copy');
   assert.match(workspaceSource, /from '\.\/angle\/_lib\/angle-workspace-types'/, 'workspace should import angle local types');
@@ -67,16 +67,23 @@ test('angle workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /ANGLE_GUEST_EXAMPLE_OUTPUT_URL/, 'guest output preview belongs in angle-output-panel.tsx');
   assert.doesNotMatch(workspaceSource, /copy\.previousJobs/, 'recent output rail belongs in angle-output-panel.tsx');
   assert.doesNotMatch(workspaceSource, /angle-preview-/, 'output download wiring belongs in angle-output-panel.tsx');
+  assert.doesNotMatch(workspaceSource, /<AngleSourceImagePanel/, 'source image JSX belongs in angle-generation-settings-panel.tsx');
+  assert.doesNotMatch(workspaceSource, /<AngleOrbitSelector/, 'orbit selector JSX belongs in angle-generation-settings-panel.tsx');
+  assert.doesNotMatch(workspaceSource, /<AngleCameraControls/, 'camera controls JSX belongs in angle-generation-settings-panel.tsx');
+  assert.doesNotMatch(workspaceSource, /formatUsdCompact/, 'cost display formatting belongs in angle-generation-settings-panel.tsx');
+  assert.doesNotMatch(workspaceSource, /Loader2/, 'generation loading icon belongs in angle-generation-settings-panel.tsx');
+  assert.doesNotMatch(workspaceSource, /WandSparkles/, 'generation action icon belongs in angle-generation-settings-panel.tsx');
   assert.doesNotMatch(workspaceSource, /copy\.sourceReady/, 'source image controls belong in angle-source-image-panel.tsx');
   assert.doesNotMatch(workspaceSource, /copy\.cameraControls/, 'camera sliders belong in angle-camera-controls.tsx');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 650, `AngleWorkspace should stay below 650 lines after source and camera extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 570, `AngleWorkspace should stay below 570 lines after generation settings panel extraction, got ${lineCount}`);
 });
 
 test('angle helper modules expose the expected workspace contract', () => {
   const libraryModalSource = readFileSync(libraryModalPath, 'utf8');
   const cameraControlsSource = readFileSync(cameraControlsPath, 'utf8');
+  const generationSettingsPanelSource = readFileSync(generationSettingsPanelPath, 'utf8');
   const orbitSelectorSource = readFileSync(orbitSelectorPath, 'utf8');
   const outputMosaicSource = readFileSync(outputMosaicPath, 'utf8');
   const outputPanelSource = readFileSync(outputPanelPath, 'utf8');
@@ -91,6 +98,12 @@ test('angle helper modules expose the expected workspace contract', () => {
   assert.match(libraryModalSource, /export function AngleImageLibraryModal/, 'library modal module should export AngleImageLibraryModal');
   assert.match(cameraControlsSource, /export function AngleCameraControls/, 'camera controls module should export AngleCameraControls');
   assert.match(cameraControlsSource, /sanitizeParams/, 'camera controls should own slider sanitation');
+  assert.match(generationSettingsPanelSource, /export function AngleGenerationSettingsPanel/, 'generation settings panel should be exported');
+  assert.match(generationSettingsPanelSource, /AngleSourceImagePanel/, 'generation settings panel should compose source image controls');
+  assert.match(generationSettingsPanelSource, /AngleOrbitSelector/, 'generation settings panel should compose orbit selector');
+  assert.match(generationSettingsPanelSource, /AngleCameraControls/, 'generation settings panel should compose camera controls');
+  assert.match(generationSettingsPanelSource, /formatUsdCompact/, 'generation settings panel should own cost display formatting');
+  assert.match(generationSettingsPanelSource, /WandSparkles/, 'generation settings panel should own generate button icon');
   assert.match(orbitSelectorSource, /export function AngleOrbitSelector/, 'orbit selector module should export AngleOrbitSelector');
   assert.match(orbitSelectorSource, /dynamic\(\(\) => import\('@\/components\/tools\/AngleOrbitCanvas'\)/, 'orbit selector should own the dynamic canvas import');
   assert.match(outputMosaicSource, /export function AngleOutputMosaic/, 'output mosaic module should export AngleOutputMosaic');

--- a/tests/upscale-workspace-architecture.test.ts
+++ b/tests/upscale-workspace-architecture.test.ts
@@ -17,6 +17,7 @@ const sourceMediaHookPath = join(root, 'frontend/src/components/tools/upscale/_h
 const controlsPath = join(root, 'frontend/src/components/tools/upscale/_components/upscale-workspace-controls.tsx');
 const inputPanelsPath = join(root, 'frontend/src/components/tools/upscale/_components/UpscaleInputPanels.tsx');
 const heroSummaryCardPath = join(root, 'frontend/src/components/tools/upscale/_components/UpscaleHeroSummaryCard.tsx');
+const libraryModalPath = join(root, 'frontend/src/components/tools/upscale/_components/UpscaleLibraryModal.tsx');
 const previewCardPath = join(root, 'frontend/src/components/tools/upscale/_components/UpscalePreviewCard.tsx');
 const recentRailPath = join(root, 'frontend/src/components/tools/upscale/_components/UpscaleRecentRail.tsx');
 
@@ -35,6 +36,7 @@ test('upscale workspace delegates copy, local types, and helper logic', () => {
   assert.ok(existsSync(controlsPath), 'upscale workspace controls should live in colocated components');
   assert.ok(existsSync(inputPanelsPath), 'upscale input panels should live in colocated components');
   assert.ok(existsSync(heroSummaryCardPath), 'upscale hero summary should live in a colocated component');
+  assert.ok(existsSync(libraryModalPath), 'upscale library modal should live in a colocated component');
   assert.ok(existsSync(previewCardPath), 'upscale preview card should live in a colocated component');
   assert.ok(existsSync(recentRailPath), 'upscale recent rail should live in a colocated component');
 
@@ -49,6 +51,7 @@ test('upscale workspace delegates copy, local types, and helper logic', () => {
   assert.match(workspaceSource, /from '\.\/upscale\/_hooks\/useUpscaleSourceMedia'/, 'workspace should import source media hook');
   assert.match(workspaceSource, /from '\.\/upscale\/_components\/UpscaleInputPanels'/, 'workspace should import input panels');
   assert.match(workspaceSource, /from '\.\/upscale\/_components\/UpscaleHeroSummaryCard'/, 'workspace should import hero summary card');
+  assert.match(workspaceSource, /from '\.\/upscale\/_components\/UpscaleLibraryModal'/, 'workspace should import library modal');
   assert.match(workspaceSource, /from '\.\/upscale\/_components\/UpscalePreviewCard'/, 'workspace should import preview card');
   assert.match(workspaceSource, /from '\.\/upscale\/_components\/UpscaleRecentRail'/, 'workspace should import recent rail');
 });
@@ -89,9 +92,13 @@ test('upscale workspace does not regain extracted ownership', () => {
   assert.doesNotMatch(workspaceSource, /Drop file here/, 'upload dropzone JSX belongs in UpscaleInputPanels');
   assert.doesNotMatch(workspaceSource, /Choose how you want to enhance/, 'recipe panel JSX belongs in UpscaleInputPanels');
   assert.doesNotMatch(workspaceSource, /<SelectMenu/, 'recipe selectors belong in UpscaleInputPanels');
+  assert.doesNotMatch(workspaceSource, /<AssetLibraryBrowser/, 'library browser JSX belongs in UpscaleLibraryModal');
+  assert.doesNotMatch(workspaceSource, /RefreshCw/, 'library refresh action belongs in UpscaleLibraryModal');
+  assert.doesNotMatch(workspaceSource, /copy\.libraryRefresh/, 'library refresh copy belongs in UpscaleLibraryModal');
+  assert.doesNotMatch(workspaceSource, /copy\.libraryUse/, 'library asset actions belong in UpscaleLibraryModal');
 
   const lineCount = workspaceSource.split('\n').length;
-  assert.ok(lineCount <= 670, `UpscaleWorkspace should stay below 670 lines after input panel extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 620, `UpscaleWorkspace should stay below 620 lines after library modal extraction, got ${lineCount}`);
 });
 
 test('upscale helper modules expose the expected workspace contract', () => {
@@ -107,6 +114,7 @@ test('upscale helper modules expose the expected workspace contract', () => {
   const controlsSource = readFileSync(controlsPath, 'utf8');
   const inputPanelsSource = readFileSync(inputPanelsPath, 'utf8');
   const heroSummaryCardSource = readFileSync(heroSummaryCardPath, 'utf8');
+  const libraryModalSource = readFileSync(libraryModalPath, 'utf8');
   const previewCardSource = readFileSync(previewCardPath, 'utf8');
   const recentRailSource = readFileSync(recentRailPath, 'utf8');
 
@@ -168,6 +176,10 @@ test('upscale helper modules expose the expected workspace contract', () => {
   assert.match(inputPanelsSource, /SelectMenu/, 'input panels should own recipe selectors');
   assert.match(heroSummaryCardSource, /export function UpscaleHeroSummaryCard/, 'hero summary card should be exported');
   assert.match(heroSummaryCardSource, /WandSparkles/, 'hero summary card should own its action icon');
+  assert.match(libraryModalSource, /export function UpscaleLibraryModal/, 'library modal should be exported');
+  assert.match(libraryModalSource, /AssetLibraryBrowser/, 'library modal should own the shared library browser');
+  assert.match(libraryModalSource, /RefreshCw/, 'library modal should own refresh action rendering');
+  assert.match(libraryModalSource, /copy\.libraryUse/, 'library modal should own asset action copy');
   assert.match(previewCardSource, /export function UpscalePreviewCard/, 'preview card should be exported');
   assert.match(previewCardSource, /PREVIEW_ZOOM_OPTIONS/, 'preview card should own zoom controls');
   assert.match(previewCardSource, /ChevronsLeftRight/, 'preview card should own compare affordance');


### PR DESCRIPTION
## Summary
- Extracted the Angle generation settings card into `angle-generation-settings-panel.tsx`.
- Extracted the Upscale asset library modal into `UpscaleLibraryModal.tsx`.
- Kept workspace files focused on state, handlers, and orchestration while preserving existing UI and callbacks.
- Updated architecture contracts to lock the new component boundaries.

## Validation
- `pnpm --dir frontend exec tsc --noEmit --pretty false`
- `node --test tests/upscale-workspace-architecture.test.ts tests/angle-workspace-architecture.test.ts`
- `npm --prefix frontend run lint`
- `npm run lint:exposure`
- `npm run architecture:audit -- --min-lines 500`
- `npm run test:validate` (729/729)
- `git diff --check`

## Notes
- Latest `origin/main` was fetched before push; branch is based on merge commit `6e6bffad`.
- Local uncommitted billing/rate-limit files were intentionally excluded from this PR.