### PR TITLE
Split shared frontend surfaces

### DIFF
--- a/frontend/components/AssetDropzone.tsx
+++ b/frontend/components/AssetDropzone.tsx
@@ -1,77 +1,30 @@
 'use client';
-/* eslint-disable @next/next/no-img-element */
 
 import clsx from 'clsx';
 import { useMemo, useCallback, useRef } from 'react';
-import type { ChangeEvent, ClipboardEvent, DragEvent, KeyboardEvent, ReactNode } from 'react';
-import { Lock, Trash2 } from 'lucide-react';
+import type { ChangeEvent, ClipboardEvent, DragEvent, ReactNode } from 'react';
 import type { EngineCaps, EngineInputField, EngineModeUiCaps as CapabilityCaps } from '@/types/engines';
-import { Button } from '@/components/ui/Button';
-import { AudioEqualizerBadge } from '@/components/ui/AudioEqualizerBadge';
 import { getVisibleAssetSlots } from '@/lib/asset-slot-layout';
 import { useI18n } from '@/lib/i18n/I18nProvider';
 import { getLocalizedAssetDropzoneCopy, normalizeUiLocale } from '@/lib/ltx-localization';
+import { AssetDropzoneSlot } from '@/components/asset-dropzone/AssetDropzoneSlot';
+import {
+  readMediaDuration,
+  resolveSlotLabel,
+  VEO_REFERENCE_WARNING_ENGINES,
+} from '@/components/asset-dropzone/asset-dropzone-helpers';
+import type {
+  AssetFieldRole,
+  AssetSlotAttachment,
+  AssetUploadMeta,
+} from '@/components/asset-dropzone/asset-dropzone-types';
 
-const VEO_REFERENCE_WARNING_ENGINES = new Set(['veo-3-1', 'veo-3-1-fast', 'veo-3-1-lite']);
-
-function resolveSlotLabel(
-  field: EngineInputField,
-  role: AssetFieldRole,
-  slotIndex: number,
-  assetCopy: ReturnType<typeof getLocalizedAssetDropzoneCopy>
-): string {
-  const sequence = slotIndex + 1;
-  const normalizedId = String(field.id ?? '').toLowerCase();
-
-  if (field.slotLabelPattern) {
-    return field.slotLabelPattern
-      .replace(/\{n\}/g, String(sequence))
-      .replace(/\{index\}/g, String(sequence));
-  }
-
-  if (normalizedId === 'image_url' || normalizedId === 'input_image') return assetCopy.startImageSlot;
-  if (normalizedId === 'end_image_url') return assetCopy.endImageSlot;
-  if (normalizedId === 'first_frame_url') return assetCopy.firstFrameSlot;
-  if (normalizedId === 'last_frame_url') return assetCopy.lastFrameSlot;
-  if (normalizedId === 'image_urls' || normalizedId.endsWith('_image_urls') || (role === 'reference' && field.type === 'image')) {
-    return assetCopy.referenceImageSlot(sequence);
-  }
-  if (normalizedId === 'video_urls' || normalizedId.endsWith('_video_urls') || normalizedId.includes('reference_video')) {
-    return assetCopy.referenceVideoSlot(sequence);
-  }
-  if (normalizedId === 'audio_urls' || normalizedId.endsWith('_audio_urls') || normalizedId.includes('reference_audio')) {
-    return assetCopy.referenceAudioSlot(sequence);
-  }
-  if (field.type === 'video') return assetCopy.sourceVideoSlot;
-  if (field.type === 'audio') return assetCopy.sourceAudioSlot;
-  return field.label ?? assetCopy.imageSlot;
-}
-
-export type AssetSlotAttachment = {
-  kind: 'image' | 'video' | 'audio';
-  name: string;
-  size: number;
-  type: string;
-  previewUrl: string;
-  status?: 'uploading' | 'ready' | 'error';
-  error?: string;
-  badge?: string;
-};
-
-export type AssetFieldRole = 'primary' | 'reference' | 'frame' | 'generic';
-
-export type AssetFieldConfig = {
-  field: EngineInputField;
-  required: boolean;
-  role?: AssetFieldRole;
-  headerAction?: ReactNode;
-  disabled?: boolean;
-  disabledReason?: string | null;
-};
-
-export type AssetUploadMeta = {
-  durationSec?: number;
-};
+export type {
+  AssetFieldConfig,
+  AssetFieldRole,
+  AssetSlotAttachment,
+  AssetUploadMeta,
+} from '@/components/asset-dropzone/asset-dropzone-types';
 
 interface AssetDropzoneProps {
   engine: EngineCaps;
@@ -134,32 +87,6 @@ export function AssetDropzone({
   })();
   const limits = engine.inputLimits;
   const constraints = engine.inputSchema?.constraints ?? {};
-  const readMediaDuration = useCallback((file: File, type: 'audio' | 'video') => {
-    return new Promise<number | null>((resolve) => {
-      if (typeof window === 'undefined') {
-        resolve(null);
-        return;
-      }
-      const objectUrl = URL.createObjectURL(file);
-      const element = document.createElement(type);
-      const cleanup = () => {
-        URL.revokeObjectURL(objectUrl);
-        element.removeAttribute('src');
-        element.load?.();
-      };
-      element.preload = 'metadata';
-      element.onloadedmetadata = () => {
-        const duration = Number.isFinite(element.duration) ? element.duration : null;
-        cleanup();
-        resolve(duration);
-      };
-      element.onerror = () => {
-        cleanup();
-        resolve(null);
-      };
-      element.src = objectUrl;
-    });
-  }, []);
   const hideRequiredSlotCopy =
     field.type === 'image' &&
     (role === 'primary' || role === 'reference') &&
@@ -242,7 +169,6 @@ export function AssetDropzone({
       limits.videoMaxMB,
       onError,
       onSelect,
-      readMediaDuration,
     ]
   );
 
@@ -459,284 +385,47 @@ export function AssetDropzone({
           )}
         >
           {displaySlots.map(({ asset, slotIndex }) => {
-            const slotRequired = slotIndex < minCount;
-            const showRequiredHint = slotRequired && engine.id !== 'wan-2-6' && !hideRequiredSlotCopy;
             const canOpenLibrary = Boolean(onOpenLibrary && (field.type === 'image' || field.type === 'video'));
-            const flattenSlotSurface = displaySlots.length === 1 && !isCollectionField;
-            const isCollectionAddTile = isCollectionField && asset == null && filledAssetCount > 0;
-            const filledSingleSlot = flattenSlotSurface && asset != null;
-            const allowClick = asset == null || asset?.kind !== 'audio';
             const slotLabel = resolveSlotLabel(field, role, slotIndex, assetCopy);
-            const isLockedEmptySlot = disabled && !asset;
-            const slotDescription =
-              isLockedEmptySlot
-                ? null
-                : displaySlots.length === 1
-                ? field.description ?? roleDescription
-                : isCollectionField && asset == null && filledAssetCount === 0
-                  ? field.description ?? roleDescription
-                : null;
-            const slotMeta =
-              isLockedEmptySlot
-                ? null
-                : (displaySlots.length === 1 || (isCollectionField && asset == null && filledAssetCount === 0)
-                ? helperLines.slice(0, 2)
-                : [])
-                .filter((value) => value.trim().length > 0)
-                .join(' • ') || null;
-            const triggerFilePicker = () => {
-              if (disabled) {
-                handleDisabledAttempt();
-                return;
-              }
-              inputRefs.current[slotIndex]?.click();
-            };
-            const triggerLibrary = () => {
-              if (disabled) {
-                handleDisabledAttempt();
-                return;
-              }
-              onOpenLibrary?.(field, slotIndex);
-            };
-
-            const triggerSelection = () => {
-              if (disabled && !asset) {
-                handleDisabledAttempt();
-                return;
-              }
-              if (!allowClick) return;
-              if (asset) {
-                if (canOpenLibrary) {
-                  triggerLibrary();
-                  return;
-                }
-                triggerFilePicker();
-                return;
-              }
-              triggerFilePicker();
-            };
 
             return (
-              <div
+              <AssetDropzoneSlot
                 key={`${field.id}-slot-${slotIndex}`}
-                tabIndex={0}
-                className={clsx(
-                  'relative flex w-full flex-col justify-center overflow-hidden text-center text-[12px] text-text-muted transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg',
-                  filledSingleSlot
-                    ? fullBleedSingleAsset
-                      ? 'min-h-[260px] h-full rounded-none border-0 bg-transparent'
-                      : 'min-h-[228px] rounded-[20px] border border-border/60 bg-surface dark:border-white/8 dark:bg-white/[0.05]'
-                    : flattenSlotSurface
-                      ? 'min-h-[132px] rounded-[18px] border-0 bg-transparent'
-                      : 'h-40 rounded-[18px] border border-border/60 bg-surface/80 dark:border-white/[0.09] dark:bg-white/[0.045]',
-                  allowClick
-                    ? filledSingleSlot
-                      ? 'cursor-pointer hover:border-brand/50'
-                      : flattenSlotSurface
-                        ? 'cursor-pointer hover:bg-surface-2/70 dark:hover:bg-white/[0.05]'
-                        : 'cursor-pointer hover:border-brand/50 hover:bg-surface-2 dark:hover:border-brand/35 dark:hover:bg-white/[0.07]'
-                    : 'cursor-default',
-                  disabled && !asset && 'cursor-not-allowed border-border/70 bg-surface/60 hover:border-border/70 hover:bg-surface/60 dark:border-white/[0.08] dark:bg-white/[0.03] dark:hover:border-white/[0.08] dark:hover:bg-white/[0.03]'
-                )}
-                onClick={triggerSelection}
-                onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
-                  if (event.key !== 'Enter' && event.key !== ' ') return;
-                  event.preventDefault();
-                  triggerSelection();
+                accept={accept}
+                asset={asset}
+                assetCopy={assetCopy}
+                canOpenLibrary={canOpenLibrary}
+                disabled={disabled}
+                disabledReason={disabledReason}
+                displaySlotCount={displaySlots.length}
+                engineId={engine.id}
+                field={field}
+                filledAssetCount={filledAssetCount}
+                fullBleedSingleAsset={fullBleedSingleAsset}
+                helperLines={helperLines}
+                hideRequiredSlotCopy={hideRequiredSlotCopy}
+                inputRef={(element) => {
+                  inputRefs.current[slotIndex] = element;
                 }}
-                title={asset ? undefined : disabledReason ?? assetCopy.upload}
-                onDragOver={(event) => {
-                  event.preventDefault();
+                isCollectionField={isCollectionField}
+                minCount={minCount}
+                roleDescription={roleDescription}
+                slotIndex={slotIndex}
+                slotLabel={slotLabel}
+                onDisabledAttempt={handleDisabledAttempt}
+                onDrop={(event, targetSlotIndex) => {
+                  void handleDrop(event, targetSlotIndex);
                 }}
-                onDrop={(event) => {
-                  if (disabled) {
-                    handleDisabledAttempt();
-                    return;
-                  }
-                  void handleDrop(event, slotIndex);
+                onInputChange={(event, targetSlotIndex) => {
+                  void onInputChange(event, targetSlotIndex);
                 }}
-                onPaste={(event) => {
-                  if (disabled) {
-                    handleDisabledAttempt();
-                    return;
-                  }
-                  void handlePaste(event, slotIndex);
+                onOpenLibrarySlot={(targetSlotIndex) => onOpenLibrary?.(field, targetSlotIndex)}
+                onPaste={(event, targetSlotIndex) => {
+                  void handlePaste(event, targetSlotIndex);
                 }}
-              >
-                <input
-                  ref={(element) => {
-                    inputRefs.current[slotIndex] = element;
-                  }}
-                  type="file"
-                  accept={accept}
-                  className="sr-only"
-                  disabled={disabled}
-                  onChange={(event) => {
-                    void onInputChange(event, slotIndex);
-                  }}
-                />
-                {asset ? (
-                  <>
-                    {fullBleedSingleAsset ? (
-                      <div className="pointer-events-none absolute inset-x-0 top-0 z-[1] h-24 bg-gradient-to-b from-black/55 via-black/18 to-transparent" />
-                    ) : null}
-                    {asset.kind === 'image' ? (
-                      <img src={asset.previewUrl} alt={asset.name} className="absolute inset-0 h-full w-full bg-surface object-cover" />
-                    ) : asset.kind === 'audio' ? (
-                      <div className="absolute inset-0 flex items-center justify-center bg-surface p-4">
-                        <audio src={asset.previewUrl} controls className="w-full" />
-                      </div>
-                    ) : (
-                      <>
-                        <video src={asset.previewUrl} controls preload="metadata" className="absolute inset-0 h-full w-full bg-black object-cover" />
-                        <AudioEqualizerBadge tone="light" size="sm" label={assetCopy.videoIncludesAudio} />
-                      </>
-                    )}
-                    {asset.badge ? (
-                      <div className="absolute left-3 top-3 z-10">
-                        <span className="inline-flex items-center rounded-full border border-white/24 bg-black/58 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-white shadow-[0_10px_24px_rgba(0,0,0,0.18)] backdrop-blur">
-                          {asset.badge}
-                        </span>
-                      </div>
-                    ) : null}
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="ghost"
-                      className="absolute right-3 top-3 z-10 h-9 w-9 rounded-full border border-white/30 bg-black/62 p-0 text-white shadow-[0_10px_24px_rgba(0,0,0,0.22)] backdrop-blur transition hover:bg-black/78 focus-visible:ring-2 focus-visible:ring-white/70"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onRemove?.(field, slotIndex);
-                      }}
-                      aria-label={assetCopy.remove}
-                      title={assetCopy.remove}
-                    >
-                      <Trash2 className="h-4 w-4" aria-hidden />
-                    </Button>
-                    {asset.status === 'uploading' ? (
-                      <div className="absolute inset-0 flex items-center justify-center bg-surface-on-media-dark-50 px-3 text-xs font-medium uppercase tracking-widest text-on-inverse">
-                        {assetCopy.uploading}
-                      </div>
-                    ) : null}
-                    {asset.status === 'error' ? (
-                      <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-surface-on-media-dark-60 px-4 text-center text-xs text-on-inverse">
-                        <span>{asset.error ?? assetCopy.uploadFailed}</span>
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="ghost"
-                          className="min-h-0 h-auto rounded-full bg-surface px-3 py-1 text-[11px] font-medium text-text-primary shadow-none hover:bg-surface"
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            onRemove?.(field, slotIndex);
-                          }}
-                        >
-                          {assetCopy.remove}
-                        </Button>
-                      </div>
-                    ) : null}
-                  </>
-                ) : (
-                  <div
-                    className={clsx(
-                      'flex h-full flex-col items-center justify-center px-4 text-center',
-                      isCollectionAddTile ? 'gap-3 py-4' : 'gap-4'
-                    )}
-                  >
-                    {isCollectionAddTile ? (
-                      <span className="absolute left-3 top-3 inline-flex min-w-7 items-center justify-center rounded-full border border-border/70 bg-surface px-2 py-1 text-[10px] font-semibold text-text-muted dark:border-white/10 dark:bg-white/[0.06] dark:text-white/58">
-                        +
-                      </span>
-                    ) : null}
-                    <div
-                      className={clsx(
-                        'flex h-8 w-8 items-center justify-center rounded-full border text-text-secondary',
-                        isLockedEmptySlot
-                          ? 'border-border/80 bg-surface text-text-muted dark:border-white/12 dark:bg-white/[0.04] dark:text-white/58'
-                          : 'border-border/75 bg-surface-2/80 dark:border-brand/25 dark:bg-brand/15 dark:text-brand'
-                      )}
-                    >
-                      {isLockedEmptySlot ? (
-                        <Lock className="h-3.5 w-3.5" aria-hidden />
-                      ) : (
-                        <svg aria-hidden viewBox="0 0 20 20" className="h-3.5 w-3.5">
-                          <path
-                            d="M10 4.5v11m-5.5-5.5h11"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="1.5"
-                            strokeLinecap="round"
-                          />
-                        </svg>
-                      )}
-                    </div>
-                    <div className={clsx('space-y-1', isCollectionAddTile && 'space-y-0')}>
-                      {slotLabel ? (
-                        <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-secondary dark:text-white/86">
-                          {slotLabel}
-                        </p>
-                      ) : null}
-                      {isLockedEmptySlot && disabledReason ? (
-                        <p className="max-w-[16rem] text-[11px] font-medium leading-4 text-text-secondary dark:text-white/72">
-                          {disabledReason}
-                        </p>
-                      ) : null}
-                      {slotDescription ? (
-                        <p className="max-w-[16rem] text-[11px] leading-4 text-text-muted dark:text-white/58">
-                          {slotDescription}
-                        </p>
-                      ) : null}
-                      {slotMeta ? (
-                        <p className="max-w-[16rem] text-[10px] leading-4 text-text-muted/90 dark:text-white/46">
-                          {slotMeta}
-                        </p>
-                      ) : null}
-                      {disabledReason && slotIndex === 0 && !isLockedEmptySlot ? (
-                        <p className="max-w-[16rem] text-[10px] leading-4 text-text-muted dark:text-white/54">
-                          {disabledReason}
-                        </p>
-                      ) : null}
-                      {showRequiredHint && !disabledReason ? (
-                        <span className="text-[10px] text-warning dark:text-[#f6c667]">{assetCopy.neededBeforeGenerating}</span>
-                      ) : null}
-                    </div>
-                    {!isLockedEmptySlot ? (
-                      <div className="flex w-full flex-wrap items-center justify-center gap-2">
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="outline"
-                          className="min-h-0 h-auto rounded-full border-border px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-secondary hover:border-text-muted hover:bg-transparent hover:text-text-primary dark:border-white/14 dark:bg-white/[0.045] dark:text-white/78 dark:hover:border-brand/30 dark:hover:bg-white/[0.08] dark:hover:text-white"
-                          disabled={disabled}
-                          title={disabledReason ?? undefined}
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            triggerFilePicker();
-                          }}
-                        >
-                          {assetCopy.upload}
-                        </Button>
-                        {canOpenLibrary ? (
-                          <Button
-                            type="button"
-                            size="sm"
-                            variant="ghost"
-                            className="min-h-0 h-auto rounded-full px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-secondary hover:bg-surface-2 hover:text-text-primary dark:text-white/78 dark:hover:bg-white/[0.08] dark:hover:text-white"
-                            disabled={disabled}
-                            title={disabledReason ?? undefined}
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              triggerLibrary();
-                            }}
-                          >
-                            {assetCopy.library}
-                          </Button>
-                        ) : null}
-                      </div>
-                    ) : null}
-                  </div>
-                )}
-              </div>
+                onRemoveSlot={(targetSlotIndex) => onRemove?.(field, targetSlotIndex)}
+                onSelectFileSlot={(targetSlotIndex) => inputRefs.current[targetSlotIndex]?.click()}
+              />
             );
           })}
         </div>

--- a/frontend/components/Composer.tsx
+++ b/frontend/components/Composer.tsx
@@ -3,139 +3,24 @@
 
 import clsx from 'clsx';
 import { useMemo, useCallback, useRef, useEffect, useState } from 'react';
-import type { Ref, ReactNode } from 'react';
-import type { EngineCaps, EngineInputField, EngineModeUiCaps as CapabilityCaps, Mode, PreflightResponse } from '@/types/engines';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { CURRENCY_LOCALE } from '@/lib/intl';
-import {
-  AssetDropzone,
-  type AssetFieldConfig,
-  type AssetFieldRole,
-  type AssetSlotAttachment,
-  type AssetUploadMeta,
-} from '@/components/AssetDropzone';
+import { AssetDropzone } from '@/components/AssetDropzone';
+import { ComposerMultiPromptEditor } from '@/components/composer/ComposerMultiPromptEditor';
+import { ComposerPromotedActionIcon } from '@/components/composer/ComposerPromotedActionIcon';
+import { DEFAULT_COMPOSER_COPY, type ComposerCopy } from '@/components/composer/composer-copy';
 import { useI18n } from '@/lib/i18n/I18nProvider';
-export type ComposerAttachment = AssetSlotAttachment;
-export type { AssetFieldConfig, AssetFieldRole, AssetUploadMeta };
+import type { ComposerProps } from '@/components/composer/composer-types';
 
-export type MultiPromptScene = {
-  id: string;
-  prompt: string;
-  duration: number;
-};
-
-type ComposerModeToggle = {
-  mode: Mode | null;
-  label: string;
-  disabled?: boolean;
-  disabledReason?: string;
-};
-
-export type ComposerPromotedAction = {
-  id: string;
-  label: string;
-  tooltip?: string;
-  active: boolean;
-  icon: 'sparkles' | 'shield';
-  onToggle: () => void;
-  disabled?: boolean;
-};
-
-interface Props {
-  engine: EngineCaps;
-  caps?: CapabilityCaps;
-  prompt: string;
-  onPromptChange: (value: string) => void;
-  negativePrompt?: string;
-  onNegativePromptChange?: (value: string) => void;
-  price: number | null;
-  currency: string;
-  isLoading: boolean;
-  error?: string;
-  messages?: string[];
-  textareaRef?: Ref<HTMLTextAreaElement>;
-  onGenerate?: () => void;
-  iterations?: number;
-  preflight?: PreflightResponse | null;
-  promptField?: EngineInputField;
-  promptRequired: boolean;
-  promptPlaceholder?: string;
-  promptPlaceholderWithAsset?: string;
-  negativePromptField?: EngineInputField;
-  negativePromptRequired?: boolean;
-  assetFields: AssetFieldConfig[];
-  assets: Record<string, (ComposerAttachment | null)[]>;
-  onAssetAdd?: (field: EngineInputField, file: File, slotIndex?: number, meta?: AssetUploadMeta) => void;
-  onAssetRemove?: (field: EngineInputField, index: number) => void;
-  onNotice?: (message: string) => void;
-  onOpenLibrary?: (field: EngineInputField, slotIndex: number) => void;
-  onAssetUrlSelect?: (field: EngineInputField, url: string, slotIndex: number) => void;
-  settingsBar?: ReactNode;
-  modeToggles?: ComposerModeToggle[];
-  activeManualMode?: Mode | null;
-  onModeToggle?: (mode: Mode | null) => void;
-  promotedActions?: ComposerPromotedAction[];
-  multiPrompt?: {
-    enabled: boolean;
-    scenes: MultiPromptScene[];
-    totalDurationSec: number;
-    minDurationSec: number;
-    maxDurationSec: number;
-    onToggle: (enabled: boolean) => void;
-    onAddScene: () => void;
-    onRemoveScene: (id: string) => void;
-    onUpdateScene: (id: string, patch: Partial<Pick<MultiPromptScene, 'prompt' | 'duration'>>) => void;
-    error?: string | null;
-  } | null;
-  extraFields?: ReactNode;
-  afterAssets?: ReactNode;
-  disableGenerate?: boolean;
-  workflowNotice?: string | null;
-  generateLabel?: string;
-  generateLoadingLabel?: string;
-}
-
-const DEFAULT_COMPOSER_COPY = {
-  title: 'Composer',
-  subtitle: 'Enhance prompt • Non-destructive reruns',
-  badges: {
-    payg: 'Pay-as-you-go',
-    priceBefore: 'Price-before',
-    alwaysCurrent: 'Always-current',
-  },
-  priceLabel: 'This render: {amount}',
-  memberLabel: 'Member price — You save {percent}%',
-  labels: {
-    required: 'Required',
-    optional: 'Optional',
-  },
-  prompt: {
-    placeholder: 'Describe the scene…',
-    placeholderWithImage: 'Describe how the image should move / transform…',
-  },
-  negativePrompt: {
-    placeholder: 'Elements to avoid…',
-    requiredHint: 'Required',
-  },
-  assetSlots: {
-    imageCtaLabel: 'Generate reference images',
-    imageCtaHref: '/app/image',
-    referenceWarning: '',
-  },
-  shortcuts: {
-    generate: 'Cmd+Enter • Generate',
-    price: 'G • Price-before',
-    seed: 'S • Lock seed',
-  },
-  iterationsLabel: '×{count}',
-  button: {
-    idle: 'Generate',
-    loading: 'Checking price…',
-  },
-} as const;
-
-type ComposerCopy = typeof DEFAULT_COMPOSER_COPY;
+export type {
+  AssetFieldConfig,
+  AssetFieldRole,
+  AssetUploadMeta,
+  ComposerAttachment,
+  ComposerPromotedAction,
+  MultiPromptScene,
+} from '@/components/composer/composer-types';
 
 export function Composer({
   engine,
@@ -177,7 +62,7 @@ export function Composer({
   workflowNotice,
   generateLabel,
   generateLoadingLabel,
-}: Props) {
+}: ComposerProps) {
   const { t } = useI18n();
   const composerCopy = useMemo<ComposerCopy>(() => {
     const localized = t('workspace.generate.composer', DEFAULT_COMPOSER_COPY) as Partial<ComposerCopy> | undefined;
@@ -426,77 +311,16 @@ export function Composer({
                     aria-pressed={action.active}
                     className="min-h-0 h-8 rounded-full px-2.5 py-0 text-[10px] font-semibold dark:border-white/12 dark:bg-white/[0.05] dark:hover:bg-white/[0.08]"
                   >
-                    <span className="shrink-0">{renderPromotedActionIcon(action.icon)}</span>
+                    <span className="shrink-0">
+                      <ComposerPromotedActionIcon icon={action.icon} />
+                    </span>
                     <span className="whitespace-nowrap">{action.label}</span>
                   </Button>
                 ))}
               </div>
             </div>
             {multiPromptEnabled && multiPrompt ? (
-              <div className="space-y-3 px-4 pb-4">
-                {multiPrompt.scenes.map((scene, index) => (
-                  <div
-                    key={scene.id}
-                    className="rounded-input border border-border bg-surface p-3 text-sm text-text-secondary dark:border-white/8 dark:bg-white/[0.04] dark:text-white/72"
-                  >
-                    <div className="flex items-center justify-between">
-                      <span className="text-[12px] uppercase tracking-micro text-text-muted">Scene {index + 1}</span>
-                      {multiPrompt.scenes.length > 1 && (
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => multiPrompt.onRemoveScene(scene.id)}
-                          className="min-h-0 h-auto px-2 py-1 text-[11px]"
-                        >
-                          Remove
-                        </Button>
-                      )}
-                    </div>
-                    <textarea
-                      value={scene.prompt}
-                      onChange={(event) => multiPrompt.onUpdateScene(scene.id, { prompt: event.currentTarget.value })}
-                      placeholder={`Scene ${index + 1} prompt`}
-                      rows={3}
-                      className="mt-2 w-full rounded-input border border-border bg-surface px-3 py-2 text-sm leading-5 text-text-primary placeholder:text-text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:border-white/8 dark:bg-white/[0.03] dark:text-white dark:placeholder:text-white/35"
-                    />
-                    <div className="mt-2 flex items-center gap-2 text-[12px] text-text-muted">
-                      <span>Duration (s)</span>
-                      <input
-                        type="number"
-                        min={multiPrompt.minDurationSec}
-                        max={multiPrompt.maxDurationSec}
-                        value={scene.duration}
-                        onChange={(event) =>
-                          multiPrompt.onUpdateScene(scene.id, {
-                            duration: Math.max(0, Math.round(Number(event.currentTarget.value))),
-                          })
-                        }
-                        className="w-20 rounded-input border border-border bg-surface px-2 py-1 text-right text-xs text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:border-white/8 dark:bg-white/[0.03] dark:text-white"
-                      />
-                    </div>
-                  </div>
-                ))}
-                <div className="flex flex-wrap items-center justify-between gap-2 text-[12px] text-text-muted">
-                  <span>
-                    Total: {multiPrompt.totalDurationSec}s · Min {multiPrompt.minDurationSec}s · Max {multiPrompt.maxDurationSec}s
-                  </span>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    onClick={multiPrompt.onAddScene}
-                    className="min-h-0 h-auto rounded-full px-3 py-1.5 text-[11px] uppercase tracking-micro"
-                  >
-                    + Scene
-                  </Button>
-                </div>
-                {multiPrompt.error ? (
-                  <div className="rounded-input border border-error-border bg-error-bg px-3 py-2 text-[12px] text-error">
-                    {multiPrompt.error}
-                  </div>
-                ) : null}
-              </div>
+              <ComposerMultiPromptEditor multiPrompt={multiPrompt} />
             ) : (
               <textarea
                 value={prompt}
@@ -639,43 +463,5 @@ export function Composer({
         </ul>
       ) : null}
     </Card>
-  );
-}
-
-function renderPromotedActionIcon(icon: ComposerPromotedAction['icon']) {
-  if (icon === 'shield') {
-    return (
-      <svg aria-hidden viewBox="0 0 20 20" className="h-4 w-4">
-        <path
-          d="M10 2.5 4.5 4.8v4.6c0 3.3 2 6.2 5.1 7.5l.4.1.4-.1c3.1-1.3 5.1-4.2 5.1-7.5V4.8L10 2.5Z"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        <path
-          d="m7.8 10.1 1.5 1.5 3-3.2"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </svg>
-    );
-  }
-
-  return (
-    <svg aria-hidden viewBox="0 0 20 20" className="h-4 w-4">
-      <path
-        d="M10 2.8 11.6 6l3.5.5-2.6 2.5.6 3.5L10 10.9 6.9 12.5l.6-3.5-2.6-2.5 3.5-.5L10 2.8Z"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
   );
 }

--- a/frontend/components/MediaLightbox.tsx
+++ b/frontend/components/MediaLightbox.tsx
@@ -1,208 +1,20 @@
 'use client';
 
-import clsx from 'clsx';
-import Image from 'next/image';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  AudioWaveform,
-  CalendarDays,
-  ChevronRight,
-  Clock3,
-  Download,
-  ExternalLink,
-  Film,
-  Link as LinkIcon,
-  Monitor,
-  Play,
-  RefreshCw,
-  Sparkles,
-  WandSparkles,
-  X,
-  type LucideIcon,
-} from 'lucide-react';
-import { AudioEqualizerBadge } from '@/components/ui/AudioEqualizerBadge';
-import { CopyPromptButton } from '@/components/CopyPromptButton';
-import { Button, ButtonLink } from '@/components/ui/Button';
 import { copyTextToClipboard } from '@/lib/clipboard';
 import { suggestDownloadFilename, triggerAppDownload } from '@/lib/download';
-import type { JobSurface } from '@/types/billing';
+import { MediaLightboxEntryCard } from '@/components/media-lightbox/MediaLightboxEntryCard';
+import type {
+  MediaLightboxEntry,
+  MediaLightboxLibraryState,
+  MediaLightboxLoadingState,
+  MediaLightboxProps,
+} from '@/components/media-lightbox/media-lightbox-types';
 
-export interface MediaLightboxEntry {
-  id: string;
-  label: string;
-  videoUrl?: string | null;
-  previewUrl?: string | null;
-  audioUrl?: string | null;
-  imageUrl?: string | null;
-  thumbUrl?: string | null;
-  aspectRatio?: string | null;
-  jobId?: string | null;
-  surface?: JobSurface | null;
-  status?: 'pending' | 'completed' | 'failed';
-  progress?: number | null;
-  message?: string | null;
-  engineLabel?: string | null;
-  engineId?: string | null;
-  durationSec?: number | null;
-  createdAt?: string | null;
-  indexable?: boolean;
-  visibility?: 'public' | 'private';
-  hasAudio?: boolean;
-  mediaType?: 'image' | 'video' | 'audio';
-  prompt?: string | null;
-  priceCents?: number | null;
-  currency?: string | null;
-  curated?: boolean;
-}
-
-export interface MediaLightboxProps {
-  title: string;
-  subtitle?: string;
-  prompt?: string | null;
-  metadata?: Array<{ label: string; value: string }>;
-  entries: MediaLightboxEntry[];
-  onClose: () => void;
-  onRefreshEntry?: (entry: MediaLightboxEntry) => Promise<void> | void;
-  onSaveToLibrary?: (entry: MediaLightboxEntry) => Promise<void>;
-  onRemixEntry?: (entry: MediaLightboxEntry) => void;
-  remixLabel?: string;
-  onUseTemplate?: (entry: MediaLightboxEntry) => void;
-  templateLabel?: string;
-}
-
-function isVerticalAspect(aspectRatio?: string | null): boolean {
-  if (!aspectRatio) return false;
-  const value = aspectRatio.toLowerCase();
-  if (!value.includes(':')) return false;
-  const [w, h] = value.split(':').map((part) => Number(part));
-  if (!Number.isFinite(w) || !Number.isFinite(h) || h === 0) return false;
-  return h > w;
-}
-
-function formatPromptPreview(prompt: string, maxLength = 220): string {
-  const normalized = prompt.replace(/\s+/g, ' ').trim();
-  if (!normalized) return '';
-  if (normalized.length <= maxLength) return normalized;
-  return `${normalized.slice(0, maxLength).trim()}…`;
-}
-
-function isUuidLike(value: string): boolean {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
-}
-
-function formatEntryDate(value?: string | null): string | null {
-  if (!value) return null;
-  try {
-    return new Intl.DateTimeFormat(undefined, {
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-    }).format(new Date(value));
-  } catch {
-    return value;
-  }
-}
-
-function resolveStatusLabel(status?: MediaLightboxEntry['status']): string | null {
-  if (status === 'pending') return 'Processing';
-  if (status === 'failed') return 'Failed';
-  if (status === 'completed') return 'Ready';
-  return null;
-}
-
-function statusBadgeClass(status?: MediaLightboxEntry['status']): string {
-  if (status === 'failed') return 'border-warning-border bg-warning-bg text-warning';
-  if (status === 'pending') return 'border-brand/30 bg-[var(--brand-soft)] text-brand';
-  return 'border-[var(--brand-border)] bg-[var(--brand-soft)] text-brand';
-}
-
-function resolveOpenLabel(entry: MediaLightboxEntry): string {
-  if (entry.audioUrl && !entry.videoUrl) return 'Open audio';
-  if (entry.imageUrl && !entry.videoUrl) return 'Open image';
-  return 'Open in player';
-}
-
-function MetaItem({ icon: Icon, label, value }: { icon: LucideIcon; label: string; value: string }) {
-  return (
-    <div className="flex min-w-[132px] items-center gap-3 border-r border-hairline pr-5 last:border-r-0">
-      <Icon className="h-5 w-5 shrink-0 text-text-muted" aria-hidden />
-      <div className="min-w-0">
-        <p className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">{label}</p>
-        <p className="truncate text-sm font-semibold text-text-primary">{value}</p>
-      </div>
-    </div>
-  );
-}
-
-function ActionCard({
-  icon: Icon,
-  title,
-  body,
-  disabled,
-  onClick,
-}: {
-  icon: LucideIcon;
-  title: string;
-  body: string;
-  disabled?: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      className={clsx(
-        'group flex min-h-[108px] items-center gap-3 rounded-[16px] border border-hairline bg-surface-2/70 p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-        disabled ? 'cursor-not-allowed opacity-55' : 'hover:border-[var(--brand-border)] hover:bg-[var(--brand-soft)]'
-      )}
-    >
-      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[var(--brand-soft)] text-brand">
-        <Icon className="h-4 w-4" aria-hidden />
-      </span>
-      <span className="min-w-0 flex-1">
-        <span className="block text-sm font-semibold text-text-primary">{title}</span>
-        <span className="mt-1 block text-xs leading-relaxed text-text-secondary">{body}</span>
-      </span>
-      <ChevronRight className="h-4 w-4 text-brand transition-transform group-hover:translate-x-0.5" aria-hidden />
-    </button>
-  );
-}
-
-function RenderDecorVisual({ previewUrl }: { previewUrl?: string | null }) {
-  return (
-    <div className="relative hidden min-h-[118px] overflow-hidden rounded-[16px] border border-hairline bg-[linear-gradient(145deg,#f7faff_0%,#eef4ff_52%,#e6f2ed_100%)] p-3 xl:block">
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_80%_22%,rgba(62,142,114,0.18),transparent_34%),radial-gradient(circle_at_18%_88%,rgba(78,125,226,0.16),transparent_42%)]" />
-      <div className="absolute -right-8 -top-8 h-24 w-24 rounded-full bg-white/70 blur-2xl" />
-      <div className="relative ml-auto mt-1 h-[86px] w-[132px] rotate-[-5deg] overflow-hidden rounded-[18px] border border-white/75 bg-[#17243b] shadow-[0_18px_34px_rgba(31,58,96,0.22)]">
-        {previewUrl ? (
-          <Image src={previewUrl} alt="" fill className="object-cover" sizes="132px" />
-        ) : (
-          <svg viewBox="0 0 132 86" className="h-full w-full" aria-hidden>
-            <rect width="132" height="86" fill="#AFC4E6" />
-            <path d="M0 0h132v52C100 36 73 34 52 46 31 57 13 55 0 46Z" fill="#DDE8FB" opacity="0.78" />
-            <path d="M0 66c19-12 39-15 61-8 19 6 33 1 47-10 9-7 17-9 24-7v45H0Z" fill="#203A60" opacity="0.62" />
-            <path d="M12 24h42M12 36h26" stroke="#FFFFFF" strokeWidth="5" strokeLinecap="round" opacity="0.58" />
-          </svg>
-        )}
-        <div className="absolute inset-0 bg-gradient-to-t from-black/45 via-black/5 to-white/15" />
-        <div className="absolute bottom-3 left-3 flex h-8 w-8 items-center justify-center rounded-full bg-white text-[#27456c] shadow-card">
-          <Play className="h-3.5 w-3.5 fill-current" aria-hidden />
-        </div>
-        <div className="absolute bottom-4 left-12 h-1.5 w-16 overflow-hidden rounded-full bg-white/40">
-          <div className="h-full w-2/3 rounded-full bg-white" />
-        </div>
-      </div>
-      <div className="absolute bottom-4 left-5 h-9 w-12 rotate-[8deg] rounded-[10px] border border-white/70 bg-white/75 shadow-[0_10px_22px_rgba(31,58,96,0.14)]">
-        <div className="mx-auto mt-2 h-2 w-7 rounded-full bg-[#9cb2d2]" />
-        <div className="mx-auto mt-1.5 h-2 w-5 rounded-full bg-[#c2d1e8]" />
-      </div>
-      <div className="absolute right-5 top-4 h-3 w-3 rounded-full bg-success/70 shadow-[0_0_0_6px_rgba(62,142,114,0.10)]" />
-    </div>
-  );
-}
+export type {
+  MediaLightboxEntry,
+  MediaLightboxProps,
+} from '@/components/media-lightbox/media-lightbox-types';
 
 export function MediaLightbox({
   title,
@@ -219,9 +31,9 @@ export function MediaLightbox({
   templateLabel,
 }: MediaLightboxProps) {
   const [copiedId, setCopiedId] = useState<string | null>(null);
-  const [refreshStates, setRefreshStates] = useState<Record<string, { loading: boolean; error: string | null }>>({});
-  const [downloadStates, setDownloadStates] = useState<Record<string, { loading: boolean; error: string | null }>>({});
-  const [libraryStates, setLibraryStates] = useState<Record<string, { loading: boolean; success: boolean; error: string | null }>>({});
+  const [refreshStates, setRefreshStates] = useState<Record<string, MediaLightboxLoadingState>>({});
+  const [downloadStates, setDownloadStates] = useState<Record<string, MediaLightboxLoadingState>>({});
+  const [libraryStates, setLibraryStates] = useState<Record<string, MediaLightboxLibraryState>>({});
 
   const handleCopyLink = useCallback(
     async (entryId: string, url?: string | null) => {
@@ -424,301 +236,46 @@ export function MediaLightbox({
         ) : null}
 
         <section className="space-y-8">
-          {entries.map((entry, index) => {
-            const videoUrl = entry.videoUrl ?? undefined;
-            const audioUrl = entry.audioUrl ?? undefined;
-            const imageUrl = entry.imageUrl ?? undefined;
-            const thumbUrl = entry.thumbUrl ?? undefined;
-            const mediaUrl = entry.videoUrl ?? entry.audioUrl ?? entry.imageUrl ?? entry.thumbUrl ?? null;
-            const libraryState = libraryStates[entry.id];
-            const isProcessing = entry.status === 'pending';
-            const progressLabel =
-              typeof entry.progress === 'number'
-                ? `${Math.max(0, Math.min(100, Math.round(entry.progress)))}%`
-                : isProcessing
-                  ? 'Processing'
-                  : undefined;
-            const statusLabel = resolveStatusLabel(entry.status);
-            const createdLabel = formatEntryDate(entry.createdAt) ?? specs.find((item) => item.label.toLowerCase() === 'created')?.value ?? null;
-            const isVertical = isVerticalAspect(entry.aspectRatio);
-            const refreshState = refreshStates[entry.id];
-            const isRefreshing = Boolean(refreshState?.loading);
-            const refreshError = refreshState?.error ?? null;
-            const refreshTarget = entry.jobId ?? entry.id;
-            const hasRefreshTarget = typeof refreshTarget === 'string' && refreshTarget.trim().length > 0;
-            const canRefresh =
-              Boolean(onRefreshEntry) &&
-              hasRefreshTarget &&
-              (entry.status === 'pending' || (!entry.videoUrl && !entry.audioUrl));
-            const canRemix = Boolean(onRemixEntry);
-            const canTemplate = Boolean(onUseTemplate) && !entry.curated;
-            const downloadState = downloadStates[entry.id];
-            const isDownloading = Boolean(downloadState?.loading);
-            const downloadError = downloadState?.error ?? null;
-            const showPrompt = Boolean(prompt) && index === 0;
-            const displayTitle = entry.engineLabel ?? subtitle ?? title;
-            const detailSpecs = [
-              ...(entry.jobId ? [{ label: 'Job ID', value: entry.jobId }] : []),
-              ...specs.filter((item) => !['engine', 'created', 'date'].includes(item.label.toLowerCase())),
-            ].filter((item) => Boolean(item.value));
-            const technicalSpecs = [
-              ...(entry.aspectRatio ? [{ label: 'Aspect', value: entry.aspectRatio, icon: Monitor }] : []),
-              ...(typeof entry.durationSec === 'number' ? [{ label: 'Duration', value: `${entry.durationSec}s`, icon: Clock3 }] : []),
-              { label: 'Audio', value: entry.hasAudio ? 'Yes' : audioUrl ? 'Audio file' : 'No', icon: AudioWaveform },
-            ];
-
-            return (
-              <article key={entry.id}>
-                <header className="flex items-start justify-between gap-4">
-                  <div className="min-w-0">
-                    <div className="flex flex-wrap items-center gap-3">
-                      <h3 className="text-2xl font-semibold text-text-primary">{displayTitle}</h3>
-                      {statusLabel ? (
-                        <span className={clsx('rounded-pill border px-3 py-1 text-[11px] font-semibold uppercase tracking-micro', statusBadgeClass(entry.status))}>
-                          {statusLabel}
-                        </span>
-                      ) : null}
-                    </div>
-                    <div className="mt-5 flex flex-wrap items-center gap-y-3 text-sm text-text-primary">
-                      {entry.engineLabel ? (
-                        <MetaItem icon={Film} label="Engine" value={entry.engineLabel} />
-                      ) : null}
-                      {typeof entry.durationSec === 'number' ? (
-                        <MetaItem icon={Clock3} label="Duration" value={`${entry.durationSec}s`} />
-                      ) : null}
-                      {entry.aspectRatio ? (
-                        <MetaItem icon={Monitor} label="Aspect" value={entry.aspectRatio} />
-                      ) : null}
-                      <MetaItem icon={AudioWaveform} label="Audio" value={entry.hasAudio || audioUrl ? 'Yes' : 'No'} />
-                      {createdLabel ? (
-                        <MetaItem icon={CalendarDays} label="Created" value={createdLabel} />
-                      ) : null}
-                    </div>
-                  </div>
-                  {index === 0 ? (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      onClick={onClose}
-                      aria-label="Close"
-                      className="h-9 w-9 shrink-0 rounded-full border-hairline bg-surface p-0 text-text-secondary hover:bg-surface-2 hover:text-text-primary"
-                    >
-                      <X className="h-4 w-4" aria-hidden />
-                    </Button>
-                  ) : null}
-                </header>
-
-                <div className="mt-6 grid gap-5 lg:grid-cols-[minmax(0,1fr)_310px]">
-                  <div>
-                    <div
-                      className={clsx(
-                        'relative overflow-hidden rounded-[18px] border border-hairline bg-black shadow-card',
-                        isVertical ? 'mx-auto aspect-[9/16] max-h-[58vh] max-w-sm' : 'aspect-video'
-                      )}
-                    >
-                      {videoUrl ? (
-                        <video
-                          key={videoUrl}
-                          src={videoUrl}
-                          poster={thumbUrl}
-                          className="absolute inset-0 h-full w-full object-contain"
-                          controls
-                          playsInline
-                          autoPlay={index === 0}
-                          muted
-                          preload={index === 0 ? 'auto' : 'none'}
-                        />
-                      ) : audioUrl ? (
-                        <div className="absolute inset-0 flex flex-col items-center justify-center overflow-hidden bg-[radial-gradient(circle_at_top,_rgba(124,85,234,0.28),_transparent_52%),linear-gradient(135deg,_rgba(15,23,42,0.98),_rgba(30,41,59,0.88))] px-6 py-6 text-center">
-                          {thumbUrl ? <Image src={thumbUrl} alt="" fill className="object-cover opacity-20" sizes="(max-width: 1024px) 100vw, calc(100vw - 360px)" /> : null}
-                          <div className="relative flex h-20 w-20 items-center justify-center rounded-full border border-white/15 bg-white/10">
-                            {/* eslint-disable-next-line @next/next/no-img-element */}
-                            <img src="/assets/icons/audio.svg" alt="" className="h-10 w-10 opacity-95" />
-                          </div>
-                          <p className="relative mt-5 text-xs font-semibold uppercase tracking-[0.14em] text-white/70">
-                            Audio output
-                          </p>
-                          <div className="relative mt-5 w-full max-w-xl">
-                            <audio controls src={audioUrl} className="w-full" />
-                          </div>
-                        </div>
-                      ) : imageUrl || thumbUrl ? (
-                        <Image src={imageUrl ?? thumbUrl ?? ''} alt="" fill className="object-contain" sizes="(max-width: 1024px) 100vw, calc(100vw - 360px)" />
-                      ) : (
-                        <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-surface-2 via-surface to-surface-2 text-[12px] font-medium uppercase tracking-micro text-text-muted">
-                          Preview unavailable
-                        </div>
-                      )}
-                      {entry.hasAudio ? <AudioEqualizerBadge tone="light" size="sm" label="Audio available" /> : null}
-                      {isProcessing && (
-                        <div className="absolute inset-0 flex flex-col items-center justify-center bg-surface-on-media-dark-45 px-3 text-center text-[11px] text-on-inverse backdrop-blur-sm">
-                          <span className="uppercase tracking-micro">Processing...</span>
-                          {entry.message ? <span className="mt-1 line-clamp-2 text-on-media-80">{entry.message}</span> : null}
-                          {progressLabel ? <span className="mt-1 text-[12px] font-semibold text-on-inverse">{progressLabel}</span> : null}
-                        </div>
-                      )}
-                    </div>
-
-                    <div className="mt-7 flex flex-wrap justify-center gap-4">
-                      {canRefresh ? (
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="md"
-                          onClick={() => {
-                            void handleRefreshEntry(entry).catch(() => undefined);
-                          }}
-                          disabled={isRefreshing}
-                          className="min-w-[180px] border-[var(--brand-border)] px-5 text-brand hover:bg-[var(--brand-soft)]"
-                        >
-                          <RefreshCw className="h-4 w-4" aria-hidden />
-                          {isRefreshing ? 'Checking...' : 'Refresh status'}
-                        </Button>
-                      ) : null}
-                      <ButtonLink
-                        linkComponent="a"
-                        href={mediaUrl ?? '#'}
-                        target="_blank"
-                        rel="noreferrer"
-                        size="md"
-                        className={clsx('min-w-[180px] px-5', !mediaUrl && 'pointer-events-none opacity-50')}
-                      >
-                        <ExternalLink className="h-4 w-4" aria-hidden />
-                        {resolveOpenLabel(entry)}
-                      </ButtonLink>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="md"
-                        onClick={() => handleDownloadEntry(entry, mediaUrl)}
-                        disabled={!mediaUrl || isDownloading}
-                        className="min-w-[180px] border-hairline px-5 text-text-primary hover:bg-surface-2"
-                      >
-                        <Download className="h-4 w-4" aria-hidden />
-                        {isDownloading ? 'Downloading...' : 'Download'}
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="md"
-                        onClick={() => handleCopyLink(entry.id, mediaUrl)}
-                        disabled={!mediaUrl}
-                        className="min-w-[180px] border-hairline px-5 text-text-primary hover:bg-surface-2"
-                      >
-                        <LinkIcon className="h-4 w-4" aria-hidden />
-                        {copiedId === entry.id ? 'Link copied' : 'Copy link'}
-                      </Button>
-                    </div>
-                  </div>
-
-                  <aside className="space-y-0 overflow-hidden rounded-[18px] border border-hairline bg-surface-2/60">
-                    <div className="p-5">
-                      <p className="text-xs font-semibold uppercase tracking-micro text-text-muted">Render details</p>
-                      <dl className="mt-4 space-y-4 text-sm">
-                        {detailSpecs.length > 0 ? (
-                          detailSpecs.map((item) => (
-                            <div key={`${entry.id}-detail-${item.label}`}>
-                              <dt className="text-xs font-medium text-text-muted">{item.label}</dt>
-                              <dd className="mt-1 break-words font-medium text-text-primary">{item.value}</dd>
-                            </div>
-                          ))
-                        ) : (
-                          <div>
-                            <dt className="text-xs font-medium text-text-muted">Render</dt>
-                            <dd className="mt-1 font-medium text-text-primary">{entry.label || title}</dd>
-                          </div>
-                        )}
-                      </dl>
-                    </div>
-
-                    {showPrompt ? (
-                      <div className="border-t border-hairline p-5">
-                        <div className="flex items-center justify-between gap-2">
-                          <p className="text-xs font-semibold uppercase tracking-micro text-text-muted">Prompt</p>
-                          <CopyPromptButton prompt={prompt ?? ''} copyLabel="Copy" copiedLabel="Copied" />
-                        </div>
-                        <p className="mt-3 text-sm leading-relaxed text-text-primary">
-                          {formatPromptPreview(prompt ?? '')}
-                        </p>
-                        {prompt && prompt.trim().length > 220 ? (
-                          <details className="group mt-3">
-                            <summary className="flex cursor-pointer items-center gap-2 text-xs font-semibold uppercase tracking-micro text-brand">
-                              <span className="group-open:hidden">Show more</span>
-                              <span className="hidden group-open:inline">Show less</span>
-                            </summary>
-                            <p className="mt-2 whitespace-pre-line text-sm leading-relaxed text-text-secondary">{prompt}</p>
-                          </details>
-                        ) : null}
-                      </div>
-                    ) : null}
-                  </aside>
-                </div>
-
-                <div className="mt-8 border-t border-hairline pt-5">
-                  <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-                    {onRemixEntry ? (
-                      <ActionCard
-                        icon={WandSparkles}
-                        title={remixLabel ?? 'Remix'}
-                        body="Create a new version based on this render"
-                        disabled={!canRemix}
-                        onClick={() => onRemixEntry(entry)}
-                      />
-                    ) : null}
-                    {onUseTemplate ? (
-                      <ActionCard
-                        icon={CalendarDays}
-                        title={templateLabel ?? 'Use as template'}
-                        body="Reuse settings and prompt for a new render"
-                        disabled={!canTemplate}
-                        onClick={() => onUseTemplate(entry)}
-                      />
-                    ) : null}
-                    {onSaveToLibrary ? (
-                      <ActionCard
-                        icon={Sparkles}
-                        title={
-                          libraryState?.loading
-                            ? 'Saving...'
-                            : libraryState?.success
-                              ? 'Saved'
-                              : libraryState?.error
-                                ? 'Retry save'
-                                : 'Save to library'
-                        }
-                        body="Keep this media in your library"
-                        disabled={!mediaUrl || libraryState?.loading}
-                        onClick={() => handleSaveEntryToLibrary(entry, mediaUrl)}
-                      />
-                    ) : null}
-                    <div className="rounded-[16px] border border-hairline bg-surface-2/70 p-4">
-                      <div className="space-y-3">
-                        {technicalSpecs.map((item) => {
-                          const Icon = item.icon;
-                          return (
-                            <div key={`${entry.id}-tech-${item.label}`} className="flex items-center gap-3 text-sm">
-                              <Icon className="h-4 w-4 text-text-muted" aria-hidden />
-                              <span className="min-w-20 text-text-muted">{item.label}</span>
-                              <span className="font-semibold text-text-primary">{item.value}</span>
-                            </div>
-                          );
-                        })}
-                      </div>
-                    </div>
-                    <RenderDecorVisual previewUrl={thumbUrl ?? imageUrl ?? null} />
-                  </div>
-                </div>
-
-                {entry.message && !isProcessing && !isUuidLike(entry.message.trim()) ? (
-                  <p className="mt-4 text-sm text-text-secondary">{entry.message}</p>
-                ) : null}
-                {downloadError ? <p className="mt-2 text-xs text-state-warning">{downloadError}</p> : null}
-                {refreshError ? <p className="mt-2 text-xs text-state-warning">{refreshError}</p> : null}
-                {libraryState?.error ? <p className="mt-2 text-xs text-state-warning">{libraryState.error}</p> : null}
-              </article>
-            );
-          })}
+          {entries.map((entry, index) => (
+            <MediaLightboxEntryCard
+              key={entry.id}
+              copiedId={copiedId}
+              detailSpecsBase={specs}
+              downloadState={downloadStates[entry.id]}
+              entry={entry}
+              index={index}
+              libraryState={libraryStates[entry.id]}
+              prompt={prompt}
+              refreshState={refreshStates[entry.id]}
+              remixLabel={remixLabel}
+              subtitle={subtitle}
+              templateLabel={templateLabel}
+              title={title}
+              onClose={onClose}
+              onCopyLink={(entryId, url) => {
+                void handleCopyLink(entryId, url);
+              }}
+              onDownloadEntry={(targetEntry, url) => {
+                void handleDownloadEntry(targetEntry, url);
+              }}
+              onRefreshEntry={
+                onRefreshEntry
+                  ? (targetEntry) => {
+                      void handleRefreshEntry(targetEntry);
+                    }
+                  : undefined
+              }
+              onRemixEntry={onRemixEntry}
+              onSaveEntryToLibrary={
+                onSaveToLibrary
+                  ? (targetEntry, mediaUrl) => {
+                      void handleSaveEntryToLibrary(targetEntry, mediaUrl);
+                    }
+                  : undefined
+              }
+              onUseTemplate={onUseTemplate}
+            />
+          ))}
         </section>
       </div>
     </div>

--- a/frontend/components/QuadPreviewPanel.tsx
+++ b/frontend/components/QuadPreviewPanel.tsx
@@ -3,109 +3,22 @@
 import clsx from 'clsx';
 import Image from 'next/image';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { PriceFactorsBar, type PriceFactorKind } from '@/components/PriceFactorsBar';
+import { PriceFactorsBar } from '@/components/PriceFactorsBar';
 import { Card } from '@/components/ui/Card';
-import { EngineIcon } from '@/components/ui/EngineIcon';
 import { MediaLightbox, type MediaLightboxEntry } from '@/components/MediaLightbox';
-import { AudioEqualizerBadge } from '@/components/ui/AudioEqualizerBadge';
+import { QuadMosaicFigure } from '@/components/quad-preview/QuadMosaicFigure';
+import { QuadSingleTilesGrid } from '@/components/quad-preview/QuadSingleTilesGrid';
+import { buildTilesWithPlaceholders, formatCurrency } from '@/components/quad-preview/quad-preview-helpers';
 import { Button } from '@/components/ui/Button';
 import { PRIMARY_VIDEO_READY_EVENT } from '@/lib/video-warmup-events';
-import type { EngineCaps, PreflightResponse } from '@/types/engines';
+import type { QuadMosaicStatus, QuadPreviewPanelProps } from '@/components/quad-preview/quad-preview-types';
 
-export type QuadTileAction = 'continue' | 'refine' | 'branch' | 'copy' | 'open';
-export type QuadGroupAction = 'open' | 'compare' | 'hero';
-
-export interface QuadPreviewTile {
-  localKey: string;
-  batchId: string;
-  id: string;
-  jobId?: string;
-  iterationIndex: number;
-  iterationCount: number;
-  videoUrl?: string;
-  previewVideoUrl?: string;
-  thumbUrl?: string;
-  aspectRatio: string;
-  progress: number;
-  message: string;
-  priceCents?: number;
-  currency?: string;
-  durationSec: number;
-  engineLabel: string;
-  engineId: string;
-  etaLabel?: string;
-  prompt: string;
-  status: 'pending' | 'completed' | 'failed';
-  hasAudio?: boolean;
-}
-
-interface QuadPreviewPanelProps {
-  tiles: QuadPreviewTile[];
-  heroKey?: string;
-  preflight: PreflightResponse | null;
-  iterations: number;
-  currency: string;
-  totalPriceCents?: number | null;
-  onNavigateFactor?: (kind: PriceFactorKind) => void;
-  onTileAction: (action: QuadTileAction, tile: QuadPreviewTile) => void;
-  onGroupAction: (action: QuadGroupAction, tile?: QuadPreviewTile) => void;
-  onSelectHero: (tile: QuadPreviewTile) => void;
-  engineMap: Map<string, EngineCaps>;
-  onSaveComposite?: () => void;
-  onRefreshJob?: (jobId: string) => Promise<void> | void;
-}
-
-const TILE_ACTIONS: Array<{ id: QuadTileAction; label: string; icon: string }> = [
-  { id: 'continue', label: 'Continue', icon: '/assets/icons/play.svg' },
-  { id: 'refine', label: 'Refine', icon: '/assets/icons/remix.svg' },
-  { id: 'branch', label: 'Branch', icon: '/assets/icons/extend.svg' },
-  { id: 'copy', label: 'Copy prompt', icon: '/assets/icons/copy.svg' },
-  { id: 'open', label: 'Open in player', icon: '/assets/icons/expand.svg' },
-];
-
-function getAspectClass(aspectRatio?: string | null): string {
-  const normalized = (aspectRatio ?? '').trim();
-  switch (normalized) {
-    case '1:1':
-    case 'square':
-      return 'aspect-square';
-    case '9:16':
-    case '9/16':
-      return 'aspect-[9/16]';
-    case '9:21':
-    case '9/21':
-      return 'aspect-[9/21]';
-    case '16:9':
-    case '16/9':
-      return 'aspect-[16/9]';
-    case '3:4':
-    case '3/4':
-      return 'aspect-[3/4]';
-    case '4:3':
-    case '4/3':
-      return 'aspect-[4/3]';
-    case '4:5':
-    case '4/5':
-      return 'aspect-[4/5]';
-    case '5:4':
-    case '5/4':
-      return 'aspect-[5/4]';
-    case '21:9':
-    case '21/9':
-      return 'aspect-[21/9]';
-    default:
-      return 'aspect-[16/9]';
-  }
-}
-
-function formatCurrency(amountCents?: number, currency = 'USD') {
-  if (typeof amountCents !== 'number') return null;
-  try {
-    return new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(amountCents / 100);
-  } catch {
-    return `${currency} ${(amountCents / 100).toFixed(2)}`;
-  }
-}
+export type {
+  QuadGroupAction,
+  QuadPreviewPanelProps,
+  QuadPreviewTile,
+  QuadTileAction,
+} from '@/components/quad-preview/quad-preview-types';
 
 export function QuadPreviewPanel({
   tiles,
@@ -129,31 +42,10 @@ export function QuadPreviewPanel({
   const sortedTiles = useMemo(() => [...tiles].sort((a, b) => a.iterationIndex - b.iterationIndex), [tiles]);
   const iterationCount = sortedTiles[0]?.iterationCount ?? iterations ?? 1;
 
-  const tilesWithPlaceholders: Array<QuadPreviewTile | null> = useMemo(() => {
-    if (sortedTiles.length === 0) return [];
-
-    const primaryAspectRatio = sortedTiles[0]?.aspectRatio ?? '16:9';
-    const desiredSlots = (() => {
-      if (iterationCount <= 1) return 1;
-      if (iterationCount === 2) return 2;
-      if (primaryAspectRatio === '9:16' && iterationCount === 3) return 3;
-      if (iterationCount >= 3) return 4;
-      return 1;
-    })();
-
-    const list: Array<QuadPreviewTile | null> = [...sortedTiles];
-    while (list.length < desiredSlots) {
-      list.push(null);
-    }
-
-    if (primaryAspectRatio === '9:16' && desiredSlots === 4 && sortedTiles.length === 2) {
-      const first = sortedTiles[0] ?? null;
-      const second = sortedTiles[1] ?? null;
-      return [null, first, second, null];
-    }
-
-    return list.slice(0, desiredSlots);
-  }, [sortedTiles, iterationCount]);
+  const tilesWithPlaceholders = useMemo(
+    () => buildTilesWithPlaceholders(sortedTiles, iterationCount),
+    [sortedTiles, iterationCount]
+  );
 
   const totalPrice = useMemo(() => {
     if (typeof totalPriceCents === 'number') return formatCurrency(totalPriceCents, currency);
@@ -164,7 +56,6 @@ export function QuadPreviewPanel({
   const primaryAspect = sortedTiles[0]?.aspectRatio ?? '16:9';
   const isVerticalComposite = primaryAspect === '9:16';
   const mosaicSlots = tilesWithPlaceholders.length;
-  const compositeAspectClass = getAspectClass(primaryAspect);
   const mosaicGridClass = useMemo(() => {
     if (mosaicSlots <= 1) return 'grid-cols-1';
     if (isVerticalComposite) {
@@ -178,7 +69,7 @@ export function QuadPreviewPanel({
 
   const mosaicTiles = useMemo(() => tilesWithPlaceholders.slice(0, mosaicSlots), [tilesWithPlaceholders, mosaicSlots]);
   const mosaicStatusMap = useMemo(() => {
-    const map = new Map<string, { status: QuadPreviewTile['status']; progress: number; message: string; etaLabel?: string }>();
+    const map = new Map<string, QuadMosaicStatus>();
     sortedTiles.forEach((tile) => {
       map.set(tile.localKey, { status: tile.status, progress: tile.progress, message: tile.message, etaLabel: tile.etaLabel });
     });
@@ -265,275 +156,34 @@ export function QuadPreviewPanel({
         onNavigate={onNavigateFactor}
       />
 
-      {iterationCount > 1 && (
-        <figure className="overflow-hidden rounded-card border border-border bg-surface-glass-80 p-3 text-center">
-          <div className={clsx('relative w-full', compositeAspectClass)}>
-            <div className={clsx('absolute inset-0 grid gap-2 rounded-card bg-placeholder p-1', mosaicGridClass)}>
-              {mosaicTiles.map((preview, index) => {
-                const slotKey = preview?.localKey ?? `slot-${index}`;
-                const statusInfo = preview?.localKey ? mosaicStatusMap.get(preview.localKey) : undefined;
-                const cellAspect = getAspectClass(preview?.aspectRatio ?? primaryAspect);
-                const tileStatus = statusInfo?.status ?? preview?.status ?? 'pending';
-                const failureMessageRaw = statusInfo?.message ?? preview?.message ?? null;
-                const failureMessage =
-                  failureMessageRaw && typeof failureMessageRaw === 'string'
-                    ? failureMessageRaw.replace(/\s+/g, ' ').trim()
-                    : null;
-                const showPendingOverlay = tileStatus !== 'completed' && tileStatus !== 'failed';
-                const showFailedOverlay = tileStatus === 'failed';
-                const shouldPlayPreview = Boolean(isPlaying && preview?.localKey === heroTile?.localKey);
+      {iterationCount > 1 ? (
+        <QuadMosaicFigure
+          heroTile={heroTile}
+          isPlaying={isPlaying}
+          mosaicGridClass={mosaicGridClass}
+          mosaicStatusMap={mosaicStatusMap}
+          mosaicTiles={mosaicTiles}
+          primaryAspect={primaryAspect}
+          onPrimaryVideoReady={handlePrimaryVideoReady}
+        />
+      ) : null}
 
-                return (
-                  <div
-                    key={slotKey}
-                    data-quad-cell={slotKey}
-                    className="relative flex items-center justify-center overflow-hidden rounded-input bg-surface-glass-70"
-                  >
-                    <div className={clsx('relative h-full w-full', cellAspect)}>
-                      {tileStatus !== 'failed' && preview?.videoUrl ? (
-                        <video
-                          data-quad-video={shouldPlayPreview ? 'active' : 'idle'}
-                          data-quad-fallback
-                          src={preview.videoUrl}
-                          className="absolute inset-0 h-full w-full object-cover pointer-events-none"
-                          autoPlay={shouldPlayPreview}
-                          muted
-                          playsInline
-                          loop
-                          preload={shouldPlayPreview ? 'auto' : 'none'}
-                          poster={preview?.thumbUrl}
-                          onLoadedData={() => handlePrimaryVideoReady(preview?.localKey)}
-                          onCanPlay={() => handlePrimaryVideoReady(preview?.localKey)}
-                        />
-                      ) : tileStatus !== 'failed' && preview?.thumbUrl ? (
-                        <Image
-                          data-quad-fallback
-                          src={preview.thumbUrl}
-                          alt=""
-                          fill
-                          sizes="(max-width: 768px) 50vw, 320px"
-                          className="absolute inset-0 object-cover pointer-events-none"
-                          priority={false}
-                        />
-                      ) : (
-                        <div className="absolute inset-0 bg-gradient-to-br from-surface-2 via-surface to-surface-2" />
-                      )}
-                      {Boolean(preview?.hasAudio) && tileStatus !== 'failed' ? (
-                        <AudioEqualizerBadge tone="light" size="sm" label="Audio available" />
-                      ) : null}
-                    </div>
-                    <div className="absolute inset-0 z-10" data-quad-player-root={slotKey} />
-                    {showPendingOverlay && (
-                      <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-surface-on-media-dark-45 px-2 text-center text-[10px] text-on-inverse backdrop-blur-sm">
-                        <span className="uppercase tracking-micro">Processing</span>
-                        {(statusInfo?.message || preview?.message) && (
-                          <span className="mt-1 max-w-[140px] text-[10px] text-on-media-80">
-                            {statusInfo?.message ?? preview?.message}
-                          </span>
-                        )}
-                        {typeof statusInfo?.progress === 'number' && (
-                          <span className="mt-1 text-[10px] font-semibold">{statusInfo.progress}%</span>
-                        )}
-                        {statusInfo?.etaLabel && <span className="mt-1 text-[9px] text-on-media-70">{statusInfo.etaLabel}</span>}
-                      </div>
-                    )}
-                    {showFailedOverlay && (
-                      <div className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-1 rounded-input bg-error-bg px-3 text-center text-[10px] text-error">
-                        <span className="font-semibold uppercase tracking-micro text-error">Failed</span>
-                        {failureMessage && <span className="line-clamp-4 text-[10px] leading-tight text-error">{failureMessage}</span>}
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-          <figcaption className="mt-2 text-[11px] text-text-muted">Composite preview</figcaption>
-        </figure>
-      )}
-
-      {iterationCount <= 1 && (
-        <div
-          className={clsx(
-            'grid grid-gap-sm',
-            sortedTiles.length === 1 ? 'md:grid-cols-1' : 'md:grid-cols-2',
-            iterationCount >= 3 ? 'auto-rows-[minmax(120px,1fr)]' : undefined
-          )}
-        >
-          {tilesWithPlaceholders.map((tile, index) => {
-            if (!tile) {
-              return (
-                <div
-                  key={`placeholder-${index}`}
-                  className="flex rounded-card border border-dashed border-border bg-gradient-to-br from-surface-2 via-surface to-surface-2"
-                />
-              );
-            }
-
-            const engineCaps = engineMap.get(tile.engineId);
-            const statusLabel =
-              tile.status === 'completed' ? 'Final' : tile.status === 'failed' ? 'Failed' : 'Processing';
-            const formattedPrice = formatCurrency(tile.priceCents, tile.currency ?? currency);
-            const versionLabel = `V${tile.iterationIndex + 1}`;
-            const branchLabel = `Branch ${String.fromCharCode(65 + tile.iterationIndex)}`;
-            const isHero = heroKey === tile.localKey;
-            const tileAspectClass = getAspectClass(tile.aspectRatio);
-            const isFailed = tile.status === 'failed';
-            const failureMessage =
-              tile.message && typeof tile.message === 'string' ? tile.message.replace(/\s+/g, ' ').trim() : null;
-            const shouldPlayPreview = Boolean(isPlaying && tile.localKey === heroTile?.localKey);
-
-            return (
-              <div
-                key={tile.localKey}
-                className={clsx(
-                  'flex flex-col overflow-hidden rounded-card border',
-                  isFailed
-                    ? 'border-error-border bg-error-bg shadow-card'
-                    : isHero
-                      ? 'border-brand shadow-lg'
-                      : 'border-border bg-surface-glass-85 shadow-card'
-                )}
-              >
-                <div
-                  className={clsx(
-                    'flex items-center justify-between gap-2 border-b px-3 py-2 text-[11px] font-semibold uppercase tracking-micro',
-                    isFailed
-                      ? 'border-error-border bg-error-bg text-error'
-                      : 'border-hairline bg-surface text-text-muted'
-                  )}
-                >
-                  <span className="inline-flex items-center gap-2">
-                    <span className={clsx('rounded-full px-2 py-0.5', isHero ? 'bg-surface-2 text-brand' : 'bg-surface-on-media-dark-5 text-text-secondary')}>
-                      {versionLabel}
-                    </span>
-                    <span>{statusLabel}</span>
-                    <span className="hidden sm:inline text-text-secondary">{branchLabel}</span>
-                  </span>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    onClick={() => onSelectHero(tile)}
-                    className={clsx(
-                      'min-h-0 h-auto rounded-full px-2 py-0.5 text-[10px]',
-                      isHero ? 'border-brand bg-brand text-on-brand' : 'border-hairline bg-surface text-text-secondary hover:border-text-muted hover:bg-surface-2'
-                    )}
-                  >
-                    <Image src="/assets/icons/pin.svg" alt="" width={12} height={12} className="h-3 w-3" aria-hidden />
-                    Hero
-                  </Button>
-                </div>
-
-                <div className={clsx('relative bg-placeholder', tileAspectClass)} data-quad-tile={tile.localKey}>
-                  <div className="relative h-full w-full">
-                    {tile.status !== 'failed' && tile.videoUrl ? (
-                      <video
-                        data-quad-video={shouldPlayPreview ? 'active' : 'idle'}
-                        data-quad-tile-fallback
-                        key={tile.videoUrl}
-                        src={tile.videoUrl}
-                        className="absolute inset-0 h-full w-full object-cover pointer-events-none"
-                        muted
-                        playsInline
-                        autoPlay={shouldPlayPreview}
-                        loop
-                        preload={shouldPlayPreview ? 'auto' : 'none'}
-                        poster={tile.thumbUrl}
-                        onLoadedData={() => handlePrimaryVideoReady(tile.localKey)}
-                        onCanPlay={() => handlePrimaryVideoReady(tile.localKey)}
-                      />
-                    ) : tile.status !== 'failed' && tile.thumbUrl ? (
-                      <Image
-                        src={tile.thumbUrl}
-                        alt=""
-                        fill
-                        sizes="(max-width: 768px) 100vw, 50vw"
-                        className="absolute inset-0 object-cover pointer-events-none"
-                        priority={false}
-                      />
-                    ) : (
-                      <div className="absolute inset-0 bg-gradient-to-br from-surface-2 via-surface to-surface-2" />
-                    )}
-                    {tile.status !== 'failed' && tile.videoUrl && tile.hasAudio ? (
-                      <AudioEqualizerBadge tone="light" size="sm" label="Audio available" />
-                    ) : null}
-                  </div>
-                  <div className="absolute inset-0 z-10" data-quad-tile-root={tile.localKey} />
-                  {tile.status === 'failed' ? (
-                    <div className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-2 bg-error-bg px-4 text-center text-[12px] text-error backdrop-blur-sm">
-                      <span className="font-semibold uppercase tracking-micro text-error">Generation failed</span>
-                      <span className="text-[11px] leading-snug text-error">
-                        {failureMessage ??
-                          'The service reported a failure without details. Try again. If it fails repeatedly, contact support with your request ID.'}
-                      </span>
-                    </div>
-                  ) : tile.status !== 'completed' ? (
-                    <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-surface-on-media-dark-40 px-4 text-center text-[12px] text-on-inverse backdrop-blur-sm">
-                      <span className="uppercase tracking-micro">Processing</span>
-                      {tile.message && <span className="mt-1 text-[11px] text-on-media-80">{tile.message}</span>}
-                      <span className="mt-2 text-[11px] font-semibold text-on-media-90">{tile.progress}%</span>
-                    </div>
-                  ) : null}
-                </div>
-
-                <div className="flex flex-col gap-2 border-t border-hairline bg-surface px-3 py-2 text-[12px] text-text-secondary">
-                  {isFailed && (
-                    <div className="rounded-md border border-error-border bg-error-bg px-3 py-2 text-left">
-                      <p className="text-[10px] font-semibold uppercase tracking-micro text-error">Refund note</p>
-                      <p className="mt-1 text-[11px] leading-snug text-error">
-                        {failureMessage ??
-                          'The service reported a failure without details. Try again. If it fails repeatedly, contact support with your request ID.'}
-                      </p>
-                    </div>
-                  )}
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="inline-flex items-center gap-2 font-medium text-text-primary">
-                      <EngineIcon engine={engineCaps ?? undefined} label={tile.engineLabel} size={28} className="shrink-0" />
-                      {tile.engineLabel}
-                    </span>
-                    {formattedPrice && <span className="text-[11px] font-semibold text-text-primary">{formattedPrice}</span>}
-                  </div>
-                  <div className="flex items-center justify-between text-[11px] text-text-muted">
-                    <span>{tile.durationSec}s</span>
-                    <span>
-                      {tile.etaLabel ??
-                        (tile.status === 'completed' ? 'Ready' : tile.status === 'failed' ? 'Failed' : 'Estimating…')}
-                    </span>
-                  </div>
-                </div>
-
-                <div className="flex items-center justify-between gap-1 border-t border-hairline bg-surface px-2 py-1.5">
-                  <div className="flex gap-1">
-                    {TILE_ACTIONS.map((action) => (
-                      <Button
-                        key={action.id}
-                        type="button"
-                        size="sm"
-                        variant="outline"
-                        onClick={() => onTileAction(action.id, tile)}
-                        className="h-8 w-8 min-h-0 rounded-full border-hairline bg-surface p-0 text-text-secondary hover:border-text-muted hover:bg-surface-2"
-                        aria-label={action.label}
-                      >
-                        <Image src={action.icon} alt="" width={14} height={14} className="h-3.5 w-3.5" aria-hidden />
-                      </Button>
-                    ))}
-                  </div>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    onClick={() => onGroupAction('open', tile)}
-                    className="min-h-0 h-auto rounded-full border-hairline bg-surface px-2.5 py-1 text-[11px] font-semibold uppercase tracking-micro text-text-secondary hover:border-text-muted hover:bg-surface-2"
-                  >
-                    View
-                  </Button>
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      )}
+      {iterationCount <= 1 ? (
+        <QuadSingleTilesGrid
+          currency={currency}
+          engineMap={engineMap}
+          heroKey={heroKey}
+          heroTile={heroTile}
+          isPlaying={isPlaying}
+          iterationCount={iterationCount}
+          sortedTilesLength={sortedTiles.length}
+          tilesWithPlaceholders={tilesWithPlaceholders}
+          onGroupAction={onGroupAction}
+          onPrimaryVideoReady={handlePrimaryVideoReady}
+          onSelectHero={onSelectHero}
+          onTileAction={onTileAction}
+        />
+      ) : null}
 
       <div className="mt-3 flex flex-wrap items-center justify-between gap-2 rounded-input border border-dashed border-border bg-surface-glass-70 px-3 py-2 text-[11px] font-medium uppercase tracking-micro text-text-muted">
         <div className="flex flex-wrap items-center gap-2">

--- a/frontend/components/asset-dropzone/AssetDropzoneSlot.tsx
+++ b/frontend/components/asset-dropzone/AssetDropzoneSlot.tsx
@@ -1,0 +1,349 @@
+'use client';
+/* eslint-disable @next/next/no-img-element */
+
+import clsx from 'clsx';
+import type { ChangeEvent, ClipboardEvent, DragEvent, KeyboardEvent } from 'react';
+import { Lock, Trash2 } from 'lucide-react';
+import type { EngineInputField } from '@/types/engines';
+import { AudioEqualizerBadge } from '@/components/ui/AudioEqualizerBadge';
+import { Button } from '@/components/ui/Button';
+import type { getLocalizedAssetDropzoneCopy } from '@/lib/ltx-localization';
+import type { AssetSlotAttachment } from './asset-dropzone-types';
+
+type AssetDropzoneCopy = ReturnType<typeof getLocalizedAssetDropzoneCopy>;
+
+type AssetDropzoneSlotProps = {
+  accept: string;
+  asset: AssetSlotAttachment | null;
+  assetCopy: AssetDropzoneCopy;
+  canOpenLibrary: boolean;
+  disabled: boolean;
+  disabledReason: string | null;
+  displaySlotCount: number;
+  engineId: string;
+  field: EngineInputField;
+  filledAssetCount: number;
+  fullBleedSingleAsset: boolean;
+  helperLines: string[];
+  hideRequiredSlotCopy: boolean;
+  inputRef: (element: HTMLInputElement | null) => void;
+  isCollectionField: boolean;
+  minCount: number;
+  roleDescription: string | null;
+  slotIndex: number;
+  slotLabel: string;
+  onDisabledAttempt: () => void;
+  onDrop: (event: DragEvent<HTMLDivElement>, slotIndex: number) => void;
+  onInputChange: (event: ChangeEvent<HTMLInputElement>, slotIndex: number) => void;
+  onOpenLibrarySlot: (slotIndex: number) => void;
+  onPaste: (event: ClipboardEvent<HTMLDivElement>, slotIndex: number) => void;
+  onRemoveSlot: (slotIndex: number) => void;
+  onSelectFileSlot: (slotIndex: number) => void;
+};
+
+export function AssetDropzoneSlot({
+  accept,
+  asset,
+  assetCopy,
+  canOpenLibrary,
+  disabled,
+  disabledReason,
+  displaySlotCount,
+  engineId,
+  field,
+  filledAssetCount,
+  fullBleedSingleAsset,
+  helperLines,
+  hideRequiredSlotCopy,
+  inputRef,
+  isCollectionField,
+  minCount,
+  roleDescription,
+  slotIndex,
+  slotLabel,
+  onDisabledAttempt,
+  onDrop,
+  onInputChange,
+  onOpenLibrarySlot,
+  onPaste,
+  onRemoveSlot,
+  onSelectFileSlot,
+}: AssetDropzoneSlotProps) {
+  const slotRequired = slotIndex < minCount;
+  const showRequiredHint = slotRequired && engineId !== 'wan-2-6' && !hideRequiredSlotCopy;
+  const flattenSlotSurface = displaySlotCount === 1 && !isCollectionField;
+  const isCollectionAddTile = isCollectionField && asset == null && filledAssetCount > 0;
+  const filledSingleSlot = flattenSlotSurface && asset != null;
+  const allowClick = asset == null || asset?.kind !== 'audio';
+  const isLockedEmptySlot = disabled && !asset;
+  const slotDescription =
+    isLockedEmptySlot
+      ? null
+      : displaySlotCount === 1
+        ? field.description ?? roleDescription
+        : isCollectionField && asset == null && filledAssetCount === 0
+          ? field.description ?? roleDescription
+          : null;
+  const slotMeta =
+    isLockedEmptySlot
+      ? null
+      : (displaySlotCount === 1 || (isCollectionField && asset == null && filledAssetCount === 0)
+          ? helperLines.slice(0, 2)
+          : []
+        )
+          .filter((value) => value.trim().length > 0)
+          .join(' • ') || null;
+
+  const triggerFilePicker = () => {
+    if (disabled) {
+      onDisabledAttempt();
+      return;
+    }
+    onSelectFileSlot(slotIndex);
+  };
+
+  const triggerLibrary = () => {
+    if (disabled) {
+      onDisabledAttempt();
+      return;
+    }
+    onOpenLibrarySlot(slotIndex);
+  };
+
+  const triggerSelection = () => {
+    if (disabled && !asset) {
+      onDisabledAttempt();
+      return;
+    }
+    if (!allowClick) return;
+    if (asset) {
+      if (canOpenLibrary) {
+        triggerLibrary();
+        return;
+      }
+      triggerFilePicker();
+      return;
+    }
+    triggerFilePicker();
+  };
+
+  return (
+    <div
+      tabIndex={0}
+      className={clsx(
+        'relative flex w-full flex-col justify-center overflow-hidden text-center text-[12px] text-text-muted transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg',
+        filledSingleSlot
+          ? fullBleedSingleAsset
+            ? 'min-h-[260px] h-full rounded-none border-0 bg-transparent'
+            : 'min-h-[228px] rounded-[20px] border border-border/60 bg-surface dark:border-white/8 dark:bg-white/[0.05]'
+          : flattenSlotSurface
+            ? 'min-h-[132px] rounded-[18px] border-0 bg-transparent'
+            : 'h-40 rounded-[18px] border border-border/60 bg-surface/80 dark:border-white/[0.09] dark:bg-white/[0.045]',
+        allowClick
+          ? filledSingleSlot
+            ? 'cursor-pointer hover:border-brand/50'
+            : flattenSlotSurface
+              ? 'cursor-pointer hover:bg-surface-2/70 dark:hover:bg-white/[0.05]'
+              : 'cursor-pointer hover:border-brand/50 hover:bg-surface-2 dark:hover:border-brand/35 dark:hover:bg-white/[0.07]'
+          : 'cursor-default',
+        disabled && !asset && 'cursor-not-allowed border-border/70 bg-surface/60 hover:border-border/70 hover:bg-surface/60 dark:border-white/[0.08] dark:bg-white/[0.03] dark:hover:border-white/[0.08] dark:hover:bg-white/[0.03]'
+      )}
+      onClick={triggerSelection}
+      onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        event.preventDefault();
+        triggerSelection();
+      }}
+      title={asset ? undefined : disabledReason ?? assetCopy.upload}
+      onDragOver={(event) => {
+        event.preventDefault();
+      }}
+      onDrop={(event) => {
+        if (disabled) {
+          onDisabledAttempt();
+          return;
+        }
+        onDrop(event, slotIndex);
+      }}
+      onPaste={(event) => {
+        if (disabled) {
+          onDisabledAttempt();
+          return;
+        }
+        onPaste(event, slotIndex);
+      }}
+    >
+      <input
+        ref={inputRef}
+        type="file"
+        accept={accept}
+        className="sr-only"
+        disabled={disabled}
+        onChange={(event) => {
+          onInputChange(event, slotIndex);
+        }}
+      />
+      {asset ? (
+        <>
+          {fullBleedSingleAsset ? (
+            <div className="pointer-events-none absolute inset-x-0 top-0 z-[1] h-24 bg-gradient-to-b from-black/55 via-black/18 to-transparent" />
+          ) : null}
+          {asset.kind === 'image' ? (
+            <img src={asset.previewUrl} alt={asset.name} className="absolute inset-0 h-full w-full bg-surface object-cover" />
+          ) : asset.kind === 'audio' ? (
+            <div className="absolute inset-0 flex items-center justify-center bg-surface p-4">
+              <audio src={asset.previewUrl} controls className="w-full" />
+            </div>
+          ) : (
+            <>
+              <video src={asset.previewUrl} controls preload="metadata" className="absolute inset-0 h-full w-full bg-black object-cover" />
+              <AudioEqualizerBadge tone="light" size="sm" label={assetCopy.videoIncludesAudio} />
+            </>
+          )}
+          {asset.badge ? (
+            <div className="absolute left-3 top-3 z-10">
+              <span className="inline-flex items-center rounded-full border border-white/24 bg-black/58 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-white shadow-[0_10px_24px_rgba(0,0,0,0.18)] backdrop-blur">
+                {asset.badge}
+              </span>
+            </div>
+          ) : null}
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="absolute right-3 top-3 z-10 h-9 w-9 rounded-full border border-white/30 bg-black/62 p-0 text-white shadow-[0_10px_24px_rgba(0,0,0,0.22)] backdrop-blur transition hover:bg-black/78 focus-visible:ring-2 focus-visible:ring-white/70"
+            onClick={(event) => {
+              event.stopPropagation();
+              onRemoveSlot(slotIndex);
+            }}
+            aria-label={assetCopy.remove}
+            title={assetCopy.remove}
+          >
+            <Trash2 className="h-4 w-4" aria-hidden />
+          </Button>
+          {asset.status === 'uploading' ? (
+            <div className="absolute inset-0 flex items-center justify-center bg-surface-on-media-dark-50 px-3 text-xs font-medium uppercase tracking-widest text-on-inverse">
+              {assetCopy.uploading}
+            </div>
+          ) : null}
+          {asset.status === 'error' ? (
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-surface-on-media-dark-60 px-4 text-center text-xs text-on-inverse">
+              <span>{asset.error ?? assetCopy.uploadFailed}</span>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                className="min-h-0 h-auto rounded-full bg-surface px-3 py-1 text-[11px] font-medium text-text-primary shadow-none hover:bg-surface"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onRemoveSlot(slotIndex);
+                }}
+              >
+                {assetCopy.remove}
+              </Button>
+            </div>
+          ) : null}
+        </>
+      ) : (
+        <div
+          className={clsx(
+            'flex h-full flex-col items-center justify-center px-4 text-center',
+            isCollectionAddTile ? 'gap-3 py-4' : 'gap-4'
+          )}
+        >
+          {isCollectionAddTile ? (
+            <span className="absolute left-3 top-3 inline-flex min-w-7 items-center justify-center rounded-full border border-border/70 bg-surface px-2 py-1 text-[10px] font-semibold text-text-muted dark:border-white/10 dark:bg-white/[0.06] dark:text-white/58">
+              +
+            </span>
+          ) : null}
+          <div
+            className={clsx(
+              'flex h-8 w-8 items-center justify-center rounded-full border text-text-secondary',
+              isLockedEmptySlot
+                ? 'border-border/80 bg-surface text-text-muted dark:border-white/12 dark:bg-white/[0.04] dark:text-white/58'
+                : 'border-border/75 bg-surface-2/80 dark:border-brand/25 dark:bg-brand/15 dark:text-brand'
+            )}
+          >
+            {isLockedEmptySlot ? (
+              <Lock className="h-3.5 w-3.5" aria-hidden />
+            ) : (
+              <svg aria-hidden viewBox="0 0 20 20" className="h-3.5 w-3.5">
+                <path
+                  d="M10 4.5v11m-5.5-5.5h11"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                />
+              </svg>
+            )}
+          </div>
+          <div className={clsx('space-y-1', isCollectionAddTile && 'space-y-0')}>
+            {slotLabel ? (
+              <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-secondary dark:text-white/86">
+                {slotLabel}
+              </p>
+            ) : null}
+            {isLockedEmptySlot && disabledReason ? (
+              <p className="max-w-[16rem] text-[11px] font-medium leading-4 text-text-secondary dark:text-white/72">
+                {disabledReason}
+              </p>
+            ) : null}
+            {slotDescription ? (
+              <p className="max-w-[16rem] text-[11px] leading-4 text-text-muted dark:text-white/58">
+                {slotDescription}
+              </p>
+            ) : null}
+            {slotMeta ? (
+              <p className="max-w-[16rem] text-[10px] leading-4 text-text-muted/90 dark:text-white/46">
+                {slotMeta}
+              </p>
+            ) : null}
+            {disabledReason && slotIndex === 0 && !isLockedEmptySlot ? (
+              <p className="max-w-[16rem] text-[10px] leading-4 text-text-muted dark:text-white/54">
+                {disabledReason}
+              </p>
+            ) : null}
+            {showRequiredHint && !disabledReason ? (
+              <span className="text-[10px] text-warning dark:text-[#f6c667]">{assetCopy.neededBeforeGenerating}</span>
+            ) : null}
+          </div>
+          {!isLockedEmptySlot ? (
+            <div className="flex w-full flex-wrap items-center justify-center gap-2">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="min-h-0 h-auto rounded-full border-border px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-secondary hover:border-text-muted hover:bg-transparent hover:text-text-primary dark:border-white/14 dark:bg-white/[0.045] dark:text-white/78 dark:hover:border-brand/30 dark:hover:bg-white/[0.08] dark:hover:text-white"
+                disabled={disabled}
+                title={disabledReason ?? undefined}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  triggerFilePicker();
+                }}
+              >
+                {assetCopy.upload}
+              </Button>
+              {canOpenLibrary ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  className="min-h-0 h-auto rounded-full px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-text-secondary hover:bg-surface-2 hover:text-text-primary dark:text-white/78 dark:hover:bg-white/[0.08] dark:hover:text-white"
+                  disabled={disabled}
+                  title={disabledReason ?? undefined}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    triggerLibrary();
+                  }}
+                >
+                  {assetCopy.library}
+                </Button>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/asset-dropzone/asset-dropzone-helpers.ts
+++ b/frontend/components/asset-dropzone/asset-dropzone-helpers.ts
@@ -1,0 +1,65 @@
+import type { EngineInputField } from '@/types/engines';
+import type { getLocalizedAssetDropzoneCopy } from '@/lib/ltx-localization';
+import type { AssetFieldRole } from './asset-dropzone-types';
+
+export const VEO_REFERENCE_WARNING_ENGINES = new Set(['veo-3-1', 'veo-3-1-fast', 'veo-3-1-lite']);
+
+export function resolveSlotLabel(
+  field: EngineInputField,
+  role: AssetFieldRole,
+  slotIndex: number,
+  assetCopy: ReturnType<typeof getLocalizedAssetDropzoneCopy>
+): string {
+  const sequence = slotIndex + 1;
+  const normalizedId = String(field.id ?? '').toLowerCase();
+
+  if (field.slotLabelPattern) {
+    return field.slotLabelPattern
+      .replace(/\{n\}/g, String(sequence))
+      .replace(/\{index\}/g, String(sequence));
+  }
+
+  if (normalizedId === 'image_url' || normalizedId === 'input_image') return assetCopy.startImageSlot;
+  if (normalizedId === 'end_image_url') return assetCopy.endImageSlot;
+  if (normalizedId === 'first_frame_url') return assetCopy.firstFrameSlot;
+  if (normalizedId === 'last_frame_url') return assetCopy.lastFrameSlot;
+  if (normalizedId === 'image_urls' || normalizedId.endsWith('_image_urls') || (role === 'reference' && field.type === 'image')) {
+    return assetCopy.referenceImageSlot(sequence);
+  }
+  if (normalizedId === 'video_urls' || normalizedId.endsWith('_video_urls') || normalizedId.includes('reference_video')) {
+    return assetCopy.referenceVideoSlot(sequence);
+  }
+  if (normalizedId === 'audio_urls' || normalizedId.endsWith('_audio_urls') || normalizedId.includes('reference_audio')) {
+    return assetCopy.referenceAudioSlot(sequence);
+  }
+  if (field.type === 'video') return assetCopy.sourceVideoSlot;
+  if (field.type === 'audio') return assetCopy.sourceAudioSlot;
+  return field.label ?? assetCopy.imageSlot;
+}
+
+export function readMediaDuration(file: File, type: 'audio' | 'video') {
+  return new Promise<number | null>((resolve) => {
+    if (typeof window === 'undefined') {
+      resolve(null);
+      return;
+    }
+    const objectUrl = URL.createObjectURL(file);
+    const element = document.createElement(type);
+    const cleanup = () => {
+      URL.revokeObjectURL(objectUrl);
+      element.removeAttribute('src');
+      element.load?.();
+    };
+    element.preload = 'metadata';
+    element.onloadedmetadata = () => {
+      const duration = Number.isFinite(element.duration) ? element.duration : null;
+      cleanup();
+      resolve(duration);
+    };
+    element.onerror = () => {
+      cleanup();
+      resolve(null);
+    };
+    element.src = objectUrl;
+  });
+}

--- a/frontend/components/asset-dropzone/asset-dropzone-types.ts
+++ b/frontend/components/asset-dropzone/asset-dropzone-types.ts
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react';
+import type { EngineInputField } from '@/types/engines';
+
+export type AssetSlotAttachment = {
+  kind: 'image' | 'video' | 'audio';
+  name: string;
+  size: number;
+  type: string;
+  previewUrl: string;
+  status?: 'uploading' | 'ready' | 'error';
+  error?: string;
+  badge?: string;
+};
+
+export type AssetFieldRole = 'primary' | 'reference' | 'frame' | 'generic';
+
+export type AssetFieldConfig = {
+  field: EngineInputField;
+  required: boolean;
+  role?: AssetFieldRole;
+  headerAction?: ReactNode;
+  disabled?: boolean;
+  disabledReason?: string | null;
+};
+
+export type AssetUploadMeta = {
+  durationSec?: number;
+};

--- a/frontend/components/composer/ComposerMultiPromptEditor.tsx
+++ b/frontend/components/composer/ComposerMultiPromptEditor.tsx
@@ -1,0 +1,75 @@
+import { Button } from '@/components/ui/Button';
+import type { ComposerProps } from './composer-types';
+
+type ComposerMultiPromptEditorProps = {
+  multiPrompt: NonNullable<ComposerProps['multiPrompt']>;
+};
+
+export function ComposerMultiPromptEditor({ multiPrompt }: ComposerMultiPromptEditorProps) {
+  return (
+    <div className="space-y-3 px-4 pb-4">
+      {multiPrompt.scenes.map((scene, index) => (
+        <div
+          key={scene.id}
+          className="rounded-input border border-border bg-surface p-3 text-sm text-text-secondary dark:border-white/8 dark:bg-white/[0.04] dark:text-white/72"
+        >
+          <div className="flex items-center justify-between">
+            <span className="text-[12px] uppercase tracking-micro text-text-muted">Scene {index + 1}</span>
+            {multiPrompt.scenes.length > 1 ? (
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={() => multiPrompt.onRemoveScene(scene.id)}
+                className="min-h-0 h-auto px-2 py-1 text-[11px]"
+              >
+                Remove
+              </Button>
+            ) : null}
+          </div>
+          <textarea
+            value={scene.prompt}
+            onChange={(event) => multiPrompt.onUpdateScene(scene.id, { prompt: event.currentTarget.value })}
+            placeholder={`Scene ${index + 1} prompt`}
+            rows={3}
+            className="mt-2 w-full rounded-input border border-border bg-surface px-3 py-2 text-sm leading-5 text-text-primary placeholder:text-text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:border-white/8 dark:bg-white/[0.03] dark:text-white dark:placeholder:text-white/35"
+          />
+          <div className="mt-2 flex items-center gap-2 text-[12px] text-text-muted">
+            <span>Duration (s)</span>
+            <input
+              type="number"
+              min={multiPrompt.minDurationSec}
+              max={multiPrompt.maxDurationSec}
+              value={scene.duration}
+              onChange={(event) =>
+                multiPrompt.onUpdateScene(scene.id, {
+                  duration: Math.max(0, Math.round(Number(event.currentTarget.value))),
+                })
+              }
+              className="w-20 rounded-input border border-border bg-surface px-2 py-1 text-right text-xs text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:border-white/8 dark:bg-white/[0.03] dark:text-white"
+            />
+          </div>
+        </div>
+      ))}
+      <div className="flex flex-wrap items-center justify-between gap-2 text-[12px] text-text-muted">
+        <span>
+          Total: {multiPrompt.totalDurationSec}s · Min {multiPrompt.minDurationSec}s · Max {multiPrompt.maxDurationSec}s
+        </span>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={multiPrompt.onAddScene}
+          className="min-h-0 h-auto rounded-full px-3 py-1.5 text-[11px] uppercase tracking-micro"
+        >
+          + Scene
+        </Button>
+      </div>
+      {multiPrompt.error ? (
+        <div className="rounded-input border border-error-border bg-error-bg px-3 py-2 text-[12px] text-error">
+          {multiPrompt.error}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/components/composer/ComposerPromotedActionIcon.tsx
+++ b/frontend/components/composer/ComposerPromotedActionIcon.tsx
@@ -1,0 +1,43 @@
+import type { ComposerPromotedAction } from './composer-types';
+
+type ComposerPromotedActionIconProps = {
+  icon: ComposerPromotedAction['icon'];
+};
+
+export function ComposerPromotedActionIcon({ icon }: ComposerPromotedActionIconProps) {
+  if (icon === 'shield') {
+    return (
+      <svg aria-hidden viewBox="0 0 20 20" className="h-4 w-4">
+        <path
+          d="M10 2.5 4.5 4.8v4.6c0 3.3 2 6.2 5.1 7.5l.4.1.4-.1c3.1-1.3 5.1-4.2 5.1-7.5V4.8L10 2.5Z"
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
+        />
+        <path
+          d="m7.8 10.1 1.5 1.5 3-3.2"
+          fill="none"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
+        />
+      </svg>
+    );
+  }
+
+  return (
+    <svg aria-hidden viewBox="0 0 20 20" className="h-4 w-4">
+      <path
+        d="M10 2.8 11.6 6l3.5.5-2.6 2.5.6 3.5L10 10.9 6.9 12.5l.6-3.5-2.6-2.5 3.5-.5L10 2.8Z"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.5"
+      />
+    </svg>
+  );
+}

--- a/frontend/components/composer/composer-copy.ts
+++ b/frontend/components/composer/composer-copy.ts
@@ -1,0 +1,40 @@
+export const DEFAULT_COMPOSER_COPY = {
+  title: 'Composer',
+  subtitle: 'Enhance prompt • Non-destructive reruns',
+  badges: {
+    payg: 'Pay-as-you-go',
+    priceBefore: 'Price-before',
+    alwaysCurrent: 'Always-current',
+  },
+  priceLabel: 'This render: {amount}',
+  memberLabel: 'Member price — You save {percent}%',
+  labels: {
+    required: 'Required',
+    optional: 'Optional',
+  },
+  prompt: {
+    placeholder: 'Describe the scene…',
+    placeholderWithImage: 'Describe how the image should move / transform…',
+  },
+  negativePrompt: {
+    placeholder: 'Elements to avoid…',
+    requiredHint: 'Required',
+  },
+  assetSlots: {
+    imageCtaLabel: 'Generate reference images',
+    imageCtaHref: '/app/image',
+    referenceWarning: '',
+  },
+  shortcuts: {
+    generate: 'Cmd+Enter • Generate',
+    price: 'G • Price-before',
+    seed: 'S • Lock seed',
+  },
+  iterationsLabel: '×{count}',
+  button: {
+    idle: 'Generate',
+    loading: 'Checking price…',
+  },
+} as const;
+
+export type ComposerCopy = typeof DEFAULT_COMPOSER_COPY;

--- a/frontend/components/composer/composer-types.ts
+++ b/frontend/components/composer/composer-types.ts
@@ -1,0 +1,88 @@
+import type { Ref, ReactNode } from 'react';
+import type { EngineCaps, EngineInputField, EngineModeUiCaps as CapabilityCaps, Mode, PreflightResponse } from '@/types/engines';
+import type {
+  AssetFieldConfig,
+  AssetFieldRole,
+  AssetSlotAttachment,
+  AssetUploadMeta,
+} from '@/components/AssetDropzone';
+
+export type ComposerAttachment = AssetSlotAttachment;
+export type { AssetFieldConfig, AssetFieldRole, AssetUploadMeta };
+
+export type MultiPromptScene = {
+  id: string;
+  prompt: string;
+  duration: number;
+};
+
+export type ComposerModeToggle = {
+  mode: Mode | null;
+  label: string;
+  disabled?: boolean;
+  disabledReason?: string;
+};
+
+export type ComposerPromotedAction = {
+  id: string;
+  label: string;
+  tooltip?: string;
+  active: boolean;
+  icon: 'sparkles' | 'shield';
+  onToggle: () => void;
+  disabled?: boolean;
+};
+
+export interface ComposerProps {
+  engine: EngineCaps;
+  caps?: CapabilityCaps;
+  prompt: string;
+  onPromptChange: (value: string) => void;
+  negativePrompt?: string;
+  onNegativePromptChange?: (value: string) => void;
+  price: number | null;
+  currency: string;
+  isLoading: boolean;
+  error?: string;
+  messages?: string[];
+  textareaRef?: Ref<HTMLTextAreaElement>;
+  onGenerate?: () => void;
+  iterations?: number;
+  preflight?: PreflightResponse | null;
+  promptField?: EngineInputField;
+  promptRequired: boolean;
+  promptPlaceholder?: string;
+  promptPlaceholderWithAsset?: string;
+  negativePromptField?: EngineInputField;
+  negativePromptRequired?: boolean;
+  assetFields: AssetFieldConfig[];
+  assets: Record<string, (ComposerAttachment | null)[]>;
+  onAssetAdd?: (field: EngineInputField, file: File, slotIndex?: number, meta?: AssetUploadMeta) => void;
+  onAssetRemove?: (field: EngineInputField, index: number) => void;
+  onNotice?: (message: string) => void;
+  onOpenLibrary?: (field: EngineInputField, slotIndex: number) => void;
+  onAssetUrlSelect?: (field: EngineInputField, url: string, slotIndex: number) => void;
+  settingsBar?: ReactNode;
+  modeToggles?: ComposerModeToggle[];
+  activeManualMode?: Mode | null;
+  onModeToggle?: (mode: Mode | null) => void;
+  promotedActions?: ComposerPromotedAction[];
+  multiPrompt?: {
+    enabled: boolean;
+    scenes: MultiPromptScene[];
+    totalDurationSec: number;
+    minDurationSec: number;
+    maxDurationSec: number;
+    onToggle: (enabled: boolean) => void;
+    onAddScene: () => void;
+    onRemoveScene: (id: string) => void;
+    onUpdateScene: (id: string, patch: Partial<Pick<MultiPromptScene, 'prompt' | 'duration'>>) => void;
+    error?: string | null;
+  } | null;
+  extraFields?: ReactNode;
+  afterAssets?: ReactNode;
+  disableGenerate?: boolean;
+  workflowNotice?: string | null;
+  generateLabel?: string;
+  generateLoadingLabel?: string;
+}

--- a/frontend/components/marketing/ModelsGallery.tsx
+++ b/frontend/components/marketing/ModelsGallery.tsx
@@ -1,195 +1,28 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Link } from '@/i18n/navigation';
 import { usePathname, useSearchParams, useRouter as useNextRouter } from 'next/navigation';
-import type { LocalizedLinkHref } from '@/i18n/navigation';
-import { SelectMenu, type SelectOption } from '@/components/ui/SelectMenu';
-import { Search } from 'lucide-react';
 import { ModelCard } from '@/components/marketing/ModelsGalleryCard';
-import { formatTemplate } from '@/components/marketing/models-gallery-utils';
+import { ModelsGalleryCompareBar } from '@/components/marketing/models-gallery/ModelsGalleryCompareBar';
+import { ModelsGalleryFilters } from '@/components/marketing/models-gallery/ModelsGalleryFilters';
+import { resolveModelsGalleryCopy } from '@/components/marketing/models-gallery/models-gallery-copy';
+import {
+  filterModelGalleryCards,
+  hasActiveModelsGalleryFilters,
+  sortModelGalleryCards,
+  type ModelsGalleryFilterState,
+} from '@/components/marketing/models-gallery/models-gallery-filtering';
+import type {
+  GalleryFilterKey,
+  ModelGalleryCard,
+  ModelsGalleryCompareHref,
+  ModelsGalleryCopy,
+} from '@/components/marketing/models-gallery/models-gallery-types';
 
-export type ModelGalleryCard = {
-  id: string;
-  label: string;
-  provider?: string | null;
-  engineId?: string | null;
-  brandId?: string | null;
-  description: string;
-  versionLabel?: string;
-  overallScore?: number | null;
-  priceNote?: string | null;
-  priceNoteHref?: string | null;
-  href: LocalizedLinkHref;
-  backgroundColor?: string | null;
-  textColor?: string | null;
-  strengths?: string[];
-  capabilities?: string[];
-  stats?: {
-    priceFrom?: string | null;
-    maxDuration?: string | null;
-    maxResolution?: string | null;
-  };
-  statsLabels?: {
-    duration?: string;
-  };
-  audioAvailable?: boolean;
-  compareDisabled?: boolean;
-  filterMeta?: {
-    t2v?: boolean;
-    i2v?: boolean;
-    v2v?: boolean;
-    firstLast?: boolean;
-    extend?: boolean;
-    lipSync?: boolean;
-    audio?: boolean;
-    maxResolution?: number | null;
-    maxDuration?: number | null;
-    priceFrom?: number | null;
-    legacy?: boolean;
-  };
-};
-
-type GalleryFilterKey = 'sort' | 'mode' | 'format' | 'duration' | 'price' | 'age';
+export type { GalleryFilterKey, ModelGalleryCard, ModelsGalleryCopy } from '@/components/marketing/models-gallery/models-gallery-types';
 
 const INITIAL_COUNT = 6;
 const LOAD_COUNT = 6;
-
-export type ModelsGalleryCopy = {
-  compareLabel?: string;
-  compareTooltip?: string;
-  compareAria?: string;
-  strengthsLabel?: string;
-  stats?: {
-    from?: string;
-    maxDurShort?: string;
-    maxDurLong?: string;
-    maxResShort?: string;
-    maxResLong?: string;
-    typeShort?: string;
-    typeLong?: string;
-  };
-  audioAvailableLabel?: string;
-  filters?: {
-    sort?: { label?: string; options?: Record<string, string> };
-    mode?: { label?: string; options?: Record<string, string> };
-    format?: { label?: string; options?: Record<string, string> };
-    duration?: { label?: string; options?: Record<string, string> };
-    price?: { label?: string; options?: Record<string, string> };
-    age?: { label?: string; options?: Record<string, string> };
-    searchPlaceholder?: string;
-    clear?: string;
-  };
-  compareBar?: {
-    selectedTemplate?: string;
-    selectTwo?: string;
-    clear?: string;
-    compare?: string;
-  };
-  capabilityTooltips?: Record<string, string>;
-};
-
-const DEFAULT_COPY: Required<ModelsGalleryCopy> = {
-  compareLabel: 'Compare',
-  compareTooltip: 'Select to compare',
-  compareAria: 'Select {engine} to compare',
-  strengthsLabel: 'Strengths',
-  stats: {
-    from: 'From',
-    maxDurShort: 'Max dur.',
-    maxDurLong: 'Max duration',
-    maxResShort: 'Max res.',
-    maxResLong: 'Max resolution',
-    typeShort: 'Type',
-    typeLong: 'Type',
-  },
-  audioAvailableLabel: 'Audio available',
-  filters: {
-    sort: {
-      label: 'Sort by',
-      options: {
-        featured: 'Featured',
-        score: 'Score',
-        price: 'Price',
-        duration: 'Duration',
-        resolution: 'Resolution',
-        name: 'Name',
-      },
-    },
-    mode: {
-      label: 'Mode',
-      options: {
-        all: 'All',
-        t2v: 'T2V',
-        i2v: 'I2V',
-        v2v: 'V2V',
-        firstLast: 'First/Last',
-        extend: 'Extend',
-        lipSync: 'Lip sync',
-        audio: 'Audio',
-      },
-    },
-    format: {
-      label: 'Format',
-      options: {
-        all: 'All',
-        720: '720p+',
-        1080: '1080p+',
-        2160: '4K',
-      },
-    },
-    duration: {
-      label: 'Duration',
-      options: {
-        all: 'All',
-        8: '≤8s',
-        '10-15': '10–15s',
-        20: '20s+',
-      },
-    },
-    price: {
-      label: 'Price',
-      options: {
-        all: 'All',
-        cheap: '$',
-        mid: '$$',
-        premium: '$$$',
-      },
-    },
-    age: {
-      label: 'Models',
-      options: {
-        latest: 'Latest',
-        legacy: 'Legacy',
-        all: 'All',
-      },
-    },
-    searchPlaceholder: 'Search models...',
-    clear: 'Clear filters',
-  },
-  compareBar: {
-    selectedTemplate: 'Selected: {left} + {right}',
-    selectTwo: 'Select two engines to compare',
-    clear: 'Clear',
-    compare: 'Compare',
-  },
-  capabilityTooltips: {
-    T2V: 'Text-to-video',
-    I2V: 'Image-to-video',
-    V2V: 'Video-to-video',
-    'First/Last': 'First frame / last frame',
-    Extend: 'Extend / continue',
-  },
-};
-
-function FilterControl({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div className="flex items-center gap-3">
-      <span className="whitespace-nowrap text-xs font-semibold text-text-secondary">{label}</span>
-      {children}
-    </div>
-  );
-}
 
 export function ModelsGallery({
   cards,
@@ -204,139 +37,8 @@ export function ModelsGallery({
   visibleFilters?: GalleryFilterKey[];
   allowCompare?: boolean;
 }) {
-  const filtersCopy = copy?.filters ?? {};
-  const sortBase = DEFAULT_COPY.filters.sort ?? { options: {} };
-  const modeBase = DEFAULT_COPY.filters.mode ?? { options: {} };
-  const formatBase = DEFAULT_COPY.filters.format ?? { options: {} };
-  const durationBase = DEFAULT_COPY.filters.duration ?? { options: {} };
-  const priceBase = DEFAULT_COPY.filters.price ?? { options: {} };
-  const ageBase = DEFAULT_COPY.filters.age ?? { options: {} };
-  const sortCopy = {
-    ...sortBase,
-    ...filtersCopy.sort,
-    options: { ...(sortBase.options ?? {}), ...(filtersCopy.sort?.options ?? {}) },
-  };
-  const modeCopy = {
-    ...modeBase,
-    ...filtersCopy.mode,
-    options: { ...(modeBase.options ?? {}), ...(filtersCopy.mode?.options ?? {}) },
-  };
-  const formatCopy = {
-    ...formatBase,
-    ...filtersCopy.format,
-    options: { ...(formatBase.options ?? {}), ...(filtersCopy.format?.options ?? {}) },
-  };
-  const durationCopy = {
-    ...durationBase,
-    ...filtersCopy.duration,
-    options: { ...(durationBase.options ?? {}), ...(filtersCopy.duration?.options ?? {}) },
-  };
-  const priceCopy = {
-    ...priceBase,
-    ...filtersCopy.price,
-    options: { ...(priceBase.options ?? {}), ...(filtersCopy.price?.options ?? {}) },
-  };
-  const ageCopy = {
-    ...ageBase,
-    ...filtersCopy.age,
-    options: { ...(ageBase.options ?? {}), ...(filtersCopy.age?.options ?? {}) },
-  };
-  const compareLabel = copy?.compareLabel ?? DEFAULT_COPY.compareLabel;
-  const compareTooltip = copy?.compareTooltip ?? DEFAULT_COPY.compareTooltip;
-  const compareAria = copy?.compareAria ?? DEFAULT_COPY.compareAria;
-  const strengthsLabel = copy?.strengthsLabel ?? DEFAULT_COPY.strengthsLabel;
-  const statsDefaults: Required<NonNullable<ModelsGalleryCopy['stats']>> = {
-    from: 'From',
-    maxDurShort: 'Max dur.',
-    maxDurLong: 'Max duration',
-    maxResShort: 'Max res.',
-    maxResLong: 'Max resolution',
-    typeShort: 'Type',
-    typeLong: 'Type',
-  };
-  const statsOverride = copy?.stats ?? {};
-  const statsLabels: Required<NonNullable<ModelsGalleryCopy['stats']>> = {
-    from: statsOverride.from ?? statsDefaults.from,
-    maxDurShort: statsOverride.maxDurShort ?? statsDefaults.maxDurShort,
-    maxDurLong: statsOverride.maxDurLong ?? statsDefaults.maxDurLong,
-    maxResShort: statsOverride.maxResShort ?? statsDefaults.maxResShort,
-    maxResLong: statsOverride.maxResLong ?? statsDefaults.maxResLong,
-    typeShort: statsOverride.typeShort ?? statsDefaults.typeShort,
-    typeLong: statsOverride.typeLong ?? statsDefaults.typeLong,
-  };
-  const audioAvailableLabel = copy?.audioAvailableLabel ?? DEFAULT_COPY.audioAvailableLabel;
-  const compareBarDefaults: Required<NonNullable<ModelsGalleryCopy['compareBar']>> = {
-    selectedTemplate: 'Selected: {left} + {right}',
-    selectTwo: 'Select two engines to compare',
-    clear: 'Clear',
-    compare: 'Compare',
-  };
-  const compareBarOverride = copy?.compareBar ?? {};
-  const compareBar: Required<NonNullable<ModelsGalleryCopy['compareBar']>> = {
-    selectedTemplate: compareBarOverride.selectedTemplate ?? compareBarDefaults.selectedTemplate,
-    selectTwo: compareBarOverride.selectTwo ?? compareBarDefaults.selectTwo,
-    clear: compareBarOverride.clear ?? compareBarDefaults.clear,
-    compare: compareBarOverride.compare ?? compareBarDefaults.compare,
-  };
-  const capabilityTooltips = { ...DEFAULT_COPY.capabilityTooltips, ...(copy?.capabilityTooltips ?? {}) };
-  const filterClearLabel = filtersCopy.clear ?? DEFAULT_COPY.filters.clear;
-  const searchPlaceholder = filtersCopy.searchPlaceholder ?? DEFAULT_COPY.filters.searchPlaceholder;
-  const filterSelectButtonClassName =
-    'h-11 min-w-[136px] rounded-[8px] border-hairline bg-bg px-4 text-xs font-semibold text-text-primary shadow-sm hover:border-[var(--brand-border)] hover:bg-surface-2';
-  const sortLabel = sortCopy.label ?? 'Sort by';
-  const modeLabel = modeCopy.label ?? 'Mode';
-  const formatLabel = formatCopy.label ?? 'Format';
-  const durationLabel = durationCopy.label ?? 'Duration';
-  const priceLabel = priceCopy.label ?? 'Price';
-  const ageLabel = ageCopy.label ?? 'Models';
+  const resolvedCopy = useMemo(() => resolveModelsGalleryCopy(copy), [copy]);
   const visibleFilterSet = useMemo(() => new Set<GalleryFilterKey>(visibleFilters), [visibleFilters]);
-
-  const MODE_OPTIONS: SelectOption[] = [
-    { value: 'all', label: modeCopy.options.all },
-    { value: 't2v', label: modeCopy.options.t2v },
-    { value: 'i2v', label: modeCopy.options.i2v },
-    { value: 'v2v', label: modeCopy.options.v2v },
-    { value: 'firstLast', label: modeCopy.options.firstLast },
-    { value: 'extend', label: modeCopy.options.extend },
-    { value: 'lipSync', label: modeCopy.options.lipSync },
-    { value: 'audio', label: modeCopy.options.audio },
-  ];
-
-  const FORMAT_OPTIONS: SelectOption[] = [
-    { value: 'all', label: formatCopy.options.all },
-    { value: '720', label: formatCopy.options[720] },
-    { value: '1080', label: formatCopy.options[1080] },
-    { value: '2160', label: formatCopy.options[2160] },
-  ];
-
-  const DURATION_OPTIONS: SelectOption[] = [
-    { value: 'all', label: durationCopy.options.all },
-    { value: '8', label: durationCopy.options[8] },
-    { value: '10-15', label: durationCopy.options['10-15'] },
-    { value: '20', label: durationCopy.options[20] },
-  ];
-
-  const PRICE_OPTIONS: SelectOption[] = [
-    { value: 'all', label: priceCopy.options.all },
-    { value: 'cheap', label: priceCopy.options.cheap },
-    { value: 'mid', label: priceCopy.options.mid },
-    { value: 'premium', label: priceCopy.options.premium },
-  ];
-
-  const AGE_OPTIONS: SelectOption[] = [
-    { value: 'latest', label: ageCopy.options.latest },
-    { value: 'legacy', label: ageCopy.options.legacy },
-    { value: 'all', label: ageCopy.options.all },
-  ];
-
-  const SORT_OPTIONS: SelectOption[] = [
-    { value: 'featured', label: sortCopy.options.featured },
-    { value: 'score', label: sortCopy.options.score },
-    { value: 'price', label: sortCopy.options.price },
-    { value: 'duration', label: sortCopy.options.duration },
-    { value: 'resolution', label: sortCopy.options.resolution },
-    { value: 'name', label: sortCopy.options.name },
-  ];
   const [visibleCount, setVisibleCount] = useState(INITIAL_COUNT);
   const observerRef = useRef<HTMLDivElement | null>(null);
   const searchParams = useSearchParams();
@@ -351,6 +53,17 @@ export function ModelsGallery({
   const [selectedSort, setSelectedSort] = useState('featured');
   const [selectedAge, setSelectedAge] = useState('latest');
   const [searchQuery, setSearchQuery] = useState('');
+  const filterState: ModelsGalleryFilterState = useMemo(
+    () => ({
+      searchQuery,
+      selectedAge,
+      selectedDuration,
+      selectedFormat,
+      selectedMode,
+      selectedPrice,
+    }),
+    [searchQuery, selectedAge, selectedDuration, selectedFormat, selectedMode, selectedPrice]
+  );
 
   const appendCards = useCallback(
     (maxCount: number) => {
@@ -393,7 +106,9 @@ export function ModelsGallery({
   }, [allowCompare, compareMode]);
 
   const cardById = useMemo(() => new Map(cards.map((card) => [card.id, card])), [cards]);
-  const selectedCards = selectedIds.map((id) => cardById.get(id)).filter(Boolean);
+  const selectedCards = selectedIds
+    .map((id) => cardById.get(id))
+    .filter((card): card is ModelGalleryCard => Boolean(card));
 
   const enableCompareMode = useCallback(() => {
     if (!allowCompare) return;
@@ -436,98 +151,14 @@ export function ModelsGallery({
     setSearchQuery('');
   };
 
-  const hasActiveFilters =
-    selectedMode !== 'all' ||
-    selectedFormat !== 'all' ||
-    selectedDuration !== 'all' ||
-    selectedPrice !== 'all' ||
-    selectedAge !== 'latest' ||
-    searchQuery.trim().length > 0;
+  const hasActiveFilters = hasActiveModelsGalleryFilters(filterState);
 
-  const filteredCards = useMemo(() => {
-    const normalizedQuery = searchQuery.trim().toLowerCase();
-    return cards.filter((card) => {
-      const meta = card.filterMeta;
-      if (!meta) return !hasActiveFilters;
-      if (normalizedQuery) {
-        const haystack = [
-          card.label,
-          card.provider,
-          card.description,
-          ...(card.strengths ?? []),
-          ...(card.capabilities ?? []),
-          card.stats?.priceFrom,
-          card.stats?.maxDuration,
-          card.stats?.maxResolution,
-        ]
-          .filter(Boolean)
-          .join(' ')
-          .toLowerCase();
-        if (!haystack.includes(normalizedQuery)) return false;
-      }
-      if (selectedMode !== 'all') {
-        if (selectedMode === 'audio') {
-          if (!meta.audio) return false;
-        } else if (!meta[selectedMode as keyof typeof meta]) {
-          return false;
-        }
-      }
-      if (selectedFormat !== 'all') {
-        if (!meta.maxResolution) return false;
-        const threshold = Number(selectedFormat);
-        if (meta.maxResolution == null || meta.maxResolution < threshold) return false;
-      }
-      if (selectedDuration !== 'all') {
-        if (!meta.maxDuration) return false;
-        if (selectedDuration === '8' && meta.maxDuration > 8) return false;
-        if (selectedDuration === '10-15' && (meta.maxDuration < 10 || meta.maxDuration > 15)) return false;
-        if (selectedDuration === '20' && meta.maxDuration < 20) return false;
-      }
-      if (selectedPrice !== 'all') {
-        if (meta.priceFrom == null) return false;
-        if (selectedPrice === 'cheap' && meta.priceFrom > 0.08) return false;
-        if (selectedPrice === 'mid' && !(meta.priceFrom > 0.08 && meta.priceFrom <= 0.2)) return false;
-        if (selectedPrice === 'premium' && meta.priceFrom <= 0.2) return false;
-      }
-      if (selectedAge !== 'all') {
-        const isLegacy = Boolean(meta.legacy);
-        if (selectedAge === 'latest' && isLegacy) return false;
-        if (selectedAge === 'legacy' && !isLegacy) return false;
-      }
-      return true;
-    });
-  }, [cards, hasActiveFilters, searchQuery, selectedMode, selectedFormat, selectedDuration, selectedPrice, selectedAge]);
+  const filteredCards = useMemo(
+    () => filterModelGalleryCards(cards, filterState, hasActiveFilters),
+    [cards, filterState, hasActiveFilters]
+  );
 
-  const sortedCards = useMemo(() => {
-    const sortable = [...filteredCards];
-    const compareNumbers = (a?: number | null, b?: number | null, direction: 'asc' | 'desc' = 'desc') => {
-      const aVal =
-        typeof a === 'number' ? a : direction === 'asc' ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
-      const bVal =
-        typeof b === 'number' ? b : direction === 'asc' ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
-      return direction === 'asc' ? aVal - bVal : bVal - aVal;
-    };
-    switch (selectedSort) {
-      case 'score':
-        sortable.sort((a, b) => compareNumbers(a.overallScore ?? null, b.overallScore ?? null, 'desc'));
-        break;
-      case 'price':
-        sortable.sort((a, b) => compareNumbers(a.filterMeta?.priceFrom ?? null, b.filterMeta?.priceFrom ?? null, 'asc'));
-        break;
-      case 'duration':
-        sortable.sort((a, b) => compareNumbers(a.filterMeta?.maxDuration ?? null, b.filterMeta?.maxDuration ?? null, 'desc'));
-        break;
-      case 'resolution':
-        sortable.sort((a, b) => compareNumbers(a.filterMeta?.maxResolution ?? null, b.filterMeta?.maxResolution ?? null, 'desc'));
-        break;
-      case 'name':
-        sortable.sort((a, b) => a.label.localeCompare(b.label));
-        break;
-      default:
-        break;
-    }
-    return sortable;
-  }, [filteredCards, selectedSort]);
+  const sortedCards = useMemo(() => sortModelGalleryCards(filteredCards, selectedSort), [filteredCards, selectedSort]);
 
   useEffect(() => {
     if (visibleCount >= sortedCards.length) return undefined;
@@ -568,7 +199,7 @@ export function ModelsGallery({
     disableCompareMode();
   };
 
-  const compareHref = useMemo(() => {
+  const compareHref = useMemo<ModelsGalleryCompareHref | null>(() => {
     if (selectedIds.length !== 2) return null;
     const [leftId, rightId] = selectedIds;
     const sorted = [leftId, rightId].sort();
@@ -579,92 +210,26 @@ export function ModelsGallery({
 
   return (
     <>
-      <div
-        className="mt-0 flex flex-col gap-4 rounded-[8px] border border-hairline bg-surface-glass-95 px-5 py-5 shadow-[0_18px_44px_rgba(15,23,42,0.07),0_4px_14px_rgba(15,23,42,0.035)] backdrop-blur md:flex-row md:items-center md:justify-between dark:bg-surface-glass-80 sm:px-8"
-        id="models-compare-toggle"
-      >
-        <div className="flex flex-wrap items-center gap-x-5 gap-y-3">
-          {visibleFilterSet.has('sort') ? (
-            <FilterControl label={sortLabel}>
-              <SelectMenu
-                options={SORT_OPTIONS}
-                value={selectedSort}
-                onChange={(value) => setSelectedSort(String(value))}
-                buttonClassName={filterSelectButtonClassName}
-              />
-            </FilterControl>
-          ) : null}
-          {visibleFilterSet.has('mode') ? (
-            <FilterControl label={modeLabel}>
-              <SelectMenu
-                options={MODE_OPTIONS}
-                value={selectedMode}
-                onChange={(value) => setSelectedMode(String(value))}
-                buttonClassName={filterSelectButtonClassName}
-              />
-            </FilterControl>
-          ) : null}
-          {visibleFilterSet.has('format') ? (
-            <FilterControl label={formatLabel}>
-              <SelectMenu
-                options={FORMAT_OPTIONS}
-                value={selectedFormat}
-                onChange={(value) => setSelectedFormat(String(value))}
-                buttonClassName={filterSelectButtonClassName}
-              />
-            </FilterControl>
-          ) : null}
-          {visibleFilterSet.has('duration') ? (
-            <FilterControl label={durationLabel}>
-              <SelectMenu
-                options={DURATION_OPTIONS}
-                value={selectedDuration}
-                onChange={(value) => setSelectedDuration(String(value))}
-                buttonClassName={filterSelectButtonClassName}
-              />
-            </FilterControl>
-          ) : null}
-          {visibleFilterSet.has('price') ? (
-            <FilterControl label={priceLabel}>
-              <SelectMenu
-                options={PRICE_OPTIONS}
-                value={selectedPrice}
-                onChange={(value) => setSelectedPrice(String(value))}
-                buttonClassName={filterSelectButtonClassName}
-              />
-            </FilterControl>
-          ) : null}
-          {visibleFilterSet.has('age') ? (
-            <FilterControl label={ageLabel}>
-              <SelectMenu
-                options={AGE_OPTIONS}
-                value={selectedAge}
-                onChange={(value) => setSelectedAge(String(value))}
-                buttonClassName={filterSelectButtonClassName}
-              />
-            </FilterControl>
-          ) : null}
-          {hasActiveFilters ? (
-            <button
-              type="button"
-              onClick={clearFilters}
-              className="h-11 rounded-[8px] border border-hairline bg-bg px-3 text-xs font-semibold text-text-secondary transition hover:border-text-muted hover:text-text-primary"
-            >
-              {filterClearLabel}
-            </button>
-          ) : null}
-        </div>
-        <label className="relative min-w-0 md:w-[300px] lg:w-[340px]">
-          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted" aria-hidden="true" />
-          <span className="sr-only">{searchPlaceholder}</span>
-          <input
-            value={searchQuery}
-            onChange={(event) => setSearchQuery(event.target.value)}
-            placeholder={searchPlaceholder}
-            className="h-11 w-full rounded-[8px] border border-hairline bg-bg pl-9 pr-3 text-sm font-medium text-text-primary shadow-sm outline-none transition placeholder:text-text-muted/75 hover:border-[var(--brand-border)] focus:border-[var(--brand-border)] focus:ring-2 focus:ring-[color:var(--brand-border)]"
-          />
-        </label>
-      </div>
+      <ModelsGalleryFilters
+        copy={resolvedCopy}
+        hasActiveFilters={hasActiveFilters}
+        searchQuery={searchQuery}
+        selectedAge={selectedAge}
+        selectedDuration={selectedDuration}
+        selectedFormat={selectedFormat}
+        selectedMode={selectedMode}
+        selectedPrice={selectedPrice}
+        selectedSort={selectedSort}
+        visibleFilterSet={visibleFilterSet}
+        onAgeChange={setSelectedAge}
+        onClearFilters={clearFilters}
+        onDurationChange={setSelectedDuration}
+        onFormatChange={setSelectedFormat}
+        onModeChange={setSelectedMode}
+        onPriceChange={setSelectedPrice}
+        onSearchChange={setSearchQuery}
+        onSortChange={setSelectedSort}
+      />
 
       <div className="mt-6 grid grid-cols-2 gap-3 sm:gap-5 lg:grid-cols-3">
         {sortedCards.slice(0, visibleCount).map((card) => (
@@ -673,13 +238,13 @@ export function ModelsGallery({
             card={card}
             ctaLabel={ctaLabel}
             compareMode={compareMode}
-            compareLabel={compareLabel}
-            compareTooltip={compareTooltip}
-            compareAria={compareAria}
-            strengthsLabel={strengthsLabel}
-            statsLabels={statsLabels}
-            capabilityTooltips={capabilityTooltips}
-            audioAvailableLabel={audioAvailableLabel}
+            compareLabel={resolvedCopy.compareLabel}
+            compareTooltip={resolvedCopy.compareTooltip}
+            compareAria={resolvedCopy.compareAria}
+            strengthsLabel={resolvedCopy.strengthsLabel}
+            statsLabels={resolvedCopy.statsLabels}
+            capabilityTooltips={resolvedCopy.capabilityTooltips}
+            audioAvailableLabel={resolvedCopy.audioAvailableLabel}
             compareEnabled={allowCompare}
             selected={selectedIds.includes(card.id)}
             onToggle={() => handleToggleCard(card.id)}
@@ -689,7 +254,7 @@ export function ModelsGallery({
       </div>
       {!sortedCards.length ? (
         <div className="mt-8 rounded-[18px] border border-dashed border-hairline bg-surface/80 px-5 py-8 text-center text-sm font-medium text-text-secondary">
-          {filterClearLabel}
+          {resolvedCopy.filterClearLabel}
         </div>
       ) : null}
       {visibleCount < sortedCards.length ? (
@@ -697,41 +262,12 @@ export function ModelsGallery({
       ) : null}
 
       {allowCompare && compareMode ? (
-        <div className="fixed inset-x-4 bottom-6 z-40 mx-auto max-w-4xl rounded-2xl border border-white/60 bg-[linear-gradient(180deg,rgba(255,255,255,0.92),rgba(255,255,255,0.78))] px-4 py-3 shadow-[0_18px_40px_rgba(15,23,42,0.22),0_6px_16px_rgba(15,23,42,0.16)] backdrop-blur dark:border-white/10 dark:bg-[linear-gradient(180deg,rgba(15,23,42,0.92),rgba(2,6,23,0.9))]">
-          <span className="pointer-events-none absolute inset-x-0 top-0 h-6 bg-[linear-gradient(180deg,rgba(255,255,255,0.7),transparent)] dark:bg-[linear-gradient(180deg,rgba(255,255,255,0.08),transparent)]" />
-          <div className="relative flex flex-wrap items-center justify-between gap-3 text-sm">
-            <div className="font-semibold text-text-primary">
-              {selectedCards.length === 2
-                ? formatTemplate(compareBar.selectedTemplate, {
-                    left: selectedCards[0]?.label ?? '',
-                    right: selectedCards[1]?.label ?? '',
-                  })
-                : compareBar.selectTwo}
-            </div>
-            <div className="flex flex-wrap items-center gap-2">
-              <button
-                type="button"
-                onClick={handleClear}
-                className="rounded-full border border-hairline px-3 py-1 text-xs font-semibold text-text-secondary transition hover:border-text-muted hover:text-text-primary"
-              >
-                {compareBar.clear}
-              </button>
-              {compareHref ? (
-                <Link
-                  href={compareHref}
-                  prefetch={false}
-                  className="rounded-full bg-text-primary px-4 py-1 text-xs font-semibold text-bg transition hover:opacity-90"
-                >
-                  {compareBar.compare}
-                </Link>
-              ) : (
-                <span className="rounded-full border border-hairline px-4 py-1 text-xs font-semibold text-text-muted">
-                  {compareBar.compare}
-                </span>
-              )}
-            </div>
-          </div>
-        </div>
+        <ModelsGalleryCompareBar
+          compareBar={resolvedCopy.compareBar}
+          compareHref={compareHref}
+          selectedCards={selectedCards}
+          onClear={handleClear}
+        />
       ) : null}
     </>
   );

--- a/frontend/components/marketing/PriceEstimator.tsx
+++ b/frontend/components/marketing/PriceEstimator.tsx
@@ -9,9 +9,11 @@ import { getPricingKernel } from '@/lib/pricing-kernel';
 import { getEngineSelectFamilyRank } from '@/lib/engine-family-priority';
 import { selectPricingRule, type PricingRuleLite } from '@/lib/pricing-rules';
 import { applyEnginePricingOverride, buildPricingDefinition } from '@/lib/pricing-definition';
-import { Button } from '@/components/ui/Button';
 import { EngineSelect } from '@/components/ui/EngineSelect';
-import { SelectMenu, type SelectOption } from '@/components/ui/SelectMenu';
+import type { SelectOption } from '@/components/ui/SelectMenu';
+import { PriceEstimatorSelectGroup } from '@/components/marketing/price-estimator/PriceEstimatorSelectGroup';
+import { PriceEstimatorSummaryPanel } from '@/components/marketing/price-estimator/PriceEstimatorSummaryPanel';
+import { buildPriceEstimatorSummaryLabels } from '@/components/marketing/price-estimator/price-estimator-summary-labels';
 import {
   buildAudioAddonPayload,
   buildEngineOption,
@@ -32,28 +34,6 @@ export interface PriceEstimatorProps {
   enginePricingOverrides?: Record<string, EnginePricingDetails | null | undefined>;
   defaultEngineId?: string;
   defaultDurationSec?: number;
-}
-
-function SelectGroup({
-  label,
-  options,
-  value,
-  onChange,
-  className,
-}: {
-  label: string;
-  options: SelectOption[];
-  value: SelectOption['value'];
-  onChange: (value: SelectOption['value']) => void;
-  className?: string;
-}) {
-  if (!options.length) return null;
-  return (
-    <div className={clsx('flex min-w-0 flex-col gap-1', className)}>
-      <span className="text-[10px] uppercase tracking-micro text-text-muted">{label}</span>
-      <SelectMenu options={options} value={value} onChange={onChange} />
-    </div>
-  );
 }
 
 export function PriceEstimator({
@@ -328,23 +308,14 @@ export function PriceEstimator({
   const currency = bypassPricing ? 'USD' : pricingSnapshot?.currency ?? selectedEngine?.currency ?? 'USD';
   const tiers = dictionary.pricing.member.tiers;
   const tooltip = dictionary.pricing.member.tooltip;
-  const memberNames = useMemo(() => {
-    const map = new Map<MemberTier, string>();
-    MEMBER_ORDER.forEach((tier, index) => {
-      const translation = tiers[index]?.name ?? tier;
-      map.set(tier, translation as string);
-    });
-    return map;
-  }, [tiers]);
-
-  const memberBenefits = useMemo(() => {
-    const map = new Map<MemberTier, string>();
-    MEMBER_ORDER.forEach((tier, index) => {
-      const benefit = dictionary.pricing.member.tiers[index]?.benefit ?? '';
-      map.set(tier, benefit);
-    });
-    return map;
-  }, [dictionary.pricing.member.tiers]);
+  const memberNames = useMemo(
+    () => new Map<MemberTier, string>(MEMBER_ORDER.map((tier, index) => [tier, (tiers[index]?.name ?? tier) as string])),
+    [tiers]
+  );
+  const memberBenefits = useMemo(
+    () => new Map<MemberTier, string>(MEMBER_ORDER.map((tier, index) => [tier, dictionary.pricing.member.tiers[index]?.benefit ?? ''])),
+    [dictionary.pricing.member.tiers]
+  );
 
   const chargedNote =
     dictionary.pricing.estimator.chargedNote ?? t('pricing.estimator.chargedNote', 'Charged only if render succeeds.') ??
@@ -357,6 +328,13 @@ export function PriceEstimator({
   const durationDisplay = activeDurationOption?.label ?? `${duration}s`;
   const discountPercent = Math.round(pricing.discountRate * 100);
   const memberBenefitCopy = memberBenefits.get(memberTier);
+  const summaryLabels = buildPriceEstimatorSummaryLabels({
+    chargedNote,
+    fields,
+    memberTooltipLabel,
+    priceChipSuffix,
+    t,
+  });
 
   return (
     <div className="flex flex-col gap-3">
@@ -425,7 +403,7 @@ export function PriceEstimator({
               <div className="grid gap-3 sm:grid-cols-2">
                 {selectedEngine?.showResolution !== false ? (
                   <div className="price-estimator-border price-estimator-surface relative rounded-[16px] border border-hairline bg-bg p-2 focus-within:z-20">
-                    <SelectGroup
+                    <PriceEstimatorSelectGroup
                       label={fields.resolution}
                       options={resolutionSelectOptions}
                       value={selectedResolution}
@@ -456,7 +434,7 @@ export function PriceEstimator({
 
                 {selectedEngine?.showDuration !== false ? (
                   <div className="price-estimator-border price-estimator-surface relative rounded-[16px] border border-hairline bg-bg p-2 focus-within:z-20">
-                    <SelectGroup
+                    <PriceEstimatorSelectGroup
                       label={fields.duration}
                       options={durationSelectOptions}
                       value={duration}
@@ -474,7 +452,7 @@ export function PriceEstimator({
 
                 {selectedEngine?.audioToggle ? (
                   <div className="price-estimator-border price-estimator-surface relative rounded-[16px] border border-hairline bg-bg p-2 focus-within:z-20">
-                    <SelectGroup
+                    <PriceEstimatorSelectGroup
                       label={t('pricing.estimator.audioLabel', 'Audio') ?? 'Audio'}
                       options={[
                         { value: true, label: t('pricing.estimator.audioOn', 'On') ?? 'On' },
@@ -493,112 +471,23 @@ export function PriceEstimator({
 
           </div>
 
-          <aside className="border-t border-hairline bg-surface-2/70 p-5 text-sm text-text-secondary sm:p-6 lg:border-l lg:border-t-0">
-            <div className="stack-gap">
-              <div className="stack-gap-sm">
-                <span className="inline-flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.24em] text-text-muted">
-                  <span className="flex h-5 w-5 items-center justify-center rounded-full border border-hairline bg-surface text-[10px] tracking-normal text-text-muted">
-                    2
-                  </span>
-                  {estimateLabels.heading}
-                </span>
-                <p className="text-5xl font-semibold tracking-tight text-text-primary sm:text-6xl">
-                  {formatCurrency(pricing.total, currency)}
-                </p>
-                <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-text-muted">
-                  {priceChipSuffix ?? t('pricing.priceChipSuffix', 'Price before you generate.')}
-                </p>
-              </div>
-
-              <dl className="grid gap-3 border-b border-hairline pb-4 text-sm">
-                <div className="flex items-center justify-between gap-4">
-                  <dt className="text-text-secondary">{t('pricing.estimator.engineLabel', 'Engine')}</dt>
-                  <dd className="text-right font-semibold text-text-primary">{selectedEngine?.label ?? '—'}</dd>
-                </div>
-                {selectedEngine?.showDuration !== false ? (
-                  <div className="flex items-center justify-between gap-4">
-                    <dt className="text-text-secondary">{t('pricing.estimator.durationLabel', 'Duration')}</dt>
-                    <dd className="text-right font-semibold text-text-primary">{durationDisplay}</dd>
-                  </div>
-                ) : null}
-                {selectedEngine?.showResolution !== false ? (
-                  <div className="flex items-center justify-between gap-4">
-                    <dt className="text-text-secondary">{t('pricing.estimator.resolutionLabel', 'Resolution')}</dt>
-                    <dd className="text-right font-semibold text-text-primary">
-                      {activeResolution?.label ?? selectedResolution?.toUpperCase()}
-                    </dd>
-                  </div>
-                ) : null}
-                <div className="flex items-center justify-between gap-4">
-                  <dt className="text-text-secondary">{t('pricing.estimator.audioLabel', 'Audio') ?? 'Audio'}</dt>
-                  <dd className="text-right font-semibold text-text-primary">
-                    {selectedEngine?.audioIncluded || audioEnabled
-                      ? t('pricing.estimator.audioOn', 'On')
-                      : t('pricing.estimator.audioOff', 'Off')}
-                  </dd>
-                </div>
-                <div className="flex items-center justify-between gap-4">
-                  <dt className="text-text-secondary">{t('pricing.estimator.engineRateLabel', 'Engine rate')}</dt>
-                  <dd className="text-right font-semibold text-text-primary">
-                    {formatCurrency(rate, currency)}
-                    {selectedEngine?.rateUnit ?? '/s'}
-                  </dd>
-                </div>
-              </dl>
-
-              <div className="stack-gap-sm">
-                <div className="flex items-center justify-between gap-3">
-                  <span className="text-[10px] font-semibold uppercase tracking-[0.22em] text-text-muted">
-                    {estimateLabels.memberChipPrefix}
-                  </span>
-                  <span className="rounded-full bg-state-success/15 px-3 py-1 text-xs font-semibold text-state-success">
-                    {memberTier === 'Member' ? memberNames.get('Member') ?? 'Member' : `${discountPercent}%`}
-                  </span>
-                </div>
-                {memberBenefitCopy ? <p className="text-xs text-text-muted">{memberBenefitCopy}</p> : null}
-                <div>
-                  <span className="text-[10px] font-semibold uppercase tracking-[0.22em] text-text-muted">
-                    {fields.memberStatus}
-                  </span>
-                  <div className="mt-2 grid grid-cols-3 gap-2 rounded-full border border-hairline bg-surface p-1">
-                    {MEMBER_ORDER.map((tier) => {
-                      const selected = tier === memberTier;
-                      return (
-                        <Button
-                          key={tier}
-                          type="button"
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => setMemberTier(tier)}
-                          className={clsx(
-                            'member-status-pill min-h-0 h-8 rounded-full px-2 text-xs font-semibold',
-                            selected
-                              ? 'bg-text-primary !text-bg shadow-card hover:bg-text-primary hover:!text-bg'
-                              : 'bg-transparent !text-text-secondary hover:bg-surface-2 hover:!text-text-primary'
-                          )}
-                          aria-pressed={selected}
-                        >
-                          {memberNames.get(tier) ?? tier}
-                        </Button>
-                      );
-                    })}
-                  </div>
-                  <p className="mt-2 text-[11px] text-text-muted" aria-label={memberTooltipLabel} title={memberTooltipLabel}>
-                    {memberTooltipLabel}
-                  </p>
-                </div>
-              </div>
-
-              <div className="stack-gap-xs text-xs text-text-muted">
-                {selectedEngine?.audioIncluded ? (
-                  <p className="font-semibold text-text-secondary">
-                    {t('pricing.estimator.audioIncluded', 'Audio included by default')}
-                  </p>
-                ) : null}
-                <p>{chargedNote}</p>
-              </div>
-            </div>
-          </aside>
+          <PriceEstimatorSummaryPanel
+            activeResolutionLabel={activeResolution?.label}
+            audioEnabled={audioEnabled}
+            currency={currency}
+            discountPercent={discountPercent}
+            durationDisplay={durationDisplay}
+            estimateLabels={estimateLabels}
+            labels={summaryLabels}
+            memberBenefitCopy={memberBenefitCopy}
+            memberNames={memberNames}
+            memberTier={memberTier}
+            priceTotal={pricing.total}
+            rate={rate}
+            selectedEngine={selectedEngine}
+            selectedResolution={selectedResolution}
+            onMemberTierChange={setMemberTier}
+          />
         </div>
       </div>
 

--- a/frontend/components/marketing/models-gallery/ModelsGalleryCompareBar.tsx
+++ b/frontend/components/marketing/models-gallery/ModelsGalleryCompareBar.tsx
@@ -1,0 +1,55 @@
+import { Link } from '@/i18n/navigation';
+import { formatTemplate } from '@/components/marketing/models-gallery-utils';
+import type { ModelGalleryCard, ModelsGalleryCompareBarCopy, ModelsGalleryCompareHref } from './models-gallery-types';
+
+type ModelsGalleryCompareBarProps = {
+  compareBar: ModelsGalleryCompareBarCopy;
+  compareHref: ModelsGalleryCompareHref | null;
+  selectedCards: ModelGalleryCard[];
+  onClear: () => void;
+};
+
+export function ModelsGalleryCompareBar({
+  compareBar,
+  compareHref,
+  selectedCards,
+  onClear,
+}: ModelsGalleryCompareBarProps) {
+  return (
+    <div className="fixed inset-x-4 bottom-6 z-40 mx-auto max-w-4xl rounded-2xl border border-white/60 bg-[linear-gradient(180deg,rgba(255,255,255,0.92),rgba(255,255,255,0.78))] px-4 py-3 shadow-[0_18px_40px_rgba(15,23,42,0.22),0_6px_16px_rgba(15,23,42,0.16)] backdrop-blur dark:border-white/10 dark:bg-[linear-gradient(180deg,rgba(15,23,42,0.92),rgba(2,6,23,0.9))]">
+      <span className="pointer-events-none absolute inset-x-0 top-0 h-6 bg-[linear-gradient(180deg,rgba(255,255,255,0.7),transparent)] dark:bg-[linear-gradient(180deg,rgba(255,255,255,0.08),transparent)]" />
+      <div className="relative flex flex-wrap items-center justify-between gap-3 text-sm">
+        <div className="font-semibold text-text-primary">
+          {selectedCards.length === 2
+            ? formatTemplate(compareBar.selectedTemplate, {
+                left: selectedCards[0]?.label ?? '',
+                right: selectedCards[1]?.label ?? '',
+              })
+            : compareBar.selectTwo}
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={onClear}
+            className="rounded-full border border-hairline px-3 py-1 text-xs font-semibold text-text-secondary transition hover:border-text-muted hover:text-text-primary"
+          >
+            {compareBar.clear}
+          </button>
+          {compareHref ? (
+            <Link
+              href={compareHref}
+              prefetch={false}
+              className="rounded-full bg-text-primary px-4 py-1 text-xs font-semibold text-bg transition hover:opacity-90"
+            >
+              {compareBar.compare}
+            </Link>
+          ) : (
+            <span className="rounded-full border border-hairline px-4 py-1 text-xs font-semibold text-text-muted">
+              {compareBar.compare}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/marketing/models-gallery/ModelsGalleryFilters.tsx
+++ b/frontend/components/marketing/models-gallery/ModelsGalleryFilters.tsx
@@ -1,0 +1,117 @@
+import { Search } from 'lucide-react';
+import { SelectMenu } from '@/components/ui/SelectMenu';
+import type { ReactNode } from 'react';
+import type { GalleryFilterKey } from './models-gallery-types';
+import type { ResolvedModelsGalleryCopy } from './models-gallery-copy';
+
+type ModelsGalleryFiltersProps = {
+  copy: Pick<ResolvedModelsGalleryCopy, 'filterClearLabel' | 'filterLabels' | 'filterOptions' | 'searchPlaceholder'>;
+  hasActiveFilters: boolean;
+  searchQuery: string;
+  selectedAge: string;
+  selectedDuration: string;
+  selectedFormat: string;
+  selectedMode: string;
+  selectedPrice: string;
+  selectedSort: string;
+  visibleFilterSet: Set<GalleryFilterKey>;
+  onAgeChange: (value: string) => void;
+  onClearFilters: () => void;
+  onDurationChange: (value: string) => void;
+  onFormatChange: (value: string) => void;
+  onModeChange: (value: string) => void;
+  onPriceChange: (value: string) => void;
+  onSearchChange: (value: string) => void;
+  onSortChange: (value: string) => void;
+};
+
+function FilterControl({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="whitespace-nowrap text-xs font-semibold text-text-secondary">{label}</span>
+      {children}
+    </div>
+  );
+}
+
+export function ModelsGalleryFilters({
+  copy,
+  hasActiveFilters,
+  searchQuery,
+  selectedAge,
+  selectedDuration,
+  selectedFormat,
+  selectedMode,
+  selectedPrice,
+  selectedSort,
+  visibleFilterSet,
+  onAgeChange,
+  onClearFilters,
+  onDurationChange,
+  onFormatChange,
+  onModeChange,
+  onPriceChange,
+  onSearchChange,
+  onSortChange,
+}: ModelsGalleryFiltersProps) {
+  const filterSelectButtonClassName =
+    'h-11 min-w-[136px] rounded-[8px] border-hairline bg-bg px-4 text-xs font-semibold text-text-primary shadow-sm hover:border-[var(--brand-border)] hover:bg-surface-2';
+  const controls = [
+    { key: 'sort', label: copy.filterLabels.sort, options: copy.filterOptions.sort, value: selectedSort, onChange: onSortChange },
+    { key: 'mode', label: copy.filterLabels.mode, options: copy.filterOptions.mode, value: selectedMode, onChange: onModeChange },
+    { key: 'format', label: copy.filterLabels.format, options: copy.filterOptions.format, value: selectedFormat, onChange: onFormatChange },
+    {
+      key: 'duration',
+      label: copy.filterLabels.duration,
+      options: copy.filterOptions.duration,
+      value: selectedDuration,
+      onChange: onDurationChange,
+    },
+    { key: 'price', label: copy.filterLabels.price, options: copy.filterOptions.price, value: selectedPrice, onChange: onPriceChange },
+    { key: 'age', label: copy.filterLabels.age, options: copy.filterOptions.age, value: selectedAge, onChange: onAgeChange },
+  ] as const;
+
+  return (
+    <div
+      className="mt-0 flex flex-col gap-4 rounded-[8px] border border-hairline bg-surface-glass-95 px-5 py-5 shadow-[0_18px_44px_rgba(15,23,42,0.07),0_4px_14px_rgba(15,23,42,0.035)] backdrop-blur md:flex-row md:items-center md:justify-between dark:bg-surface-glass-80 sm:px-8"
+      id="models-compare-toggle"
+    >
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-3">
+        {controls.map((control) =>
+          visibleFilterSet.has(control.key) ? (
+            <FilterControl key={control.key} label={control.label}>
+              <SelectMenu
+                options={control.options}
+                value={control.value}
+                onChange={(value) => control.onChange(String(value))}
+                buttonClassName={filterSelectButtonClassName}
+              />
+            </FilterControl>
+          ) : null
+        )}
+        {hasActiveFilters ? (
+          <button
+            type="button"
+            onClick={onClearFilters}
+            className="h-11 rounded-[8px] border border-hairline bg-bg px-3 text-xs font-semibold text-text-secondary transition hover:border-text-muted hover:text-text-primary"
+          >
+            {copy.filterClearLabel}
+          </button>
+        ) : null}
+      </div>
+      <label className="relative min-w-0 md:w-[300px] lg:w-[340px]">
+        <Search
+          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted"
+          aria-hidden="true"
+        />
+        <span className="sr-only">{copy.searchPlaceholder}</span>
+        <input
+          value={searchQuery}
+          onChange={(event) => onSearchChange(event.target.value)}
+          placeholder={copy.searchPlaceholder}
+          className="h-11 w-full rounded-[8px] border border-hairline bg-bg pl-9 pr-3 text-sm font-medium text-text-primary shadow-sm outline-none transition placeholder:text-text-muted/75 hover:border-[var(--brand-border)] focus:border-[var(--brand-border)] focus:ring-2 focus:ring-[color:var(--brand-border)]"
+        />
+      </label>
+    </div>
+  );
+}

--- a/frontend/components/marketing/models-gallery/models-gallery-copy.ts
+++ b/frontend/components/marketing/models-gallery/models-gallery-copy.ts
@@ -1,0 +1,224 @@
+import type { SelectOption } from '@/components/ui/SelectMenu';
+import type {
+  GalleryFilterKey,
+  ModelsGalleryCompareBarCopy,
+  ModelsGalleryCopy,
+  ModelsGalleryStatsLabels,
+} from './models-gallery-types';
+
+type FilterCopy = NonNullable<ModelsGalleryCopy['filters']>;
+
+const DEFAULT_STATS_LABELS: ModelsGalleryStatsLabels = {
+  from: 'From',
+  maxDurShort: 'Max dur.',
+  maxDurLong: 'Max duration',
+  maxResShort: 'Max res.',
+  maxResLong: 'Max resolution',
+  typeShort: 'Type',
+  typeLong: 'Type',
+};
+
+const DEFAULT_COMPARE_BAR: ModelsGalleryCompareBarCopy = {
+  selectedTemplate: 'Selected: {left} + {right}',
+  selectTwo: 'Select two engines to compare',
+  clear: 'Clear',
+  compare: 'Compare',
+};
+
+export const DEFAULT_MODELS_GALLERY_COPY: Required<ModelsGalleryCopy> = {
+  compareLabel: 'Compare',
+  compareTooltip: 'Select to compare',
+  compareAria: 'Select {engine} to compare',
+  strengthsLabel: 'Strengths',
+  stats: DEFAULT_STATS_LABELS,
+  audioAvailableLabel: 'Audio available',
+  filters: {
+    sort: {
+      label: 'Sort by',
+      options: {
+        featured: 'Featured',
+        score: 'Score',
+        price: 'Price',
+        duration: 'Duration',
+        resolution: 'Resolution',
+        name: 'Name',
+      },
+    },
+    mode: {
+      label: 'Mode',
+      options: {
+        all: 'All',
+        t2v: 'T2V',
+        i2v: 'I2V',
+        v2v: 'V2V',
+        firstLast: 'First/Last',
+        extend: 'Extend',
+        lipSync: 'Lip sync',
+        audio: 'Audio',
+      },
+    },
+    format: {
+      label: 'Format',
+      options: {
+        all: 'All',
+        720: '720p+',
+        1080: '1080p+',
+        2160: '4K',
+      },
+    },
+    duration: {
+      label: 'Duration',
+      options: {
+        all: 'All',
+        8: '≤8s',
+        '10-15': '10–15s',
+        20: '20s+',
+      },
+    },
+    price: {
+      label: 'Price',
+      options: {
+        all: 'All',
+        cheap: '$',
+        mid: '$$',
+        premium: '$$$',
+      },
+    },
+    age: {
+      label: 'Models',
+      options: {
+        latest: 'Latest',
+        legacy: 'Legacy',
+        all: 'All',
+      },
+    },
+    searchPlaceholder: 'Search models...',
+    clear: 'Clear filters',
+  },
+  compareBar: DEFAULT_COMPARE_BAR,
+  capabilityTooltips: {
+    T2V: 'Text-to-video',
+    I2V: 'Image-to-video',
+    V2V: 'Video-to-video',
+    'First/Last': 'First frame / last frame',
+    Extend: 'Extend / continue',
+  },
+};
+
+export type ResolvedModelsGalleryCopy = {
+  audioAvailableLabel: string;
+  capabilityTooltips: Record<string, string>;
+  compareAria: string;
+  compareBar: ModelsGalleryCompareBarCopy;
+  compareLabel: string;
+  compareTooltip: string;
+  filterClearLabel: string;
+  filterLabels: Record<GalleryFilterKey, string>;
+  filterOptions: Record<GalleryFilterKey, SelectOption[]>;
+  searchPlaceholder: string;
+  statsLabels: ModelsGalleryStatsLabels;
+  strengthsLabel: string;
+};
+
+function mergeFilterCopy<K extends keyof FilterCopy>(key: K, filtersCopy: FilterCopy) {
+  const base = DEFAULT_MODELS_GALLERY_COPY.filters[key] as { label?: string; options?: Record<string, string> } | undefined;
+  const override = filtersCopy[key] as { label?: string; options?: Record<string, string> } | undefined;
+  return {
+    ...base,
+    ...override,
+    options: { ...(base?.options ?? {}), ...(override?.options ?? {}) },
+  };
+}
+
+function buildSelectOptions(entries: Array<[string, string | undefined]>): SelectOption[] {
+  return entries.map(([value, label]) => ({ value, label: label ?? value }));
+}
+
+export function resolveModelsGalleryCopy(copy?: ModelsGalleryCopy): ResolvedModelsGalleryCopy {
+  const filtersCopy = copy?.filters ?? {};
+  const sortCopy = mergeFilterCopy('sort', filtersCopy);
+  const modeCopy = mergeFilterCopy('mode', filtersCopy);
+  const formatCopy = mergeFilterCopy('format', filtersCopy);
+  const durationCopy = mergeFilterCopy('duration', filtersCopy);
+  const priceCopy = mergeFilterCopy('price', filtersCopy);
+  const ageCopy = mergeFilterCopy('age', filtersCopy);
+  const statsOverride = copy?.stats ?? {};
+  const compareBarOverride = copy?.compareBar ?? {};
+
+  return {
+    audioAvailableLabel: copy?.audioAvailableLabel ?? DEFAULT_MODELS_GALLERY_COPY.audioAvailableLabel,
+    capabilityTooltips: { ...DEFAULT_MODELS_GALLERY_COPY.capabilityTooltips, ...(copy?.capabilityTooltips ?? {}) },
+    compareAria: copy?.compareAria ?? DEFAULT_MODELS_GALLERY_COPY.compareAria,
+    compareBar: {
+      selectedTemplate: compareBarOverride.selectedTemplate ?? DEFAULT_COMPARE_BAR.selectedTemplate,
+      selectTwo: compareBarOverride.selectTwo ?? DEFAULT_COMPARE_BAR.selectTwo,
+      clear: compareBarOverride.clear ?? DEFAULT_COMPARE_BAR.clear,
+      compare: compareBarOverride.compare ?? DEFAULT_COMPARE_BAR.compare,
+    },
+    compareLabel: copy?.compareLabel ?? DEFAULT_MODELS_GALLERY_COPY.compareLabel,
+    compareTooltip: copy?.compareTooltip ?? DEFAULT_MODELS_GALLERY_COPY.compareTooltip,
+    filterClearLabel: filtersCopy.clear ?? DEFAULT_MODELS_GALLERY_COPY.filters.clear ?? 'Clear filters',
+    filterLabels: {
+      sort: sortCopy.label ?? 'Sort by',
+      mode: modeCopy.label ?? 'Mode',
+      format: formatCopy.label ?? 'Format',
+      duration: durationCopy.label ?? 'Duration',
+      price: priceCopy.label ?? 'Price',
+      age: ageCopy.label ?? 'Models',
+    },
+    filterOptions: {
+      sort: buildSelectOptions([
+        ['featured', sortCopy.options.featured],
+        ['score', sortCopy.options.score],
+        ['price', sortCopy.options.price],
+        ['duration', sortCopy.options.duration],
+        ['resolution', sortCopy.options.resolution],
+        ['name', sortCopy.options.name],
+      ]),
+      mode: buildSelectOptions([
+        ['all', modeCopy.options.all],
+        ['t2v', modeCopy.options.t2v],
+        ['i2v', modeCopy.options.i2v],
+        ['v2v', modeCopy.options.v2v],
+        ['firstLast', modeCopy.options.firstLast],
+        ['extend', modeCopy.options.extend],
+        ['lipSync', modeCopy.options.lipSync],
+        ['audio', modeCopy.options.audio],
+      ]),
+      format: buildSelectOptions([
+        ['all', formatCopy.options.all],
+        ['720', formatCopy.options[720]],
+        ['1080', formatCopy.options[1080]],
+        ['2160', formatCopy.options[2160]],
+      ]),
+      duration: buildSelectOptions([
+        ['all', durationCopy.options.all],
+        ['8', durationCopy.options[8]],
+        ['10-15', durationCopy.options['10-15']],
+        ['20', durationCopy.options[20]],
+      ]),
+      price: buildSelectOptions([
+        ['all', priceCopy.options.all],
+        ['cheap', priceCopy.options.cheap],
+        ['mid', priceCopy.options.mid],
+        ['premium', priceCopy.options.premium],
+      ]),
+      age: buildSelectOptions([
+        ['latest', ageCopy.options.latest],
+        ['legacy', ageCopy.options.legacy],
+        ['all', ageCopy.options.all],
+      ]),
+    },
+    searchPlaceholder: filtersCopy.searchPlaceholder ?? DEFAULT_MODELS_GALLERY_COPY.filters.searchPlaceholder ?? 'Search models...',
+    statsLabels: {
+      from: statsOverride.from ?? DEFAULT_STATS_LABELS.from,
+      maxDurShort: statsOverride.maxDurShort ?? DEFAULT_STATS_LABELS.maxDurShort,
+      maxDurLong: statsOverride.maxDurLong ?? DEFAULT_STATS_LABELS.maxDurLong,
+      maxResShort: statsOverride.maxResShort ?? DEFAULT_STATS_LABELS.maxResShort,
+      maxResLong: statsOverride.maxResLong ?? DEFAULT_STATS_LABELS.maxResLong,
+      typeShort: statsOverride.typeShort ?? DEFAULT_STATS_LABELS.typeShort,
+      typeLong: statsOverride.typeLong ?? DEFAULT_STATS_LABELS.typeLong,
+    },
+    strengthsLabel: copy?.strengthsLabel ?? DEFAULT_MODELS_GALLERY_COPY.strengthsLabel,
+  };
+}

--- a/frontend/components/marketing/models-gallery/models-gallery-filtering.ts
+++ b/frontend/components/marketing/models-gallery/models-gallery-filtering.ts
@@ -1,0 +1,109 @@
+import type { ModelGalleryCard } from './models-gallery-types';
+
+export type ModelsGalleryFilterState = {
+  searchQuery: string;
+  selectedAge: string;
+  selectedDuration: string;
+  selectedFormat: string;
+  selectedMode: string;
+  selectedPrice: string;
+};
+
+export function hasActiveModelsGalleryFilters(state: ModelsGalleryFilterState) {
+  return (
+    state.selectedMode !== 'all' ||
+    state.selectedFormat !== 'all' ||
+    state.selectedDuration !== 'all' ||
+    state.selectedPrice !== 'all' ||
+    state.selectedAge !== 'latest' ||
+    state.searchQuery.trim().length > 0
+  );
+}
+
+export function filterModelGalleryCards(
+  cards: ModelGalleryCard[],
+  state: ModelsGalleryFilterState,
+  hasActiveFilters: boolean
+) {
+  const normalizedQuery = state.searchQuery.trim().toLowerCase();
+  return cards.filter((card) => {
+    const meta = card.filterMeta;
+    if (!meta) return !hasActiveFilters;
+    if (normalizedQuery) {
+      const haystack = [
+        card.label,
+        card.provider,
+        card.description,
+        ...(card.strengths ?? []),
+        ...(card.capabilities ?? []),
+        card.stats?.priceFrom,
+        card.stats?.maxDuration,
+        card.stats?.maxResolution,
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+      if (!haystack.includes(normalizedQuery)) return false;
+    }
+    if (state.selectedMode !== 'all') {
+      if (state.selectedMode === 'audio') {
+        if (!meta.audio) return false;
+      } else if (!meta[state.selectedMode as keyof typeof meta]) {
+        return false;
+      }
+    }
+    if (state.selectedFormat !== 'all') {
+      if (!meta.maxResolution) return false;
+      const threshold = Number(state.selectedFormat);
+      if (meta.maxResolution == null || meta.maxResolution < threshold) return false;
+    }
+    if (state.selectedDuration !== 'all') {
+      if (!meta.maxDuration) return false;
+      if (state.selectedDuration === '8' && meta.maxDuration > 8) return false;
+      if (state.selectedDuration === '10-15' && (meta.maxDuration < 10 || meta.maxDuration > 15)) return false;
+      if (state.selectedDuration === '20' && meta.maxDuration < 20) return false;
+    }
+    if (state.selectedPrice !== 'all') {
+      if (meta.priceFrom == null) return false;
+      if (state.selectedPrice === 'cheap' && meta.priceFrom > 0.08) return false;
+      if (state.selectedPrice === 'mid' && !(meta.priceFrom > 0.08 && meta.priceFrom <= 0.2)) return false;
+      if (state.selectedPrice === 'premium' && meta.priceFrom <= 0.2) return false;
+    }
+    if (state.selectedAge !== 'all') {
+      const isLegacy = Boolean(meta.legacy);
+      if (state.selectedAge === 'latest' && isLegacy) return false;
+      if (state.selectedAge === 'legacy' && !isLegacy) return false;
+    }
+    return true;
+  });
+}
+
+function compareNumbers(a?: number | null, b?: number | null, direction: 'asc' | 'desc' = 'desc') {
+  const aVal = typeof a === 'number' ? a : direction === 'asc' ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+  const bVal = typeof b === 'number' ? b : direction === 'asc' ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+  return direction === 'asc' ? aVal - bVal : bVal - aVal;
+}
+
+export function sortModelGalleryCards(cards: ModelGalleryCard[], selectedSort: string) {
+  const sortable = [...cards];
+  switch (selectedSort) {
+    case 'score':
+      sortable.sort((a, b) => compareNumbers(a.overallScore ?? null, b.overallScore ?? null, 'desc'));
+      break;
+    case 'price':
+      sortable.sort((a, b) => compareNumbers(a.filterMeta?.priceFrom ?? null, b.filterMeta?.priceFrom ?? null, 'asc'));
+      break;
+    case 'duration':
+      sortable.sort((a, b) => compareNumbers(a.filterMeta?.maxDuration ?? null, b.filterMeta?.maxDuration ?? null, 'desc'));
+      break;
+    case 'resolution':
+      sortable.sort((a, b) => compareNumbers(a.filterMeta?.maxResolution ?? null, b.filterMeta?.maxResolution ?? null, 'desc'));
+      break;
+    case 'name':
+      sortable.sort((a, b) => a.label.localeCompare(b.label));
+      break;
+    default:
+      break;
+  }
+  return sortable;
+}

--- a/frontend/components/marketing/models-gallery/models-gallery-types.ts
+++ b/frontend/components/marketing/models-gallery/models-gallery-types.ts
@@ -1,0 +1,87 @@
+import type { LocalizedLinkHref } from '@/i18n/navigation';
+
+export type ModelGalleryCard = {
+  id: string;
+  label: string;
+  provider?: string | null;
+  engineId?: string | null;
+  brandId?: string | null;
+  description: string;
+  versionLabel?: string;
+  overallScore?: number | null;
+  priceNote?: string | null;
+  priceNoteHref?: string | null;
+  href: LocalizedLinkHref;
+  backgroundColor?: string | null;
+  textColor?: string | null;
+  strengths?: string[];
+  capabilities?: string[];
+  stats?: {
+    priceFrom?: string | null;
+    maxDuration?: string | null;
+    maxResolution?: string | null;
+  };
+  statsLabels?: {
+    duration?: string;
+  };
+  audioAvailable?: boolean;
+  compareDisabled?: boolean;
+  filterMeta?: {
+    t2v?: boolean;
+    i2v?: boolean;
+    v2v?: boolean;
+    firstLast?: boolean;
+    extend?: boolean;
+    lipSync?: boolean;
+    audio?: boolean;
+    maxResolution?: number | null;
+    maxDuration?: number | null;
+    priceFrom?: number | null;
+    legacy?: boolean;
+  };
+};
+
+export type GalleryFilterKey = 'sort' | 'mode' | 'format' | 'duration' | 'price' | 'age';
+
+export type ModelsGalleryCopy = {
+  compareLabel?: string;
+  compareTooltip?: string;
+  compareAria?: string;
+  strengthsLabel?: string;
+  stats?: {
+    from?: string;
+    maxDurShort?: string;
+    maxDurLong?: string;
+    maxResShort?: string;
+    maxResLong?: string;
+    typeShort?: string;
+    typeLong?: string;
+  };
+  audioAvailableLabel?: string;
+  filters?: {
+    sort?: { label?: string; options?: Record<string, string> };
+    mode?: { label?: string; options?: Record<string, string> };
+    format?: { label?: string; options?: Record<string, string> };
+    duration?: { label?: string; options?: Record<string, string> };
+    price?: { label?: string; options?: Record<string, string> };
+    age?: { label?: string; options?: Record<string, string> };
+    searchPlaceholder?: string;
+    clear?: string;
+  };
+  compareBar?: {
+    selectedTemplate?: string;
+    selectTwo?: string;
+    clear?: string;
+    compare?: string;
+  };
+  capabilityTooltips?: Record<string, string>;
+};
+
+export type ModelsGalleryStatsLabels = Required<NonNullable<ModelsGalleryCopy['stats']>>;
+export type ModelsGalleryCompareBarCopy = Required<NonNullable<ModelsGalleryCopy['compareBar']>>;
+
+export type ModelsGalleryCompareHref = {
+  pathname: '/ai-video-engines/[slug]';
+  params: { slug: string };
+  query?: { order: string };
+};

--- a/frontend/components/marketing/price-estimator/PriceEstimatorSelectGroup.tsx
+++ b/frontend/components/marketing/price-estimator/PriceEstimatorSelectGroup.tsx
@@ -1,0 +1,26 @@
+import clsx from 'clsx';
+import { SelectMenu, type SelectOption } from '@/components/ui/SelectMenu';
+
+type PriceEstimatorSelectGroupProps = {
+  label: string;
+  options: SelectOption[];
+  value: SelectOption['value'];
+  onChange: (value: SelectOption['value']) => void;
+  className?: string;
+};
+
+export function PriceEstimatorSelectGroup({
+  label,
+  options,
+  value,
+  onChange,
+  className,
+}: PriceEstimatorSelectGroupProps) {
+  if (!options.length) return null;
+  return (
+    <div className={clsx('flex min-w-0 flex-col gap-1', className)}>
+      <span className="text-[10px] uppercase tracking-micro text-text-muted">{label}</span>
+      <SelectMenu options={options} value={value} onChange={onChange} />
+    </div>
+  );
+}

--- a/frontend/components/marketing/price-estimator/PriceEstimatorSummaryPanel.tsx
+++ b/frontend/components/marketing/price-estimator/PriceEstimatorSummaryPanel.tsx
@@ -1,0 +1,167 @@
+import clsx from 'clsx';
+import { Button } from '@/components/ui/Button';
+import {
+  formatCurrency,
+  MEMBER_ORDER,
+  type MemberTier,
+} from '@/components/marketing/price-estimator/price-estimator-options';
+
+type PriceEstimatorSummaryLabels = {
+  audio: string;
+  audioIncluded: string;
+  audioOff: string;
+  audioOn: string;
+  chargedNote: string;
+  duration: string;
+  engine: string;
+  engineRate: string;
+  memberStatus: string;
+  memberTooltip: string;
+  priceChipSuffix: string;
+  resolution: string;
+};
+
+type PriceEstimatorSummaryPanelProps = {
+  activeResolutionLabel?: string | null;
+  currency: string;
+  discountPercent: number;
+  durationDisplay: string;
+  estimateLabels: Record<string, string>;
+  labels: PriceEstimatorSummaryLabels;
+  memberBenefitCopy?: string;
+  memberNames: Map<MemberTier, string>;
+  memberTier: MemberTier;
+  priceTotal: number;
+  rate: number;
+  selectedEngine?: {
+    audioIncluded?: boolean;
+    label?: string;
+    rateUnit?: string;
+    showDuration?: boolean;
+    showResolution?: boolean;
+  } | null;
+  selectedResolution?: string;
+  audioEnabled: boolean;
+  onMemberTierChange: (tier: MemberTier) => void;
+};
+
+export function PriceEstimatorSummaryPanel({
+  activeResolutionLabel,
+  currency,
+  discountPercent,
+  durationDisplay,
+  estimateLabels,
+  labels,
+  memberBenefitCopy,
+  memberNames,
+  memberTier,
+  priceTotal,
+  rate,
+  selectedEngine,
+  selectedResolution,
+  audioEnabled,
+  onMemberTierChange,
+}: PriceEstimatorSummaryPanelProps) {
+  return (
+    <aside className="border-t border-hairline bg-surface-2/70 p-5 text-sm text-text-secondary sm:p-6 lg:border-l lg:border-t-0">
+      <div className="stack-gap">
+        <div className="stack-gap-sm">
+          <span className="inline-flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.24em] text-text-muted">
+            <span className="flex h-5 w-5 items-center justify-center rounded-full border border-hairline bg-surface text-[10px] tracking-normal text-text-muted">
+              2
+            </span>
+            {estimateLabels.heading}
+          </span>
+          <p className="text-5xl font-semibold tracking-tight text-text-primary sm:text-6xl">
+            {formatCurrency(priceTotal, currency)}
+          </p>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-text-muted">
+            {labels.priceChipSuffix}
+          </p>
+        </div>
+
+        <dl className="grid gap-3 border-b border-hairline pb-4 text-sm">
+          <div className="flex items-center justify-between gap-4">
+            <dt className="text-text-secondary">{labels.engine}</dt>
+            <dd className="text-right font-semibold text-text-primary">{selectedEngine?.label ?? '—'}</dd>
+          </div>
+          {selectedEngine?.showDuration !== false ? (
+            <div className="flex items-center justify-between gap-4">
+              <dt className="text-text-secondary">{labels.duration}</dt>
+              <dd className="text-right font-semibold text-text-primary">{durationDisplay}</dd>
+            </div>
+          ) : null}
+          {selectedEngine?.showResolution !== false ? (
+            <div className="flex items-center justify-between gap-4">
+              <dt className="text-text-secondary">{labels.resolution}</dt>
+              <dd className="text-right font-semibold text-text-primary">
+                {activeResolutionLabel ?? selectedResolution?.toUpperCase()}
+              </dd>
+            </div>
+          ) : null}
+          <div className="flex items-center justify-between gap-4">
+            <dt className="text-text-secondary">{labels.audio}</dt>
+            <dd className="text-right font-semibold text-text-primary">
+              {selectedEngine?.audioIncluded || audioEnabled ? labels.audioOn : labels.audioOff}
+            </dd>
+          </div>
+          <div className="flex items-center justify-between gap-4">
+            <dt className="text-text-secondary">{labels.engineRate}</dt>
+            <dd className="text-right font-semibold text-text-primary">
+              {formatCurrency(rate, currency)}
+              {selectedEngine?.rateUnit ?? '/s'}
+            </dd>
+          </div>
+        </dl>
+
+        <div className="stack-gap-sm">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-[10px] font-semibold uppercase tracking-[0.22em] text-text-muted">
+              {estimateLabels.memberChipPrefix}
+            </span>
+            <span className="rounded-full bg-state-success/15 px-3 py-1 text-xs font-semibold text-state-success">
+              {memberTier === 'Member' ? memberNames.get('Member') ?? 'Member' : `${discountPercent}%`}
+            </span>
+          </div>
+          {memberBenefitCopy ? <p className="text-xs text-text-muted">{memberBenefitCopy}</p> : null}
+          <div>
+            <span className="text-[10px] font-semibold uppercase tracking-[0.22em] text-text-muted">
+              {labels.memberStatus}
+            </span>
+            <div className="mt-2 grid grid-cols-3 gap-2 rounded-full border border-hairline bg-surface p-1">
+              {MEMBER_ORDER.map((tier) => {
+                const selected = tier === memberTier;
+                return (
+                  <Button
+                    key={tier}
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => onMemberTierChange(tier)}
+                    className={clsx(
+                      'member-status-pill min-h-0 h-8 rounded-full px-2 text-xs font-semibold',
+                      selected
+                        ? 'bg-text-primary !text-bg shadow-card hover:bg-text-primary hover:!text-bg'
+                        : 'bg-transparent !text-text-secondary hover:bg-surface-2 hover:!text-text-primary'
+                    )}
+                    aria-pressed={selected}
+                  >
+                    {memberNames.get(tier) ?? tier}
+                  </Button>
+                );
+              })}
+            </div>
+            <p className="mt-2 text-[11px] text-text-muted" aria-label={labels.memberTooltip} title={labels.memberTooltip}>
+              {labels.memberTooltip}
+            </p>
+          </div>
+        </div>
+
+        <div className="stack-gap-xs text-xs text-text-muted">
+          {selectedEngine?.audioIncluded ? <p className="font-semibold text-text-secondary">{labels.audioIncluded}</p> : null}
+          <p>{labels.chargedNote}</p>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/components/marketing/price-estimator/price-estimator-summary-labels.ts
+++ b/frontend/components/marketing/price-estimator/price-estimator-summary-labels.ts
@@ -1,0 +1,32 @@
+type PriceEstimatorTranslate = (key: string, fallback: string) => string | null | undefined;
+
+type BuildPriceEstimatorSummaryLabelsInput = {
+  chargedNote: string;
+  fields: Record<string, string>;
+  memberTooltipLabel: string;
+  priceChipSuffix?: string | null;
+  t: PriceEstimatorTranslate;
+};
+
+export function buildPriceEstimatorSummaryLabels({
+  chargedNote,
+  fields,
+  memberTooltipLabel,
+  priceChipSuffix,
+  t,
+}: BuildPriceEstimatorSummaryLabelsInput) {
+  return {
+    audio: t('pricing.estimator.audioLabel', 'Audio') ?? 'Audio',
+    audioIncluded: t('pricing.estimator.audioIncluded', 'Audio included by default') ?? 'Audio included by default',
+    audioOff: t('pricing.estimator.audioOff', 'Off') ?? 'Off',
+    audioOn: t('pricing.estimator.audioOn', 'On') ?? 'On',
+    chargedNote,
+    duration: t('pricing.estimator.durationLabel', 'Duration') ?? 'Duration',
+    engine: t('pricing.estimator.engineLabel', 'Engine') ?? 'Engine',
+    engineRate: t('pricing.estimator.engineRateLabel', 'Engine rate') ?? 'Engine rate',
+    memberStatus: fields.memberStatus,
+    memberTooltip: memberTooltipLabel,
+    priceChipSuffix: priceChipSuffix ?? t('pricing.priceChipSuffix', 'Price before you generate.') ?? 'Price before you generate.',
+    resolution: t('pricing.estimator.resolutionLabel', 'Resolution') ?? 'Resolution',
+  };
+}

--- a/frontend/components/media-lightbox/MediaLightboxEntryCard.tsx
+++ b/frontend/components/media-lightbox/MediaLightboxEntryCard.tsx
@@ -1,0 +1,446 @@
+'use client';
+
+import clsx from 'clsx';
+import Image from 'next/image';
+import {
+  AudioWaveform,
+  CalendarDays,
+  ChevronRight,
+  Clock3,
+  Download,
+  ExternalLink,
+  Film,
+  Link as LinkIcon,
+  Monitor,
+  Play,
+  RefreshCw,
+  Sparkles,
+  WandSparkles,
+  X,
+  type LucideIcon,
+} from 'lucide-react';
+import { AudioEqualizerBadge } from '@/components/ui/AudioEqualizerBadge';
+import { CopyPromptButton } from '@/components/CopyPromptButton';
+import { Button, ButtonLink } from '@/components/ui/Button';
+import {
+  formatEntryDate,
+  formatPromptPreview,
+  isUuidLike,
+  isVerticalAspect,
+  resolveOpenLabel,
+  resolveStatusLabel,
+  statusBadgeClass,
+} from './media-lightbox-helpers';
+import type {
+  MediaLightboxEntry,
+  MediaLightboxLibraryState,
+  MediaLightboxLoadingState,
+} from './media-lightbox-types';
+
+function MetaItem({ icon: Icon, label, value }: { icon: LucideIcon; label: string; value: string }) {
+  return (
+    <div className="flex min-w-[132px] items-center gap-3 border-r border-hairline pr-5 last:border-r-0">
+      <Icon className="h-5 w-5 shrink-0 text-text-muted" aria-hidden />
+      <div className="min-w-0">
+        <p className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">{label}</p>
+        <p className="truncate text-sm font-semibold text-text-primary">{value}</p>
+      </div>
+    </div>
+  );
+}
+
+function ActionCard({
+  icon: Icon,
+  title,
+  body,
+  disabled,
+  onClick,
+}: {
+  icon: LucideIcon;
+  title: string;
+  body: string;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={clsx(
+        'group flex min-h-[108px] items-center gap-3 rounded-[16px] border border-hairline bg-surface-2/70 p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        disabled ? 'cursor-not-allowed opacity-55' : 'hover:border-[var(--brand-border)] hover:bg-[var(--brand-soft)]'
+      )}
+    >
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[var(--brand-soft)] text-brand">
+        <Icon className="h-4 w-4" aria-hidden />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-sm font-semibold text-text-primary">{title}</span>
+        <span className="mt-1 block text-xs leading-relaxed text-text-secondary">{body}</span>
+      </span>
+      <ChevronRight className="h-4 w-4 text-brand transition-transform group-hover:translate-x-0.5" aria-hidden />
+    </button>
+  );
+}
+
+function RenderDecorVisual({ previewUrl }: { previewUrl?: string | null }) {
+  return (
+    <div className="relative hidden min-h-[118px] overflow-hidden rounded-[16px] border border-hairline bg-[linear-gradient(145deg,#f7faff_0%,#eef4ff_52%,#e6f2ed_100%)] p-3 xl:block">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_80%_22%,rgba(62,142,114,0.18),transparent_34%),radial-gradient(circle_at_18%_88%,rgba(78,125,226,0.16),transparent_42%)]" />
+      <div className="absolute -right-8 -top-8 h-24 w-24 rounded-full bg-white/70 blur-2xl" />
+      <div className="relative ml-auto mt-1 h-[86px] w-[132px] rotate-[-5deg] overflow-hidden rounded-[18px] border border-white/75 bg-[#17243b] shadow-[0_18px_34px_rgba(31,58,96,0.22)]">
+        {previewUrl ? (
+          <Image src={previewUrl} alt="" fill className="object-cover" sizes="132px" />
+        ) : (
+          <svg viewBox="0 0 132 86" className="h-full w-full" aria-hidden>
+            <rect width="132" height="86" fill="#AFC4E6" />
+            <path d="M0 0h132v52C100 36 73 34 52 46 31 57 13 55 0 46Z" fill="#DDE8FB" opacity="0.78" />
+            <path d="M0 66c19-12 39-15 61-8 19 6 33 1 47-10 9-7 17-9 24-7v45H0Z" fill="#203A60" opacity="0.62" />
+            <path d="M12 24h42M12 36h26" stroke="#FFFFFF" strokeWidth="5" strokeLinecap="round" opacity="0.58" />
+          </svg>
+        )}
+        <div className="absolute inset-0 bg-gradient-to-t from-black/45 via-black/5 to-white/15" />
+        <div className="absolute bottom-3 left-3 flex h-8 w-8 items-center justify-center rounded-full bg-white text-[#27456c] shadow-card">
+          <Play className="h-3.5 w-3.5 fill-current" aria-hidden />
+        </div>
+        <div className="absolute bottom-4 left-12 h-1.5 w-16 overflow-hidden rounded-full bg-white/40">
+          <div className="h-full w-2/3 rounded-full bg-white" />
+        </div>
+      </div>
+      <div className="absolute bottom-4 left-5 h-9 w-12 rotate-[8deg] rounded-[10px] border border-white/70 bg-white/75 shadow-[0_10px_22px_rgba(31,58,96,0.14)]">
+        <div className="mx-auto mt-2 h-2 w-7 rounded-full bg-[#9cb2d2]" />
+        <div className="mx-auto mt-1.5 h-2 w-5 rounded-full bg-[#c2d1e8]" />
+      </div>
+      <div className="absolute right-5 top-4 h-3 w-3 rounded-full bg-success/70 shadow-[0_0_0_6px_rgba(62,142,114,0.10)]" />
+    </div>
+  );
+}
+
+type MediaLightboxEntryCardProps = {
+  copiedId: string | null;
+  detailSpecsBase: Array<{ label: string; value: string }>;
+  downloadState?: MediaLightboxLoadingState;
+  entry: MediaLightboxEntry;
+  index: number;
+  libraryState?: MediaLightboxLibraryState;
+  prompt?: string | null;
+  refreshState?: MediaLightboxLoadingState;
+  remixLabel?: string;
+  subtitle?: string;
+  templateLabel?: string;
+  title: string;
+  onClose: () => void;
+  onCopyLink: (entryId: string, url?: string | null) => void;
+  onDownloadEntry: (entry: MediaLightboxEntry, url?: string | null) => void;
+  onRefreshEntry?: (entry: MediaLightboxEntry) => void;
+  onRemixEntry?: (entry: MediaLightboxEntry) => void;
+  onSaveEntryToLibrary?: (entry: MediaLightboxEntry, mediaUrl?: string | null) => void;
+  onUseTemplate?: (entry: MediaLightboxEntry) => void;
+};
+
+export function MediaLightboxEntryCard({
+  copiedId,
+  detailSpecsBase,
+  downloadState,
+  entry,
+  index,
+  libraryState,
+  prompt,
+  refreshState,
+  remixLabel,
+  subtitle,
+  templateLabel,
+  title,
+  onClose,
+  onCopyLink,
+  onDownloadEntry,
+  onRefreshEntry,
+  onRemixEntry,
+  onSaveEntryToLibrary,
+  onUseTemplate,
+}: MediaLightboxEntryCardProps) {
+  const videoUrl = entry.videoUrl ?? undefined;
+  const audioUrl = entry.audioUrl ?? undefined;
+  const imageUrl = entry.imageUrl ?? undefined;
+  const thumbUrl = entry.thumbUrl ?? undefined;
+  const mediaUrl = entry.videoUrl ?? entry.audioUrl ?? entry.imageUrl ?? entry.thumbUrl ?? null;
+  const isProcessing = entry.status === 'pending';
+  const progressLabel =
+    typeof entry.progress === 'number'
+      ? `${Math.max(0, Math.min(100, Math.round(entry.progress)))}%`
+      : isProcessing
+        ? 'Processing'
+        : undefined;
+  const statusLabel = resolveStatusLabel(entry.status);
+  const createdLabel =
+    formatEntryDate(entry.createdAt) ??
+    detailSpecsBase.find((item) => item.label.toLowerCase() === 'created')?.value ??
+    null;
+  const isVertical = isVerticalAspect(entry.aspectRatio);
+  const isRefreshing = Boolean(refreshState?.loading);
+  const refreshError = refreshState?.error ?? null;
+  const refreshTarget = entry.jobId ?? entry.id;
+  const hasRefreshTarget = typeof refreshTarget === 'string' && refreshTarget.trim().length > 0;
+  const canRefresh =
+    Boolean(onRefreshEntry) &&
+    hasRefreshTarget &&
+    (entry.status === 'pending' || (!entry.videoUrl && !entry.audioUrl));
+  const canRemix = Boolean(onRemixEntry);
+  const canTemplate = Boolean(onUseTemplate) && !entry.curated;
+  const isDownloading = Boolean(downloadState?.loading);
+  const downloadError = downloadState?.error ?? null;
+  const showPrompt = Boolean(prompt) && index === 0;
+  const displayTitle = entry.engineLabel ?? subtitle ?? title;
+  const detailSpecs = [
+    ...(entry.jobId ? [{ label: 'Job ID', value: entry.jobId }] : []),
+    ...detailSpecsBase.filter((item) => !['engine', 'created', 'date'].includes(item.label.toLowerCase())),
+  ].filter((item) => Boolean(item.value));
+  const technicalSpecs = [
+    ...(entry.aspectRatio ? [{ label: 'Aspect', value: entry.aspectRatio, icon: Monitor }] : []),
+    ...(typeof entry.durationSec === 'number' ? [{ label: 'Duration', value: `${entry.durationSec}s`, icon: Clock3 }] : []),
+    { label: 'Audio', value: entry.hasAudio ? 'Yes' : audioUrl ? 'Audio file' : 'No', icon: AudioWaveform },
+  ];
+
+  return (
+    <article>
+      <header className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-3">
+            <h3 className="text-2xl font-semibold text-text-primary">{displayTitle}</h3>
+            {statusLabel ? (
+              <span className={clsx('rounded-pill border px-3 py-1 text-[11px] font-semibold uppercase tracking-micro', statusBadgeClass(entry.status))}>
+                {statusLabel}
+              </span>
+            ) : null}
+          </div>
+          <div className="mt-5 flex flex-wrap items-center gap-y-3 text-sm text-text-primary">
+            {entry.engineLabel ? <MetaItem icon={Film} label="Engine" value={entry.engineLabel} /> : null}
+            {typeof entry.durationSec === 'number' ? <MetaItem icon={Clock3} label="Duration" value={`${entry.durationSec}s`} /> : null}
+            {entry.aspectRatio ? <MetaItem icon={Monitor} label="Aspect" value={entry.aspectRatio} /> : null}
+            <MetaItem icon={AudioWaveform} label="Audio" value={entry.hasAudio || audioUrl ? 'Yes' : 'No'} />
+            {createdLabel ? <MetaItem icon={CalendarDays} label="Created" value={createdLabel} /> : null}
+          </div>
+        </div>
+        {index === 0 ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onClose}
+            aria-label="Close"
+            className="h-9 w-9 shrink-0 rounded-full border-hairline bg-surface p-0 text-text-secondary hover:bg-surface-2 hover:text-text-primary"
+          >
+            <X className="h-4 w-4" aria-hidden />
+          </Button>
+        ) : null}
+      </header>
+
+      <div className="mt-6 grid gap-5 lg:grid-cols-[minmax(0,1fr)_310px]">
+        <div>
+          <div
+            className={clsx(
+              'relative overflow-hidden rounded-[18px] border border-hairline bg-black shadow-card',
+              isVertical ? 'mx-auto aspect-[9/16] max-h-[58vh] max-w-sm' : 'aspect-video'
+            )}
+          >
+            {videoUrl ? (
+              <video
+                key={videoUrl}
+                src={videoUrl}
+                poster={thumbUrl}
+                className="absolute inset-0 h-full w-full object-contain"
+                controls
+                playsInline
+                autoPlay={index === 0}
+                muted
+                preload={index === 0 ? 'auto' : 'none'}
+              />
+            ) : audioUrl ? (
+              <div className="absolute inset-0 flex flex-col items-center justify-center overflow-hidden bg-[radial-gradient(circle_at_top,_rgba(124,85,234,0.28),_transparent_52%),linear-gradient(135deg,_rgba(15,23,42,0.98),_rgba(30,41,59,0.88))] px-6 py-6 text-center">
+                {thumbUrl ? <Image src={thumbUrl} alt="" fill className="object-cover opacity-20" sizes="(max-width: 1024px) 100vw, calc(100vw - 360px)" /> : null}
+                <div className="relative flex h-20 w-20 items-center justify-center rounded-full border border-white/15 bg-white/10">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src="/assets/icons/audio.svg" alt="" className="h-10 w-10 opacity-95" />
+                </div>
+                <p className="relative mt-5 text-xs font-semibold uppercase tracking-[0.14em] text-white/70">
+                  Audio output
+                </p>
+                <div className="relative mt-5 w-full max-w-xl">
+                  <audio controls src={audioUrl} className="w-full" />
+                </div>
+              </div>
+            ) : imageUrl || thumbUrl ? (
+              <Image src={imageUrl ?? thumbUrl ?? ''} alt="" fill className="object-contain" sizes="(max-width: 1024px) 100vw, calc(100vw - 360px)" />
+            ) : (
+              <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-surface-2 via-surface to-surface-2 text-[12px] font-medium uppercase tracking-micro text-text-muted">
+                Preview unavailable
+              </div>
+            )}
+            {entry.hasAudio ? <AudioEqualizerBadge tone="light" size="sm" label="Audio available" /> : null}
+            {isProcessing ? (
+              <div className="absolute inset-0 flex flex-col items-center justify-center bg-surface-on-media-dark-45 px-3 text-center text-[11px] text-on-inverse backdrop-blur-sm">
+                <span className="uppercase tracking-micro">Processing...</span>
+                {entry.message ? <span className="mt-1 line-clamp-2 text-on-media-80">{entry.message}</span> : null}
+                {progressLabel ? <span className="mt-1 text-[12px] font-semibold text-on-inverse">{progressLabel}</span> : null}
+              </div>
+            ) : null}
+          </div>
+
+          <div className="mt-7 flex flex-wrap justify-center gap-4">
+            {canRefresh ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="md"
+                onClick={() => onRefreshEntry?.(entry)}
+                disabled={isRefreshing}
+                className="min-w-[180px] border-[var(--brand-border)] px-5 text-brand hover:bg-[var(--brand-soft)]"
+              >
+                <RefreshCw className="h-4 w-4" aria-hidden />
+                {isRefreshing ? 'Checking...' : 'Refresh status'}
+              </Button>
+            ) : null}
+            <ButtonLink
+              linkComponent="a"
+              href={mediaUrl ?? '#'}
+              target="_blank"
+              rel="noreferrer"
+              size="md"
+              className={clsx('min-w-[180px] px-5', !mediaUrl && 'pointer-events-none opacity-50')}
+            >
+              <ExternalLink className="h-4 w-4" aria-hidden />
+              {resolveOpenLabel(entry)}
+            </ButtonLink>
+            <Button
+              type="button"
+              variant="outline"
+              size="md"
+              onClick={() => onDownloadEntry(entry, mediaUrl)}
+              disabled={!mediaUrl || isDownloading}
+              className="min-w-[180px] border-hairline px-5 text-text-primary hover:bg-surface-2"
+            >
+              <Download className="h-4 w-4" aria-hidden />
+              {isDownloading ? 'Downloading...' : 'Download'}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="md"
+              onClick={() => onCopyLink(entry.id, mediaUrl)}
+              disabled={!mediaUrl}
+              className="min-w-[180px] border-hairline px-5 text-text-primary hover:bg-surface-2"
+            >
+              <LinkIcon className="h-4 w-4" aria-hidden />
+              {copiedId === entry.id ? 'Link copied' : 'Copy link'}
+            </Button>
+          </div>
+        </div>
+
+        <aside className="space-y-0 overflow-hidden rounded-[18px] border border-hairline bg-surface-2/60">
+          <div className="p-5">
+            <p className="text-xs font-semibold uppercase tracking-micro text-text-muted">Render details</p>
+            <dl className="mt-4 space-y-4 text-sm">
+              {detailSpecs.length > 0 ? (
+                detailSpecs.map((item) => (
+                  <div key={`${entry.id}-detail-${item.label}`}>
+                    <dt className="text-xs font-medium text-text-muted">{item.label}</dt>
+                    <dd className="mt-1 break-words font-medium text-text-primary">{item.value}</dd>
+                  </div>
+                ))
+              ) : (
+                <div>
+                  <dt className="text-xs font-medium text-text-muted">Render</dt>
+                  <dd className="mt-1 font-medium text-text-primary">{entry.label || title}</dd>
+                </div>
+              )}
+            </dl>
+          </div>
+
+          {showPrompt ? (
+            <div className="border-t border-hairline p-5">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-xs font-semibold uppercase tracking-micro text-text-muted">Prompt</p>
+                <CopyPromptButton prompt={prompt ?? ''} copyLabel="Copy" copiedLabel="Copied" />
+              </div>
+              <p className="mt-3 text-sm leading-relaxed text-text-primary">
+                {formatPromptPreview(prompt ?? '')}
+              </p>
+              {prompt && prompt.trim().length > 220 ? (
+                <details className="group mt-3">
+                  <summary className="flex cursor-pointer items-center gap-2 text-xs font-semibold uppercase tracking-micro text-brand">
+                    <span className="group-open:hidden">Show more</span>
+                    <span className="hidden group-open:inline">Show less</span>
+                  </summary>
+                  <p className="mt-2 whitespace-pre-line text-sm leading-relaxed text-text-secondary">{prompt}</p>
+                </details>
+              ) : null}
+            </div>
+          ) : null}
+        </aside>
+      </div>
+
+      <div className="mt-8 border-t border-hairline pt-5">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {onRemixEntry ? (
+            <ActionCard
+              icon={WandSparkles}
+              title={remixLabel ?? 'Remix'}
+              body="Create a new version based on this render"
+              disabled={!canRemix}
+              onClick={() => onRemixEntry(entry)}
+            />
+          ) : null}
+          {onUseTemplate ? (
+            <ActionCard
+              icon={CalendarDays}
+              title={templateLabel ?? 'Use as template'}
+              body="Reuse settings and prompt for a new render"
+              disabled={!canTemplate}
+              onClick={() => onUseTemplate(entry)}
+            />
+          ) : null}
+          {onSaveEntryToLibrary ? (
+            <ActionCard
+              icon={Sparkles}
+              title={
+                libraryState?.loading
+                  ? 'Saving...'
+                  : libraryState?.success
+                    ? 'Saved'
+                    : libraryState?.error
+                      ? 'Retry save'
+                      : 'Save to library'
+              }
+              body="Keep this media in your library"
+              disabled={!mediaUrl || libraryState?.loading}
+              onClick={() => onSaveEntryToLibrary(entry, mediaUrl)}
+            />
+          ) : null}
+          <div className="rounded-[16px] border border-hairline bg-surface-2/70 p-4">
+            <div className="space-y-3">
+              {technicalSpecs.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <div key={`${entry.id}-tech-${item.label}`} className="flex items-center gap-3 text-sm">
+                    <Icon className="h-4 w-4 text-text-muted" aria-hidden />
+                    <span className="min-w-20 text-text-muted">{item.label}</span>
+                    <span className="font-semibold text-text-primary">{item.value}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+          <RenderDecorVisual previewUrl={thumbUrl ?? imageUrl ?? null} />
+        </div>
+      </div>
+
+      {entry.message && !isProcessing && !isUuidLike(entry.message.trim()) ? (
+        <p className="mt-4 text-sm text-text-secondary">{entry.message}</p>
+      ) : null}
+      {downloadError ? <p className="mt-2 text-xs text-state-warning">{downloadError}</p> : null}
+      {refreshError ? <p className="mt-2 text-xs text-state-warning">{refreshError}</p> : null}
+      {libraryState?.error ? <p className="mt-2 text-xs text-state-warning">{libraryState.error}</p> : null}
+    </article>
+  );
+}

--- a/frontend/components/media-lightbox/media-lightbox-helpers.ts
+++ b/frontend/components/media-lightbox/media-lightbox-helpers.ts
@@ -1,0 +1,55 @@
+import type { MediaLightboxEntry } from './media-lightbox-types';
+
+export function isVerticalAspect(aspectRatio?: string | null): boolean {
+  if (!aspectRatio) return false;
+  const value = aspectRatio.toLowerCase();
+  if (!value.includes(':')) return false;
+  const [w, h] = value.split(':').map((part) => Number(part));
+  if (!Number.isFinite(w) || !Number.isFinite(h) || h === 0) return false;
+  return h > w;
+}
+
+export function formatPromptPreview(prompt: string, maxLength = 220): string {
+  const normalized = prompt.replace(/\s+/g, ' ').trim();
+  if (!normalized) return '';
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength).trim()}…`;
+}
+
+export function isUuidLike(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+}
+
+export function formatEntryDate(value?: string | null): string | null {
+  if (!value) return null;
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(new Date(value));
+  } catch {
+    return value;
+  }
+}
+
+export function resolveStatusLabel(status?: MediaLightboxEntry['status']): string | null {
+  if (status === 'pending') return 'Processing';
+  if (status === 'failed') return 'Failed';
+  if (status === 'completed') return 'Ready';
+  return null;
+}
+
+export function statusBadgeClass(status?: MediaLightboxEntry['status']): string {
+  if (status === 'failed') return 'border-warning-border bg-warning-bg text-warning';
+  if (status === 'pending') return 'border-brand/30 bg-[var(--brand-soft)] text-brand';
+  return 'border-[var(--brand-border)] bg-[var(--brand-soft)] text-brand';
+}
+
+export function resolveOpenLabel(entry: MediaLightboxEntry): string {
+  if (entry.audioUrl && !entry.videoUrl) return 'Open audio';
+  if (entry.imageUrl && !entry.videoUrl) return 'Open image';
+  return 'Open in player';
+}

--- a/frontend/components/media-lightbox/media-lightbox-types.ts
+++ b/frontend/components/media-lightbox/media-lightbox-types.ts
@@ -1,0 +1,55 @@
+import type { JobSurface } from '@/types/billing';
+
+export interface MediaLightboxEntry {
+  id: string;
+  label: string;
+  videoUrl?: string | null;
+  previewUrl?: string | null;
+  audioUrl?: string | null;
+  imageUrl?: string | null;
+  thumbUrl?: string | null;
+  aspectRatio?: string | null;
+  jobId?: string | null;
+  surface?: JobSurface | null;
+  status?: 'pending' | 'completed' | 'failed';
+  progress?: number | null;
+  message?: string | null;
+  engineLabel?: string | null;
+  engineId?: string | null;
+  durationSec?: number | null;
+  createdAt?: string | null;
+  indexable?: boolean;
+  visibility?: 'public' | 'private';
+  hasAudio?: boolean;
+  mediaType?: 'image' | 'video' | 'audio';
+  prompt?: string | null;
+  priceCents?: number | null;
+  currency?: string | null;
+  curated?: boolean;
+}
+
+export interface MediaLightboxProps {
+  title: string;
+  subtitle?: string;
+  prompt?: string | null;
+  metadata?: Array<{ label: string; value: string }>;
+  entries: MediaLightboxEntry[];
+  onClose: () => void;
+  onRefreshEntry?: (entry: MediaLightboxEntry) => Promise<void> | void;
+  onSaveToLibrary?: (entry: MediaLightboxEntry) => Promise<void>;
+  onRemixEntry?: (entry: MediaLightboxEntry) => void;
+  remixLabel?: string;
+  onUseTemplate?: (entry: MediaLightboxEntry) => void;
+  templateLabel?: string;
+}
+
+export type MediaLightboxLoadingState = {
+  loading: boolean;
+  error: string | null;
+};
+
+export type MediaLightboxLibraryState = {
+  loading: boolean;
+  success: boolean;
+  error: string | null;
+};

--- a/frontend/components/quad-preview/QuadMosaicFigure.tsx
+++ b/frontend/components/quad-preview/QuadMosaicFigure.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import clsx from 'clsx';
+import Image from 'next/image';
+import { AudioEqualizerBadge } from '@/components/ui/AudioEqualizerBadge';
+import { getAspectClass } from './quad-preview-helpers';
+import type { QuadMosaicStatus, QuadPreviewTile } from './quad-preview-types';
+
+type QuadMosaicFigureProps = {
+  heroTile?: QuadPreviewTile;
+  isPlaying: boolean;
+  mosaicGridClass: string;
+  mosaicStatusMap: Map<string, QuadMosaicStatus>;
+  mosaicTiles: Array<QuadPreviewTile | null>;
+  primaryAspect: string;
+  onPrimaryVideoReady: (tileKey?: string | null) => void;
+};
+
+export function QuadMosaicFigure({
+  heroTile,
+  isPlaying,
+  mosaicGridClass,
+  mosaicStatusMap,
+  mosaicTiles,
+  primaryAspect,
+  onPrimaryVideoReady,
+}: QuadMosaicFigureProps) {
+  return (
+    <figure className="overflow-hidden rounded-card border border-border bg-surface-glass-80 p-3 text-center">
+      <div className={clsx('relative w-full', getAspectClass(primaryAspect))}>
+        <div className={clsx('absolute inset-0 grid gap-2 rounded-card bg-placeholder p-1', mosaicGridClass)}>
+          {mosaicTiles.map((preview, index) => {
+            const slotKey = preview?.localKey ?? `slot-${index}`;
+            const statusInfo = preview?.localKey ? mosaicStatusMap.get(preview.localKey) : undefined;
+            const cellAspect = getAspectClass(preview?.aspectRatio ?? primaryAspect);
+            const tileStatus = statusInfo?.status ?? preview?.status ?? 'pending';
+            const failureMessageRaw = statusInfo?.message ?? preview?.message ?? null;
+            const failureMessage =
+              failureMessageRaw && typeof failureMessageRaw === 'string'
+                ? failureMessageRaw.replace(/\s+/g, ' ').trim()
+                : null;
+            const showPendingOverlay = tileStatus !== 'completed' && tileStatus !== 'failed';
+            const showFailedOverlay = tileStatus === 'failed';
+            const shouldPlayPreview = Boolean(isPlaying && preview?.localKey === heroTile?.localKey);
+
+            return (
+              <div
+                key={slotKey}
+                data-quad-cell={slotKey}
+                className="relative flex items-center justify-center overflow-hidden rounded-input bg-surface-glass-70"
+              >
+                <div className={clsx('relative h-full w-full', cellAspect)}>
+                  {tileStatus !== 'failed' && preview?.videoUrl ? (
+                    <video
+                      data-quad-video={shouldPlayPreview ? 'active' : 'idle'}
+                      data-quad-fallback
+                      src={preview.videoUrl}
+                      className="absolute inset-0 h-full w-full object-cover pointer-events-none"
+                      autoPlay={shouldPlayPreview}
+                      muted
+                      playsInline
+                      loop
+                      preload={shouldPlayPreview ? 'auto' : 'none'}
+                      poster={preview?.thumbUrl}
+                      onLoadedData={() => onPrimaryVideoReady(preview?.localKey)}
+                      onCanPlay={() => onPrimaryVideoReady(preview?.localKey)}
+                    />
+                  ) : tileStatus !== 'failed' && preview?.thumbUrl ? (
+                    <Image
+                      data-quad-fallback
+                      src={preview.thumbUrl}
+                      alt=""
+                      fill
+                      sizes="(max-width: 768px) 50vw, 320px"
+                      className="absolute inset-0 object-cover pointer-events-none"
+                      priority={false}
+                    />
+                  ) : (
+                    <div className="absolute inset-0 bg-gradient-to-br from-surface-2 via-surface to-surface-2" />
+                  )}
+                  {Boolean(preview?.hasAudio) && tileStatus !== 'failed' ? (
+                    <AudioEqualizerBadge tone="light" size="sm" label="Audio available" />
+                  ) : null}
+                </div>
+                <div className="absolute inset-0 z-10" data-quad-player-root={slotKey} />
+                {showPendingOverlay ? (
+                  <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-surface-on-media-dark-45 px-2 text-center text-[10px] text-on-inverse backdrop-blur-sm">
+                    <span className="uppercase tracking-micro">Processing</span>
+                    {(statusInfo?.message || preview?.message) ? (
+                      <span className="mt-1 max-w-[140px] text-[10px] text-on-media-80">
+                        {statusInfo?.message ?? preview?.message}
+                      </span>
+                    ) : null}
+                    {typeof statusInfo?.progress === 'number' ? (
+                      <span className="mt-1 text-[10px] font-semibold">{statusInfo.progress}%</span>
+                    ) : null}
+                    {statusInfo?.etaLabel ? <span className="mt-1 text-[9px] text-on-media-70">{statusInfo.etaLabel}</span> : null}
+                  </div>
+                ) : null}
+                {showFailedOverlay ? (
+                  <div className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-1 rounded-input bg-error-bg px-3 text-center text-[10px] text-error">
+                    <span className="font-semibold uppercase tracking-micro text-error">Failed</span>
+                    {failureMessage ? <span className="line-clamp-4 text-[10px] leading-tight text-error">{failureMessage}</span> : null}
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      <figcaption className="mt-2 text-[11px] text-text-muted">Composite preview</figcaption>
+    </figure>
+  );
+}

--- a/frontend/components/quad-preview/QuadSingleTilesGrid.tsx
+++ b/frontend/components/quad-preview/QuadSingleTilesGrid.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import clsx from 'clsx';
+import Image from 'next/image';
+import { AudioEqualizerBadge } from '@/components/ui/AudioEqualizerBadge';
+import { Button } from '@/components/ui/Button';
+import { EngineIcon } from '@/components/ui/EngineIcon';
+import { formatCurrency, getAspectClass, TILE_ACTIONS } from './quad-preview-helpers';
+import type { QuadGroupAction, QuadPreviewTile, QuadTileAction } from './quad-preview-types';
+import type { EngineCaps } from '@/types/engines';
+
+type QuadSingleTilesGridProps = {
+  currency: string;
+  engineMap: Map<string, EngineCaps>;
+  heroKey?: string;
+  heroTile?: QuadPreviewTile;
+  isPlaying: boolean;
+  iterationCount: number;
+  sortedTilesLength: number;
+  tilesWithPlaceholders: Array<QuadPreviewTile | null>;
+  onGroupAction: (action: QuadGroupAction, tile?: QuadPreviewTile) => void;
+  onPrimaryVideoReady: (tileKey?: string | null) => void;
+  onSelectHero: (tile: QuadPreviewTile) => void;
+  onTileAction: (action: QuadTileAction, tile: QuadPreviewTile) => void;
+};
+
+export function QuadSingleTilesGrid({
+  currency,
+  engineMap,
+  heroKey,
+  heroTile,
+  isPlaying,
+  iterationCount,
+  sortedTilesLength,
+  tilesWithPlaceholders,
+  onGroupAction,
+  onPrimaryVideoReady,
+  onSelectHero,
+  onTileAction,
+}: QuadSingleTilesGridProps) {
+  return (
+    <div
+      className={clsx(
+        'grid grid-gap-sm',
+        sortedTilesLength === 1 ? 'md:grid-cols-1' : 'md:grid-cols-2',
+        iterationCount >= 3 ? 'auto-rows-[minmax(120px,1fr)]' : undefined
+      )}
+    >
+      {tilesWithPlaceholders.map((tile, index) => {
+        if (!tile) {
+          return (
+            <div
+              key={`placeholder-${index}`}
+              className="flex rounded-card border border-dashed border-border bg-gradient-to-br from-surface-2 via-surface to-surface-2"
+            />
+          );
+        }
+
+        const engineCaps = engineMap.get(tile.engineId);
+        const statusLabel =
+          tile.status === 'completed' ? 'Final' : tile.status === 'failed' ? 'Failed' : 'Processing';
+        const formattedPrice = formatCurrency(tile.priceCents, tile.currency ?? currency);
+        const versionLabel = `V${tile.iterationIndex + 1}`;
+        const branchLabel = `Branch ${String.fromCharCode(65 + tile.iterationIndex)}`;
+        const isHero = heroKey === tile.localKey;
+        const tileAspectClass = getAspectClass(tile.aspectRatio);
+        const isFailed = tile.status === 'failed';
+        const failureMessage =
+          tile.message && typeof tile.message === 'string' ? tile.message.replace(/\s+/g, ' ').trim() : null;
+        const shouldPlayPreview = Boolean(isPlaying && tile.localKey === heroTile?.localKey);
+
+        return (
+          <div
+            key={tile.localKey}
+            className={clsx(
+              'flex flex-col overflow-hidden rounded-card border',
+              isFailed
+                ? 'border-error-border bg-error-bg shadow-card'
+                : isHero
+                  ? 'border-brand shadow-lg'
+                  : 'border-border bg-surface-glass-85 shadow-card'
+            )}
+          >
+            <div
+              className={clsx(
+                'flex items-center justify-between gap-2 border-b px-3 py-2 text-[11px] font-semibold uppercase tracking-micro',
+                isFailed ? 'border-error-border bg-error-bg text-error' : 'border-hairline bg-surface text-text-muted'
+              )}
+            >
+              <span className="inline-flex items-center gap-2">
+                <span className={clsx('rounded-full px-2 py-0.5', isHero ? 'bg-surface-2 text-brand' : 'bg-surface-on-media-dark-5 text-text-secondary')}>
+                  {versionLabel}
+                </span>
+                <span>{statusLabel}</span>
+                <span className="hidden sm:inline text-text-secondary">{branchLabel}</span>
+              </span>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => onSelectHero(tile)}
+                className={clsx(
+                  'min-h-0 h-auto rounded-full px-2 py-0.5 text-[10px]',
+                  isHero ? 'border-brand bg-brand text-on-brand' : 'border-hairline bg-surface text-text-secondary hover:border-text-muted hover:bg-surface-2'
+                )}
+              >
+                <Image src="/assets/icons/pin.svg" alt="" width={12} height={12} className="h-3 w-3" aria-hidden />
+                Hero
+              </Button>
+            </div>
+
+            <div className={clsx('relative bg-placeholder', tileAspectClass)} data-quad-tile={tile.localKey}>
+              <div className="relative h-full w-full">
+                {tile.status !== 'failed' && tile.videoUrl ? (
+                  <video
+                    data-quad-video={shouldPlayPreview ? 'active' : 'idle'}
+                    data-quad-tile-fallback
+                    key={tile.videoUrl}
+                    src={tile.videoUrl}
+                    className="absolute inset-0 h-full w-full object-cover pointer-events-none"
+                    muted
+                    playsInline
+                    autoPlay={shouldPlayPreview}
+                    loop
+                    preload={shouldPlayPreview ? 'auto' : 'none'}
+                    poster={tile.thumbUrl}
+                    onLoadedData={() => onPrimaryVideoReady(tile.localKey)}
+                    onCanPlay={() => onPrimaryVideoReady(tile.localKey)}
+                  />
+                ) : tile.status !== 'failed' && tile.thumbUrl ? (
+                  <Image
+                    src={tile.thumbUrl}
+                    alt=""
+                    fill
+                    sizes="(max-width: 768px) 100vw, 50vw"
+                    className="absolute inset-0 object-cover pointer-events-none"
+                    priority={false}
+                  />
+                ) : (
+                  <div className="absolute inset-0 bg-gradient-to-br from-surface-2 via-surface to-surface-2" />
+                )}
+                {tile.status !== 'failed' && tile.videoUrl && tile.hasAudio ? (
+                  <AudioEqualizerBadge tone="light" size="sm" label="Audio available" />
+                ) : null}
+              </div>
+              <div className="absolute inset-0 z-10" data-quad-tile-root={tile.localKey} />
+              {tile.status === 'failed' ? (
+                <div className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-2 bg-error-bg px-4 text-center text-[12px] text-error backdrop-blur-sm">
+                  <span className="font-semibold uppercase tracking-micro text-error">Generation failed</span>
+                  <span className="text-[11px] leading-snug text-error">
+                    {failureMessage ??
+                      'The service reported a failure without details. Try again. If it fails repeatedly, contact support with your request ID.'}
+                  </span>
+                </div>
+              ) : tile.status !== 'completed' ? (
+                <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-surface-on-media-dark-40 px-4 text-center text-[12px] text-on-inverse backdrop-blur-sm">
+                  <span className="uppercase tracking-micro">Processing</span>
+                  {tile.message ? <span className="mt-1 text-[11px] text-on-media-80">{tile.message}</span> : null}
+                  <span className="mt-2 text-[11px] font-semibold text-on-media-90">{tile.progress}%</span>
+                </div>
+              ) : null}
+            </div>
+
+            <div className="flex flex-col gap-2 border-t border-hairline bg-surface px-3 py-2 text-[12px] text-text-secondary">
+              {isFailed ? (
+                <div className="rounded-md border border-error-border bg-error-bg px-3 py-2 text-left">
+                  <p className="text-[10px] font-semibold uppercase tracking-micro text-error">Refund note</p>
+                  <p className="mt-1 text-[11px] leading-snug text-error">
+                    {failureMessage ??
+                      'The service reported a failure without details. Try again. If it fails repeatedly, contact support with your request ID.'}
+                  </p>
+                </div>
+              ) : null}
+              <div className="flex items-center justify-between gap-2">
+                <span className="inline-flex items-center gap-2 font-medium text-text-primary">
+                  <EngineIcon engine={engineCaps ?? undefined} label={tile.engineLabel} size={28} className="shrink-0" />
+                  {tile.engineLabel}
+                </span>
+                {formattedPrice ? <span className="text-[11px] font-semibold text-text-primary">{formattedPrice}</span> : null}
+              </div>
+              <div className="flex items-center justify-between text-[11px] text-text-muted">
+                <span>{tile.durationSec}s</span>
+                <span>
+                  {tile.etaLabel ??
+                    (tile.status === 'completed' ? 'Ready' : tile.status === 'failed' ? 'Failed' : 'Estimating…')}
+                </span>
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between gap-1 border-t border-hairline bg-surface px-2 py-1.5">
+              <div className="flex gap-1">
+                {TILE_ACTIONS.map((action) => (
+                  <Button
+                    key={action.id}
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => onTileAction(action.id, tile)}
+                    className="h-8 w-8 min-h-0 rounded-full border-hairline bg-surface p-0 text-text-secondary hover:border-text-muted hover:bg-surface-2"
+                    aria-label={action.label}
+                  >
+                    <Image src={action.icon} alt="" width={14} height={14} className="h-3.5 w-3.5" aria-hidden />
+                  </Button>
+                ))}
+              </div>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => onGroupAction('open', tile)}
+                className="min-h-0 h-auto rounded-full border-hairline bg-surface px-2.5 py-1 text-[11px] font-semibold uppercase tracking-micro text-text-secondary hover:border-text-muted hover:bg-surface-2"
+              >
+                View
+              </Button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/components/quad-preview/quad-preview-helpers.ts
+++ b/frontend/components/quad-preview/quad-preview-helpers.ts
@@ -1,0 +1,79 @@
+import type { QuadPreviewTile, QuadTileAction } from './quad-preview-types';
+
+export const TILE_ACTIONS: Array<{ id: QuadTileAction; label: string; icon: string }> = [
+  { id: 'continue', label: 'Continue', icon: '/assets/icons/play.svg' },
+  { id: 'refine', label: 'Refine', icon: '/assets/icons/remix.svg' },
+  { id: 'branch', label: 'Branch', icon: '/assets/icons/extend.svg' },
+  { id: 'copy', label: 'Copy prompt', icon: '/assets/icons/copy.svg' },
+  { id: 'open', label: 'Open in player', icon: '/assets/icons/expand.svg' },
+];
+
+export function getAspectClass(aspectRatio?: string | null): string {
+  const normalized = (aspectRatio ?? '').trim();
+  switch (normalized) {
+    case '1:1':
+    case 'square':
+      return 'aspect-square';
+    case '9:16':
+    case '9/16':
+      return 'aspect-[9/16]';
+    case '9:21':
+    case '9/21':
+      return 'aspect-[9/21]';
+    case '16:9':
+    case '16/9':
+      return 'aspect-[16/9]';
+    case '3:4':
+    case '3/4':
+      return 'aspect-[3/4]';
+    case '4:3':
+    case '4/3':
+      return 'aspect-[4/3]';
+    case '4:5':
+    case '4/5':
+      return 'aspect-[4/5]';
+    case '5:4':
+    case '5/4':
+      return 'aspect-[5/4]';
+    case '21:9':
+    case '21/9':
+      return 'aspect-[21/9]';
+    default:
+      return 'aspect-[16/9]';
+  }
+}
+
+export function formatCurrency(amountCents?: number, currency = 'USD') {
+  if (typeof amountCents !== 'number') return null;
+  try {
+    return new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(amountCents / 100);
+  } catch {
+    return `${currency} ${(amountCents / 100).toFixed(2)}`;
+  }
+}
+
+export function buildTilesWithPlaceholders(sortedTiles: QuadPreviewTile[], iterationCount: number): Array<QuadPreviewTile | null> {
+  if (sortedTiles.length === 0) return [];
+
+  const primaryAspectRatio = sortedTiles[0]?.aspectRatio ?? '16:9';
+  const desiredSlots = (() => {
+    if (iterationCount <= 1) return 1;
+    if (iterationCount === 2) return 2;
+    if (primaryAspectRatio === '9:16' && iterationCount === 3) return 3;
+    if (iterationCount >= 3) return 4;
+    return 1;
+  })();
+
+  const list: Array<QuadPreviewTile | null> = [...sortedTiles];
+  while (list.length < desiredSlots) {
+    list.push(null);
+  }
+
+  if (primaryAspectRatio === '9:16' && desiredSlots === 4 && sortedTiles.length === 2) {
+    const first = sortedTiles[0] ?? null;
+    const second = sortedTiles[1] ?? null;
+    return [null, first, second, null];
+  }
+
+  return list.slice(0, desiredSlots);
+}

--- a/frontend/components/quad-preview/quad-preview-types.ts
+++ b/frontend/components/quad-preview/quad-preview-types.ts
@@ -1,0 +1,52 @@
+import type { PriceFactorKind } from '@/components/PriceFactorsBar';
+import type { EngineCaps, PreflightResponse } from '@/types/engines';
+
+export type QuadTileAction = 'continue' | 'refine' | 'branch' | 'copy' | 'open';
+export type QuadGroupAction = 'open' | 'compare' | 'hero';
+
+export interface QuadPreviewTile {
+  localKey: string;
+  batchId: string;
+  id: string;
+  jobId?: string;
+  iterationIndex: number;
+  iterationCount: number;
+  videoUrl?: string;
+  previewVideoUrl?: string;
+  thumbUrl?: string;
+  aspectRatio: string;
+  progress: number;
+  message: string;
+  priceCents?: number;
+  currency?: string;
+  durationSec: number;
+  engineLabel: string;
+  engineId: string;
+  etaLabel?: string;
+  prompt: string;
+  status: 'pending' | 'completed' | 'failed';
+  hasAudio?: boolean;
+}
+
+export interface QuadPreviewPanelProps {
+  tiles: QuadPreviewTile[];
+  heroKey?: string;
+  preflight: PreflightResponse | null;
+  iterations: number;
+  currency: string;
+  totalPriceCents?: number | null;
+  onNavigateFactor?: (kind: PriceFactorKind) => void;
+  onTileAction: (action: QuadTileAction, tile: QuadPreviewTile) => void;
+  onGroupAction: (action: QuadGroupAction, tile?: QuadPreviewTile) => void;
+  onSelectHero: (tile: QuadPreviewTile) => void;
+  engineMap: Map<string, EngineCaps>;
+  onSaveComposite?: () => void;
+  onRefreshJob?: (jobId: string) => Promise<void> | void;
+}
+
+export type QuadMosaicStatus = {
+  status: QuadPreviewTile['status'];
+  progress: number;
+  message: string;
+  etaLabel?: string;
+};

--- a/tests/composer-architecture.test.ts
+++ b/tests/composer-architecture.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const root = process.cwd();
+const composerPath = join(root, 'frontend/components/Composer.tsx');
+const composerTypesPath = join(root, 'frontend/components/composer/composer-types.ts');
+const composerCopyPath = join(root, 'frontend/components/composer/composer-copy.ts');
+const multiPromptEditorPath = join(root, 'frontend/components/composer/ComposerMultiPromptEditor.tsx');
+const promotedActionIconPath = join(root, 'frontend/components/composer/ComposerPromotedActionIcon.tsx');
+
+const composerSource = readFileSync(composerPath, 'utf8');
+const composerTypesSource = readFileSync(composerTypesPath, 'utf8');
+const composerCopySource = readFileSync(composerCopyPath, 'utf8');
+const multiPromptEditorSource = readFileSync(multiPromptEditorPath, 'utf8');
+const promotedActionIconSource = readFileSync(promotedActionIconPath, 'utf8');
+
+test('composer delegates copy, contracts, multi-prompt, and promoted action icon ownership', () => {
+  for (const path of [composerPath, composerTypesPath, composerCopyPath, multiPromptEditorPath, promotedActionIconPath]) {
+    assert.ok(existsSync(path), `${path} should exist`);
+  }
+
+  assert.match(composerSource, /<ComposerMultiPromptEditor/, 'Composer should compose the focused multi-prompt editor');
+  assert.match(composerSource, /<ComposerPromotedActionIcon/, 'Composer should compose the focused promoted action icon');
+  assert.doesNotMatch(composerSource, /export const DEFAULT_COMPOSER_COPY|function renderPromotedActionIcon/, 'copy and icon drawing belong in focused modules');
+  assert.doesNotMatch(composerSource, /type MultiPromptScene|interface ComposerProps/, 'composer contracts belong in composer-types.ts');
+  assert.match(composerTypesSource, /export interface ComposerProps/, 'composer types should own the public props contract');
+  assert.match(composerTypesSource, /export type MultiPromptScene/, 'composer types should own multi-prompt scene contracts');
+  assert.match(composerCopySource, /export const DEFAULT_COMPOSER_COPY/, 'composer copy should own default copy');
+  assert.match(multiPromptEditorSource, /export function ComposerMultiPromptEditor/, 'multi-prompt editor should own scene rendering');
+  assert.match(promotedActionIconSource, /export function ComposerPromotedActionIcon/, 'promoted action icon should own icon drawing');
+
+  const lineCount = composerSource.split('\n').length;
+  assert.ok(lineCount <= 500, `Composer.tsx should stay below 500 lines after composer surface extraction, got ${lineCount}`);
+});

--- a/tests/models-gallery-architecture.test.ts
+++ b/tests/models-gallery-architecture.test.ts
@@ -7,17 +7,34 @@ const root = process.cwd();
 const galleryPath = join(root, 'frontend/components/marketing/ModelsGallery.tsx');
 const cardPath = join(root, 'frontend/components/marketing/ModelsGalleryCard.tsx');
 const utilsPath = join(root, 'frontend/components/marketing/models-gallery-utils.ts');
+const filtersPath = join(root, 'frontend/components/marketing/models-gallery/ModelsGalleryFilters.tsx');
+const compareBarPath = join(root, 'frontend/components/marketing/models-gallery/ModelsGalleryCompareBar.tsx');
+const copyPath = join(root, 'frontend/components/marketing/models-gallery/models-gallery-copy.ts');
+const filteringPath = join(root, 'frontend/components/marketing/models-gallery/models-gallery-filtering.ts');
+const typesPath = join(root, 'frontend/components/marketing/models-gallery/models-gallery-types.ts');
 
 const gallerySource = readFileSync(galleryPath, 'utf8');
 const cardSource = readFileSync(cardPath, 'utf8');
 const utilsSource = readFileSync(utilsPath, 'utf8');
+const filtersSource = readFileSync(filtersPath, 'utf8');
+const compareBarSource = readFileSync(compareBarPath, 'utf8');
+const copySource = readFileSync(copyPath, 'utf8');
+const filteringSource = readFileSync(filteringPath, 'utf8');
+const typesSource = readFileSync(typesPath, 'utf8');
 
 test('models gallery delegates card rendering and visual helpers', () => {
   assert.ok(existsSync(galleryPath), 'models gallery should exist');
   assert.ok(existsSync(cardPath), 'models gallery card should live in a focused component');
   assert.ok(existsSync(utilsPath), 'models gallery visual helpers should live in a focused module');
+  assert.ok(existsSync(filtersPath), 'models gallery filters should live in a focused component');
+  assert.ok(existsSync(compareBarPath), 'models gallery compare bar should live in a focused component');
+  assert.ok(existsSync(copyPath), 'models gallery copy should live in a focused module');
+  assert.ok(existsSync(filteringPath), 'models gallery filtering should live in a focused module');
+  assert.ok(existsSync(typesPath), 'models gallery contracts should live in a focused module');
   assert.match(gallerySource, /from '@\/components\/marketing\/ModelsGalleryCard'/);
-  assert.match(gallerySource, /from '@\/components\/marketing\/models-gallery-utils'/);
+  assert.match(gallerySource, /ModelsGalleryFilters/);
+  assert.match(gallerySource, /ModelsGalleryCompareBar/);
+  assert.match(compareBarSource, /from '@\/components\/marketing\/models-gallery-utils'/);
 });
 
 test('models gallery does not regain card rendering ownership', () => {
@@ -27,9 +44,11 @@ test('models gallery does not regain card rendering ownership', () => {
   assert.doesNotMatch(gallerySource, /normalizeCtaLabel/, 'CTA normalization belongs in models-gallery-utils.ts');
   assert.doesNotMatch(gallerySource, /getCapabilityIcon/, 'capability icon mapping belongs in models-gallery-utils.ts');
   assert.doesNotMatch(gallerySource, /ArrowRight/, 'card CTA icon belongs in ModelsGalleryCard.tsx');
+  assert.doesNotMatch(gallerySource, /const DEFAULT_COPY|function FilterControl/, 'copy and filter rendering belong in split modules');
+  assert.doesNotMatch(gallerySource, /compareNumbers|normalizedQuery/, 'filtering and sorting logic belongs in models-gallery-filtering.ts');
 
   const lineCount = gallerySource.split('\n').length;
-  assert.ok(lineCount <= 750, `ModelsGallery should stay below 750 lines after card extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 300, `ModelsGallery should stay below 300 lines after gallery surface extraction, got ${lineCount}`);
 });
 
 test('models gallery card modules expose the expected contract', () => {
@@ -41,4 +60,10 @@ test('models gallery card modules expose the expected contract', () => {
   assert.match(utilsSource, /export function formatTemplate/);
   assert.match(utilsSource, /export function normalizeCtaLabel/);
   assert.match(utilsSource, /export function getCapabilityIcon/);
+  assert.match(filtersSource, /export function ModelsGalleryFilters/);
+  assert.match(compareBarSource, /export function ModelsGalleryCompareBar/);
+  assert.match(copySource, /export function resolveModelsGalleryCopy/);
+  assert.match(filteringSource, /export function filterModelGalleryCards/);
+  assert.match(filteringSource, /export function sortModelGalleryCards/);
+  assert.match(typesSource, /export type ModelGalleryCard/);
 });

--- a/tests/price-estimator-architecture.test.ts
+++ b/tests/price-estimator-architecture.test.ts
@@ -6,13 +6,24 @@ import test from 'node:test';
 const root = process.cwd();
 const estimatorPath = join(root, 'frontend/components/marketing/PriceEstimator.tsx');
 const optionsPath = join(root, 'frontend/components/marketing/price-estimator/price-estimator-options.ts');
+const selectGroupPath = join(root, 'frontend/components/marketing/price-estimator/PriceEstimatorSelectGroup.tsx');
+const summaryPanelPath = join(root, 'frontend/components/marketing/price-estimator/PriceEstimatorSummaryPanel.tsx');
+const summaryLabelsPath = join(root, 'frontend/components/marketing/price-estimator/price-estimator-summary-labels.ts');
 
 const estimatorSource = readFileSync(estimatorPath, 'utf8');
 const optionsSource = readFileSync(optionsPath, 'utf8');
+const selectGroupSource = readFileSync(selectGroupPath, 'utf8');
+const summaryPanelSource = readFileSync(summaryPanelPath, 'utf8');
+const summaryLabelsSource = readFileSync(summaryLabelsPath, 'utf8');
 
 test('price estimator delegates engine option pricing helpers', () => {
   assert.ok(existsSync(optionsPath), 'price estimator option helpers should live in a focused module');
+  assert.ok(existsSync(selectGroupPath), 'price estimator select groups should live in a focused component');
+  assert.ok(existsSync(summaryPanelPath), 'price estimator summary should live in a focused component');
+  assert.ok(existsSync(summaryLabelsPath), 'price estimator summary labels should live in a focused helper');
   assert.match(estimatorSource, /from '@\/components\/marketing\/price-estimator\/price-estimator-options'/);
+  assert.match(estimatorSource, /PriceEstimatorSelectGroup/);
+  assert.match(estimatorSource, /PriceEstimatorSummaryPanel/);
   assert.match(optionsSource, /export const MEMBER_ORDER/);
   assert.match(optionsSource, /export const FAL_ENGINE_REGISTRY/);
   assert.match(optionsSource, /export const PER_IMAGE_ENGINE_IDS/);
@@ -30,7 +41,12 @@ test('price estimator component does not regain option builder ownership', () =>
   assert.doesNotMatch(estimatorSource, /function collectDurationOptions\(/, 'duration option collection belongs in price-estimator-options.ts');
   assert.doesNotMatch(estimatorSource, /function buildEngineOption\(/, 'engine option building belongs in price-estimator-options.ts');
   assert.doesNotMatch(estimatorSource, /function formatCurrency\(/, 'currency formatting belongs in price-estimator-options.ts');
+  assert.doesNotMatch(estimatorSource, /function SelectGroup\(/, 'select group rendering belongs in PriceEstimatorSelectGroup.tsx');
+  assert.doesNotMatch(estimatorSource, /member-status-pill/, 'member tier summary controls belong in PriceEstimatorSummaryPanel.tsx');
 
   const lineCount = estimatorSource.split('\n').length;
-  assert.ok(lineCount <= 620, `PriceEstimator.tsx should stay below 620 lines after option helper extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 500, `PriceEstimator.tsx should stay below 500 lines after summary extraction, got ${lineCount}`);
+  assert.match(selectGroupSource, /export function PriceEstimatorSelectGroup/);
+  assert.match(summaryPanelSource, /export function PriceEstimatorSummaryPanel/);
+  assert.match(summaryLabelsSource, /export function buildPriceEstimatorSummaryLabels/);
 });

--- a/tests/shared-media-surfaces-architecture.test.ts
+++ b/tests/shared-media-surfaces-architecture.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const root = process.cwd();
+
+const assetDropzonePath = join(root, 'frontend/components/AssetDropzone.tsx');
+const assetDropzoneSlotPath = join(root, 'frontend/components/asset-dropzone/AssetDropzoneSlot.tsx');
+const assetDropzoneHelpersPath = join(root, 'frontend/components/asset-dropzone/asset-dropzone-helpers.ts');
+const assetDropzoneTypesPath = join(root, 'frontend/components/asset-dropzone/asset-dropzone-types.ts');
+
+const mediaLightboxPath = join(root, 'frontend/components/MediaLightbox.tsx');
+const mediaLightboxEntryCardPath = join(root, 'frontend/components/media-lightbox/MediaLightboxEntryCard.tsx');
+const mediaLightboxHelpersPath = join(root, 'frontend/components/media-lightbox/media-lightbox-helpers.ts');
+const mediaLightboxTypesPath = join(root, 'frontend/components/media-lightbox/media-lightbox-types.ts');
+
+const quadPreviewPath = join(root, 'frontend/components/QuadPreviewPanel.tsx');
+const quadMosaicFigurePath = join(root, 'frontend/components/quad-preview/QuadMosaicFigure.tsx');
+const quadSingleTilesGridPath = join(root, 'frontend/components/quad-preview/QuadSingleTilesGrid.tsx');
+const quadPreviewHelpersPath = join(root, 'frontend/components/quad-preview/quad-preview-helpers.ts');
+const quadPreviewTypesPath = join(root, 'frontend/components/quad-preview/quad-preview-types.ts');
+
+test('shared media surfaces delegate slot, entry rendering, helper, and type ownership', () => {
+  for (const path of [
+    assetDropzonePath,
+    assetDropzoneSlotPath,
+    assetDropzoneHelpersPath,
+    assetDropzoneTypesPath,
+    mediaLightboxPath,
+    mediaLightboxEntryCardPath,
+    mediaLightboxHelpersPath,
+    mediaLightboxTypesPath,
+    quadPreviewPath,
+    quadMosaicFigurePath,
+    quadSingleTilesGridPath,
+    quadPreviewHelpersPath,
+    quadPreviewTypesPath,
+  ]) {
+    assert.ok(existsSync(path), `${path} should exist`);
+  }
+
+  const assetDropzoneSource = readFileSync(assetDropzonePath, 'utf8');
+  const assetDropzoneSlotSource = readFileSync(assetDropzoneSlotPath, 'utf8');
+  const assetDropzoneHelpersSource = readFileSync(assetDropzoneHelpersPath, 'utf8');
+  const assetDropzoneTypesSource = readFileSync(assetDropzoneTypesPath, 'utf8');
+
+  assert.match(assetDropzoneSource, /<AssetDropzoneSlot/, 'AssetDropzone should compose a focused slot component');
+  assert.doesNotMatch(assetDropzoneSource, /function resolveSlotLabel|function readMediaDuration/, 'AssetDropzone should not own helper logic');
+  assert.doesNotMatch(assetDropzoneSource, /AudioEqualizerBadge|Trash2|<audio|<video/, 'AssetDropzone should not own slot media rendering');
+  assert.match(assetDropzoneSlotSource, /export function AssetDropzoneSlot/, 'AssetDropzoneSlot should own slot rendering');
+  assert.match(assetDropzoneHelpersSource, /export function resolveSlotLabel/, 'asset dropzone helpers should own slot labels');
+  assert.match(assetDropzoneHelpersSource, /export function readMediaDuration/, 'asset dropzone helpers should own browser duration probing');
+  assert.match(assetDropzoneTypesSource, /export type AssetSlotAttachment/, 'asset dropzone types should own public attachment types');
+
+  const mediaLightboxSource = readFileSync(mediaLightboxPath, 'utf8');
+  const mediaLightboxEntryCardSource = readFileSync(mediaLightboxEntryCardPath, 'utf8');
+  const mediaLightboxHelpersSource = readFileSync(mediaLightboxHelpersPath, 'utf8');
+  const mediaLightboxTypesSource = readFileSync(mediaLightboxTypesPath, 'utf8');
+
+  assert.match(mediaLightboxSource, /<MediaLightboxEntryCard/, 'MediaLightbox should compose a focused entry card');
+  assert.doesNotMatch(mediaLightboxSource, /function formatPromptPreview|function RenderDecorVisual|function ActionCard/, 'MediaLightbox should not own entry rendering helpers');
+  assert.match(mediaLightboxEntryCardSource, /export function MediaLightboxEntryCard/, 'MediaLightboxEntryCard should own entry rendering');
+  assert.match(mediaLightboxEntryCardSource, /function RenderDecorVisual/, 'entry card should own decorative render visuals');
+  assert.match(mediaLightboxHelpersSource, /export function formatPromptPreview/, 'media lightbox helpers should own prompt formatting');
+  assert.match(mediaLightboxHelpersSource, /export function resolveStatusLabel/, 'media lightbox helpers should own status labels');
+  assert.match(mediaLightboxTypesSource, /export interface MediaLightboxEntry/, 'media lightbox types should own public entry contracts');
+
+  const quadPreviewSource = readFileSync(quadPreviewPath, 'utf8');
+  const quadMosaicFigureSource = readFileSync(quadMosaicFigurePath, 'utf8');
+  const quadSingleTilesGridSource = readFileSync(quadSingleTilesGridPath, 'utf8');
+  const quadPreviewHelpersSource = readFileSync(quadPreviewHelpersPath, 'utf8');
+  const quadPreviewTypesSource = readFileSync(quadPreviewTypesPath, 'utf8');
+
+  assert.match(quadPreviewSource, /<QuadMosaicFigure/, 'QuadPreviewPanel should compose a focused mosaic figure');
+  assert.match(quadPreviewSource, /<QuadSingleTilesGrid/, 'QuadPreviewPanel should compose focused single-take tiles');
+  assert.doesNotMatch(quadPreviewSource, /TILE_ACTIONS|data-quad-cell|data-quad-tile-fallback/, 'QuadPreviewPanel should not own tile rendering details');
+  assert.match(quadMosaicFigureSource, /export function QuadMosaicFigure/, 'QuadMosaicFigure should own mosaic rendering');
+  assert.match(quadSingleTilesGridSource, /export function QuadSingleTilesGrid/, 'QuadSingleTilesGrid should own single-take tile rendering');
+  assert.match(quadPreviewHelpersSource, /export const TILE_ACTIONS/, 'quad preview helpers should own tile action metadata');
+  assert.match(quadPreviewHelpersSource, /export function getAspectClass/, 'quad preview helpers should own aspect classes');
+  assert.match(quadPreviewHelpersSource, /export function buildTilesWithPlaceholders/, 'quad preview helpers should own placeholder composition');
+  assert.match(quadPreviewTypesSource, /export interface QuadPreviewTile/, 'quad preview types should own public tile contracts');
+
+  assert.ok(assetDropzoneSource.split('\n').length <= 460, 'AssetDropzone should stay below 460 lines');
+  assert.ok(assetDropzoneSlotSource.split('\n').length <= 380, 'AssetDropzoneSlot should stay below 380 lines');
+  assert.ok(mediaLightboxSource.split('\n').length <= 320, 'MediaLightbox should stay below 320 lines');
+  assert.ok(mediaLightboxEntryCardSource.split('\n').length <= 470, 'MediaLightboxEntryCard should stay below 470 lines');
+  assert.ok(quadPreviewSource.split('\n').length <= 260, 'QuadPreviewPanel should stay below 260 lines');
+  assert.ok(quadMosaicFigureSource.split('\n').length <= 150, 'QuadMosaicFigure should stay below 150 lines');
+  assert.ok(quadSingleTilesGridSource.split('\n').length <= 260, 'QuadSingleTilesGrid should stay below 260 lines');
+});


### PR DESCRIPTION
## Summary
- split AssetDropzone, MediaLightbox, QuadPreviewPanel, Composer, ModelsGallery, and PriceEstimator into focused helper/type/component modules
- added architecture contract tests to keep those surfaces below the agreed line thresholds
- kept public component/type exports stable for existing workspace and marketing imports

## Verification
- node --test tests/shared-media-surfaces-architecture.test.ts tests/models-gallery-architecture.test.ts tests/price-estimator-architecture.test.ts tests/composer-architecture.test.ts
- pnpm --dir frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- npm run test:validate
- npm run architecture:audit -- --min-lines 500
- Playwright smoke on local dev server http://localhost:3001: /app, /models, /pricing all returned 200 without crash text
