### PR TITLE
Split navigation and consent surfaces

### DIFF
--- a/frontend/components/HeaderBar.tsx
+++ b/frontend/components/HeaderBar.tsx
@@ -1,10 +1,9 @@
 'use client';
 
 import clsx from 'clsx';
-import { NAV_ITEMS } from '@/components/AppSidebar';
 import Link from 'next/link';
 import { useEffect, useMemo, useRef, useState, useId } from 'react';
-import { ChevronDown, Moon, Sun, Wallet } from 'lucide-react';
+import { ChevronDown, Moon, Sun } from 'lucide-react';
 import { ReconsentPrompt } from '@/components/legal/ReconsentPrompt';
 import { AppLanguageToggle } from '@/components/AppLanguageToggle';
 import { useI18n } from '@/lib/i18n/I18nProvider';
@@ -13,10 +12,12 @@ import { Button, ButtonLink } from '@/components/ui/Button';
 import { UIIcon } from '@/components/ui/UIIcon';
 import { MARKETING_NAV_DROPDOWNS, MARKETING_TOP_NAV_LINKS } from '@/config/navigation';
 import { SERVICE_NOTICE_POLLING_INTERVAL_MS } from '@/lib/service-notice-polling';
+import { HeaderAccountMenu } from '@/components/header/HeaderAccountMenu';
 import { HeaderLogoMark } from '@/components/header/HeaderLogoMark';
+import { HeaderMobileMenu } from '@/components/header/HeaderMobileMenu';
+import { HeaderWalletStatus } from '@/components/header/HeaderWalletStatus';
 import {
   getGuestMobileNavItems,
-  GUEST_MOBILE_NAV_ICONS,
   normalizeMarketingLinks,
   resolveLocalizedHref,
 } from '@/components/header/header-nav-helpers';
@@ -394,47 +395,15 @@ export function HeaderBar() {
         </div>
 
         <div className="flex items-center gap-2 text-xs text-text-muted sm:gap-3">
-          <div className="relative" onMouseEnter={openWalletPrompt} onMouseLeave={scheduleWalletPromptClose}>
-            <Link
-              href="/billing"
-              prefetch={false}
-              className="flex h-10 items-center gap-1 rounded-input border border-hairline bg-surface px-2 py-1 text-text-primary shadow-sm transition-colors hover:border-border-hover hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:gap-1.5 lg:gap-2 lg:px-3"
-              aria-describedby={walletPromptOpen ? walletPromptId : undefined}
-              onFocus={openWalletPrompt}
-              onBlur={scheduleWalletPromptClose}
-            >
-              <UIIcon icon={Wallet} size={16} className="text-text-primary" />
-              <span className="text-xs font-semibold tracking-normal text-text-primary sm:text-sm">
-                {wallet ? `$${wallet.balance.toFixed(2)}` : authResolved ? '--' : '...'}
-              </span>
-            </Link>
-            {walletPromptOpen ? (
-              <div
-                id={walletPromptId}
-                role="status"
-                className="absolute right-0 top-full z-10 mt-2 w-64 rounded-card border border-hairline bg-surface p-3 text-left text-xs text-text-primary shadow-card"
-                onMouseEnter={openWalletPrompt}
-                onMouseLeave={scheduleWalletPromptClose}
-              >
-                <p className="text-[11px] font-semibold uppercase tracking-micro text-text-secondary">
-                  {t('workspace.header.walletTopUp.label', 'Top up available')}
-                </p>
-                <p className="mt-1 text-sm text-text-primary">
-                  {t('workspace.header.walletTopUp.copy', 'Click to add funds and keep generating without interruption.')}
-                </p>
-                <ButtonLink
-                  href="/billing"
-                  prefetch={false}
-                  size="sm"
-                  className="mt-3 w-full shadow-card"
-                  onFocus={openWalletPrompt}
-                  onBlur={scheduleWalletPromptClose}
-                >
-                  {t('workspace.header.walletTopUp.cta', 'Top up now')}
-                </ButtonLink>
-              </div>
-            ) : null}
-          </div>
+          <HeaderWalletStatus
+            authResolved={authResolved}
+            promptId={walletPromptId}
+            t={t}
+            wallet={wallet}
+            walletPromptOpen={walletPromptOpen}
+            onOpenPrompt={openWalletPrompt}
+            onSchedulePromptClose={scheduleWalletPromptClose}
+          />
           <div className="hidden items-center gap-1 md:flex">
             <AppLanguageToggle />
             <Button
@@ -451,83 +420,19 @@ export function HeaderBar() {
             </Button>
           </div>
           {email ? (
-            <div className="relative">
-              <Button
-                ref={avatarRef}
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => setAccountMenuOpen((prev) => !prev)}
-                className="h-10 w-10 min-h-0 rounded-full border border-hairline bg-surface-2 p-0 text-sm font-semibold text-text-primary shadow-sm hover:bg-surface-3"
-                aria-haspopup="menu"
-                aria-expanded={accountMenuOpen}
-              >
-                {initials}
-                <span className="absolute -bottom-0.5 left-1/2 flex h-4 w-4 -translate-x-1/2 items-center justify-center text-[10px] text-text-muted opacity-40">
-                  <svg viewBox="0 0 12 12" aria-hidden="true" className="h-2.5 w-2.5">
-                    <path d="m2.2 4.6 3.8 3.8 3.8-3.8" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
-                  </svg>
-                </span>
-              </Button>
-              {accountMenuOpen && (
-                <div
-                  ref={menuRef}
-                  className="absolute right-0 mt-3 w-56 rounded-card border border-hairline bg-surface p-3 text-sm text-text-primary shadow-card"
-                  role="menu"
-                >
-                  <div className="mb-3 rounded-input bg-bg px-3 py-2">
-                    <p className="text-xs uppercase tracking-micro text-text-muted">
-                      {t('workspace.header.signedIn', 'Signed in')}
-                    </p>
-                    <p className="mt-1 truncate text-sm font-medium text-text-primary">{email}</p>
-                  </div>
-                  <nav className="mb-2 flex flex-col gap-1" aria-label={t('workspace.header.primaryNav', 'Primary navigation')}>
-                    {NAV_ITEMS.map((item) => {
-                      const label = t(`workspace.sidebar.links.${item.id}`, item.label);
-                      const badgeLabel = item.badge
-                        ? t(`workspace.sidebar.badges.${item.badgeKey ?? item.id}`, item.badge)
-                        : null;
-                      return (
-                        <Link
-                          key={item.id}
-                          href={item.href}
-                          role="menuitem"
-                          className="flex items-center justify-between rounded-input px-3 py-2 text-sm font-medium text-text-primary transition hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                          onClick={() => setAccountMenuOpen(false)}
-                        >
-                          <span>{label}</span>
-                          {badgeLabel ? (
-                              <span className="rounded-full bg-surface-2 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-micro text-text-primary">
-                              {badgeLabel}
-                            </span>
-                          ) : null}
-                        </Link>
-                      );
-                    })}
-                    {isAdmin ? (
-                      <Link
-                        href="/admin"
-                        role="menuitem"
-                        className="flex items-center justify-between rounded-input px-3 py-2 text-sm font-medium text-text-primary transition hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                        onClick={handleAdminNavigation}
-                      >
-                        <span>Admin</span>
-                      </Link>
-                    ) : null}
-                  </nav>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="w-full justify-between px-3 py-2 text-sm font-medium text-text-primary hover:bg-surface-2"
-                    onClick={handleSignOut}
-                  >
-                    {t('workspace.header.signOut', 'Sign out')}
-                    <span className="text-[11px] uppercase tracking-micro text-text-muted">⌘⇧Q</span>
-                  </Button>
-                </div>
-              )}
-            </div>
+            <HeaderAccountMenu
+              accountMenuOpen={accountMenuOpen}
+              avatarRef={avatarRef}
+              email={email}
+              initials={initials}
+              isAdmin={isAdmin}
+              menuRef={menuRef}
+              t={t}
+              onAdminNavigation={handleAdminNavigation}
+              onCloseAccountMenu={() => setAccountMenuOpen(false)}
+              onSignOut={handleSignOut}
+              onToggleAccountMenu={() => setAccountMenuOpen((prev) => !prev)}
+            />
           ) : authResolved ? (
             <div className="flex items-center gap-1.5 sm:gap-2">
               <ButtonLink
@@ -554,206 +459,26 @@ export function HeaderBar() {
         </div>
       </header>
       {mobileMenuOpen ? (
-        <div className="fixed inset-0 z-50 bg-bg px-4 py-6 sm:px-6">
-          <div className="mx-auto flex max-w-sm items-center justify-end">
-            <Button
-              type="button"
-              size="sm"
-              variant="ghost"
-              className="min-h-0 h-9 w-9 rounded-full border border-hairline bg-surface p-2 text-text-primary"
-              aria-label={t('workspace.header.mobileClose', 'Close menu')}
-              onClick={() => setMobileMenuOpen(false)}
-            >
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
-                <line x1="6" y1="6" x2="18" y2="18" />
-                <line x1="18" y1="6" x2="6" y2="18" />
-              </svg>
-            </Button>
-          </div>
-          <div className="mx-auto mt-5 max-w-sm stack-gap-lg">
-            <div className="flex justify-end gap-2">
-              <AppLanguageToggle />
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-9 w-9 p-0 text-text-primary hover:bg-surface-2"
-                aria-label={themeToggleLabel}
-                onClick={toggleTheme}
-              >
-                <span className="inline-flex h-4 w-4 items-center justify-center">
-                  <UIIcon icon={theme === 'dark' ? Sun : Moon} size={16} strokeWidth={1.75} />
-                </span>
-              </Button>
-            </div>
-            <nav className="flex flex-col gap-3 text-base font-semibold text-text-primary">
-              {!isAuthenticated ? (
-                <div className="rounded-[28px] border border-hairline bg-surface px-4 py-4 shadow-card">
-                  <div className="mb-3 flex items-center justify-between gap-3">
-                    <div>
-                      <p className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">Workspace</p>
-                      <p className="mt-1 text-sm font-medium text-text-primary">Open the app without dead ends.</p>
-                    </div>
-                  </div>
-                  <div className="grid grid-cols-1 gap-2">
-                    {guestMobileNavItems.map((item) => {
-                      const Icon = GUEST_MOBILE_NAV_ICONS[item.id as keyof typeof GUEST_MOBILE_NAV_ICONS];
-                      const label = t(`workspace.sidebar.links.${item.id}`, item.label);
-                      const currentPath = pathname ?? '';
-                      const isActive =
-                        item.id === 'generate'
-                          ? currentPath === item.href
-                          : currentPath === item.href || currentPath.startsWith(`${item.href}/`);
-                      return (
-                        <Link
-                          key={item.id}
-                          href={item.href}
-                          prefetch={false}
-                          className={clsx(
-                            'flex items-center gap-3 rounded-2xl border px-4 py-3 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-                            isActive
-                              ? 'border-border bg-surface-2 text-text-primary'
-                              : 'border-hairline bg-bg text-text-primary hover:bg-surface-2'
-                          )}
-                          onClick={() => setMobileMenuOpen(false)}
-                        >
-                          <span className="flex h-9 w-9 items-center justify-center rounded-xl border border-hairline bg-surface text-text-primary">
-                            <UIIcon icon={Icon} size={18} />
-                          </span>
-                          <span>{label}</span>
-                        </Link>
-                      );
-                    })}
-                  </div>
-                </div>
-              ) : null}
-              {marketingLinks.map((item) => {
-                const dropdown = MARKETING_NAV_DROPDOWNS[item.key];
-                const label = t(`nav.linkLabels.${item.key}`, item.key);
-                if (!dropdown) {
-                  const href = item.href;
-                  const currentPath = pathname ?? '';
-                  const isActive = currentPath === href || currentPath.startsWith(`${href}/`);
-                  return (
-                    <Link
-                      key={item.href}
-                      href={item.href}
-                      prefetch={false}
-                      className={clsx(
-                        'rounded-2xl border border-hairline px-4 py-3',
-                        isActive ? 'bg-surface-2 text-text-primary' : 'bg-surface'
-                      )}
-                      onClick={() => setMobileMenuOpen(false)}
-                    >
-                      {label}
-                    </Link>
-                  );
-                }
-                const panelId = `mobile-${item.key}-panel`;
-                const isOpen = Boolean(mobileDropdownOpen[item.key]);
-                const allLabel = t(dropdown.allLabelKey, dropdown.allLabelFallback);
-                return (
-                  <div key={item.href} className="rounded-2xl border border-hairline bg-surface px-4 py-3">
-                    <button
-                      type="button"
-                      className="flex w-full items-center justify-between text-left text-sm font-semibold text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                      aria-expanded={isOpen}
-                      aria-controls={panelId}
-                      onClick={() =>
-                        setMobileDropdownOpen((prev) => ({
-                          ...prev,
-                          [item.key]: !prev[item.key],
-                        }))
-                      }
-                    >
-                      <span>{label}</span>
-                      <UIIcon
-                        icon={ChevronDown}
-                        size={14}
-                        strokeWidth={1.6}
-                        className={clsx('text-text-muted transition-transform', isOpen ? 'rotate-180' : undefined)}
-                      />
-                    </button>
-                    {isOpen ? (
-                      <div id={panelId} className="mt-2 flex flex-col gap-1 text-sm font-medium text-text-secondary">
-                        <Link
-                          href={resolveLocalizedHref(dropdown.allHref)}
-                          onClick={() => setMobileMenuOpen(false)}
-                          className="rounded-input px-2 py-2 text-sm font-semibold text-text-primary transition hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                        >
-                          {allLabel}
-                        </Link>
-                        {dropdown.items.map((entry) => {
-                          const href = resolveLocalizedHref(entry.href);
-                          return (
-                            <Link
-                              key={entry.key}
-                              href={href}
-                              onClick={() => setMobileMenuOpen(false)}
-                              className="rounded-input px-2 py-2 transition hover:bg-surface-2 hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                            >
-                              {t(`nav.dropdown.${item.key}.items.${entry.key}`, entry.label)}
-                            </Link>
-                          );
-                        })}
-                        {dropdown.sections?.map((section) => {
-                          const sectionLabel = section.titleKey
-                            ? t(section.titleKey, section.titleFallback ?? section.key)
-                            : (section.titleFallback ?? label);
-
-                          return (
-                            <div key={section.key} className="mt-2 border-t border-hairline pt-2">
-                              {!section.hideTitle && sectionLabel ? (
-                                <p className="px-2 py-1 text-xs font-semibold uppercase tracking-micro text-text-muted">
-                                  {sectionLabel}
-                                </p>
-                              ) : null}
-                              {section.items.map((entry) => {
-                                const href = resolveLocalizedHref(entry.href);
-                                return (
-                                  <Link
-                                    key={entry.key}
-                                    href={href}
-                                    onClick={() => setMobileMenuOpen(false)}
-                                    className={clsx(
-                                      'block rounded-input px-2 py-2 transition hover:bg-surface-2 hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-                                      entry.emphasized ? 'font-semibold text-text-primary' : undefined
-                                    )}
-                                  >
-                                    {t(`nav.dropdown.${item.key}.sections.${section.key}.items.${entry.key}`, entry.label)}
-                                  </Link>
-                                );
-                              })}
-                            </div>
-                          );
-                        })}
-                      </div>
-                    ) : null}
-                  </div>
-                );
-              })}
-            </nav>
-            {isAuthenticated ? null : (
-              <div className="stack-gap-sm">
-                <Link
-                  href="/login?next=/app"
-                  className="block rounded-2xl border border-hairline px-4 py-3 text-center text-base font-semibold text-text-primary shadow-card"
-                  onClick={() => setMobileMenuOpen(false)}
-                >
-                  {loginLabel}
-                </Link>
-                <Link
-                  href="/app"
-                  prefetch={false}
-                  className="block rounded-2xl bg-brand px-4 py-3 text-center text-base font-semibold text-on-brand shadow-card"
-                  onClick={() => setMobileMenuOpen(false)}
-                >
-                  {ctaLabel}
-                </Link>
-              </div>
-            )}
-          </div>
-        </div>
+        <HeaderMobileMenu
+          ctaLabel={ctaLabel}
+          guestMobileNavItems={guestMobileNavItems}
+          isAuthenticated={isAuthenticated}
+          loginLabel={loginLabel}
+          marketingLinks={marketingLinks}
+          mobileDropdownOpen={mobileDropdownOpen}
+          pathname={pathname}
+          t={t}
+          theme={theme}
+          themeToggleLabel={themeToggleLabel}
+          onClose={() => setMobileMenuOpen(false)}
+          onToggleDropdown={(key) =>
+            setMobileDropdownOpen((prev) => ({
+              ...prev,
+              [key]: !prev[key],
+            }))
+          }
+          onToggleTheme={toggleTheme}
+        />
       ) : null}
       <ReconsentPrompt enabled={authResolved && isAuthenticated} />
     </>

--- a/frontend/components/header/HeaderAccountMenu.tsx
+++ b/frontend/components/header/HeaderAccountMenu.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import Link from 'next/link';
+import type { MouseEvent, RefObject } from 'react';
+import { NAV_ITEMS } from '@/components/AppSidebar';
+import { Button } from '@/components/ui/Button';
+
+type HeaderTranslate = (key: string, fallback: string) => string | undefined;
+
+type HeaderAccountMenuProps = {
+  accountMenuOpen: boolean;
+  avatarRef: RefObject<HTMLButtonElement>;
+  email: string;
+  initials: string;
+  isAdmin: boolean;
+  menuRef: RefObject<HTMLDivElement>;
+  t: HeaderTranslate;
+  onAdminNavigation: (event: MouseEvent<HTMLAnchorElement>) => void;
+  onSignOut: () => void;
+  onToggleAccountMenu: () => void;
+  onCloseAccountMenu: () => void;
+};
+
+export function HeaderAccountMenu({
+  accountMenuOpen,
+  avatarRef,
+  email,
+  initials,
+  isAdmin,
+  menuRef,
+  t,
+  onAdminNavigation,
+  onSignOut,
+  onToggleAccountMenu,
+  onCloseAccountMenu,
+}: HeaderAccountMenuProps) {
+  return (
+    <div className="relative">
+      <Button
+        ref={avatarRef}
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={onToggleAccountMenu}
+        className="h-10 w-10 min-h-0 rounded-full border border-hairline bg-surface-2 p-0 text-sm font-semibold text-text-primary shadow-sm hover:bg-surface-3"
+        aria-haspopup="menu"
+        aria-expanded={accountMenuOpen}
+      >
+        {initials}
+        <span className="absolute -bottom-0.5 left-1/2 flex h-4 w-4 -translate-x-1/2 items-center justify-center text-[10px] text-text-muted opacity-40">
+          <svg viewBox="0 0 12 12" aria-hidden="true" className="h-2.5 w-2.5">
+            <path
+              d="m2.2 4.6 3.8 3.8 3.8-3.8"
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="1.6"
+            />
+          </svg>
+        </span>
+      </Button>
+      {accountMenuOpen ? (
+        <div
+          ref={menuRef}
+          className="absolute right-0 mt-3 w-56 rounded-card border border-hairline bg-surface p-3 text-sm text-text-primary shadow-card"
+          role="menu"
+        >
+          <div className="mb-3 rounded-input bg-bg px-3 py-2">
+            <p className="text-xs uppercase tracking-micro text-text-muted">
+              {t('workspace.header.signedIn', 'Signed in')}
+            </p>
+            <p className="mt-1 truncate text-sm font-medium text-text-primary">{email}</p>
+          </div>
+          <nav className="mb-2 flex flex-col gap-1" aria-label={t('workspace.header.primaryNav', 'Primary navigation')}>
+            {NAV_ITEMS.map((item) => {
+              const label = t(`workspace.sidebar.links.${item.id}`, item.label);
+              const badgeLabel = item.badge ? t(`workspace.sidebar.badges.${item.badgeKey ?? item.id}`, item.badge) : null;
+              return (
+                <Link
+                  key={item.id}
+                  href={item.href}
+                  role="menuitem"
+                  className="flex items-center justify-between rounded-input px-3 py-2 text-sm font-medium text-text-primary transition hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  onClick={onCloseAccountMenu}
+                >
+                  <span>{label}</span>
+                  {badgeLabel ? (
+                    <span className="rounded-full bg-surface-2 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-micro text-text-primary">
+                      {badgeLabel}
+                    </span>
+                  ) : null}
+                </Link>
+              );
+            })}
+            {isAdmin ? (
+              <Link
+                href="/admin"
+                role="menuitem"
+                className="flex items-center justify-between rounded-input px-3 py-2 text-sm font-medium text-text-primary transition hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                onClick={onAdminNavigation}
+              >
+                <span>Admin</span>
+              </Link>
+            ) : null}
+          </nav>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="w-full justify-between px-3 py-2 text-sm font-medium text-text-primary hover:bg-surface-2"
+            onClick={onSignOut}
+          >
+            {t('workspace.header.signOut', 'Sign out')}
+            <span className="text-[11px] uppercase tracking-micro text-text-muted">⌘⇧Q</span>
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/components/header/HeaderMobileMenu.tsx
+++ b/frontend/components/header/HeaderMobileMenu.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import clsx from 'clsx';
+import Link from 'next/link';
+import { ChevronDown, Moon, Sun } from 'lucide-react';
+import { NAV_ITEMS } from '@/components/AppSidebar';
+import { AppLanguageToggle } from '@/components/AppLanguageToggle';
+import { Button } from '@/components/ui/Button';
+import { UIIcon } from '@/components/ui/UIIcon';
+import { MARKETING_NAV_DROPDOWNS } from '@/config/navigation';
+import {
+  GUEST_MOBILE_NAV_ICONS,
+  resolveLocalizedHref,
+  type HeaderMarketingLink,
+} from '@/components/header/header-nav-helpers';
+
+type HeaderTranslate = (key: string, fallback: string) => string | undefined;
+type GuestMobileNavItem = (typeof NAV_ITEMS)[number];
+
+type HeaderMobileMenuProps = {
+  ctaLabel?: string;
+  guestMobileNavItems: GuestMobileNavItem[];
+  isAuthenticated: boolean;
+  loginLabel?: string;
+  marketingLinks: HeaderMarketingLink[];
+  mobileDropdownOpen: Record<string, boolean>;
+  pathname: string | null;
+  t: HeaderTranslate;
+  theme: 'light' | 'dark';
+  themeToggleLabel?: string;
+  onClose: () => void;
+  onToggleDropdown: (key: string) => void;
+  onToggleTheme: () => void;
+};
+
+export function HeaderMobileMenu({
+  ctaLabel,
+  guestMobileNavItems,
+  isAuthenticated,
+  loginLabel,
+  marketingLinks,
+  mobileDropdownOpen,
+  pathname,
+  t,
+  theme,
+  themeToggleLabel,
+  onClose,
+  onToggleDropdown,
+  onToggleTheme,
+}: HeaderMobileMenuProps) {
+  return (
+    <div className="fixed inset-0 z-50 bg-bg px-4 py-6 sm:px-6">
+      <div className="mx-auto flex max-w-sm items-center justify-end">
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          className="min-h-0 h-9 w-9 rounded-full border border-hairline bg-surface p-2 text-text-primary"
+          aria-label={t('workspace.header.mobileClose', 'Close menu')}
+          onClick={onClose}
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            className="h-5 w-5"
+          >
+            <line x1="6" y1="6" x2="18" y2="18" />
+            <line x1="18" y1="6" x2="6" y2="18" />
+          </svg>
+        </Button>
+      </div>
+      <div className="mx-auto mt-5 max-w-sm stack-gap-lg">
+        <div className="flex justify-end gap-2">
+          <AppLanguageToggle />
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-9 w-9 p-0 text-text-primary hover:bg-surface-2"
+            aria-label={themeToggleLabel ?? (theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme')}
+            onClick={onToggleTheme}
+          >
+            <span className="inline-flex h-4 w-4 items-center justify-center">
+              <UIIcon icon={theme === 'dark' ? Sun : Moon} size={16} strokeWidth={1.75} />
+            </span>
+          </Button>
+        </div>
+        <nav className="flex flex-col gap-3 text-base font-semibold text-text-primary">
+          {!isAuthenticated ? (
+            <div className="rounded-[28px] border border-hairline bg-surface px-4 py-4 shadow-card">
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">Workspace</p>
+                  <p className="mt-1 text-sm font-medium text-text-primary">Open the app without dead ends.</p>
+                </div>
+              </div>
+              <div className="grid grid-cols-1 gap-2">
+                {guestMobileNavItems.map((item) => {
+                  const Icon = GUEST_MOBILE_NAV_ICONS[item.id as keyof typeof GUEST_MOBILE_NAV_ICONS];
+                  const label = t(`workspace.sidebar.links.${item.id}`, item.label);
+                  const currentPath = pathname ?? '';
+                  const isActive =
+                    item.id === 'generate'
+                      ? currentPath === item.href
+                      : currentPath === item.href || currentPath.startsWith(`${item.href}/`);
+                  return (
+                    <Link
+                      key={item.id}
+                      href={item.href}
+                      prefetch={false}
+                      className={clsx(
+                        'flex items-center gap-3 rounded-2xl border px-4 py-3 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                        isActive
+                          ? 'border-border bg-surface-2 text-text-primary'
+                          : 'border-hairline bg-bg text-text-primary hover:bg-surface-2'
+                      )}
+                      onClick={onClose}
+                    >
+                      <span className="flex h-9 w-9 items-center justify-center rounded-xl border border-hairline bg-surface text-text-primary">
+                        <UIIcon icon={Icon} size={18} />
+                      </span>
+                      <span>{label}</span>
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+          ) : null}
+          {marketingLinks.map((item) => {
+            const dropdown = MARKETING_NAV_DROPDOWNS[item.key];
+            const label = t(`nav.linkLabels.${item.key}`, item.key);
+            if (!dropdown) {
+              const href = item.href;
+              const currentPath = pathname ?? '';
+              const isActive = currentPath === href || currentPath.startsWith(`${href}/`);
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  prefetch={false}
+                  className={clsx(
+                    'rounded-2xl border border-hairline px-4 py-3',
+                    isActive ? 'bg-surface-2 text-text-primary' : 'bg-surface'
+                  )}
+                  onClick={onClose}
+                >
+                  {label}
+                </Link>
+              );
+            }
+            const panelId = `mobile-${item.key}-panel`;
+            const isOpen = Boolean(mobileDropdownOpen[item.key]);
+            const allLabel = t(dropdown.allLabelKey, dropdown.allLabelFallback);
+            return (
+              <div key={item.href} className="rounded-2xl border border-hairline bg-surface px-4 py-3">
+                <button
+                  type="button"
+                  className="flex w-full items-center justify-between text-left text-sm font-semibold text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  aria-expanded={isOpen}
+                  aria-controls={panelId}
+                  onClick={() => onToggleDropdown(item.key)}
+                >
+                  <span>{label}</span>
+                  <UIIcon
+                    icon={ChevronDown}
+                    size={14}
+                    strokeWidth={1.6}
+                    className={clsx('text-text-muted transition-transform', isOpen ? 'rotate-180' : undefined)}
+                  />
+                </button>
+                {isOpen ? (
+                  <div id={panelId} className="mt-2 flex flex-col gap-1 text-sm font-medium text-text-secondary">
+                    <Link
+                      href={resolveLocalizedHref(dropdown.allHref)}
+                      onClick={onClose}
+                      className="rounded-input px-2 py-2 text-sm font-semibold text-text-primary transition hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                      {allLabel}
+                    </Link>
+                    {dropdown.items.map((entry) => {
+                      const href = resolveLocalizedHref(entry.href);
+                      return (
+                        <Link
+                          key={entry.key}
+                          href={href}
+                          onClick={onClose}
+                          className="rounded-input px-2 py-2 transition hover:bg-surface-2 hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        >
+                          {t(`nav.dropdown.${item.key}.items.${entry.key}`, entry.label)}
+                        </Link>
+                      );
+                    })}
+                    {dropdown.sections?.map((section) => {
+                      const sectionLabel = section.titleKey
+                        ? t(section.titleKey, section.titleFallback ?? section.key)
+                        : (section.titleFallback ?? label);
+
+                      return (
+                        <div key={section.key} className="mt-2 border-t border-hairline pt-2">
+                          {!section.hideTitle && sectionLabel ? (
+                            <p className="px-2 py-1 text-xs font-semibold uppercase tracking-micro text-text-muted">
+                              {sectionLabel}
+                            </p>
+                          ) : null}
+                          {section.items.map((entry) => {
+                            const href = resolveLocalizedHref(entry.href);
+                            return (
+                              <Link
+                                key={entry.key}
+                                href={href}
+                                onClick={onClose}
+                                className={clsx(
+                                  'block rounded-input px-2 py-2 transition hover:bg-surface-2 hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                                  entry.emphasized ? 'font-semibold text-text-primary' : undefined
+                                )}
+                              >
+                                {t(`nav.dropdown.${item.key}.sections.${section.key}.items.${entry.key}`, entry.label)}
+                              </Link>
+                            );
+                          })}
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </nav>
+        {isAuthenticated ? null : (
+          <div className="stack-gap-sm">
+            <Link
+              href="/login?next=/app"
+              className="block rounded-2xl border border-hairline px-4 py-3 text-center text-base font-semibold text-text-primary shadow-card"
+              onClick={onClose}
+            >
+              {loginLabel ?? 'Log in'}
+            </Link>
+            <Link
+              href="/app"
+              prefetch={false}
+              className="block rounded-2xl bg-brand px-4 py-3 text-center text-base font-semibold text-on-brand shadow-card"
+              onClick={onClose}
+            >
+              {ctaLabel ?? 'Generate'}
+            </Link>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/header/HeaderWalletStatus.tsx
+++ b/frontend/components/header/HeaderWalletStatus.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import Link from 'next/link';
+import { Wallet } from 'lucide-react';
+import { ButtonLink } from '@/components/ui/Button';
+import { UIIcon } from '@/components/ui/UIIcon';
+
+type HeaderTranslate = (key: string, fallback: string) => string | undefined;
+
+type HeaderWalletStatusProps = {
+  authResolved: boolean;
+  promptId: string;
+  t: HeaderTranslate;
+  wallet: { balance: number } | null;
+  walletPromptOpen: boolean;
+  onOpenPrompt: () => void;
+  onSchedulePromptClose: () => void;
+};
+
+export function HeaderWalletStatus({
+  authResolved,
+  promptId,
+  t,
+  wallet,
+  walletPromptOpen,
+  onOpenPrompt,
+  onSchedulePromptClose,
+}: HeaderWalletStatusProps) {
+  return (
+    <div className="relative" onMouseEnter={onOpenPrompt} onMouseLeave={onSchedulePromptClose}>
+      <Link
+        href="/billing"
+        prefetch={false}
+        className="flex h-10 items-center gap-1 rounded-input border border-hairline bg-surface px-2 py-1 text-text-primary shadow-sm transition-colors hover:border-border-hover hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:gap-1.5 lg:gap-2 lg:px-3"
+        aria-describedby={walletPromptOpen ? promptId : undefined}
+        onFocus={onOpenPrompt}
+        onBlur={onSchedulePromptClose}
+      >
+        <UIIcon icon={Wallet} size={16} className="text-text-primary" />
+        <span className="text-xs font-semibold tracking-normal text-text-primary sm:text-sm">
+          {wallet ? `$${wallet.balance.toFixed(2)}` : authResolved ? '--' : '...'}
+        </span>
+      </Link>
+      {walletPromptOpen ? (
+        <div
+          id={promptId}
+          role="status"
+          className="absolute right-0 top-full z-10 mt-2 w-64 rounded-card border border-hairline bg-surface p-3 text-left text-xs text-text-primary shadow-card"
+          onMouseEnter={onOpenPrompt}
+          onMouseLeave={onSchedulePromptClose}
+        >
+          <p className="text-[11px] font-semibold uppercase tracking-micro text-text-secondary">
+            {t('workspace.header.walletTopUp.label', 'Top up available')}
+          </p>
+          <p className="mt-1 text-sm text-text-primary">
+            {t('workspace.header.walletTopUp.copy', 'Click to add funds and keep generating without interruption.')}
+          </p>
+          <ButtonLink
+            href="/billing"
+            prefetch={false}
+            size="sm"
+            className="mt-3 w-full shadow-card"
+            onFocus={onOpenPrompt}
+            onBlur={onSchedulePromptClose}
+          >
+            {t('workspace.header.walletTopUp.cta', 'Top up now')}
+          </ButtonLink>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/components/legal/CookieBanner.tsx
+++ b/frontend/components/legal/CookieBanner.tsx
@@ -2,254 +2,21 @@
 
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { usePathname } from 'next/navigation';
-import { CONSENT_COOKIE_NAME, createDefaultConsent, mergeConsent, parseConsent, serializeConsent, type ConsentCategory, type ConsentRecord } from '@/lib/consent';
-import { setAnalyticsConsentCookie, setClarityConsent } from '@/lib/clarity-client';
+import { createDefaultConsent, mergeConsent, parseConsent, type ConsentCategory, type ConsentRecord } from '@/lib/consent';
 import { Button } from '@/components/ui/Button';
-
-type BannerState =
-  | { ready: false }
-  | {
-      ready: true;
-      version: string;
-      consent: ConsentRecord | null;
-    };
-
-type FetchState = 'idle' | 'saving';
-
-const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 395; // ~13 months
-const DEFAULT_CHOICES: Record<ConsentCategory, boolean> = {
-  analytics: false,
-  ads: false,
-};
-
-const PUBLIC_GOOGLE_CONSENT_MODE = (process.env.NEXT_PUBLIC_GOOGLE_CONSENT_MODE ?? 'auto').toLowerCase();
-const ANALYTICS_STORAGE_KEY = 'mv-consent-analytics';
-const ANALYTICS_GRANTED_VALUE = 'granted';
-const OPEN_PREFERENCES_EVENT = 'consent:open-preferences';
-
-type CookieBannerLocale = 'en' | 'fr' | 'es';
-
-const COOKIE_BANNER_COPY: Record<
-  CookieBannerLocale,
-  {
-    title: string;
-    body: string;
-    actions: {
-      acceptAll: string;
-      rejectAll: string;
-      manageChoices: string;
-      hideChoices: string;
-      savePreferences: string;
-      saving: string;
-    };
-    preferences: {
-      title: string;
-      analytics: { title: string; body: string };
-      ads: { title: string; body: string };
-    };
-    errors: {
-      loadVersion: string;
-      save: string;
-    };
-  }
-> = {
-  en: {
-    title: 'Cookies & Privacy',
-    body:
-      "We use essential cookies to run the site. With your consent, we'll enable analytics to improve the product and advertising tags for campaign measurement. You can change your choices anytime.",
-    actions: {
-      acceptAll: 'Accept all',
-      rejectAll: 'Reject all',
-      manageChoices: 'Manage choices',
-      hideChoices: 'Hide choices',
-      savePreferences: 'Save preferences',
-      saving: 'Saving…',
-    },
-    preferences: {
-      title: 'Preferences',
-      analytics: {
-        title: 'Analytics cookies',
-        body: 'Help us measure usage and improve features.',
-      },
-      ads: {
-        title: 'Advertising cookies',
-        body: 'Measure campaigns and improve relevance.',
-      },
-    },
-    errors: {
-      loadVersion: 'Failed to load cookie policy version',
-      save: 'Unable to store your preferences.',
-    },
-  },
-  fr: {
-    title: 'Cookies et confidentialité',
-    body:
-      'Nous utilisons des cookies essentiels pour faire fonctionner le site. Avec votre accord, nous activerons les analytics pour améliorer le produit et les balises publicitaires pour mesurer les campagnes. Vous pouvez modifier vos choix à tout moment.',
-    actions: {
-      acceptAll: 'Tout accepter',
-      rejectAll: 'Tout refuser',
-      manageChoices: 'Gérer mes choix',
-      hideChoices: 'Masquer les choix',
-      savePreferences: 'Enregistrer les préférences',
-      saving: 'Enregistrement…',
-    },
-    preferences: {
-      title: 'Préférences',
-      analytics: {
-        title: 'Cookies analytiques',
-        body: 'Aidez-nous à mesurer l’usage et à améliorer les fonctionnalités.',
-      },
-      ads: {
-        title: 'Cookies publicitaires',
-        body: 'Mesurez les campagnes et améliorez leur pertinence.',
-      },
-    },
-    errors: {
-      loadVersion: 'Impossible de charger la version de la politique cookies',
-      save: 'Impossible d’enregistrer vos préférences.',
-    },
-  },
-  es: {
-    title: 'Cookies y privacidad',
-    body:
-      'Usamos cookies esenciales para que el sitio funcione. Con tu consentimiento, activaremos analytics para mejorar el producto y etiquetas publicitarias para medir campañas. Puedes cambiar tus elecciones en cualquier momento.',
-    actions: {
-      acceptAll: 'Aceptar todo',
-      rejectAll: 'Rechazar todo',
-      manageChoices: 'Gestionar elecciones',
-      hideChoices: 'Ocultar elecciones',
-      savePreferences: 'Guardar preferencias',
-      saving: 'Guardando…',
-    },
-    preferences: {
-      title: 'Preferencias',
-      analytics: {
-        title: 'Cookies analíticas',
-        body: 'Ayúdanos a medir el uso y mejorar las funciones.',
-      },
-      ads: {
-        title: 'Cookies publicitarias',
-        body: 'Mide campañas y mejora la relevancia.',
-      },
-    },
-    errors: {
-      loadVersion: 'No se pudo cargar la versión de la política de cookies',
-      save: 'No se pudieron guardar tus preferencias.',
-    },
-  },
-};
-
-function resolveCookieBannerLocale(pathname: string | null): CookieBannerLocale {
-  if (typeof document !== 'undefined') {
-    const cookies = document.cookie ? document.cookie.split(';') : [];
-    for (const entry of cookies) {
-      const [rawKey, ...rest] = entry.trim().split('=');
-      const key = rawKey.trim();
-      if (key !== 'NEXT_LOCALE' && key !== 'mv-locale') continue;
-      const value = decodeURIComponent(rest.join('=')).trim();
-      if (value === 'fr' || value === 'es' || value === 'en') {
-        return value;
-      }
-    }
-  }
-  if (pathname?.startsWith('/fr')) return 'fr';
-  if (pathname?.startsWith('/es')) return 'es';
-  return 'en';
-}
-
-function readCookie(): string | null {
-  if (typeof document === 'undefined') return null;
-  const cookies = document.cookie ? document.cookie.split(';') : [];
-  for (const entry of cookies) {
-    const [key, ...rest] = entry.trim().split('=');
-    if (key === CONSENT_COOKIE_NAME) {
-      return decodeURIComponent(rest.join('='));
-    }
-  }
-  return null;
-}
-
-function writeCookie(record: ConsentRecord) {
-  if (typeof document === 'undefined') return;
-  const payload = encodeURIComponent(serializeConsent(record));
-  document.cookie = `${CONSENT_COOKIE_NAME}=${payload}; Path=/; Max-Age=${COOKIE_MAX_AGE_SECONDS}; SameSite=Lax`;
-}
-
-function broadcastConsent(record: ConsentRecord) {
-  if (typeof window === 'undefined') return;
-  window.dispatchEvent(
-    new CustomEvent('consent:updated', {
-      detail: {
-        version: record.version,
-        categories: record.categories,
-        timestamp: record.timestamp,
-      },
-    })
-  );
-}
-
-function setLocalAnalyticsFlag(granted: boolean) {
-  if (typeof window === 'undefined') return;
-  try {
-    if (granted) {
-      window.localStorage.setItem(ANALYTICS_STORAGE_KEY, ANALYTICS_GRANTED_VALUE);
-    } else {
-      window.localStorage.removeItem(ANALYTICS_STORAGE_KEY);
-    }
-  } catch {
-    // ignore storage errors
-  }
-}
-
-function updateGoogleConsent(categories: ConsentRecord['categories']) {
-  if (typeof window === 'undefined') return;
-  if (PUBLIC_GOOGLE_CONSENT_MODE === 'false' || PUBLIC_GOOGLE_CONSENT_MODE === 'off') {
-    return;
-  }
-
-  const consentUpdate = {
-    ad_storage: categories.ads ? 'granted' : 'denied',
-    ad_user_data: categories.ads ? 'granted' : 'denied',
-    ad_personalization: categories.ads ? 'granted' : 'denied',
-    analytics_storage: categories.analytics ? 'granted' : 'denied',
-  };
-
-  const helpers = window as typeof window & {
-    gtag?: (...args: unknown[]) => void;
-    gtagConsentUpdate?: (payload: Record<string, string>) => void;
-    dataLayer?: Array<Record<string, unknown>>;
-  };
-
-  if (typeof helpers.gtagConsentUpdate === 'function') {
-    helpers.gtagConsentUpdate(consentUpdate);
-    return;
-  }
-
-  if (typeof helpers.gtag === 'function') {
-    helpers.gtag('consent', 'update', consentUpdate);
-    return;
-  }
-
-  if (Array.isArray(helpers.dataLayer)) {
-    helpers.dataLayer.push({
-      event: 'consent_update',
-      ...consentUpdate,
-    });
-  }
-}
-
-async function persistToServer(categories: ConsentRecord['categories']) {
-  try {
-    await fetch('/api/legal/cookies', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ categories }),
-    });
-  } catch (error) {
-    console.warn('[cookie-consent] failed to persist to server', error);
-  }
-}
+import { CookiePreferencesPanel } from '@/components/legal/CookiePreferencesPanel';
+import { COOKIE_BANNER_COPY, resolveCookieBannerLocale } from '@/components/legal/cookie-banner-copy';
+import {
+  applyStoredConsentEffects,
+  clearLocalAnalyticsFlag,
+  DEFAULT_CHOICES,
+  OPEN_PREFERENCES_EVENT,
+  persistCookieConsent,
+  readConsentCookie,
+  writeConsentCookie,
+  type BannerState,
+  type FetchState,
+} from '@/components/legal/cookie-banner-client';
 
 export function CookieBanner() {
   const pathname = usePathname();
@@ -269,7 +36,6 @@ export function CookieBanner() {
 
   const consent = state.ready ? state.consent : null;
   const version = state.ready ? state.version : null;
-
   const hasMadeChoice = state.ready && consent !== null && consent.version === version;
 
   const closePreferences = useCallback(
@@ -290,6 +56,11 @@ export function CookieBanner() {
     [consent]
   );
 
+  const applyPersistedConsent = useCallback((nextConsent: ConsentRecord, nextVersion: string) => {
+    setState({ ready: true, version: nextVersion, consent: nextConsent });
+    applyStoredConsentEffects(nextConsent);
+  }, []);
+
   const bootstrap = useCallback(async () => {
     try {
       const res = await fetch('/api/legal/cookies/version', { cache: 'no-store' });
@@ -297,43 +68,32 @@ export function CookieBanner() {
       if (!res.ok || !json?.ok || typeof json.version !== 'string') {
         throw new Error(json?.error ?? copy.errors.loadVersion);
       }
-      const stored = parseConsent(readCookie());
+      const stored = parseConsent(readConsentCookie());
       if (stored && stored.version === json.version) {
-        setState({ ready: true, version: json.version, consent: stored });
-        broadcastConsent(stored);
-        setAnalyticsConsentCookie(Boolean(stored.categories.analytics));
-        setLocalAnalyticsFlag(Boolean(stored.categories.analytics));
-        setClarityConsent(Boolean(stored.categories.analytics));
-        updateGoogleConsent(stored.categories);
+        applyPersistedConsent(stored, json.version);
       } else {
         setState({ ready: true, version: json.version, consent: null });
-        setLocalAnalyticsFlag(false);
+        clearLocalAnalyticsFlag();
       }
     } catch (err) {
       console.warn('[cookie-consent] bootstrap failed', err);
       const fallbackVersion = '2025-10-26';
-      const stored = parseConsent(readCookie());
+      const stored = parseConsent(readConsentCookie());
       if (stored && stored.version === fallbackVersion) {
-        setState({ ready: true, version: fallbackVersion, consent: stored });
-        broadcastConsent(stored);
-        setAnalyticsConsentCookie(Boolean(stored.categories.analytics));
-        setLocalAnalyticsFlag(Boolean(stored.categories.analytics));
-        setClarityConsent(Boolean(stored.categories.analytics));
-        updateGoogleConsent(stored.categories);
+        applyPersistedConsent(stored, fallbackVersion);
       } else {
         setState({ ready: true, version: fallbackVersion, consent: null });
-        setLocalAnalyticsFlag(false);
+        clearLocalAnalyticsFlag();
       }
     }
-  }, [copy.errors.loadVersion]);
+  }, [applyPersistedConsent, copy.errors.loadVersion]);
 
   useEffect(() => {
     void bootstrap();
   }, [bootstrap]);
 
   useEffect(() => {
-    if (!state.ready) return;
-    if (!showPreferences) return;
+    if (!state.ready || !showPreferences) return;
     setDraft(consent ? { ...consent.categories } : { ...DEFAULT_CHOICES });
   }, [consent, showPreferences, state.ready]);
 
@@ -372,37 +132,19 @@ export function CookieBanner() {
           timestamp: Date.now(),
           categories,
         });
-        writeCookie(next);
+        writeConsentCookie(next);
         setState({ ready: true, version, consent: next });
-        broadcastConsent(next);
-        setAnalyticsConsentCookie(Boolean(next.categories.analytics));
-        setLocalAnalyticsFlag(Boolean(next.categories.analytics));
-        setClarityConsent(Boolean(next.categories.analytics));
-        updateGoogleConsent(next.categories);
-        await persistToServer(next.categories);
+        applyStoredConsentEffects(next);
+        await persistCookieConsent(next.categories);
         setShowPreferences(false);
       } catch (err) {
-        setError(
-          err instanceof Error ? err.message : copy.errors.save
-        );
+        setError(err instanceof Error ? err.message : copy.errors.save);
       } finally {
         setFetchState('idle');
       }
     },
     [consent, copy.errors.save, version]
   );
-
-  const handleAcceptAll = () => {
-    void applyConsent({ analytics: true, ads: true }, 'banner');
-  };
-
-  const handleRejectAll = () => {
-    void applyConsent({ analytics: false, ads: false }, 'banner');
-  };
-
-  const handleSavePreferences = () => {
-    void applyConsent(draft, 'preferences');
-  };
 
   const toggleCategory = (category: ConsentCategory) => {
     setDraft((current) => ({
@@ -423,65 +165,17 @@ export function CookieBanner() {
   };
 
   const preferencesPanel = (
-    <div
-      id={preferencesPanelId}
-      role="region"
-      aria-labelledby={preferencesTitleId}
-      className="w-full max-w-xs rounded-input border border-border bg-surface-2 p-3 sm:p-4"
-    >
-      <p id={preferencesTitleId} className="mb-3 text-xs font-semibold uppercase tracking-wide text-text-secondary">
-        {copy.preferences.title}
-      </p>
-      <div className="mb-3 flex items-start justify-between gap-4 text-sm text-text-secondary">
-        <span id={analyticsLabelId}>
-          {copy.preferences.analytics.title}
-          <span className="block text-xs text-text-muted">{copy.preferences.analytics.body}</span>
-        </span>
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          onClick={() => toggleCategory('analytics')}
-          className={`min-h-0 h-6 w-10 rounded-full border p-0 transition ${draft.analytics ? 'border-brand bg-brand' : 'border-border bg-surface'}`}
-          role="switch"
-          aria-checked={draft.analytics}
-          aria-labelledby={analyticsLabelId}
-        >
-          <span
-            className={`block h-5 w-5 translate-y-0.5 rounded-full bg-on-brand transition ${draft.analytics ? 'translate-x-4' : 'translate-x-0.5'}`}
-          />
-        </Button>
-      </div>
-      <div className="mb-3 flex items-start justify-between gap-4 text-sm text-text-secondary">
-        <span id={adsLabelId}>
-          {copy.preferences.ads.title}
-          <span className="block text-xs text-text-muted">{copy.preferences.ads.body}</span>
-        </span>
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          onClick={() => toggleCategory('ads')}
-          className={`min-h-0 h-6 w-10 rounded-full border p-0 transition ${draft.ads ? 'border-brand bg-brand' : 'border-border bg-surface'}`}
-          role="switch"
-          aria-checked={draft.ads}
-          aria-labelledby={adsLabelId}
-        >
-          <span
-            className={`block h-5 w-5 translate-y-0.5 rounded-full bg-on-brand transition ${draft.ads ? 'translate-x-4' : 'translate-x-0.5'}`}
-          />
-        </Button>
-      </div>
-      <Button
-        type="button"
-        size="sm"
-        onClick={handleSavePreferences}
-        disabled={fetchState === 'saving'}
-        className="w-full px-3 py-2 text-sm"
-      >
-        {fetchState === 'saving' ? copy.actions.saving : copy.actions.savePreferences}
-      </Button>
-    </div>
+    <CookiePreferencesPanel
+      adsLabelId={adsLabelId}
+      analyticsLabelId={analyticsLabelId}
+      copy={copy}
+      draft={draft}
+      fetchState={fetchState}
+      panelId={preferencesPanelId}
+      titleId={preferencesTitleId}
+      onSavePreferences={() => void applyConsent(draft, 'preferences')}
+      onToggleCategory={toggleCategory}
+    />
   );
 
   if (!state.ready || isAdminRoute) {
@@ -507,7 +201,7 @@ export function CookieBanner() {
               <Button
                 type="button"
                 size="sm"
-                onClick={handleAcceptAll}
+                onClick={() => void applyConsent({ analytics: true, ads: true }, 'banner')}
                 disabled={fetchState === 'saving'}
                 className="px-3 py-1.5 text-xs sm:px-4 sm:py-2 sm:text-sm"
               >
@@ -517,18 +211,18 @@ export function CookieBanner() {
                 type="button"
                 size="sm"
                 variant="outline"
-                onClick={handleRejectAll}
+                onClick={() => void applyConsent({ analytics: false, ads: false }, 'banner')}
                 disabled={fetchState === 'saving'}
                 className="border-border px-3 py-1.5 text-xs text-text-primary hover:bg-surface-hover sm:px-4 sm:py-2 sm:text-sm"
               >
                 {copy.actions.rejectAll}
               </Button>
               <Button
+                ref={manageChoicesButtonRef}
                 type="button"
                 size="sm"
                 variant="ghost"
                 onClick={handleManageChoicesToggle}
-                ref={manageChoicesButtonRef}
                 aria-expanded={showPreferences}
                 aria-controls={preferencesPanelId}
                 className="min-h-0 h-auto p-0 text-xs font-semibold text-brand underline underline-offset-4 hover:text-brandHover sm:text-sm"

--- a/frontend/components/legal/CookiePreferencesPanel.tsx
+++ b/frontend/components/legal/CookiePreferencesPanel.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import type { ConsentCategory } from '@/lib/consent';
+import { Button } from '@/components/ui/Button';
+import type { CookieBannerCopy } from '@/components/legal/cookie-banner-copy';
+import type { FetchState } from '@/components/legal/cookie-banner-client';
+
+type CookiePreferencesPanelProps = {
+  adsLabelId: string;
+  analyticsLabelId: string;
+  copy: CookieBannerCopy;
+  draft: Record<ConsentCategory, boolean>;
+  fetchState: FetchState;
+  panelId: string;
+  titleId: string;
+  onSavePreferences: () => void;
+  onToggleCategory: (category: ConsentCategory) => void;
+};
+
+export function CookiePreferencesPanel({
+  adsLabelId,
+  analyticsLabelId,
+  copy,
+  draft,
+  fetchState,
+  panelId,
+  titleId,
+  onSavePreferences,
+  onToggleCategory,
+}: CookiePreferencesPanelProps) {
+  return (
+    <div
+      id={panelId}
+      role="region"
+      aria-labelledby={titleId}
+      className="w-full max-w-xs rounded-input border border-border bg-surface-2 p-3 sm:p-4"
+    >
+      <p id={titleId} className="mb-3 text-xs font-semibold uppercase tracking-wide text-text-secondary">
+        {copy.preferences.title}
+      </p>
+      <div className="mb-3 flex items-start justify-between gap-4 text-sm text-text-secondary">
+        <span id={analyticsLabelId}>
+          {copy.preferences.analytics.title}
+          <span className="block text-xs text-text-muted">{copy.preferences.analytics.body}</span>
+        </span>
+        <PreferenceSwitch
+          checked={draft.analytics}
+          labelId={analyticsLabelId}
+          onClick={() => onToggleCategory('analytics')}
+        />
+      </div>
+      <div className="mb-3 flex items-start justify-between gap-4 text-sm text-text-secondary">
+        <span id={adsLabelId}>
+          {copy.preferences.ads.title}
+          <span className="block text-xs text-text-muted">{copy.preferences.ads.body}</span>
+        </span>
+        <PreferenceSwitch checked={draft.ads} labelId={adsLabelId} onClick={() => onToggleCategory('ads')} />
+      </div>
+      <Button
+        type="button"
+        size="sm"
+        onClick={onSavePreferences}
+        disabled={fetchState === 'saving'}
+        className="w-full px-3 py-2 text-sm"
+      >
+        {fetchState === 'saving' ? copy.actions.saving : copy.actions.savePreferences}
+      </Button>
+    </div>
+  );
+}
+
+type PreferenceSwitchProps = {
+  checked: boolean;
+  labelId: string;
+  onClick: () => void;
+};
+
+function PreferenceSwitch({ checked, labelId, onClick }: PreferenceSwitchProps) {
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="ghost"
+      onClick={onClick}
+      className={`min-h-0 h-6 w-10 rounded-full border p-0 transition ${checked ? 'border-brand bg-brand' : 'border-border bg-surface'}`}
+      role="switch"
+      aria-checked={checked}
+      aria-labelledby={labelId}
+    >
+      <span
+        className={`block h-5 w-5 translate-y-0.5 rounded-full bg-on-brand transition ${checked ? 'translate-x-4' : 'translate-x-0.5'}`}
+      />
+    </Button>
+  );
+}

--- a/frontend/components/legal/cookie-banner-client.ts
+++ b/frontend/components/legal/cookie-banner-client.ts
@@ -1,0 +1,135 @@
+import {
+  CONSENT_COOKIE_NAME,
+  serializeConsent,
+  type ConsentCategory,
+  type ConsentRecord,
+} from '@/lib/consent';
+import { setAnalyticsConsentCookie, setClarityConsent } from '@/lib/clarity-client';
+
+export type BannerState =
+  | { ready: false }
+  | {
+      ready: true;
+      version: string;
+      consent: ConsentRecord | null;
+    };
+
+export type FetchState = 'idle' | 'saving';
+
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 395; // ~13 months
+const PUBLIC_GOOGLE_CONSENT_MODE = (process.env.NEXT_PUBLIC_GOOGLE_CONSENT_MODE ?? 'auto').toLowerCase();
+const ANALYTICS_STORAGE_KEY = 'mv-consent-analytics';
+const ANALYTICS_GRANTED_VALUE = 'granted';
+
+export const DEFAULT_CHOICES: Record<ConsentCategory, boolean> = {
+  analytics: false,
+  ads: false,
+};
+
+export const OPEN_PREFERENCES_EVENT = 'consent:open-preferences';
+
+export function readConsentCookie(): string | null {
+  if (typeof document === 'undefined') return null;
+  const cookies = document.cookie ? document.cookie.split(';') : [];
+  for (const entry of cookies) {
+    const [key, ...rest] = entry.trim().split('=');
+    if (key === CONSENT_COOKIE_NAME) {
+      return decodeURIComponent(rest.join('='));
+    }
+  }
+  return null;
+}
+
+export function writeConsentCookie(record: ConsentRecord) {
+  if (typeof document === 'undefined') return;
+  const payload = encodeURIComponent(serializeConsent(record));
+  document.cookie = `${CONSENT_COOKIE_NAME}=${payload}; Path=/; Max-Age=${COOKIE_MAX_AGE_SECONDS}; SameSite=Lax`;
+}
+
+export function broadcastConsent(record: ConsentRecord) {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(
+    new CustomEvent('consent:updated', {
+      detail: {
+        version: record.version,
+        categories: record.categories,
+        timestamp: record.timestamp,
+      },
+    })
+  );
+}
+
+export function applyStoredConsentEffects(record: ConsentRecord) {
+  broadcastConsent(record);
+  setAnalyticsConsentCookie(Boolean(record.categories.analytics));
+  setLocalAnalyticsFlag(Boolean(record.categories.analytics));
+  setClarityConsent(Boolean(record.categories.analytics));
+  updateGoogleConsent(record.categories);
+}
+
+export function clearLocalAnalyticsFlag() {
+  setLocalAnalyticsFlag(false);
+}
+
+export async function persistCookieConsent(categories: ConsentRecord['categories']) {
+  try {
+    await fetch('/api/legal/cookies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ categories }),
+    });
+  } catch (error) {
+    console.warn('[cookie-consent] failed to persist to server', error);
+  }
+}
+
+function setLocalAnalyticsFlag(granted: boolean) {
+  if (typeof window === 'undefined') return;
+  try {
+    if (granted) {
+      window.localStorage.setItem(ANALYTICS_STORAGE_KEY, ANALYTICS_GRANTED_VALUE);
+    } else {
+      window.localStorage.removeItem(ANALYTICS_STORAGE_KEY);
+    }
+  } catch {
+    // ignore storage errors
+  }
+}
+
+function updateGoogleConsent(categories: ConsentRecord['categories']) {
+  if (typeof window === 'undefined') return;
+  if (PUBLIC_GOOGLE_CONSENT_MODE === 'false' || PUBLIC_GOOGLE_CONSENT_MODE === 'off') {
+    return;
+  }
+
+  const consentUpdate = {
+    ad_storage: categories.ads ? 'granted' : 'denied',
+    ad_user_data: categories.ads ? 'granted' : 'denied',
+    ad_personalization: categories.ads ? 'granted' : 'denied',
+    analytics_storage: categories.analytics ? 'granted' : 'denied',
+  };
+
+  const helpers = window as typeof window & {
+    gtag?: (...args: unknown[]) => void;
+    gtagConsentUpdate?: (payload: Record<string, string>) => void;
+    dataLayer?: Array<Record<string, unknown>>;
+  };
+
+  if (typeof helpers.gtagConsentUpdate === 'function') {
+    helpers.gtagConsentUpdate(consentUpdate);
+    return;
+  }
+
+  if (typeof helpers.gtag === 'function') {
+    helpers.gtag('consent', 'update', consentUpdate);
+    return;
+  }
+
+  if (Array.isArray(helpers.dataLayer)) {
+    helpers.dataLayer.push({
+      event: 'consent_update',
+      ...consentUpdate,
+    });
+  }
+}

--- a/frontend/components/legal/cookie-banner-copy.ts
+++ b/frontend/components/legal/cookie-banner-copy.ts
@@ -1,0 +1,128 @@
+export type CookieBannerLocale = 'en' | 'fr' | 'es';
+
+export type CookieBannerCopy = {
+  title: string;
+  body: string;
+  actions: {
+    acceptAll: string;
+    rejectAll: string;
+    manageChoices: string;
+    hideChoices: string;
+    savePreferences: string;
+    saving: string;
+  };
+  preferences: {
+    title: string;
+    analytics: { title: string; body: string };
+    ads: { title: string; body: string };
+  };
+  errors: {
+    loadVersion: string;
+    save: string;
+  };
+};
+
+export const COOKIE_BANNER_COPY: Record<CookieBannerLocale, CookieBannerCopy> = {
+  en: {
+    title: 'Cookies & Privacy',
+    body:
+      "We use essential cookies to run the site. With your consent, we'll enable analytics to improve the product and advertising tags for campaign measurement. You can change your choices anytime.",
+    actions: {
+      acceptAll: 'Accept all',
+      rejectAll: 'Reject all',
+      manageChoices: 'Manage choices',
+      hideChoices: 'Hide choices',
+      savePreferences: 'Save preferences',
+      saving: 'Saving…',
+    },
+    preferences: {
+      title: 'Preferences',
+      analytics: {
+        title: 'Analytics cookies',
+        body: 'Help us measure usage and improve features.',
+      },
+      ads: {
+        title: 'Advertising cookies',
+        body: 'Measure campaigns and improve relevance.',
+      },
+    },
+    errors: {
+      loadVersion: 'Failed to load cookie policy version',
+      save: 'Unable to store your preferences.',
+    },
+  },
+  fr: {
+    title: 'Cookies et confidentialité',
+    body:
+      'Nous utilisons des cookies essentiels pour faire fonctionner le site. Avec votre accord, nous activerons les analytics pour améliorer le produit et les balises publicitaires pour mesurer les campagnes. Vous pouvez modifier vos choix à tout moment.',
+    actions: {
+      acceptAll: 'Tout accepter',
+      rejectAll: 'Tout refuser',
+      manageChoices: 'Gérer mes choix',
+      hideChoices: 'Masquer les choix',
+      savePreferences: 'Enregistrer les préférences',
+      saving: 'Enregistrement…',
+    },
+    preferences: {
+      title: 'Préférences',
+      analytics: {
+        title: 'Cookies analytiques',
+        body: 'Aidez-nous à mesurer l’usage et à améliorer les fonctionnalités.',
+      },
+      ads: {
+        title: 'Cookies publicitaires',
+        body: 'Mesurez les campagnes et améliorez leur pertinence.',
+      },
+    },
+    errors: {
+      loadVersion: 'Impossible de charger la version de la politique cookies',
+      save: 'Impossible d’enregistrer vos préférences.',
+    },
+  },
+  es: {
+    title: 'Cookies y privacidad',
+    body:
+      'Usamos cookies esenciales para que el sitio funcione. Con tu consentimiento, activaremos analytics para mejorar el producto y etiquetas publicitarias para medir campañas. Puedes cambiar tus elecciones en cualquier momento.',
+    actions: {
+      acceptAll: 'Aceptar todo',
+      rejectAll: 'Rechazar todo',
+      manageChoices: 'Gestionar elecciones',
+      hideChoices: 'Ocultar elecciones',
+      savePreferences: 'Guardar preferencias',
+      saving: 'Guardando…',
+    },
+    preferences: {
+      title: 'Preferencias',
+      analytics: {
+        title: 'Cookies analíticas',
+        body: 'Ayúdanos a medir el uso y mejorar las funciones.',
+      },
+      ads: {
+        title: 'Cookies publicitarias',
+        body: 'Mide campañas y mejora la relevancia.',
+      },
+    },
+    errors: {
+      loadVersion: 'No se pudo cargar la versión de la política de cookies',
+      save: 'No se pudieron guardar tus preferencias.',
+    },
+  },
+};
+
+export function resolveCookieBannerLocale(pathname: string | null): CookieBannerLocale {
+  if (typeof document !== 'undefined') {
+    const cookies = document.cookie ? document.cookie.split(';') : [];
+    for (const entry of cookies) {
+      const [rawKey, ...rest] = entry.trim().split('=');
+      const key = rawKey.trim();
+      if (key !== 'NEXT_LOCALE' && key !== 'mv-locale') continue;
+      const value = decodeURIComponent(rest.join('=')).trim();
+      if (value === 'fr' || value === 'es' || value === 'en') {
+        return value;
+      }
+    }
+  }
+  if (pathname?.startsWith('/fr')) return 'fr';
+  if (pathname?.startsWith('/es')) return 'es';
+  return 'en';
+}

--- a/frontend/components/marketing/MarketingAccountMenu.tsx
+++ b/frontend/components/marketing/MarketingAccountMenu.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import type { MouseEvent, RefObject } from 'react';
+import { Link } from '@/i18n/navigation';
+import { NAV_ITEMS } from '@/components/AppSidebar';
+import { Button } from '@/components/ui/Button';
+
+type MarketingTranslate = <T = unknown>(key: string, fallback?: T) => T | undefined;
+
+type MarketingAccountMenuProps = {
+  accountMenuOpen: boolean;
+  avatarRef: RefObject<HTMLButtonElement>;
+  email: string;
+  initials: string;
+  isAdmin: boolean;
+  menuRef: RefObject<HTMLDivElement>;
+  t: MarketingTranslate;
+  onAdminNavigation: (event: MouseEvent<HTMLAnchorElement>) => void;
+  onCloseAccountMenu: () => void;
+  onSignOut: () => void;
+  onToggleAccountMenu: () => void;
+};
+
+export function MarketingAccountMenu({
+  accountMenuOpen,
+  avatarRef,
+  email,
+  initials,
+  isAdmin,
+  menuRef,
+  t,
+  onAdminNavigation,
+  onCloseAccountMenu,
+  onSignOut,
+  onToggleAccountMenu,
+}: MarketingAccountMenuProps) {
+  return (
+    <div className="relative">
+      <Button
+        ref={avatarRef}
+        type="button"
+        size="sm"
+        variant="ghost"
+        onClick={onToggleAccountMenu}
+        className="min-h-0 h-10 w-10 rounded-full border border-hairline bg-surface-2 text-sm font-semibold text-text-primary shadow-card hover:bg-surface-3"
+        aria-haspopup="menu"
+        aria-expanded={accountMenuOpen}
+      >
+        {initials}
+      </Button>
+      {accountMenuOpen ? (
+        <div
+          ref={menuRef}
+          className="absolute right-0 mt-3 w-56 rounded-card border border-hairline bg-surface p-3 text-sm text-text-primary shadow-card"
+          role="menu"
+        >
+          <div className="mb-3 rounded-input bg-bg px-3 py-2">
+            <p className="text-xs uppercase tracking-micro text-text-muted">
+              {t('workspace.header.signedIn', 'Signed in')}
+            </p>
+            <p className="mt-1 truncate text-sm font-medium text-text-primary">{email}</p>
+          </div>
+          <nav className="mb-2 flex flex-col gap-1" aria-label={t('workspace.header.primaryNav', 'Primary navigation')}>
+            {NAV_ITEMS.map((item) => {
+              const label = t(`workspace.sidebar.links.${item.id}`, item.label);
+              const badgeLabel = item.badge ? t(`workspace.sidebar.badges.${item.badgeKey ?? item.id}`, item.badge) : null;
+              return (
+                <Link
+                  key={item.id}
+                  href={item.href}
+                  prefetch={false}
+                  className="flex items-center justify-between rounded-input px-3 py-2 text-sm font-medium text-text-primary transition hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  onClick={onCloseAccountMenu}
+                >
+                  <span>{label}</span>
+                  {badgeLabel ? (
+                    <span className="rounded-full bg-surface-2 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-micro text-text-primary">
+                      {badgeLabel}
+                    </span>
+                  ) : null}
+                </Link>
+              );
+            })}
+            {isAdmin ? (
+              <Link
+                href="/admin"
+                prefetch={false}
+                className="flex items-center justify-between rounded-input px-3 py-2 text-sm font-medium text-text-primary transition hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                onClick={onAdminNavigation}
+              >
+                <span>Admin</span>
+              </Link>
+            ) : null}
+          </nav>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="min-h-0 h-auto w-full justify-between rounded-input px-3 py-2 text-sm font-medium text-text-primary hover:bg-surface-2"
+            onClick={onSignOut}
+          >
+            {t('workspace.header.signOut', 'Sign out')}
+            <span className="text-[11px] uppercase tracking-micro text-text-muted">⌘⇧Q</span>
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/components/marketing/MarketingDesktopNav.tsx
+++ b/frontend/components/marketing/MarketingDesktopNav.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import clsx from 'clsx';
+import { ChevronDown } from 'lucide-react';
+import { Link } from '@/i18n/navigation';
+import { UIIcon } from '@/components/ui/UIIcon';
+import { MARKETING_NAV_DROPDOWNS } from '@/config/navigation';
+import type { MarketingTopNavLink } from '@/config/navigation';
+
+type MarketingTranslate = <T = unknown>(key: string, fallback?: T) => T | undefined;
+
+type MarketingDesktopNavProps = {
+  desktopDropdownOpen: string | null;
+  links: readonly MarketingTopNavLink[];
+  pathname: string | null;
+  t: MarketingTranslate;
+  onCloseDesktopDropdown: (delay?: number) => void;
+  onOpenDesktopDropdown: (key: string) => void;
+};
+
+export function MarketingDesktopNav({
+  desktopDropdownOpen,
+  links,
+  pathname,
+  t,
+  onCloseDesktopDropdown,
+  onOpenDesktopDropdown,
+}: MarketingDesktopNavProps) {
+  return (
+    <nav aria-label="Primary" className="hidden items-center gap-5 text-sm font-medium text-text-secondary lg:flex xl:gap-7">
+      {links.map((item) => {
+        const isActive = pathname === item.href || (item.href !== '/' && pathname?.startsWith(`${item.href}/`));
+        const dropdown = MARKETING_NAV_DROPDOWNS[item.key];
+        const label = t(`nav.linkLabels.${item.key}`, item.key);
+        if (!dropdown) {
+          return (
+            <Link
+              key={item.key}
+              href={item.href}
+              className={clsx(
+                'whitespace-nowrap transition-colors hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg',
+                isActive ? 'text-text-primary' : undefined
+              )}
+            >
+              {label}
+            </Link>
+          );
+        }
+
+        const allLabel = t(dropdown.allLabelKey, dropdown.allLabelFallback);
+        const isOpen = desktopDropdownOpen === item.key;
+        const hasSections = Boolean(dropdown.sections?.length);
+
+        return (
+          <div
+            key={item.key}
+            className="relative"
+            onMouseEnter={() => onOpenDesktopDropdown(item.key)}
+            onMouseLeave={() => onCloseDesktopDropdown()}
+            onFocus={() => onOpenDesktopDropdown(item.key)}
+            onBlur={(event) => {
+              const next = event.relatedTarget as Node | null;
+              if (!event.currentTarget.contains(next)) {
+                onCloseDesktopDropdown();
+              }
+            }}
+          >
+            <Link
+              href={item.href}
+              aria-haspopup="menu"
+              className={clsx(
+                'inline-flex items-center gap-1 whitespace-nowrap transition-colors hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg',
+                isActive ? 'text-text-primary' : undefined
+              )}
+              onClick={() => onCloseDesktopDropdown(200)}
+            >
+              <span>{label}</span>
+              <UIIcon icon={ChevronDown} size={14} strokeWidth={1.6} className="text-text-muted" />
+            </Link>
+            <div
+              className={clsx(
+                'absolute left-0 top-full z-20 pt-2 transition duration-150',
+                isOpen ? 'visible opacity-100' : 'invisible opacity-0'
+              )}
+            >
+              <div className="min-w-[240px] rounded-card border border-hairline bg-surface p-3 shadow-card">
+                <div className={clsx('grid gap-3', hasSections ? 'min-w-[520px] grid-cols-[1fr_1fr]' : 'min-w-0 grid-cols-1')}>
+                  <nav className="flex flex-col gap-1" role="menu" aria-label={label}>
+                    <Link
+                      href={dropdown.allHref}
+                      className="rounded-input px-3 py-2 text-sm font-semibold text-text-primary transition hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      role="menuitem"
+                      onClick={() => onCloseDesktopDropdown(200)}
+                    >
+                      {allLabel}
+                    </Link>
+                    {dropdown.items.map((entry) => (
+                      <Link
+                        key={entry.key}
+                        href={entry.href}
+                        className="rounded-input px-3 py-2 text-sm text-text-secondary transition hover:bg-surface-2 hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        role="menuitem"
+                        onClick={() => onCloseDesktopDropdown(200)}
+                      >
+                        {t(`nav.dropdown.${item.key}.items.${entry.key}`, entry.label)}
+                      </Link>
+                    ))}
+                  </nav>
+                  {dropdown.sections?.map((section) => {
+                    const sectionLabel = section.titleKey
+                      ? t(section.titleKey, section.titleFallback ?? section.key)
+                      : (section.titleFallback ?? label);
+
+                    return (
+                      <nav
+                        key={section.key}
+                        className="flex flex-col gap-1 border-l border-hairline pl-3"
+                        role="menu"
+                        aria-label={sectionLabel}
+                      >
+                        {!section.hideTitle && sectionLabel ? (
+                          <p className="px-3 pb-1 pt-2 text-xs font-semibold uppercase tracking-micro text-text-muted">
+                            {sectionLabel}
+                          </p>
+                        ) : null}
+                        {section.items.map((entry) => (
+                          <Link
+                            key={entry.key}
+                            href={entry.href}
+                            className={clsx(
+                              'rounded-input px-3 py-2 text-sm transition hover:bg-surface-2 hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                              entry.emphasized ? 'font-semibold text-text-primary' : 'text-text-secondary'
+                            )}
+                            role="menuitem"
+                            onClick={() => onCloseDesktopDropdown(200)}
+                          >
+                            {t(`nav.dropdown.${item.key}.sections.${section.key}.items.${entry.key}`, entry.label)}
+                          </Link>
+                        ))}
+                      </nav>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/components/marketing/MarketingMobileMenu.tsx
+++ b/frontend/components/marketing/MarketingMobileMenu.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import clsx from 'clsx';
+import { ChevronDown, Moon, Sun } from 'lucide-react';
+import { Link } from '@/i18n/navigation';
+import { LanguageToggle } from '@/components/marketing/LanguageToggle';
+import { Button } from '@/components/ui/Button';
+import { UIIcon } from '@/components/ui/UIIcon';
+import { MARKETING_NAV_DROPDOWNS } from '@/config/navigation';
+import type { MarketingTopNavLink } from '@/config/navigation';
+
+type MarketingTranslate = <T = unknown>(key: string, fallback?: T) => T | undefined;
+
+type MarketingMobileMenuProps = {
+  cta: string;
+  generateLabel: string;
+  isAuthenticated: boolean;
+  isHomePage: boolean;
+  links: readonly MarketingTopNavLink[];
+  login: string;
+  mobileDropdownOpen: Record<string, boolean>;
+  pathname: string | null;
+  t: MarketingTranslate;
+  theme: 'light' | 'dark';
+  onClose: () => void;
+  onSignOut: () => void;
+  onToggleDropdown: (key: string) => void;
+  onToggleTheme: () => void;
+};
+
+export function MarketingMobileMenu({
+  cta,
+  generateLabel,
+  isAuthenticated,
+  isHomePage,
+  links,
+  login,
+  mobileDropdownOpen,
+  pathname,
+  t,
+  theme,
+  onClose,
+  onSignOut,
+  onToggleDropdown,
+  onToggleTheme,
+}: MarketingMobileMenuProps) {
+  return (
+    <div className={clsx('fixed inset-0 z-50 bg-bg px-4 py-6 sm:px-6', isHomePage && 'home-monochrome')}>
+      <div className="mx-auto flex max-w-sm items-center justify-end">
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          className="min-h-0 h-9 w-9 rounded-full border border-hairline bg-surface p-2 text-text-primary"
+          aria-label={t('nav.mobileClose', 'Close menu')}
+          onClick={onClose}
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            className="h-5 w-5"
+          >
+            <line x1="6" y1="6" x2="18" y2="18" />
+            <line x1="18" y1="6" x2="6" y2="18" />
+          </svg>
+        </Button>
+      </div>
+      <div className="mx-auto mt-5 max-w-sm stack-gap-lg">
+        <div className="flex justify-end gap-2">
+          <LanguageToggle variant="icon" />
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-9 w-9 p-0 text-text-primary hover:bg-surface-2"
+            aria-label={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+            onClick={onToggleTheme}
+          >
+            <span className="inline-flex h-4 w-4 items-center justify-center">
+              <UIIcon icon={theme === 'dark' ? Sun : Moon} size={16} strokeWidth={1.75} />
+            </span>
+          </Button>
+        </div>
+        <nav className="flex flex-col gap-3 text-base font-semibold text-text-primary">
+          {links.map((item) => {
+            const dropdown = MARKETING_NAV_DROPDOWNS[item.key];
+            const label = t(`nav.linkLabels.${item.key}`, item.key);
+            if (!dropdown) {
+              return (
+                <Link
+                  key={item.key}
+                  href={item.href}
+                  onClick={onClose}
+                  className={clsx(
+                    'rounded-2xl border border-hairline px-4 py-3',
+                    pathname === item.href ? 'bg-surface-2 text-text-primary' : 'bg-surface'
+                  )}
+                >
+                  {label}
+                </Link>
+              );
+            }
+            const allLabel = t(dropdown.allLabelKey, dropdown.allLabelFallback);
+            const panelId = `mobile-${item.key}-panel`;
+            const isOpen = Boolean(mobileDropdownOpen[item.key]);
+            return (
+              <div key={item.key} className="rounded-2xl border border-hairline bg-surface px-4 py-3">
+                <button
+                  type="button"
+                  className="flex w-full items-center justify-between text-left text-sm font-semibold text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  aria-expanded={isOpen}
+                  aria-controls={panelId}
+                  onClick={() => onToggleDropdown(item.key)}
+                >
+                  <span>{label}</span>
+                  <UIIcon
+                    icon={ChevronDown}
+                    size={14}
+                    strokeWidth={1.6}
+                    className={clsx('text-text-muted transition-transform', isOpen ? 'rotate-180' : undefined)}
+                  />
+                </button>
+                {isOpen ? (
+                  <div id={panelId} className="mt-2 flex flex-col gap-1 text-sm font-medium text-text-secondary">
+                    <Link
+                      href={dropdown.allHref}
+                      onClick={onClose}
+                      className="rounded-input px-2 py-2 text-sm font-semibold text-text-primary transition hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                      {allLabel}
+                    </Link>
+                    {dropdown.items.map((entry) => (
+                      <Link
+                        key={entry.key}
+                        href={entry.href}
+                        onClick={onClose}
+                        className="rounded-input px-2 py-2 transition hover:bg-surface-2 hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      >
+                        {t(`nav.dropdown.${item.key}.items.${entry.key}`, entry.label)}
+                      </Link>
+                    ))}
+                    {dropdown.sections?.map((section) => {
+                      const sectionLabel = section.titleKey
+                        ? t(section.titleKey, section.titleFallback ?? section.key)
+                        : (section.titleFallback ?? label);
+
+                      return (
+                        <div key={section.key} className="mt-2 border-t border-hairline pt-2">
+                          {!section.hideTitle && sectionLabel ? (
+                            <p className="px-2 py-1 text-xs font-semibold uppercase tracking-micro text-text-muted">
+                              {sectionLabel}
+                            </p>
+                          ) : null}
+                          {section.items.map((entry) => (
+                            <Link
+                              key={entry.key}
+                              href={entry.href}
+                              onClick={onClose}
+                              className={clsx(
+                                'block rounded-input px-2 py-2 transition hover:bg-surface-2 hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                                entry.emphasized ? 'font-semibold text-text-primary' : undefined
+                              )}
+                            >
+                              {t(`nav.dropdown.${item.key}.sections.${section.key}.items.${entry.key}`, entry.label)}
+                            </Link>
+                          ))}
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </nav>
+        {isAuthenticated ? (
+          <div className="stack-gap-sm">
+            <Link
+              href="/app"
+              prefetch={false}
+              className="block rounded-2xl bg-brand px-4 py-3 text-center text-base font-semibold text-on-brand shadow-card dark:bg-white dark:text-[#030712] dark:shadow-[0_14px_32px_rgba(255,255,255,0.14)] dark:hover:bg-slate-100"
+              onClick={onClose}
+            >
+              {generateLabel}
+            </Link>
+            <Button
+              type="button"
+              size="md"
+              variant="outline"
+              className="w-full rounded-2xl border-hairline px-4 py-3 text-base font-semibold text-text-primary shadow-card"
+              onClick={onSignOut}
+            >
+              {t('workspace.header.signOut', 'Sign out')}
+            </Button>
+          </div>
+        ) : (
+          <div className="stack-gap-sm">
+            <Link
+              href="/login?next=/app"
+              prefetch={false}
+              className="block rounded-2xl border border-hairline px-4 py-3 text-center text-base font-semibold text-text-primary shadow-card"
+              onClick={onClose}
+              data-analytics-event="cta_click"
+              data-analytics-cta-name="marketing_nav_login"
+              data-analytics-cta-location="marketing_nav_mobile"
+              data-analytics-target-family="auth"
+            >
+              {login}
+            </Link>
+            <Link
+              href="/app"
+              prefetch={false}
+              className="block rounded-input bg-[image:var(--brand-gradient)] px-6 py-3 text-center text-base font-semibold text-on-brand shadow-[var(--shadow-brand-button)] transition hover:bg-[image:var(--brand-gradient-strong)] active:brightness-95"
+              onClick={onClose}
+              data-analytics-event="cta_click"
+              data-analytics-cta-name="marketing_nav_start_app"
+              data-analytics-cta-location="marketing_nav_mobile"
+              data-analytics-target-family="workspace"
+            >
+              {cta}
+            </Link>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/marketing/MarketingNav.tsx
+++ b/frontend/components/marketing/MarketingNav.tsx
@@ -4,17 +4,19 @@ import Image from 'next/image';
 import clsx from 'clsx';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Session } from '@supabase/supabase-js';
-import { ChevronDown, Moon, Sun } from 'lucide-react';
+import { Moon, Sun } from 'lucide-react';
 import { Link, usePathname } from '@/i18n/navigation';
 import { useI18n } from '@/lib/i18n/I18nProvider';
 import { LanguageToggle } from '@/components/marketing/LanguageToggle';
-import { NAV_ITEMS } from '@/components/AppSidebar';
 import { Button } from '@/components/ui/Button';
 import { UIIcon } from '@/components/ui/UIIcon';
+import { MarketingAccountMenu } from '@/components/marketing/MarketingAccountMenu';
+import { MarketingDesktopNav } from '@/components/marketing/MarketingDesktopNav';
+import { MarketingMobileMenu } from '@/components/marketing/MarketingMobileMenu';
 import { consumeLogoutIntent, setLogoutIntent } from '@/lib/logout-intent';
 import { clearLastKnownAccount, writeLastKnownUserId } from '@/lib/last-known';
 import { readBrowserSession } from '@/lib/supabase-auth-cleanup';
-import { MARKETING_NAV_DROPDOWNS, MARKETING_TOP_NAV_LINKS } from '@/config/navigation';
+import { MARKETING_TOP_NAV_LINKS } from '@/config/navigation';
 
 type MarketingNavProps = {
   initialEmail?: string | null;
@@ -309,124 +311,14 @@ export function MarketingNav({ initialEmail = null, initialIsAdmin = false }: Ma
             />
             <span className="text-sm font-semibold tracking-tight sm:text-lg">{compactBrand}</span>
           </Link>
-          <nav aria-label="Primary" className="hidden items-center gap-5 text-sm font-medium text-text-secondary lg:flex xl:gap-7">
-            {links.map((item) => {
-              const isActive = pathname === item.href || (item.href !== '/' && pathname?.startsWith(item.href + '/'));
-              const dropdown = MARKETING_NAV_DROPDOWNS[item.key];
-              const label = t(`nav.linkLabels.${item.key}`, item.key);
-              if (!dropdown) {
-                return (
-                  <Link
-                    key={item.key}
-                    href={item.href}
-                    className={clsx(
-                      'whitespace-nowrap transition-colors hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg',
-                      isActive ? 'text-text-primary' : undefined
-                    )}
-                  >
-                    {label}
-                  </Link>
-                );
-              }
-              const allLabel = t(dropdown.allLabelKey, dropdown.allLabelFallback);
-              const isOpen = desktopDropdownOpen === item.key;
-              const hasSections = Boolean(dropdown.sections?.length);
-              return (
-                <div
-                  key={item.key}
-                  className="relative"
-                  onMouseEnter={() => setDesktopDropdownOpen(item.key)}
-                  onMouseLeave={() => closeDesktopDropdown()}
-                  onFocus={() => setDesktopDropdownOpen(item.key)}
-                  onBlur={(event) => {
-                    const next = event.relatedTarget as Node | null;
-                    if (!event.currentTarget.contains(next)) {
-                      closeDesktopDropdown();
-                    }
-                  }}
-                >
-                  <Link
-                    href={item.href}
-                    aria-haspopup="menu"
-                    className={clsx(
-                      'inline-flex items-center gap-1 whitespace-nowrap transition-colors hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg',
-                      isActive ? 'text-text-primary' : undefined
-                    )}
-                    onClick={() => closeDesktopDropdown(200)}
-                  >
-                    <span>{label}</span>
-                    <UIIcon icon={ChevronDown} size={14} strokeWidth={1.6} className="text-text-muted" />
-                  </Link>
-                  <div
-                    className={clsx(
-                      'absolute left-0 top-full z-20 pt-2 transition duration-150',
-                      isOpen ? 'visible opacity-100' : 'invisible opacity-0'
-                    )}
-                  >
-                    <div className="min-w-[240px] rounded-card border border-hairline bg-surface p-3 shadow-card">
-                      <div className={clsx('grid gap-3', hasSections ? 'min-w-[520px] grid-cols-[1fr_1fr]' : 'min-w-0 grid-cols-1')}>
-                        <nav className="flex flex-col gap-1" role="menu" aria-label={label}>
-                          <Link
-                            href={dropdown.allHref}
-                            className="rounded-input px-3 py-2 text-sm font-semibold text-text-primary transition hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                            role="menuitem"
-                            onClick={() => closeDesktopDropdown(200)}
-                          >
-                            {allLabel}
-                          </Link>
-                          {dropdown.items.map((entry) => (
-                            <Link
-                              key={entry.key}
-                              href={entry.href}
-                              className="rounded-input px-3 py-2 text-sm text-text-secondary transition hover:bg-surface-2 hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                              role="menuitem"
-                              onClick={() => closeDesktopDropdown(200)}
-                            >
-                              {t(`nav.dropdown.${item.key}.items.${entry.key}`, entry.label)}
-                            </Link>
-                          ))}
-                        </nav>
-                        {dropdown.sections?.map((section) => {
-                          const sectionLabel = section.titleKey
-                            ? t(section.titleKey, section.titleFallback ?? section.key)
-                            : (section.titleFallback ?? label);
-
-                          return (
-                            <nav
-                              key={section.key}
-                              className="flex flex-col gap-1 border-l border-hairline pl-3"
-                              role="menu"
-                              aria-label={sectionLabel}
-                            >
-                              {!section.hideTitle && sectionLabel ? (
-                                <p className="px-3 pb-1 pt-2 text-xs font-semibold uppercase tracking-micro text-text-muted">
-                                  {sectionLabel}
-                                </p>
-                              ) : null}
-                              {section.items.map((entry) => (
-                                <Link
-                                  key={entry.key}
-                                  href={entry.href}
-                                  className={clsx(
-                                    'rounded-input px-3 py-2 text-sm transition hover:bg-surface-2 hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-                                    entry.emphasized ? 'font-semibold text-text-primary' : 'text-text-secondary'
-                                  )}
-                                  role="menuitem"
-                                  onClick={() => closeDesktopDropdown(200)}
-                                >
-                                  {t(`nav.dropdown.${item.key}.sections.${section.key}.items.${entry.key}`, entry.label)}
-                                </Link>
-                              ))}
-                            </nav>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
-          </nav>
+          <MarketingDesktopNav
+            desktopDropdownOpen={desktopDropdownOpen}
+            links={links}
+            pathname={pathname}
+            t={t}
+            onCloseDesktopDropdown={closeDesktopDropdown}
+            onOpenDesktopDropdown={setDesktopDropdownOpen}
+          />
         </div>
         <div className="flex items-center gap-2 whitespace-nowrap sm:gap-3 lg:gap-4">
           <div className="hidden items-center gap-1 md:flex">
@@ -454,81 +346,19 @@ export function MarketingNav({ initialEmail = null, initialIsAdmin = false }: Ma
                 <span className="sm:hidden">{generateLabelMobile}</span>
                 <span className="hidden sm:inline">{generateLabel}</span>
               </Link>
-              <div className="relative">
-                <Button
-                  ref={avatarRef}
-                  type="button"
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => setAccountMenuOpen((prev) => !prev)}
-                  className="min-h-0 h-10 w-10 rounded-full border border-hairline bg-surface-2 text-sm font-semibold text-text-primary shadow-card hover:bg-surface-3"
-                  aria-haspopup="menu"
-                  aria-expanded={accountMenuOpen}
-                >
-                  {initials}
-                </Button>
-                {accountMenuOpen && (
-                  <div
-                    ref={menuRef}
-                  className="absolute right-0 mt-3 w-56 rounded-card border border-hairline bg-surface p-3 text-sm text-text-primary shadow-card"
-                    role="menu"
-                  >
-                    <div className="mb-3 rounded-input bg-bg px-3 py-2">
-                      <p className="text-xs uppercase tracking-micro text-text-muted">
-                        {t('workspace.header.signedIn', 'Signed in')}
-                      </p>
-                      <p className="mt-1 truncate text-sm font-medium text-text-primary">{email}</p>
-                    </div>
-                    <nav
-                      className="mb-2 flex flex-col gap-1"
-                      aria-label={t('workspace.header.primaryNav', 'Primary navigation')}
-                    >
-                      {NAV_ITEMS.map((item) => {
-                        const label = t(`workspace.sidebar.links.${item.id}`, item.label);
-                        const badgeLabel = item.badge
-                          ? t(`workspace.sidebar.badges.${item.badgeKey ?? item.id}`, item.badge)
-                          : null;
-                        return (
-                          <Link
-                            key={item.id}
-                            href={item.href}
-                            prefetch={false}
-                          className="flex items-center justify-between rounded-input px-3 py-2 text-sm font-medium text-text-primary transition hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                            onClick={() => setAccountMenuOpen(false)}
-                          >
-                            <span>{label}</span>
-                            {badgeLabel ? (
-                              <span className="rounded-full bg-surface-2 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-micro text-text-primary">
-                                {badgeLabel}
-                              </span>
-                            ) : null}
-                          </Link>
-                        );
-                      })}
-                      {isAdmin ? (
-                        <Link
-                          href="/admin"
-                          prefetch={false}
-                          className="flex items-center justify-between rounded-input px-3 py-2 text-sm font-medium text-text-primary transition hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                          onClick={handleAdminNavigation}
-                        >
-                          <span>Admin</span>
-                        </Link>
-                      ) : null}
-                    </nav>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="ghost"
-                      className="min-h-0 h-auto w-full justify-between rounded-input px-3 py-2 text-sm font-medium text-text-primary hover:bg-surface-2"
-                      onClick={() => signOut({ closeAccountMenu: true })}
-                    >
-                      {t('workspace.header.signOut', 'Sign out')}
-                      <span className="text-[11px] uppercase tracking-micro text-text-muted">⌘⇧Q</span>
-                    </Button>
-                  </div>
-                )}
-              </div>
+              <MarketingAccountMenu
+                accountMenuOpen={accountMenuOpen}
+                avatarRef={avatarRef}
+                email={email ?? ''}
+                initials={initials}
+                isAdmin={isAdmin}
+                menuRef={menuRef}
+                t={t}
+                onAdminNavigation={handleAdminNavigation}
+                onCloseAccountMenu={() => setAccountMenuOpen(false)}
+                onSignOut={() => signOut({ closeAccountMenu: true })}
+                onToggleAccountMenu={() => setAccountMenuOpen((prev) => !prev)}
+              />
             </>
           ) : (
             <>
@@ -561,185 +391,27 @@ export function MarketingNav({ initialEmail = null, initialIsAdmin = false }: Ma
       </div>
     </header>
       {mobileMenuOpen ? (
-        <div className={clsx('fixed inset-0 z-50 bg-bg px-4 py-6 sm:px-6', isHomePage && 'home-monochrome')}>
-          <div className="mx-auto flex max-w-sm items-center justify-end">
-            <Button
-              type="button"
-              size="sm"
-              variant="ghost"
-              className="min-h-0 h-9 w-9 rounded-full border border-hairline bg-surface p-2 text-text-primary"
-              aria-label={t('nav.mobileClose', 'Close menu')}
-              onClick={() => setMobileMenuOpen(false)}
-            >
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
-                <line x1="6" y1="6" x2="18" y2="18" />
-                <line x1="18" y1="6" x2="6" y2="18" />
-              </svg>
-            </Button>
-          </div>
-          <div className="mx-auto mt-5 max-w-sm stack-gap-lg">
-            <div className="flex justify-end gap-2">
-              <LanguageToggle variant="icon" />
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-9 w-9 p-0 text-text-primary hover:bg-surface-2"
-                aria-label={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
-                onClick={toggleTheme}
-              >
-                <span className="inline-flex h-4 w-4 items-center justify-center">
-                  <UIIcon icon={theme === 'dark' ? Sun : Moon} size={16} strokeWidth={1.75} />
-                </span>
-              </Button>
-            </div>
-            <nav className="flex flex-col gap-3 text-base font-semibold text-text-primary">
-              {links.map((item) => {
-                const dropdown = MARKETING_NAV_DROPDOWNS[item.key];
-                const label = t(`nav.linkLabels.${item.key}`, item.key);
-                if (!dropdown) {
-                  return (
-                    <Link
-                      key={item.key}
-                      href={item.href}
-                      onClick={() => setMobileMenuOpen(false)}
-                      className={clsx(
-                        'rounded-2xl border border-hairline px-4 py-3',
-                        pathname === item.href ? 'bg-surface-2 text-text-primary' : 'bg-surface'
-                      )}
-                    >
-                      {label}
-                    </Link>
-                  );
-                }
-                const allLabel = t(dropdown.allLabelKey, dropdown.allLabelFallback);
-                const panelId = `mobile-${item.key}-panel`;
-                const isOpen = Boolean(mobileDropdownOpen[item.key]);
-                return (
-                  <div key={item.key} className="rounded-2xl border border-hairline bg-surface px-4 py-3">
-                    <button
-                      type="button"
-                      className="flex w-full items-center justify-between text-left text-sm font-semibold text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                      aria-expanded={isOpen}
-                      aria-controls={panelId}
-                      onClick={() =>
-                        setMobileDropdownOpen((prev) => ({
-                          ...prev,
-                          [item.key]: !prev[item.key],
-                        }))
-                      }
-                    >
-                      <span>{label}</span>
-                      <UIIcon
-                        icon={ChevronDown}
-                        size={14}
-                        strokeWidth={1.6}
-                        className={clsx('text-text-muted transition-transform', isOpen ? 'rotate-180' : undefined)}
-                      />
-                    </button>
-                    {isOpen ? (
-                      <div id={panelId} className="mt-2 flex flex-col gap-1 text-sm font-medium text-text-secondary">
-                        <Link
-                          href={dropdown.allHref}
-                          onClick={() => setMobileMenuOpen(false)}
-                          className="rounded-input px-2 py-2 text-sm font-semibold text-text-primary transition hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                        >
-                          {allLabel}
-                        </Link>
-                        {dropdown.items.map((entry) => (
-                          <Link
-                            key={entry.key}
-                            href={entry.href}
-                            onClick={() => setMobileMenuOpen(false)}
-                            className="rounded-input px-2 py-2 transition hover:bg-surface-2 hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                          >
-                            {t(`nav.dropdown.${item.key}.items.${entry.key}`, entry.label)}
-                          </Link>
-                        ))}
-                        {dropdown.sections?.map((section) => {
-                          const sectionLabel = section.titleKey
-                            ? t(section.titleKey, section.titleFallback ?? section.key)
-                            : (section.titleFallback ?? label);
-
-                          return (
-                            <div key={section.key} className="mt-2 border-t border-hairline pt-2">
-                              {!section.hideTitle && sectionLabel ? (
-                                <p className="px-2 py-1 text-xs font-semibold uppercase tracking-micro text-text-muted">
-                                  {sectionLabel}
-                                </p>
-                              ) : null}
-                              {section.items.map((entry) => (
-                                <Link
-                                  key={entry.key}
-                                  href={entry.href}
-                                  onClick={() => setMobileMenuOpen(false)}
-                                  className={clsx(
-                                    'block rounded-input px-2 py-2 transition hover:bg-surface-2 hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-                                    entry.emphasized ? 'font-semibold text-text-primary' : undefined
-                                  )}
-                                >
-                                  {t(`nav.dropdown.${item.key}.sections.${section.key}.items.${entry.key}`, entry.label)}
-                                </Link>
-                              ))}
-                            </div>
-                          );
-                        })}
-                      </div>
-                    ) : null}
-                  </div>
-                );
-              })}
-            </nav>
-            {isAuthenticated ? (
-              <div className="stack-gap-sm">
-                <Link
-                  href="/app"
-                  prefetch={false}
-                  className="block rounded-2xl bg-brand px-4 py-3 text-center text-base font-semibold text-on-brand shadow-card dark:bg-white dark:text-[#030712] dark:shadow-[0_14px_32px_rgba(255,255,255,0.14)] dark:hover:bg-slate-100"
-                  onClick={() => setMobileMenuOpen(false)}
-                >
-                  {generateLabel}
-                </Link>
-                      <Button
-                        type="button"
-                        size="md"
-                        variant="outline"
-                        className="w-full rounded-2xl border-hairline px-4 py-3 text-base font-semibold text-text-primary shadow-card"
-                        onClick={() => signOut({ closeMobileMenu: true })}
-                      >
-                        {t('workspace.header.signOut', 'Sign out')}
-                      </Button>
-              </div>
-            ) : (
-              <div className="stack-gap-sm">
-                <Link
-                  href="/login?next=/app"
-                  prefetch={false}
-                  className="block rounded-2xl border border-hairline px-4 py-3 text-center text-base font-semibold text-text-primary shadow-card"
-                  onClick={() => setMobileMenuOpen(false)}
-                  data-analytics-event="cta_click"
-                  data-analytics-cta-name="marketing_nav_login"
-                  data-analytics-cta-location="marketing_nav_mobile"
-                  data-analytics-target-family="auth"
-                >
-                  {login}
-                </Link>
-                <Link
-                  href="/app"
-                  prefetch={false}
-                  className="block rounded-input bg-[image:var(--brand-gradient)] px-6 py-3 text-center text-base font-semibold text-on-brand shadow-[var(--shadow-brand-button)] transition hover:bg-[image:var(--brand-gradient-strong)] active:brightness-95"
-                  onClick={() => setMobileMenuOpen(false)}
-                  data-analytics-event="cta_click"
-                  data-analytics-cta-name="marketing_nav_start_app"
-                  data-analytics-cta-location="marketing_nav_mobile"
-                  data-analytics-target-family="workspace"
-                >
-                  {cta}
-                </Link>
-              </div>
-            )}
-          </div>
-        </div>
+        <MarketingMobileMenu
+          cta={cta ?? 'Generate'}
+          generateLabel={generateLabel ?? 'Generate'}
+          isAuthenticated={isAuthenticated}
+          isHomePage={isHomePage}
+          links={links}
+          login={login ?? 'Log in'}
+          mobileDropdownOpen={mobileDropdownOpen}
+          pathname={pathname}
+          t={t}
+          theme={theme}
+          onClose={() => setMobileMenuOpen(false)}
+          onSignOut={() => signOut({ closeMobileMenu: true })}
+          onToggleDropdown={(key) =>
+            setMobileDropdownOpen((prev) => ({
+              ...prev,
+              [key]: !prev[key],
+            }))
+          }
+          onToggleTheme={toggleTheme}
+        />
       ) : null}
     </>
   );

--- a/frontend/components/marketing/SoraPromptingSidebar.tsx
+++ b/frontend/components/marketing/SoraPromptingSidebar.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+type SoraPromptingSidebarProps = {
+  engineRules: string[];
+  globalRules: string[];
+};
+
+export function SoraPromptingSidebar({ engineRules, globalRules }: SoraPromptingSidebarProps) {
+  return (
+    <aside className="lg:col-span-5">
+      <PromptingRuleCard title="Global principles" rules={globalRules} />
+      <PromptingRuleCard title="Engine quirks / what to watch for" rules={engineRules} />
+    </aside>
+  );
+}
+
+type PromptingRuleCardProps = {
+  rules: string[];
+  title: string;
+};
+
+function PromptingRuleCard({ rules, title }: PromptingRuleCardProps) {
+  return (
+    <div className="stack-gap-sm rounded-2xl border border-hairline bg-surface/80 p-4 shadow-card">
+      <h4 className="text-sm font-semibold text-text-primary">{title}</h4>
+      <ul className="list-disc space-y-1 pl-5 text-sm text-text-secondary">
+        {rules.map((rule) => (
+          <li key={rule}>{rule}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/components/marketing/SoraPromptingTabList.tsx
+++ b/frontend/components/marketing/SoraPromptingTabList.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import clsx from 'clsx';
+import { Button } from '@/components/ui/Button';
+import { buildPanelId, buildTabId, type PromptingTab, type TabId } from '@/components/marketing/sora-prompting-content';
+
+type SoraPromptingTabListProps = {
+  activeId: TabId;
+  tabs: PromptingTab[];
+  onActiveIdChange: (id: TabId) => void;
+};
+
+export function SoraPromptingTabList({ activeId, tabs, onActiveIdChange }: SoraPromptingTabListProps) {
+  return (
+    <div className="flex flex-wrap gap-2" role="tablist" aria-label="Prompt levels">
+      {tabs.map((tab) => {
+        const isActive = tab.id === activeId;
+        return (
+          <Button
+            key={tab.id}
+            type="button"
+            size="sm"
+            variant={isActive ? 'primary' : 'outline'}
+            onClick={() => onActiveIdChange(tab.id)}
+            className={clsx(
+              'min-h-0 h-auto rounded-full px-4 py-2 text-sm font-semibold',
+              isActive ? 'border border-brand' : 'border-hairline text-text-secondary hover:text-text-primary'
+            )}
+            role="tab"
+            id={buildTabId(tab.id)}
+            aria-selected={isActive}
+            aria-controls={buildPanelId(tab.id)}
+          >
+            {tab.label}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/components/marketing/SoraPromptingTabPanel.tsx
+++ b/frontend/components/marketing/SoraPromptingTabPanel.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { CopyPromptButton } from '@/components/CopyPromptButton';
+import {
+  buildPanelId,
+  buildTabId,
+  QUICK_EXAMPLE,
+  QUICK_EXAMPLE_NO_AUDIO,
+  type PromptingMode,
+  type PromptingTab,
+  type TabId,
+} from '@/components/marketing/sora-prompting-content';
+
+type SoraPromptingTabPanelProps = {
+  activeId: TabId;
+  mode: PromptingMode;
+  note?: string;
+  supportsAudio: boolean;
+  tab: PromptingTab;
+};
+
+export function SoraPromptingTabPanel({ activeId, mode, note, supportsAudio, tab }: SoraPromptingTabPanelProps) {
+  const isActive = tab.id === activeId;
+
+  return (
+    <div
+      id={buildPanelId(tab.id)}
+      role="tabpanel"
+      aria-labelledby={buildTabId(tab.id)}
+      aria-hidden={!isActive}
+      hidden={!isActive}
+    >
+      <article className="stack-gap-sm rounded-2xl border border-hairline bg-surface/80 p-4 shadow-card">
+        <header className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-1">
+            <h3 className="text-lg font-semibold text-text-primary">{tab.title}</h3>
+            {tab.description ? <p className="text-sm text-text-secondary">{tab.description}</p> : null}
+            {note ? <p className="text-xs text-text-muted">{note}</p> : null}
+          </div>
+          <CopyPromptButton prompt={tab.copy} copyLabel="Copy template" />
+        </header>
+
+        <div className="stack-gap-sm">
+          <div className="rounded-xl border border-dashed border-hairline bg-bg px-4 py-3 text-sm text-text-secondary">
+            <p className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">
+              Template (copy/paste)
+            </p>
+            <pre className="mt-2 whitespace-pre-wrap font-mono text-sm text-text-primary">{tab.copy}</pre>
+          </div>
+          {tab.id === 'quick' && mode === 'video' ? (
+            <div className="rounded-xl border border-hairline bg-surface-2 px-4 py-3 text-sm text-text-secondary">
+              <p className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">Example</p>
+              <p className="mt-2">{supportsAudio ? QUICK_EXAMPLE : QUICK_EXAMPLE_NO_AUDIO}</p>
+            </div>
+          ) : null}
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/frontend/components/marketing/SoraPromptingTabs.client.tsx
+++ b/frontend/components/marketing/SoraPromptingTabs.client.tsx
@@ -1,357 +1,20 @@
 'use client';
 
 import { useState } from 'react';
-import clsx from 'clsx';
-import { Button } from '@/components/ui/Button';
-import { CopyPromptButton } from '@/components/CopyPromptButton';
-
-const DEFAULT_GUIDE_URL =
-  'https://developers.openai.com/cookbook/examples/sora/sora2_prompting_guide/';
-
-type TabId = 'quick' | 'structured' | 'pro' | 'storyboard';
-type PromptingMode = 'video' | 'image';
-
-const DEFAULT_GLOBAL_PRINCIPLES = [
-  '1 shot = 1 camera move + 1 subject action',
-  'Use visual anchors (specific nouns > vague adjectives)',
-  'Iterate: change one thing at a time',
-];
-
-const DEFAULT_ENGINE_WHY = [
-  'Keep prompts focused: one subject, one action, one camera move.',
-  'Use concrete visual anchors (props, textures, lighting cues).',
-  'Iterate by changing a single variable per take.',
-];
-
-const DEFAULT_TAB_NOTES: Record<TabId, string> = {
-  quick: 'Quick = variations. Use for fast iteration.',
-  structured: 'Structured = consistency. Use when you need reliable results.',
-  pro: 'Pro = continuity. Use for precise, repeatable looks.',
-  storyboard: 'Storyboard = beat timing. Use for mini-stories in one clip.',
-};
-
-const STRUCTURED_TEMPLATE = `Scene (plain language):
-[Subject + setting + props + time of day. Add 2–3 distinctive visual anchors.]
-
-Cinematography:
-- Camera shot: [wide / medium / close-up, angle]
-- Camera motion: [slow push-in / handheld / pan / tracking]
-- Lens look + depth of field: [e.g., 35mm, shallow DOF]
-- Lighting + palette: [key light + 3 palette anchors]
-
-Actions (beats):
-- [Beat 1: a small, visible action]
-- [Beat 2: another clear beat]
-- [Beat 3: a final beat in the last second]
-
-Dialogue (optional):
-[Keep lines short so they fit the clip length.]
-
-Background sound:
-[One sentence: ambience + key SFX. Keep it simple.]
-
-Constraints:
-No logos, no readable text, no subtitles/overlays.`;
-
-const STRUCTURED_TEMPLATE_NO_AUDIO = `Scene (plain language):
-[Subject + setting + props + time of day. Add 2–3 distinctive visual anchors.]
-
-Cinematography:
-- Camera shot: [wide / medium / close-up, angle]
-- Camera motion: [slow push-in / handheld / pan / tracking]
-- Lens look + depth of field: [e.g., 35mm, shallow DOF]
-- Lighting + palette: [key light + 3 palette anchors]
-
-Actions (beats):
-- [Beat 1: a small, visible action]
-- [Beat 2: another clear beat]
-- [Beat 3: a final beat in the last second]
-
-Constraints:
-No logos, no readable text, no subtitles/overlays.`;
-
-const QUICK_TEMPLATE =
-  '[Style] + [Subject doing 1 clear action] + [Where] + [Camera move] + [Lighting] + [Sound cue]';
-
-const QUICK_TEMPLATE_NO_AUDIO =
-  '[Style] + [Subject doing 1 clear action] + [Where] + [Camera move] + [Lighting] + [Ending / visual payoff]';
-
-const QUICK_EXAMPLE =
-  'Handheld smartphone UGC clip of a woman unboxing a new skincare bottle at a kitchen table. She peels the seal, smiles, and turns the bottle toward camera. Soft window daylight, natural colors, subtle room tone + packaging crinkle.';
-
-const QUICK_EXAMPLE_NO_AUDIO =
-  'Handheld smartphone UGC clip of a woman unboxing a new skincare bottle at a kitchen table. She peels the seal, smiles, and turns the bottle toward camera. Soft window daylight, natural colors, clean kitchen background, product label held readable in the final beat.';
-
-const PRO_TEMPLATE = `Project / intent:
-[One-line goal. What should the viewer feel/understand?]
-
-Subject:
-[Who/what. Wardrobe/materials. 2-3 distinctive traits.]
-
-Location / set:
-[Where + time of day + weather. Add 3 visual anchors (specific nouns).]
-
-Cinematography:
-- Framing: [wide / medium / close-up] + [angle]
-- Lens feel + depth of field: [e.g., 35mm natural, shallow DOF]
-- Camera movement: [ONE move: slow dolly-in / handheld / pan / tracking]
-- Composition: [centered / rule of thirds / negative space]
-- Look (optional): [clean digital / subtle film grain / soft bloom]
-
-Lighting & color grade:
-- Key light: [soft window / golden hour / neon practicals / studio key]
-- Contrast: [low / medium / high]
-- Palette anchors: [3-5 anchors: "warm sunrise, teal shadows, amber highlights"]
-
-Action (timed beats):
-- Beat 1 (start): [visible action + camera behavior]
-- Beat 2 (middle): [visible action + camera behavior]
-- Beat 3 (end): [final action + end pose / reveal]
-
-Sound (if supported):
-- Ambience: [one line]
-- SFX cues: [1-3 cues]
-- Music (optional): [genre + intensity]
-
-Constraints:
-No logos. No readable text. No subtitles/overlays. No slow-motion. No jump cuts.`;
-
-const PRO_TEMPLATE_NO_AUDIO = `Project / intent:
-[One-line goal. What should the viewer feel/understand?]
-
-Subject:
-[Who/what. Wardrobe/materials. 2-3 distinctive traits.]
-
-Location / set:
-[Where + time of day + weather. Add 3 visual anchors (specific nouns).]
-
-Cinematography:
-- Framing: [wide / medium / close-up] + [angle]
-- Lens feel + depth of field: [e.g., 35mm natural, shallow DOF]
-- Camera movement: [ONE move: slow dolly-in / handheld / pan / tracking]
-- Composition: [centered / rule of thirds / negative space]
-- Look (optional): [clean digital / subtle film grain / soft bloom]
-
-Lighting & color grade:
-- Key light: [soft window / golden hour / neon practicals / studio key]
-- Contrast: [low / medium / high]
-- Palette anchors: [3-5 anchors: "warm sunrise, teal shadows, amber highlights"]
-
-Action (timed beats):
-- Beat 1 (start): [visible action + camera behavior]
-- Beat 2 (middle): [visible action + camera behavior]
-- Beat 3 (end): [final action + end pose / reveal]
-
-Constraints:
-No logos. No readable text. No subtitles/overlays. No slow-motion. No jump cuts.`;
-
-const STORYBOARD_TEMPLATE = `Storyboard / shot list prompt
-Duration: [4/8/12s] • Aspect: [16:9 or 9:16]
-
-Scene + continuity:
-[Same subject + same location + same wardrobe/props + same lighting throughout.]
-
-Shot 1 (0–2s):
-[Framing + subject action + camera move]
-
-Shot 2 (2–6s):
-[Framing + subject action + camera move]
-
-Shot 3 (6–8/12s):
-[Framing + final action/reveal + camera move or settle]
-
-Lighting + mood:
-[Golden hour / soft daylight / neon night… + 2–3 palette anchors]
-
-Sound (if supported):
-[Ambience + 1–2 SFX cues + optional music vibe]
-
-Constraints:
-No logos. No readable text. No subtitles/overlays. No jump cuts. No slow-motion.`;
-
-const STORYBOARD_TEMPLATE_NO_AUDIO = `Storyboard / shot list prompt
-Duration: [4/8/12s] • Aspect: [16:9 or 9:16]
-
-Scene + continuity:
-[Same subject + same location + same wardrobe/props + same lighting throughout.]
-
-Shot 1 (0–2s):
-[Framing + subject action + camera move]
-
-Shot 2 (2–6s):
-[Framing + subject action + camera move]
-
-Shot 3 (6–8/12s):
-[Framing + final action/reveal + camera move or settle]
-
-Lighting + mood:
-[Golden hour / soft daylight / neon night… + 2–3 palette anchors]
-
-Constraints:
-No logos. No readable text. No subtitles/overlays. No jump cuts. No slow-motion.`;
-
-
-const VIDEO_TABS = [
-  {
-    id: 'quick' as TabId,
-    label: 'Quick',
-    title: 'Quick prompt (fast iteration)',
-    description: 'Use 1–2 sentences when you want variations.',
-    copy: QUICK_TEMPLATE,
-  },
-  {
-    id: 'structured' as TabId,
-    label: 'Structured',
-    title: 'Structured prompt (best for reliable results)',
-    description: 'Separate information so the model can follow it consistently.',
-    copy: STRUCTURED_TEMPLATE,
-  },
-  {
-    id: 'pro' as TabId,
-    label: 'Pro',
-    title: 'Pro prompt (ultra-specific "film crew brief")',
-    description: 'Use this when you need a very specific cinematic look or continuity across shots.',
-    copy: PRO_TEMPLATE,
-  },
-  {
-    id: 'storyboard' as TabId,
-    label: 'Storyboard',
-    title: 'Storyboard prompt (multi-shot / shot list)',
-    description:
-      'Use this when you want a mini-story in one clip. A storyboard prompt (aka multi-shot / shot list prompt) gives Sora clear timing, camera direction, and continuity. Also called shot-list or sequenced prompts.',
-    copy: STORYBOARD_TEMPLATE,
-  },
-];
-
-const VIDEO_TABS_NO_AUDIO = [
-  {
-    id: 'quick' as TabId,
-    label: 'Quick',
-    title: 'Quick prompt (fast iteration)',
-    description: 'Use 1–2 sentences when you want variations.',
-    copy: QUICK_TEMPLATE_NO_AUDIO,
-  },
-  {
-    id: 'structured' as TabId,
-    label: 'Structured',
-    title: 'Structured prompt (best for reliable results)',
-    description: 'Separate information so the model can follow it consistently.',
-    copy: STRUCTURED_TEMPLATE_NO_AUDIO,
-  },
-  {
-    id: 'pro' as TabId,
-    label: 'Pro',
-    title: 'Pro prompt (ultra-specific "film crew brief")',
-    description: 'Use this when you need a very specific cinematic look or continuity across shots.',
-    copy: PRO_TEMPLATE_NO_AUDIO,
-  },
-  {
-    id: 'storyboard' as TabId,
-    label: 'Storyboard',
-    title: 'Storyboard prompt (multi-shot / shot list)',
-    description:
-      'Use this when you want a mini-story in one clip. A storyboard prompt (aka multi-shot / shot list prompt) gives clear timing, camera direction, and continuity. Also called shot-list or sequenced prompts.',
-    copy: STORYBOARD_TEMPLATE_NO_AUDIO,
-  },
-];
-
-const IMAGE_QUICK_TEMPLATE =
-  '[Style] + [Subject] + [Setting] + [Lighting] + [Mood / palette]';
-
-const IMAGE_STRUCTURED_TEMPLATE = `Subject:
-[Who/what + 1 clear action or pose.]
-
-Setting:
-[Where + time of day + 2–3 visual anchors.]
-
-Composition:
-- Framing: [wide / medium / close-up]
-- Angle: [eye-level / low / high]
-- Lens feel: [e.g., 35mm natural, shallow DOF]
-
-Lighting + palette:
-[Key light + 2–3 palette anchors]
-
-Style constraints:
-No logos. No readable text. Clean background.`;
-
-const IMAGE_PRO_TEMPLATE = `Project / intent:
-[One-line goal for the still.]
-
-Subject:
-[Who/what + wardrobe/materials + 2–3 distinctive traits.]
-
-Location / set:
-[Where + time of day + weather. Add 3 visual anchors.]
-
-Composition:
-- Framing + angle
-- Lens feel + depth of field
-- Look: [clean digital / subtle film grain / soft bloom]
-
-Lighting & grade:
-- Key light
-- Contrast
-- Palette anchors (3–5)
-
-Constraints:
-No logos. No readable text. No overlays.`;
-
-const IMAGE_TABS = [
-  {
-    id: 'quick' as TabId,
-    label: 'Quick',
-    title: 'Quick prompt (fast iteration)',
-    description: 'Use 1–2 sentences when you want variations.',
-    copy: IMAGE_QUICK_TEMPLATE,
-  },
-  {
-    id: 'structured' as TabId,
-    label: 'Structured',
-    title: 'Structured prompt (best for reliable results)',
-    description: 'Separate information so the model can follow it consistently.',
-    copy: IMAGE_STRUCTURED_TEMPLATE,
-  },
-  {
-    id: 'pro' as TabId,
-    label: 'Pro',
-    title: 'Pro prompt (ultra-specific "studio brief")',
-    description: 'Use this when you need a very specific look or continuity across shots.',
-    copy: IMAGE_PRO_TEMPLATE,
-  },
-];
-
-function buildPanelId(id: TabId) {
-  return `prompting-panel-${id}`;
-}
-
-function buildTabId(id: TabId) {
-  return `prompting-tab-${id}`;
-}
-
-type PromptingTabNotes = Partial<Record<TabId, string>>;
-
-type PromptingTab = {
-  id: TabId;
-  label: string;
-  title: string;
-  description?: string;
-  copy: string;
-};
-
-type SoraPromptingTabsProps = {
-  title?: string;
-  intro?: string;
-  tip?: string;
-  guideLabel?: string;
-  guideUrl?: string;
-  mode?: PromptingMode;
-  supportsAudio?: boolean;
-  tabs?: PromptingTab[];
-  globalPrinciples?: string[];
-  engineWhy?: string[];
-  tabNotes?: PromptingTabNotes;
-};
+import { SoraPromptingSidebar } from '@/components/marketing/SoraPromptingSidebar';
+import { SoraPromptingTabList } from '@/components/marketing/SoraPromptingTabList';
+import { SoraPromptingTabPanel } from '@/components/marketing/SoraPromptingTabPanel';
+import {
+  DEFAULT_ENGINE_WHY,
+  DEFAULT_GLOBAL_PRINCIPLES,
+  DEFAULT_GUIDE_URL,
+  DEFAULT_TAB_NOTES,
+  IMAGE_TABS,
+  VIDEO_TABS,
+  VIDEO_TABS_NO_AUDIO,
+  type SoraPromptingTabsProps,
+  type TabId,
+} from '@/components/marketing/sora-prompting-content';
 
 export function SoraPromptingTabs({
   title,
@@ -397,10 +60,7 @@ export function SoraPromptingTabs({
         ? 'Tip: duration + aspect ratio are set in the UI — your prompt controls subject, action, camera, lighting, style, and sound.'
         : 'Tip: duration + aspect ratio are set in the UI — your prompt controls subject, action, camera, lighting, style, and the visual ending.');
   const resolvedGuideUrl = guideUrl === null ? undefined : guideUrl ?? (mode === 'video' ? DEFAULT_GUIDE_URL : undefined);
-  const resolvedGuideLabel =
-    resolvedGuideUrl
-      ? guideLabel ?? (mode === 'video' ? 'Developers guide' : 'Learn more')
-      : undefined;
+  const resolvedGuideLabel = resolvedGuideUrl ? guideLabel ?? (mode === 'video' ? 'Developers guide' : 'Learn more') : undefined;
 
   return (
     <div className="stack-gap">
@@ -422,93 +82,23 @@ export function SoraPromptingTabs({
         {resolvedTip ? <p className="text-sm text-text-secondary">{resolvedTip}</p> : null}
       </div>
 
-      <div className="flex flex-wrap gap-2" role="tablist" aria-label="Prompt levels">
-        {resolvedTabs.map((tab) => {
-          const isActive = tab.id === activeId;
-          return (
-            <Button
-              key={tab.id}
-              type="button"
-              size="sm"
-              variant={isActive ? 'primary' : 'outline'}
-              onClick={() => setActiveId(tab.id)}
-              className={clsx(
-                'min-h-0 h-auto rounded-full px-4 py-2 text-sm font-semibold',
-                isActive ? 'border border-brand' : 'border-hairline text-text-secondary hover:text-text-primary'
-              )}
-              role="tab"
-              id={buildTabId(tab.id)}
-              aria-selected={isActive}
-              aria-controls={buildPanelId(tab.id)}
-            >
-              {tab.label}
-            </Button>
-          );
-        })}
-      </div>
+      <SoraPromptingTabList activeId={activeId} tabs={resolvedTabs} onActiveIdChange={setActiveId} />
 
       <div className="grid gap-6 lg:grid-cols-12">
         <div className="lg:col-span-7">
-          {resolvedTabs.map((tab) => {
-            const isActive = tab.id === activeId;
-            const note = mergedTabNotes[tab.id];
-            return (
-              <div
-                key={tab.id}
-                id={buildPanelId(tab.id)}
-                role="tabpanel"
-                aria-labelledby={buildTabId(tab.id)}
-                aria-hidden={!isActive}
-                hidden={!isActive}
-              >
-                <article className="stack-gap-sm rounded-2xl border border-hairline bg-surface/80 p-4 shadow-card">
-                  <header className="flex flex-wrap items-start justify-between gap-3">
-                    <div className="space-y-1">
-                      <h3 className="text-lg font-semibold text-text-primary">{tab.title}</h3>
-                      {tab.description ? <p className="text-sm text-text-secondary">{tab.description}</p> : null}
-                      {note ? <p className="text-xs text-text-muted">{note}</p> : null}
-                    </div>
-                    <CopyPromptButton prompt={tab.copy} copyLabel="Copy template" />
-                  </header>
-
-                  <div className="stack-gap-sm">
-                    <div className="rounded-xl border border-dashed border-hairline bg-bg px-4 py-3 text-sm text-text-secondary">
-                      <p className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">
-                        Template (copy/paste)
-                      </p>
-                      <pre className="mt-2 whitespace-pre-wrap font-mono text-sm text-text-primary">{tab.copy}</pre>
-                    </div>
-                    {tab.id === 'quick' && mode === 'video' ? (
-                      <div className="rounded-xl border border-hairline bg-surface-2 px-4 py-3 text-sm text-text-secondary">
-                        <p className="text-[11px] font-semibold uppercase tracking-micro text-text-muted">Example</p>
-                        <p className="mt-2">{supportsAudio ? QUICK_EXAMPLE : QUICK_EXAMPLE_NO_AUDIO}</p>
-                      </div>
-                    ) : null}
-                  </div>
-                </article>
-              </div>
-            );
-          })}
+          {resolvedTabs.map((tab) => (
+            <SoraPromptingTabPanel
+              key={tab.id}
+              activeId={activeId}
+              mode={mode}
+              note={mergedTabNotes[tab.id]}
+              supportsAudio={supportsAudio}
+              tab={tab}
+            />
+          ))}
         </div>
 
-        <aside className="lg:col-span-5">
-          <div className="stack-gap-sm rounded-2xl border border-hairline bg-surface/80 p-4 shadow-card">
-            <h4 className="text-sm font-semibold text-text-primary">Global principles</h4>
-            <ul className="list-disc space-y-1 pl-5 text-sm text-text-secondary">
-              {globalRules.map((rule) => (
-                <li key={rule}>{rule}</li>
-              ))}
-            </ul>
-          </div>
-          <div className="stack-gap-sm rounded-2xl border border-hairline bg-surface/80 p-4 shadow-card">
-            <h4 className="text-sm font-semibold text-text-primary">Engine quirks / what to watch for</h4>
-            <ul className="list-disc space-y-1 pl-5 text-sm text-text-secondary">
-              {engineRules.map((rule) => (
-                <li key={rule}>{rule}</li>
-              ))}
-            </ul>
-          </div>
-        </aside>
+        <SoraPromptingSidebar engineRules={engineRules} globalRules={globalRules} />
       </div>
 
       <div className="mt-8 border-t border-hairline" />

--- a/frontend/components/marketing/sora-prompting-content.ts
+++ b/frontend/components/marketing/sora-prompting-content.ts
@@ -1,0 +1,345 @@
+export const DEFAULT_GUIDE_URL =
+  'https://developers.openai.com/cookbook/examples/sora/sora2_prompting_guide/';
+
+export type TabId = 'quick' | 'structured' | 'pro' | 'storyboard';
+export type PromptingMode = 'video' | 'image';
+export type PromptingTabNotes = Partial<Record<TabId, string>>;
+
+export type PromptingTab = {
+  id: TabId;
+  label: string;
+  title: string;
+  description?: string;
+  copy: string;
+};
+
+export type SoraPromptingTabsProps = {
+  title?: string;
+  intro?: string;
+  tip?: string;
+  guideLabel?: string;
+  guideUrl?: string | null;
+  mode?: PromptingMode;
+  supportsAudio?: boolean;
+  tabs?: PromptingTab[];
+  globalPrinciples?: string[];
+  engineWhy?: string[];
+  tabNotes?: PromptingTabNotes;
+};
+
+export const DEFAULT_GLOBAL_PRINCIPLES = [
+  '1 shot = 1 camera move + 1 subject action',
+  'Use visual anchors (specific nouns > vague adjectives)',
+  'Iterate: change one thing at a time',
+];
+
+export const DEFAULT_ENGINE_WHY = [
+  'Keep prompts focused: one subject, one action, one camera move.',
+  'Use concrete visual anchors (props, textures, lighting cues).',
+  'Iterate by changing a single variable per take.',
+];
+
+export const DEFAULT_TAB_NOTES: Record<TabId, string> = {
+  quick: 'Quick = variations. Use for fast iteration.',
+  structured: 'Structured = consistency. Use when you need reliable results.',
+  pro: 'Pro = continuity. Use for precise, repeatable looks.',
+  storyboard: 'Storyboard = beat timing. Use for mini-stories in one clip.',
+};
+
+const STRUCTURED_TEMPLATE = `Scene (plain language):
+[Subject + setting + props + time of day. Add 2–3 distinctive visual anchors.]
+
+Cinematography:
+- Camera shot: [wide / medium / close-up, angle]
+- Camera motion: [slow push-in / handheld / pan / tracking]
+- Lens look + depth of field: [e.g., 35mm, shallow DOF]
+- Lighting + palette: [key light + 3 palette anchors]
+
+Actions (beats):
+- [Beat 1: a small, visible action]
+- [Beat 2: another clear beat]
+- [Beat 3: a final beat in the last second]
+
+Dialogue (optional):
+[Keep lines short so they fit the clip length.]
+
+Background sound:
+[One sentence: ambience + key SFX. Keep it simple.]
+
+Constraints:
+No logos, no readable text, no subtitles/overlays.`;
+
+const STRUCTURED_TEMPLATE_NO_AUDIO = `Scene (plain language):
+[Subject + setting + props + time of day. Add 2–3 distinctive visual anchors.]
+
+Cinematography:
+- Camera shot: [wide / medium / close-up, angle]
+- Camera motion: [slow push-in / handheld / pan / tracking]
+- Lens look + depth of field: [e.g., 35mm, shallow DOF]
+- Lighting + palette: [key light + 3 palette anchors]
+
+Actions (beats):
+- [Beat 1: a small, visible action]
+- [Beat 2: another clear beat]
+- [Beat 3: a final beat in the last second]
+
+Constraints:
+No logos, no readable text, no subtitles/overlays.`;
+
+const QUICK_TEMPLATE =
+  '[Style] + [Subject doing 1 clear action] + [Where] + [Camera move] + [Lighting] + [Sound cue]';
+
+const QUICK_TEMPLATE_NO_AUDIO =
+  '[Style] + [Subject doing 1 clear action] + [Where] + [Camera move] + [Lighting] + [Ending / visual payoff]';
+
+export const QUICK_EXAMPLE =
+  'Handheld smartphone UGC clip of a woman unboxing a new skincare bottle at a kitchen table. She peels the seal, smiles, and turns the bottle toward camera. Soft window daylight, natural colors, subtle room tone + packaging crinkle.';
+
+export const QUICK_EXAMPLE_NO_AUDIO =
+  'Handheld smartphone UGC clip of a woman unboxing a new skincare bottle at a kitchen table. She peels the seal, smiles, and turns the bottle toward camera. Soft window daylight, natural colors, clean kitchen background, product label held readable in the final beat.';
+
+const PRO_TEMPLATE = `Project / intent:
+[One-line goal. What should the viewer feel/understand?]
+
+Subject:
+[Who/what. Wardrobe/materials. 2-3 distinctive traits.]
+
+Location / set:
+[Where + time of day + weather. Add 3 visual anchors (specific nouns).]
+
+Cinematography:
+- Framing: [wide / medium / close-up] + [angle]
+- Lens feel + depth of field: [e.g., 35mm natural, shallow DOF]
+- Camera movement: [ONE move: slow dolly-in / handheld / pan / tracking]
+- Composition: [centered / rule of thirds / negative space]
+- Look (optional): [clean digital / subtle film grain / soft bloom]
+
+Lighting & color grade:
+- Key light: [soft window / golden hour / neon practicals / studio key]
+- Contrast: [low / medium / high]
+- Palette anchors: [3-5 anchors: "warm sunrise, teal shadows, amber highlights"]
+
+Action (timed beats):
+- Beat 1 (start): [visible action + camera behavior]
+- Beat 2 (middle): [visible action + camera behavior]
+- Beat 3 (end): [final action + end pose / reveal]
+
+Sound (if supported):
+- Ambience: [one line]
+- SFX cues: [1-3 cues]
+- Music (optional): [genre + intensity]
+
+Constraints:
+No logos. No readable text. No subtitles/overlays. No slow-motion. No jump cuts.`;
+
+const PRO_TEMPLATE_NO_AUDIO = `Project / intent:
+[One-line goal. What should the viewer feel/understand?]
+
+Subject:
+[Who/what. Wardrobe/materials. 2-3 distinctive traits.]
+
+Location / set:
+[Where + time of day + weather. Add 3 visual anchors (specific nouns).]
+
+Cinematography:
+- Framing: [wide / medium / close-up] + [angle]
+- Lens feel + depth of field: [e.g., 35mm natural, shallow DOF]
+- Camera movement: [ONE move: slow dolly-in / handheld / pan / tracking]
+- Composition: [centered / rule of thirds / negative space]
+- Look (optional): [clean digital / subtle film grain / soft bloom]
+
+Lighting & color grade:
+- Key light: [soft window / golden hour / neon practicals / studio key]
+- Contrast: [low / medium / high]
+- Palette anchors: [3-5 anchors: "warm sunrise, teal shadows, amber highlights"]
+
+Action (timed beats):
+- Beat 1 (start): [visible action + camera behavior]
+- Beat 2 (middle): [visible action + camera behavior]
+- Beat 3 (end): [final action + end pose / reveal]
+
+Constraints:
+No logos. No readable text. No subtitles/overlays. No slow-motion. No jump cuts.`;
+
+const STORYBOARD_TEMPLATE = `Storyboard / shot list prompt
+Duration: [4/8/12s] • Aspect: [16:9 or 9:16]
+
+Scene + continuity:
+[Same subject + same location + same wardrobe/props + same lighting throughout.]
+
+Shot 1 (0–2s):
+[Framing + subject action + camera move]
+
+Shot 2 (2–6s):
+[Framing + subject action + camera move]
+
+Shot 3 (6–8/12s):
+[Framing + final action/reveal + camera move or settle]
+
+Lighting + mood:
+[Golden hour / soft daylight / neon night… + 2–3 palette anchors]
+
+Sound (if supported):
+[Ambience + 1–2 SFX cues + optional music vibe]
+
+Constraints:
+No logos. No readable text. No subtitles/overlays. No jump cuts. No slow-motion.`;
+
+const STORYBOARD_TEMPLATE_NO_AUDIO = `Storyboard / shot list prompt
+Duration: [4/8/12s] • Aspect: [16:9 or 9:16]
+
+Scene + continuity:
+[Same subject + same location + same wardrobe/props + same lighting throughout.]
+
+Shot 1 (0–2s):
+[Framing + subject action + camera move]
+
+Shot 2 (2–6s):
+[Framing + subject action + camera move]
+
+Shot 3 (6–8/12s):
+[Framing + final action/reveal + camera move or settle]
+
+Lighting + mood:
+[Golden hour / soft daylight / neon night… + 2–3 palette anchors]
+
+Constraints:
+No logos. No readable text. No subtitles/overlays. No jump cuts. No slow-motion.`;
+
+export const VIDEO_TABS: PromptingTab[] = [
+  {
+    id: 'quick',
+    label: 'Quick',
+    title: 'Quick prompt (fast iteration)',
+    description: 'Use 1–2 sentences when you want variations.',
+    copy: QUICK_TEMPLATE,
+  },
+  {
+    id: 'structured',
+    label: 'Structured',
+    title: 'Structured prompt (best for reliable results)',
+    description: 'Separate information so the model can follow it consistently.',
+    copy: STRUCTURED_TEMPLATE,
+  },
+  {
+    id: 'pro',
+    label: 'Pro',
+    title: 'Pro prompt (ultra-specific "film crew brief")',
+    description: 'Use this when you need a very specific cinematic look or continuity across shots.',
+    copy: PRO_TEMPLATE,
+  },
+  {
+    id: 'storyboard',
+    label: 'Storyboard',
+    title: 'Storyboard prompt (multi-shot / shot list)',
+    description:
+      'Use this when you want a mini-story in one clip. A storyboard prompt (aka multi-shot / shot list prompt) gives Sora clear timing, camera direction, and continuity. Also called shot-list or sequenced prompts.',
+    copy: STORYBOARD_TEMPLATE,
+  },
+];
+
+export const VIDEO_TABS_NO_AUDIO: PromptingTab[] = [
+  {
+    id: 'quick',
+    label: 'Quick',
+    title: 'Quick prompt (fast iteration)',
+    description: 'Use 1–2 sentences when you want variations.',
+    copy: QUICK_TEMPLATE_NO_AUDIO,
+  },
+  {
+    id: 'structured',
+    label: 'Structured',
+    title: 'Structured prompt (best for reliable results)',
+    description: 'Separate information so the model can follow it consistently.',
+    copy: STRUCTURED_TEMPLATE_NO_AUDIO,
+  },
+  {
+    id: 'pro',
+    label: 'Pro',
+    title: 'Pro prompt (ultra-specific "film crew brief")',
+    description: 'Use this when you need a very specific cinematic look or continuity across shots.',
+    copy: PRO_TEMPLATE_NO_AUDIO,
+  },
+  {
+    id: 'storyboard',
+    label: 'Storyboard',
+    title: 'Storyboard prompt (multi-shot / shot list)',
+    description:
+      'Use this when you want a mini-story in one clip. A storyboard prompt (aka multi-shot / shot list prompt) gives clear timing, camera direction, and continuity. Also called shot-list or sequenced prompts.',
+    copy: STORYBOARD_TEMPLATE_NO_AUDIO,
+  },
+];
+
+const IMAGE_QUICK_TEMPLATE =
+  '[Style] + [Subject] + [Setting] + [Lighting] + [Mood / palette]';
+
+const IMAGE_STRUCTURED_TEMPLATE = `Subject:
+[Who/what + 1 clear action or pose.]
+
+Setting:
+[Where + time of day + 2–3 visual anchors.]
+
+Composition:
+- Framing: [wide / medium / close-up]
+- Angle: [eye-level / low / high]
+- Lens feel: [e.g., 35mm natural, shallow DOF]
+
+Lighting + palette:
+[Key light + 2–3 palette anchors]
+
+Style constraints:
+No logos. No readable text. Clean background.`;
+
+const IMAGE_PRO_TEMPLATE = `Project / intent:
+[One-line goal for the still.]
+
+Subject:
+[Who/what + wardrobe/materials + 2–3 distinctive traits.]
+
+Location / set:
+[Where + time of day + weather. Add 3 visual anchors.]
+
+Composition:
+- Framing + angle
+- Lens feel + depth of field
+- Look: [clean digital / subtle film grain / soft bloom]
+
+Lighting & grade:
+- Key light
+- Contrast
+- Palette anchors (3–5)
+
+Constraints:
+No logos. No readable text. No overlays.`;
+
+export const IMAGE_TABS: PromptingTab[] = [
+  {
+    id: 'quick',
+    label: 'Quick',
+    title: 'Quick prompt (fast iteration)',
+    description: 'Use 1–2 sentences when you want variations.',
+    copy: IMAGE_QUICK_TEMPLATE,
+  },
+  {
+    id: 'structured',
+    label: 'Structured',
+    title: 'Structured prompt (best for reliable results)',
+    description: 'Separate information so the model can follow it consistently.',
+    copy: IMAGE_STRUCTURED_TEMPLATE,
+  },
+  {
+    id: 'pro',
+    label: 'Pro',
+    title: 'Pro prompt (ultra-specific "studio brief")',
+    description: 'Use this when you need a very specific look or continuity across shots.',
+    copy: IMAGE_PRO_TEMPLATE,
+  },
+];
+
+export function buildPanelId(id: TabId) {
+  return `prompting-panel-${id}`;
+}
+
+export function buildTabId(id: TabId) {
+  return `prompting-tab-${id}`;
+}

--- a/tests/cookie-banner-architecture.test.ts
+++ b/tests/cookie-banner-architecture.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const root = process.cwd();
+const bannerPath = join(root, 'frontend/components/legal/CookieBanner.tsx');
+const preferencesPanelPath = join(root, 'frontend/components/legal/CookiePreferencesPanel.tsx');
+const copyPath = join(root, 'frontend/components/legal/cookie-banner-copy.ts');
+const clientPath = join(root, 'frontend/components/legal/cookie-banner-client.ts');
+
+const readSource = (path: string) => readFileSync(path, 'utf8');
+const lineCount = (source: string) => source.split('\n').length;
+
+test('cookie banner delegates copy, browser effects, and preferences rendering', () => {
+  for (const path of [bannerPath, preferencesPanelPath, copyPath, clientPath]) {
+    assert.ok(existsSync(path), `${path} should exist`);
+  }
+
+  const bannerSource = readSource(bannerPath);
+  const preferencesSource = readSource(preferencesPanelPath);
+  const copySource = readSource(copyPath);
+  const clientSource = readSource(clientPath);
+
+  assert.match(bannerSource, /<CookiePreferencesPanel/, 'CookieBanner should compose the preferences panel');
+  assert.match(bannerSource, /COOKIE_BANNER_COPY|resolveCookieBannerLocale/, 'CookieBanner should read localized copy from a focused module');
+  assert.match(bannerSource, /applyStoredConsentEffects|readConsentCookie|writeConsentCookie/, 'CookieBanner should delegate browser consent effects');
+  assert.doesNotMatch(bannerSource, /gtagConsentUpdate|dataLayer|document\.cookie|COOKIE_MAX_AGE_SECONDS|Cookies & Privacy/, 'CookieBanner should not own browser effect internals or copy tables');
+  assert.match(preferencesSource, /export function CookiePreferencesPanel|function PreferenceSwitch/, 'CookiePreferencesPanel should own preference controls');
+  assert.match(copySource, /export const COOKIE_BANNER_COPY|export function resolveCookieBannerLocale/, 'cookie banner copy module should own copy and locale resolution');
+  assert.match(clientSource, /export function readConsentCookie|export function writeConsentCookie|function updateGoogleConsent/, 'cookie banner client module should own browser side effects');
+});
+
+test('cookie banner modules stay focused', () => {
+  const bannerSource = readSource(bannerPath);
+  const preferencesSource = readSource(preferencesPanelPath);
+  const copySource = readSource(copyPath);
+  const clientSource = readSource(clientPath);
+
+  assert.ok(lineCount(bannerSource) <= 280, `CookieBanner should stay below 280 lines, got ${lineCount(bannerSource)}`);
+  assert.ok(lineCount(preferencesSource) <= 120, `CookiePreferencesPanel should stay below 120 lines, got ${lineCount(preferencesSource)}`);
+  assert.ok(lineCount(copySource) <= 160, `cookie banner copy should stay below 160 lines, got ${lineCount(copySource)}`);
+  assert.ok(lineCount(clientSource) <= 170, `cookie banner client helpers should stay below 170 lines, got ${lineCount(clientSource)}`);
+});

--- a/tests/examples-pages-performance.test.ts
+++ b/tests/examples-pages-performance.test.ts
@@ -12,6 +12,7 @@ const examplesMainVideoFeatureSource = readFileSync(
 );
 const examplesHeroVideoSource = readFileSync('frontend/components/examples/ExamplesHeroVideo.client.tsx', 'utf8');
 const marketingNavSource = readFileSync('frontend/components/marketing/MarketingNav.tsx', 'utf8');
+const marketingMobileMenuSource = readFileSync('frontend/components/marketing/MarketingMobileMenu.tsx', 'utf8');
 
 test('examples hero video keeps mobile rendering poster-first instead of autoplay loading media', () => {
   assert.match(examplesHeroVideoSource, /max-width:\s*767px/);
@@ -32,7 +33,7 @@ test('examples model landing hero links do not prefetch RSC routes during initia
 });
 
 test('marketing nav login links avoid prefetching app redirects on public pages', () => {
-  const loginLinks = marketingNavSource.match(/<Link\s+href="\/login\?next=\/app"[\s\S]*?<\/Link>/g) ?? [];
+  const loginLinks = `${marketingNavSource}\n${marketingMobileMenuSource}`.match(/<Link\s+href="\/login\?next=\/app"[\s\S]*?<\/Link>/g) ?? [];
 
   assert.equal(loginLinks.length, 2);
   for (const link of loginLinks) {

--- a/tests/marketing-navigation.test.ts
+++ b/tests/marketing-navigation.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../frontend/config/navigation.ts';
 
 const marketingNavSource = readFileSync('frontend/components/marketing/MarketingNav.tsx', 'utf8');
+const marketingDesktopNavSource = readFileSync('frontend/components/marketing/MarketingDesktopNav.tsx', 'utf8');
 const headerBarSource = readFileSync('frontend/components/HeaderBar.tsx', 'utf8');
 
 const bestForUseCaseLinks = [
@@ -76,8 +77,8 @@ test('marketing top navigation stays clean while Best-For links live inside drop
     ]
   );
 
-  assert.match(marketingNavSource, /entry\.emphasized/);
-  assert.match(marketingNavSource, /font-semibold text-text-primary/);
+  assert.match(marketingDesktopNavSource, /entry\.emphasized/);
+  assert.match(marketingDesktopNavSource, /font-semibold text-text-primary/);
 });
 
 test('localized marketing dropdown sections avoid English fallbacks', () => {

--- a/tests/navigation-surfaces-architecture.test.ts
+++ b/tests/navigation-surfaces-architecture.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const root = process.cwd();
+
+const headerBarPath = join(root, 'frontend/components/HeaderBar.tsx');
+const headerAccountMenuPath = join(root, 'frontend/components/header/HeaderAccountMenu.tsx');
+const headerMobileMenuPath = join(root, 'frontend/components/header/HeaderMobileMenu.tsx');
+const headerWalletStatusPath = join(root, 'frontend/components/header/HeaderWalletStatus.tsx');
+
+const marketingNavPath = join(root, 'frontend/components/marketing/MarketingNav.tsx');
+const marketingAccountMenuPath = join(root, 'frontend/components/marketing/MarketingAccountMenu.tsx');
+const marketingDesktopNavPath = join(root, 'frontend/components/marketing/MarketingDesktopNav.tsx');
+const marketingMobileMenuPath = join(root, 'frontend/components/marketing/MarketingMobileMenu.tsx');
+
+const readSource = (path: string) => readFileSync(path, 'utf8');
+const lineCount = (source: string) => source.split('\n').length;
+
+test('navigation surfaces delegate account, wallet, and mobile ownership', () => {
+  for (const path of [
+    headerBarPath,
+    headerAccountMenuPath,
+    headerMobileMenuPath,
+    headerWalletStatusPath,
+    marketingNavPath,
+    marketingAccountMenuPath,
+    marketingDesktopNavPath,
+    marketingMobileMenuPath,
+  ]) {
+    assert.ok(existsSync(path), `${path} should exist`);
+  }
+
+  const headerBarSource = readSource(headerBarPath);
+  const headerAccountMenuSource = readSource(headerAccountMenuPath);
+  const headerMobileMenuSource = readSource(headerMobileMenuPath);
+  const headerWalletStatusSource = readSource(headerWalletStatusPath);
+
+  assert.match(headerBarSource, /<HeaderAccountMenu/, 'HeaderBar should compose a focused account menu');
+  assert.match(headerBarSource, /<HeaderMobileMenu/, 'HeaderBar should compose a focused mobile menu');
+  assert.match(headerBarSource, /<HeaderWalletStatus/, 'HeaderBar should compose focused wallet status');
+  assert.doesNotMatch(headerBarSource, /NAV_ITEMS\.map|walletTopUp\.copy|GUEST_MOBILE_NAV_ICONS/, 'HeaderBar should not own account, wallet prompt, or guest mobile internals');
+  assert.match(headerAccountMenuSource, /NAV_ITEMS\.map/, 'HeaderAccountMenu should own authenticated menu items');
+  assert.match(headerMobileMenuSource, /GUEST_MOBILE_NAV_ICONS|MARKETING_NAV_DROPDOWNS/, 'HeaderMobileMenu should own guest and marketing mobile items');
+  assert.match(headerWalletStatusSource, /walletTopUp\.copy/, 'HeaderWalletStatus should own wallet prompt copy');
+});
+
+test('marketing nav delegates desktop, mobile, and account menu rendering', () => {
+  const marketingNavSource = readSource(marketingNavPath);
+  const accountMenuSource = readSource(marketingAccountMenuPath);
+  const desktopNavSource = readSource(marketingDesktopNavPath);
+  const mobileMenuSource = readSource(marketingMobileMenuPath);
+
+  assert.match(marketingNavSource, /<MarketingDesktopNav/, 'MarketingNav should compose a focused desktop nav');
+  assert.match(marketingNavSource, /<MarketingAccountMenu/, 'MarketingNav should compose a focused account menu');
+  assert.match(marketingNavSource, /<MarketingMobileMenu/, 'MarketingNav should compose a focused mobile menu');
+  assert.doesNotMatch(marketingNavSource, /MARKETING_NAV_DROPDOWNS|NAV_ITEMS\.map|mobileDropdownOpen\[item\.key\]|workspace\.header\.signedIn/, 'MarketingNav should not own dropdown, account, or mobile rendering internals');
+  assert.match(accountMenuSource, /NAV_ITEMS\.map|workspace\.header\.signedIn/, 'MarketingAccountMenu should own workspace account menu copy');
+  assert.match(desktopNavSource, /MARKETING_NAV_DROPDOWNS|export function MarketingDesktopNav/, 'MarketingDesktopNav should own desktop dropdown rendering');
+  assert.match(mobileMenuSource, /MARKETING_NAV_DROPDOWNS|mobileDropdownOpen\[item\.key\]|export function MarketingMobileMenu/, 'MarketingMobileMenu should own mobile dropdown rendering');
+});
+
+test('navigation orchestrators stay below page-sized component thresholds', () => {
+  const headerBarSource = readSource(headerBarPath);
+  const headerAccountMenuSource = readSource(headerAccountMenuPath);
+  const headerMobileMenuSource = readSource(headerMobileMenuPath);
+  const headerWalletStatusSource = readSource(headerWalletStatusPath);
+  const marketingNavSource = readSource(marketingNavPath);
+  const marketingAccountMenuSource = readSource(marketingAccountMenuPath);
+  const marketingDesktopNavSource = readSource(marketingDesktopNavPath);
+  const marketingMobileMenuSource = readSource(marketingMobileMenuPath);
+
+  assert.ok(lineCount(headerBarSource) <= 500, `HeaderBar should stay below 500 lines, got ${lineCount(headerBarSource)}`);
+  assert.ok(lineCount(marketingNavSource) <= 450, `MarketingNav should stay below 450 lines, got ${lineCount(marketingNavSource)}`);
+  assert.ok(lineCount(headerAccountMenuSource) <= 150, `HeaderAccountMenu should stay focused, got ${lineCount(headerAccountMenuSource)}`);
+  assert.ok(lineCount(headerMobileMenuSource) <= 300, `HeaderMobileMenu should stay focused, got ${lineCount(headerMobileMenuSource)}`);
+  assert.ok(lineCount(headerWalletStatusSource) <= 100, `HeaderWalletStatus should stay focused, got ${lineCount(headerWalletStatusSource)}`);
+  assert.ok(lineCount(marketingAccountMenuSource) <= 140, `MarketingAccountMenu should stay focused, got ${lineCount(marketingAccountMenuSource)}`);
+  assert.ok(lineCount(marketingDesktopNavSource) <= 220, `MarketingDesktopNav should stay focused, got ${lineCount(marketingDesktopNavSource)}`);
+  assert.ok(lineCount(marketingMobileMenuSource) <= 260, `MarketingMobileMenu should stay focused, got ${lineCount(marketingMobileMenuSource)}`);
+});

--- a/tests/sora-prompting-tabs-architecture.test.ts
+++ b/tests/sora-prompting-tabs-architecture.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const root = process.cwd();
+const tabsPath = join(root, 'frontend/components/marketing/SoraPromptingTabs.client.tsx');
+const tabListPath = join(root, 'frontend/components/marketing/SoraPromptingTabList.tsx');
+const tabPanelPath = join(root, 'frontend/components/marketing/SoraPromptingTabPanel.tsx');
+const sidebarPath = join(root, 'frontend/components/marketing/SoraPromptingSidebar.tsx');
+const contentPath = join(root, 'frontend/components/marketing/sora-prompting-content.ts');
+
+const readSource = (path: string) => readFileSync(path, 'utf8');
+const lineCount = (source: string) => source.split('\n').length;
+
+test('sora prompting tabs delegate tab chrome, panels, sidebar, and template content', () => {
+  for (const path of [tabsPath, tabListPath, tabPanelPath, sidebarPath, contentPath]) {
+    assert.ok(existsSync(path), `${path} should exist`);
+  }
+
+  const tabsSource = readSource(tabsPath);
+  const tabListSource = readSource(tabListPath);
+  const tabPanelSource = readSource(tabPanelPath);
+  const sidebarSource = readSource(sidebarPath);
+  const contentSource = readSource(contentPath);
+
+  assert.match(tabsSource, /<SoraPromptingTabList/, 'SoraPromptingTabs should compose a focused tab list');
+  assert.match(tabsSource, /<SoraPromptingTabPanel/, 'SoraPromptingTabs should compose focused tab panels');
+  assert.match(tabsSource, /<SoraPromptingSidebar/, 'SoraPromptingTabs should compose a focused sidebar');
+  assert.doesNotMatch(tabsSource, /STRUCTURED_TEMPLATE|CopyPromptButton|role="tab"|Global principles/, 'SoraPromptingTabs should not own templates or repeated panel chrome');
+  assert.match(tabListSource, /role="tab"|buildTabId|buildPanelId/, 'SoraPromptingTabList should own tab button wiring');
+  assert.match(tabPanelSource, /CopyPromptButton|Template \(copy\/paste\)|QUICK_EXAMPLE/, 'SoraPromptingTabPanel should own template display and examples');
+  assert.match(sidebarSource, /PromptingRuleCard|Engine quirks/, 'SoraPromptingSidebar should own side guidance cards');
+  assert.match(contentSource, /STRUCTURED_TEMPLATE|VIDEO_TABS|IMAGE_TABS|DEFAULT_TAB_NOTES/, 'sora prompting content should own templates and defaults');
+});
+
+test('sora prompting tab modules stay focused', () => {
+  const tabsSource = readSource(tabsPath);
+  const tabListSource = readSource(tabListPath);
+  const tabPanelSource = readSource(tabPanelPath);
+  const sidebarSource = readSource(sidebarPath);
+  const contentSource = readSource(contentPath);
+
+  assert.ok(lineCount(tabsSource) <= 130, `SoraPromptingTabs should stay below 130 lines, got ${lineCount(tabsSource)}`);
+  assert.ok(lineCount(tabListSource) <= 60, `SoraPromptingTabList should stay below 60 lines, got ${lineCount(tabListSource)}`);
+  assert.ok(lineCount(tabPanelSource) <= 90, `SoraPromptingTabPanel should stay below 90 lines, got ${lineCount(tabPanelSource)}`);
+  assert.ok(lineCount(sidebarSource) <= 60, `SoraPromptingSidebar should stay below 60 lines, got ${lineCount(sidebarSource)}`);
+  assert.ok(lineCount(contentSource) <= 380, `sora prompting content should stay below 380 lines, got ${lineCount(contentSource)}`);
+});


### PR DESCRIPTION
## Summary
- split HeaderBar and MarketingNav account/mobile/dropdown surfaces into focused components
- split CookieBanner copy, browser consent effects, and preferences panel
- split Sora prompting templates, tab list, panels, and sidebar
- added architecture contracts for navigation, cookie banner, and Sora prompting tabs

## Verification
- pnpm --dir frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run lint:exposure
- npm run test:validate
- npm run architecture:audit -- --min-lines 500
- git diff --check
- local smoke on /, /fr, /models/seedance-2-0, /fr/modeles/seedance-2-0, /app: 200, no crash text