### PR TITLE
Split login auth effects

### DIFF
--- a/frontend/app/(core)/login/_hooks/useLoginAuthHashSession.ts
+++ b/frontend/app/(core)/login/_hooks/useLoginAuthHashSession.ts
@@ -1,0 +1,75 @@
+import { useEffect, type Dispatch, type SetStateAction } from 'react';
+import { persistPendingAnalyticsEvent } from '@/lib/analytics-client';
+import { writeLastKnownUserId } from '@/lib/last-known';
+import { supabase } from '@/lib/supabaseClient';
+import { consumePendingGoogleLogin } from '../_lib/login-helpers';
+
+type UseLoginAuthHashSessionOptions = {
+  setError: Dispatch<SetStateAction<string | null>>;
+  setStatus: Dispatch<SetStateAction<string | null>>;
+  setStatusTone: Dispatch<SetStateAction<'info' | 'success'>>;
+};
+
+export function useLoginAuthHashSession({
+  setError,
+  setStatus,
+  setStatusTone,
+}: UseLoginAuthHashSessionOptions) {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const hash = window.location.hash;
+    if (!hash || !hash.includes('access_token=')) {
+      return;
+    }
+    const params = new URLSearchParams(hash.replace(/^#/, ''));
+    const accessToken = params.get('access_token');
+    const refreshToken =
+      params.get('refresh_token') ?? params.get('refreshToken') ?? params.get('refresh-token');
+    if (!accessToken || !refreshToken) {
+      window.history.replaceState({}, document.title, window.location.pathname + window.location.search);
+      return;
+    }
+    let cancelled = false;
+    setStatusTone('info');
+    setStatus('Completing sign-in…');
+    setError(null);
+    void supabase.auth
+      .setSession({
+        access_token: accessToken,
+        refresh_token: refreshToken,
+      })
+      .then(({ data, error }) => {
+        if (cancelled) return;
+        if (error) {
+          setError(error.message ?? 'Unable to complete sign-in.');
+          setStatus(null);
+          return;
+        }
+        if (data.session) {
+          const userId = data.session.user?.id ?? null;
+          if (userId) {
+            writeLastKnownUserId(userId);
+          }
+          if (consumePendingGoogleLogin()) {
+            persistPendingAnalyticsEvent('login_completed', {
+              route_family: 'auth',
+              auth_surface: 'login',
+              method: 'google',
+            });
+          }
+        }
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'Unable to complete sign-in.');
+        setStatus(null);
+      })
+      .finally(() => {
+        if (cancelled) return;
+        window.history.replaceState({}, document.title, window.location.pathname + window.location.search);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [setError, setStatus, setStatusTone]);
+}

--- a/frontend/app/(core)/login/_hooks/useLoginAuthenticatedRedirect.ts
+++ b/frontend/app/(core)/login/_hooks/useLoginAuthenticatedRedirect.ts
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, type MutableRefObject } from 'react';
+import { persistPendingAnalyticsEvent } from '@/lib/analytics-client';
+import { supabase } from '@/lib/supabaseClient';
+import {
+  clearStaleBrowserAuthState,
+  isInvalidRefreshTokenError,
+  readBrowserSession,
+} from '@/lib/supabase-auth-cleanup';
+import {
+  consumePendingGoogleLogin,
+  sanitizeNextPath,
+} from '../_lib/login-helpers';
+
+type UseLoginAuthenticatedRedirectOptions = {
+  completeAuthenticatedRedirect: (target: string, authenticatedUserId?: string | null) => void;
+  nextPath: string;
+  nextPathReady: boolean;
+  oauthCodeExchangeStartedRef: MutableRefObject<boolean>;
+};
+
+function persistGoogleLoginCompleted() {
+  if (consumePendingGoogleLogin()) {
+    persistPendingAnalyticsEvent('login_completed', {
+      route_family: 'auth',
+      auth_surface: 'login',
+      method: 'google',
+    });
+  }
+}
+
+export function useLoginAuthenticatedRedirect({
+  completeAuthenticatedRedirect,
+  nextPath,
+  nextPathReady,
+  oauthCodeExchangeStartedRef,
+}: UseLoginAuthenticatedRedirectOptions) {
+  const redirectFromExistingBrowserSession = useCallback(
+    async function redirectFromExistingBrowserSession(target: string): Promise<boolean> {
+      const session = await readBrowserSession();
+      const userId = session?.user?.id ?? null;
+      if (!session?.access_token || !userId) return false;
+      persistGoogleLoginCompleted();
+      completeAuthenticatedRedirect(target, userId);
+      return true;
+    },
+    [completeAuthenticatedRedirect]
+  );
+
+  useEffect(() => {
+    if (!nextPathReady) return;
+    let cancelled = false;
+
+    async function redirectIfAuthenticated() {
+      if (oauthCodeExchangeStartedRef.current) return;
+      const { data, error } = await supabase.auth.getUser();
+      if (cancelled) return;
+      if (error) {
+        if (isInvalidRefreshTokenError(error)) {
+          await clearStaleBrowserAuthState();
+        }
+        return;
+      }
+      const user = data.user ?? null;
+      if (user && nextPath) {
+        persistGoogleLoginCompleted();
+        completeAuthenticatedRedirect(sanitizeNextPath(nextPath), user.id);
+      }
+    }
+
+    void redirectIfAuthenticated();
+
+    const { data: authListener } = supabase.auth.onAuthStateChange(() => {
+      if (oauthCodeExchangeStartedRef.current) return;
+      void supabase.auth.getUser().then(({ data, error }) => {
+        if (cancelled) return;
+        if (error) {
+          if (isInvalidRefreshTokenError(error)) {
+            void clearStaleBrowserAuthState();
+          }
+          return;
+        }
+        const user = data.user ?? null;
+        if (user && nextPath) {
+          persistGoogleLoginCompleted();
+          completeAuthenticatedRedirect(sanitizeNextPath(nextPath), user.id);
+        }
+      }).catch((err) => {
+        if (cancelled) return;
+        if (isInvalidRefreshTokenError(err)) {
+          void clearStaleBrowserAuthState();
+        }
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      authListener?.subscription.unsubscribe();
+    };
+  }, [completeAuthenticatedRedirect, nextPath, nextPathReady, oauthCodeExchangeStartedRef]);
+
+  useEffect(() => {
+    if (!nextPathReady) return;
+    if (oauthCodeExchangeStartedRef.current) return;
+    let cancelled = false;
+    readBrowserSession().then((session) => {
+      if (cancelled) return;
+      if (session?.access_token) {
+        persistGoogleLoginCompleted();
+        completeAuthenticatedRedirect(sanitizeNextPath(nextPath), session.user?.id ?? null);
+      }
+    }).catch((err) => {
+      if (cancelled) return;
+      if (isInvalidRefreshTokenError(err)) {
+        void clearStaleBrowserAuthState();
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [completeAuthenticatedRedirect, nextPath, nextPathReady, oauthCodeExchangeStartedRef]);
+
+  return { redirectFromExistingBrowserSession };
+}

--- a/frontend/app/(core)/login/_hooks/useLoginOAuthCodeExchange.ts
+++ b/frontend/app/(core)/login/_hooks/useLoginOAuthCodeExchange.ts
@@ -1,0 +1,150 @@
+import { useEffect, type Dispatch, type MutableRefObject, type SetStateAction } from 'react';
+import { persistPendingAnalyticsEvent } from '@/lib/analytics-client';
+import { supabase } from '@/lib/supabaseClient';
+import {
+  clearStaleBrowserAuthState,
+  isInvalidRefreshTokenError,
+  isPkceCodeVerifierError,
+} from '@/lib/supabase-auth-cleanup';
+import { startOAuthCookieRedirectFallback } from '../_lib/oauth-cookie-fallback';
+import { AUTH_COPY, type AuthCopy, type AuthMode } from '../_lib/login-copy';
+import {
+  clearPendingGoogleLogin,
+  consumePendingGoogleLogin,
+  detectLocale,
+  sanitizeNextPath,
+} from '../_lib/login-helpers';
+
+type UseLoginOAuthCodeExchangeOptions = {
+  authCopy: AuthCopy;
+  authNavigationStartedRef: MutableRefObject<boolean>;
+  completeAuthenticatedRedirect: (target: string, authenticatedUserId?: string | null) => void;
+  nextPath: string;
+  nextPathReady: boolean;
+  oauthCodeExchangeStartedRef: MutableRefObject<boolean>;
+  redirectFromExistingBrowserSession: (target: string) => Promise<boolean>;
+  setError: Dispatch<SetStateAction<string | null>>;
+  setMode: Dispatch<SetStateAction<AuthMode>>;
+  setStatus: Dispatch<SetStateAction<string | null>>;
+  setStatusTone: Dispatch<SetStateAction<'info' | 'success'>>;
+};
+
+function persistGoogleLoginCompleted() {
+  if (consumePendingGoogleLogin()) {
+    persistPendingAnalyticsEvent('login_completed', {
+      route_family: 'auth',
+      auth_surface: 'login',
+      method: 'google',
+    });
+  }
+}
+
+export function useLoginOAuthCodeExchange({
+  authCopy,
+  authNavigationStartedRef,
+  completeAuthenticatedRedirect,
+  nextPath,
+  nextPathReady,
+  oauthCodeExchangeStartedRef,
+  redirectFromExistingBrowserSession,
+  setError,
+  setMode,
+  setStatus,
+  setStatusTone,
+}: UseLoginOAuthCodeExchangeOptions) {
+  useEffect(() => {
+    if (!nextPathReady) return;
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    const oauthCode = params.get('code');
+    const authError = params.get('authError');
+    if (!oauthCode && authError !== 'oauth_callback_failed') return;
+
+    const cleanAuthQuery = () => {
+      const cleanUrl = new URL(window.location.href);
+      cleanUrl.searchParams.delete('code');
+      cleanUrl.searchParams.delete('state');
+      cleanUrl.searchParams.delete('authError');
+      cleanUrl.searchParams.delete('error');
+      cleanUrl.searchParams.delete('error_description');
+      cleanUrl.searchParams.delete('redirect_to');
+      window.history.replaceState({}, document.title, cleanUrl.pathname + cleanUrl.search + cleanUrl.hash);
+    };
+
+    const localizedCopy = AUTH_COPY[detectLocale()] ?? authCopy;
+    setMode('signin');
+
+    if (authError === 'oauth_callback_failed') {
+      cleanAuthQuery();
+      clearPendingGoogleLogin();
+      setStatus(null);
+      setError(localizedCopy.oauthCallbackError);
+      return;
+    }
+
+    if (!oauthCode || oauthCodeExchangeStartedRef.current) return;
+    oauthCodeExchangeStartedRef.current = true;
+    cleanAuthQuery();
+    setStatusTone('info');
+    setStatus('Completing sign-in…');
+    setError(null);
+
+    let cancelled = false;
+    const target = sanitizeNextPath(params.get('next') ?? nextPath);
+    const cancelAuthCookieFallback = startOAuthCookieRedirectFallback({
+      isCancelled: () => cancelled || authNavigationStartedRef.current,
+      onAuthenticatedCookie: () => {
+        persistGoogleLoginCompleted();
+        completeAuthenticatedRedirect(target);
+      },
+    });
+    void supabase.auth
+      .exchangeCodeForSession(oauthCode)
+      .then(async ({ data, error }) => {
+        if (cancelled) return;
+        if (error || !data.session) {
+          if (isInvalidRefreshTokenError(error) || isPkceCodeVerifierError(error)) {
+            void clearStaleBrowserAuthState();
+          }
+          const fallbackRedirected = await redirectFromExistingBrowserSession(target);
+          if (cancelled || fallbackRedirected) return;
+          oauthCodeExchangeStartedRef.current = false;
+          clearPendingGoogleLogin();
+          setStatus(null);
+          setError(localizedCopy.oauthCallbackError);
+          return;
+        }
+        persistGoogleLoginCompleted();
+        completeAuthenticatedRedirect(target, data.session.user?.id ?? null);
+      })
+      .catch(async (err) => {
+        if (cancelled) return;
+        if (isInvalidRefreshTokenError(err) || isPkceCodeVerifierError(err)) {
+          void clearStaleBrowserAuthState();
+        }
+        const fallbackRedirected = await redirectFromExistingBrowserSession(target);
+        if (cancelled || fallbackRedirected) return;
+        oauthCodeExchangeStartedRef.current = false;
+        clearPendingGoogleLogin();
+        setStatus(null);
+        setError(localizedCopy.oauthCallbackError);
+      });
+
+    return () => {
+      cancelled = true;
+      cancelAuthCookieFallback();
+    };
+  }, [
+    authCopy,
+    authNavigationStartedRef,
+    completeAuthenticatedRedirect,
+    nextPath,
+    nextPathReady,
+    oauthCodeExchangeStartedRef,
+    redirectFromExistingBrowserSession,
+    setError,
+    setMode,
+    setStatus,
+    setStatusTone,
+  ]);
+}

--- a/frontend/app/(core)/login/_hooks/useLoginPageController.ts
+++ b/frontend/app/(core)/login/_hooks/useLoginPageController.ts
@@ -7,28 +7,23 @@ import { dispatchAnalyticsEvent, persistPendingAnalyticsEvent } from '@/lib/anal
 import { LOGIN_NEXT_STORAGE_KEY } from '@/lib/auth-storage';
 import { writeLastKnownUserId } from '@/lib/last-known';
 import { supabase } from '@/lib/supabaseClient';
-import {
-  clearStaleBrowserAuthState,
-  isInvalidRefreshTokenError,
-  isPkceCodeVerifierError,
-  readBrowserSession,
-} from '@/lib/supabase-auth-cleanup';
 import { canonicalizeBrowserAuthOrigin } from '@/lib/siteOrigin';
-import { startOAuthCookieRedirectFallback } from '../_lib/oauth-cookie-fallback';
 import { AUTH_COPY, type AuthMode, type Locale } from '../_lib/login-copy';
 import {
   buildAuthCallbackRedirect,
   clearPendingGoogleLogin,
-  consumePendingGoogleLogin,
   detectLocale,
   getBrowserAuthRedirectOrigin,
   markPendingGoogleLogin,
   sanitizeNextPath,
 } from '../_lib/login-helpers';
 import { useLoginAutofillSync } from './useLoginAutofillSync';
+import { useLoginAuthenticatedRedirect } from './useLoginAuthenticatedRedirect';
+import { useLoginAuthHashSession } from './useLoginAuthHashSession';
 import { useLoginBrowserLocale } from './useLoginBrowserLocale';
 import { useLoginModeFromQuery } from './useLoginModeFromQuery';
 import { useLoginNextTarget } from './useLoginNextTarget';
+import { useLoginOAuthCodeExchange } from './useLoginOAuthCodeExchange';
 
 const MIN_AGE_ENV = Number.parseInt(process.env.NEXT_PUBLIC_LEGAL_MIN_AGE ?? '15', 10);
 const LEGAL_MIN_AGE = Number.isNaN(MIN_AGE_ENV) ? 15 : MIN_AGE_ENV;
@@ -80,119 +75,26 @@ export function useLoginPageController() {
     [persistNextTarget, router]
   );
 
-  const redirectFromExistingBrowserSession = useCallback(
-    async function redirectFromExistingBrowserSession(target: string): Promise<boolean> {
-      const session = await readBrowserSession();
-      const userId = session?.user?.id ?? null;
-      if (!session?.access_token || !userId) return false;
-      if (consumePendingGoogleLogin()) {
-        persistPendingAnalyticsEvent('login_completed', {
-          route_family: 'auth',
-          auth_surface: 'login',
-          method: 'google',
-        });
-      }
-      completeAuthenticatedRedirect(target, userId);
-      return true;
-    },
-    [completeAuthenticatedRedirect]
-  );
+  const { redirectFromExistingBrowserSession } = useLoginAuthenticatedRedirect({
+    completeAuthenticatedRedirect,
+    nextPath,
+    nextPathReady,
+    oauthCodeExchangeStartedRef,
+  });
 
-  useEffect(() => {
-    if (!nextPathReady) return;
-    if (typeof window === 'undefined') return;
-    const params = new URLSearchParams(window.location.search);
-    const oauthCode = params.get('code');
-    const authError = params.get('authError');
-    if (!oauthCode && authError !== 'oauth_callback_failed') return;
-
-    const cleanAuthQuery = () => {
-      const cleanUrl = new URL(window.location.href);
-      cleanUrl.searchParams.delete('code');
-      cleanUrl.searchParams.delete('state');
-      cleanUrl.searchParams.delete('authError');
-      cleanUrl.searchParams.delete('error');
-      cleanUrl.searchParams.delete('error_description');
-      cleanUrl.searchParams.delete('redirect_to');
-      window.history.replaceState({}, document.title, cleanUrl.pathname + cleanUrl.search + cleanUrl.hash);
-    };
-
-    const localizedCopy = AUTH_COPY[detectLocale()] ?? authCopy;
-    setMode('signin');
-
-    if (authError === 'oauth_callback_failed') {
-      cleanAuthQuery();
-      clearPendingGoogleLogin();
-      setStatus(null);
-      setError(localizedCopy.oauthCallbackError);
-      return;
-    }
-
-    if (!oauthCode || oauthCodeExchangeStartedRef.current) return;
-    oauthCodeExchangeStartedRef.current = true;
-    cleanAuthQuery();
-    setStatusTone('info');
-    setStatus('Completing sign-in…');
-    setError(null);
-
-    let cancelled = false;
-    const target = sanitizeNextPath(params.get('next') ?? nextPath);
-    const cancelAuthCookieFallback = startOAuthCookieRedirectFallback({
-      isCancelled: () => cancelled || authNavigationStartedRef.current,
-      onAuthenticatedCookie: () => {
-        if (consumePendingGoogleLogin()) {
-          persistPendingAnalyticsEvent('login_completed', {
-            route_family: 'auth',
-            auth_surface: 'login',
-            method: 'google',
-          });
-        }
-        completeAuthenticatedRedirect(target);
-      },
-    });
-    void supabase.auth
-      .exchangeCodeForSession(oauthCode)
-      .then(async ({ data, error }) => {
-        if (cancelled) return;
-        if (error || !data.session) {
-          if (isInvalidRefreshTokenError(error) || isPkceCodeVerifierError(error)) {
-            void clearStaleBrowserAuthState();
-          }
-          const fallbackRedirected = await redirectFromExistingBrowserSession(target);
-          if (cancelled || fallbackRedirected) return;
-          oauthCodeExchangeStartedRef.current = false;
-          clearPendingGoogleLogin();
-          setStatus(null);
-          setError(localizedCopy.oauthCallbackError);
-          return;
-        }
-        if (consumePendingGoogleLogin()) {
-          persistPendingAnalyticsEvent('login_completed', {
-            route_family: 'auth',
-            auth_surface: 'login',
-            method: 'google',
-          });
-        }
-        completeAuthenticatedRedirect(target, data.session.user?.id ?? null);
-      })
-      .catch(async (err) => {
-        if (cancelled) return;
-        if (isInvalidRefreshTokenError(err) || isPkceCodeVerifierError(err)) {
-          void clearStaleBrowserAuthState();
-        }
-        const fallbackRedirected = await redirectFromExistingBrowserSession(target);
-        if (cancelled || fallbackRedirected) return;
-        oauthCodeExchangeStartedRef.current = false;
-        clearPendingGoogleLogin();
-        setStatus(null);
-        setError(localizedCopy.oauthCallbackError);
-      });
-
-    return () => {
-      cancelled = true;
-      cancelAuthCookieFallback();
-    };
-  }, [authCopy, completeAuthenticatedRedirect, nextPath, nextPathReady, redirectFromExistingBrowserSession]);
+  useLoginOAuthCodeExchange({
+    authCopy,
+    authNavigationStartedRef,
+    completeAuthenticatedRedirect,
+    nextPath,
+    nextPathReady,
+    oauthCodeExchangeStartedRef,
+    redirectFromExistingBrowserSession,
+    setError,
+    setMode,
+    setStatus,
+    setStatusTone,
+  });
 
   useEffect(() => {
     if (mode !== 'signup' && termsError) {
@@ -200,139 +102,17 @@ export function useLoginPageController() {
     }
   }, [mode, termsError]);
 
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const hash = window.location.hash;
-    if (!hash || !hash.includes('access_token=')) {
-      return;
-    }
-    const params = new URLSearchParams(hash.replace(/^#/, ''));
-    const accessToken = params.get('access_token');
-    const refreshToken =
-      params.get('refresh_token') ?? params.get('refreshToken') ?? params.get('refresh-token');
-    if (!accessToken || !refreshToken) {
-      window.history.replaceState({}, document.title, window.location.pathname + window.location.search);
-      return;
-    }
-    let cancelled = false;
-    setStatusTone('info');
-    setStatus('Completing sign-in…');
-    setError(null);
-    void supabase.auth
-      .setSession({
-        access_token: accessToken,
-        refresh_token: refreshToken,
-      })
-      .then(({ data, error }) => {
-        if (cancelled) return;
-        if (error) {
-          setError(error.message ?? 'Unable to complete sign-in.');
-          setStatus(null);
-          return;
-        }
-        if (data.session) {
-          const userId = data.session.user?.id ?? null;
-          if (userId) {
-            writeLastKnownUserId(userId);
-          }
-          if (consumePendingGoogleLogin()) {
-            persistPendingAnalyticsEvent('login_completed', {
-              route_family: 'auth',
-              auth_surface: 'login',
-              method: 'google',
-            });
-          }
-        }
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        setError(err instanceof Error ? err.message : 'Unable to complete sign-in.');
-        setStatus(null);
-      })
-      .finally(() => {
-        if (cancelled) return;
-        window.history.replaceState({}, document.title, window.location.pathname + window.location.search);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  useLoginAuthHashSession({
+    setError,
+    setStatus,
+    setStatusTone,
+  });
 
   useEffect(() => {
     if (mode !== 'signin' && signupSuggestion) {
       setSignupSuggestion(null);
     }
   }, [mode, signupSuggestion]);
-
-  useEffect(() => {
-    if (!nextPathReady) return;
-    let cancelled = false;
-
-    async function redirectIfAuthenticated() {
-      if (oauthCodeExchangeStartedRef.current) return;
-      const { data, error } = await supabase.auth.getUser();
-      if (cancelled) return;
-      if (error) {
-        if (isInvalidRefreshTokenError(error)) {
-          await clearStaleBrowserAuthState();
-        }
-        return;
-      }
-      const user = data.user ?? null;
-      if (user && nextPath) {
-        if (consumePendingGoogleLogin()) {
-          persistPendingAnalyticsEvent('login_completed', {
-            route_family: 'auth',
-            auth_surface: 'login',
-            method: 'google',
-          });
-        }
-        const safeTarget = sanitizeNextPath(nextPath);
-        completeAuthenticatedRedirect(safeTarget, user.id);
-      } else if (!user) {
-        // stay on page
-      }
-    }
-
-    void redirectIfAuthenticated();
-
-    const { data: authListener } = supabase.auth.onAuthStateChange(() => {
-      if (oauthCodeExchangeStartedRef.current) return;
-      void supabase.auth.getUser().then(({ data, error }) => {
-        if (cancelled) return;
-        if (error) {
-          if (isInvalidRefreshTokenError(error)) {
-            void clearStaleBrowserAuthState();
-          }
-          return;
-        }
-        const user = data.user ?? null;
-        if (user && nextPath) {
-          if (consumePendingGoogleLogin()) {
-            persistPendingAnalyticsEvent('login_completed', {
-              route_family: 'auth',
-              auth_surface: 'login',
-              method: 'google',
-            });
-          }
-          const safeTarget = sanitizeNextPath(nextPath);
-          completeAuthenticatedRedirect(safeTarget, user.id);
-        } else if (!user) {
-          // remain unauthenticated
-        }
-      }).catch((err) => {
-        if (cancelled) return;
-        if (isInvalidRefreshTokenError(err)) {
-          void clearStaleBrowserAuthState();
-        }
-      });
-    });
-
-    return () => {
-      cancelled = true;
-      authListener?.subscription.unsubscribe();
-    };
-  }, [completeAuthenticatedRedirect, nextPath, nextPathReady]);
 
   async function signInWithPassword(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -570,35 +350,6 @@ export function useLoginPageController() {
     googleOAuthStartedRef.current = false;
     setIsGoogleOAuthStarting(false);
   }
-
-  useEffect(() => {
-    if (!nextPathReady) return;
-    if (oauthCodeExchangeStartedRef.current) return;
-    let cancelled = false;
-    readBrowserSession().then((session) => {
-      if (cancelled) return;
-      if (session?.access_token) {
-        if (consumePendingGoogleLogin()) {
-          persistPendingAnalyticsEvent('login_completed', {
-            route_family: 'auth',
-            auth_surface: 'login',
-            method: 'google',
-          });
-        }
-        const safeTarget = sanitizeNextPath(nextPath);
-        completeAuthenticatedRedirect(safeTarget, session.user?.id ?? null);
-      } else {
-      }
-    }).catch((err) => {
-      if (cancelled) return;
-      if (isInvalidRefreshTokenError(err)) {
-        void clearStaleBrowserAuthState();
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [completeAuthenticatedRedirect, nextPath, nextPathReady]);
 
   const effectiveMode: Exclude<AuthMode, 'reset'> = mode === 'reset' ? 'signin' : mode;
 

--- a/tests/auth-callback-redirect.test.ts
+++ b/tests/auth-callback-redirect.test.ts
@@ -6,6 +6,8 @@ const authCallbackSource = readFileSync('frontend/app/auth/callback/route.ts', '
 const middlewareSource = readFileSync('frontend/middleware.ts', 'utf8');
 const loginPageSource = readFileSync('frontend/app/(core)/login/page.tsx', 'utf8');
 const loginControllerSource = readFileSync('frontend/app/(core)/login/_hooks/useLoginPageController.ts', 'utf8');
+const loginAuthenticatedRedirectSource = readFileSync('frontend/app/(core)/login/_hooks/useLoginAuthenticatedRedirect.ts', 'utf8');
+const loginOAuthCodeExchangeSource = readFileSync('frontend/app/(core)/login/_hooks/useLoginOAuthCodeExchange.ts', 'utf8');
 const loginSurfaceSource = readFileSync('frontend/app/(core)/login/_components/LoginAuthSurface.tsx', 'utf8');
 const loginHelpersSource = readFileSync('frontend/app/(core)/login/_lib/login-helpers.ts', 'utf8');
 const siteOriginSource = readFileSync('frontend/lib/siteOrigin.ts', 'utf8');
@@ -53,9 +55,9 @@ test('login page can consume a PKCE OAuth code directly', () => {
     'middleware should let /login?code=... reach the login page for browser-side PKCE exchange'
   );
   assert.match(
-    loginControllerSource,
+    loginOAuthCodeExchangeSource,
     /\.exchangeCodeForSession\(oauthCode\)/,
-    'the login controller should exchange direct OAuth codes with the browser Supabase client'
+    'the login OAuth code hook should exchange direct OAuth codes with the browser Supabase client'
   );
   assert.match(
     loginHelpersSource,
@@ -88,32 +90,35 @@ test('login auth success records a session hint before leaving the auth page', (
 });
 
 test('login page does not probe stale sessions while exchanging an OAuth code', () => {
-  const guardMatches = loginControllerSource.match(/if \(oauthCodeExchangeStartedRef\.current\) return;/g) ?? [];
+  const guardMatches =
+    `${loginControllerSource}\n${loginAuthenticatedRedirectSource}\n${loginOAuthCodeExchangeSource}`.match(
+      /if \(oauthCodeExchangeStartedRef\.current\) return;/g
+    ) ?? [];
 
   assert.ok(
     guardMatches.length >= 2,
     'login page should not call getUser/getSession while an OAuth code exchange is already in progress'
   );
   assert.match(
-    loginControllerSource,
+    `${loginAuthenticatedRedirectSource}\n${loginOAuthCodeExchangeSource}`,
     /clearStaleBrowserAuthState\(\)/,
-    'login controller should clear stale browser auth state after invalid refresh token errors'
+    'login auth hooks should clear stale browser auth state after invalid refresh token errors'
   );
 });
 
 test('login page redirects if OAuth exchange reports an error after a session was stored', () => {
   assert.match(
-    loginControllerSource,
+    loginAuthenticatedRedirectSource,
     /async function redirectFromExistingBrowserSession\(target: string\): Promise<boolean>/,
-    'login controller should have a fallback redirect for Safari when the session exists but the OAuth exchange response errors'
+    'login authenticated redirect hook should have a fallback redirect for Safari when the session exists but the OAuth exchange response errors'
   );
   assert.match(
-    loginControllerSource,
+    loginOAuthCodeExchangeSource,
     /const fallbackRedirected = await redirectFromExistingBrowserSession\(target\);/,
     'OAuth error handling should check the browser session before showing the login error'
   );
   assert.match(
-    loginControllerSource,
+    loginOAuthCodeExchangeSource,
     /oauthCodeExchangeStartedRef\.current = false;/,
     'OAuth error handling should release the exchange guard when no session exists'
   );
@@ -141,7 +146,7 @@ test('login page protects Google PKCE from duplicate starts and host drift', () 
     'the Google button should be disabled while the OAuth URL is being created'
   );
   assert.match(
-    loginControllerSource,
+    loginOAuthCodeExchangeSource,
     /isPkceCodeVerifierError\(error\)/,
     'PKCE verifier mismatches should trigger stale auth cleanup before the next retry'
   );

--- a/tests/login-hydration-contract.test.ts
+++ b/tests/login-hydration-contract.test.ts
@@ -9,6 +9,9 @@ const loginPaths = [
   'frontend/app/(core)/login/_hooks/useLoginBrowserLocale.ts',
   'frontend/app/(core)/login/_hooks/useLoginModeFromQuery.ts',
   'frontend/app/(core)/login/_hooks/useLoginNextTarget.ts',
+  'frontend/app/(core)/login/_hooks/useLoginAuthenticatedRedirect.ts',
+  'frontend/app/(core)/login/_hooks/useLoginAuthHashSession.ts',
+  'frontend/app/(core)/login/_hooks/useLoginOAuthCodeExchange.ts',
   'frontend/app/(core)/login/_hooks/useLoginPageController.ts',
 ];
 const loginSources = loginPaths.map((path) => readFileSync(join(process.cwd(), path), 'utf8')).join('\n');

--- a/tests/login-oauth-cookie-fallback.test.ts
+++ b/tests/login-oauth-cookie-fallback.test.ts
@@ -4,22 +4,23 @@ import test from 'node:test';
 
 const loginPageSource = readFileSync('frontend/app/(core)/login/page.tsx', 'utf8');
 const loginControllerSource = readFileSync('frontend/app/(core)/login/_hooks/useLoginPageController.ts', 'utf8');
+const loginOAuthCodeExchangeSource = readFileSync('frontend/app/(core)/login/_hooks/useLoginOAuthCodeExchange.ts', 'utf8');
 const fallbackPath = 'frontend/app/(core)/login/_lib/oauth-cookie-fallback.ts';
 
 test('login keeps OAuth cookie fallback out of page orchestration', () => {
   assert.ok(existsSync(fallbackPath), 'OAuth cookie fallback helper should be route-local');
   assert.match(
-    loginControllerSource,
+    loginOAuthCodeExchangeSource,
     /startOAuthCookieRedirectFallback\(/,
-    'login controller should delegate stalled OAuth cookie detection to a route-local helper'
+    'login OAuth code exchange hook should delegate stalled OAuth cookie detection to a route-local helper'
   );
   assert.doesNotMatch(
-    `${loginPageSource}\n${loginControllerSource}`,
+    `${loginPageSource}\n${loginControllerSource}\n${loginOAuthCodeExchangeSource}`,
     /window\.location\.replace\(buildAuthFinishUrl/,
     'login should not route through an extra auth finish page'
   );
   assert.doesNotMatch(
-    `${loginPageSource}\n${loginControllerSource}`,
+    `${loginPageSource}\n${loginControllerSource}\n${loginOAuthCodeExchangeSource}`,
     /\/auth\/finish/,
     'login should not add another intermediate auth page'
   );
@@ -46,12 +47,12 @@ test('OAuth cookie fallback redirects only after a new Supabase auth cookie appe
 
 test('login waits for the final next path before starting PKCE exchange', () => {
   assert.match(
-    loginControllerSource,
+    loginOAuthCodeExchangeSource,
     /if \(!nextPathReady\) return;\s+if \(typeof window === 'undefined'\) return;\s+const params = new URLSearchParams\(window\.location\.search\);/,
     'PKCE exchange should not start until nextPath has been resolved'
   );
   assert.match(
-    loginControllerSource,
+    loginOAuthCodeExchangeSource,
     /oauthCodeExchangeStartedRef\.current = true;[\s\S]*const target = sanitizeNextPath\(params\.get\('next'\) \?\? nextPath\);/,
     'the exchange should capture a stable redirect target after nextPathReady'
   );

--- a/tests/login-page-architecture.test.ts
+++ b/tests/login-page-architecture.test.ts
@@ -10,6 +10,9 @@ const autofillHookPath = join(root, 'frontend/app/(core)/login/_hooks/useLoginAu
 const browserLocaleHookPath = join(root, 'frontend/app/(core)/login/_hooks/useLoginBrowserLocale.ts');
 const modeQueryHookPath = join(root, 'frontend/app/(core)/login/_hooks/useLoginModeFromQuery.ts');
 const nextTargetHookPath = join(root, 'frontend/app/(core)/login/_hooks/useLoginNextTarget.ts');
+const authenticatedRedirectHookPath = join(root, 'frontend/app/(core)/login/_hooks/useLoginAuthenticatedRedirect.ts');
+const authHashSessionHookPath = join(root, 'frontend/app/(core)/login/_hooks/useLoginAuthHashSession.ts');
+const oauthCodeExchangeHookPath = join(root, 'frontend/app/(core)/login/_hooks/useLoginOAuthCodeExchange.ts');
 const copyPath = join(root, 'frontend/app/(core)/login/_lib/login-copy.ts');
 const helpersPath = join(root, 'frontend/app/(core)/login/_lib/login-helpers.ts');
 const authSurfacePath = join(root, 'frontend/app/(core)/login/_components/LoginAuthSurface.tsx');
@@ -18,6 +21,9 @@ const pageSource = readFileSync(pagePath, 'utf8');
 const controllerSource = readFileSync(controllerPath, 'utf8');
 const autofillHookSource = readFileSync(autofillHookPath, 'utf8');
 const nextTargetHookSource = readFileSync(nextTargetHookPath, 'utf8');
+const authenticatedRedirectHookSource = readFileSync(authenticatedRedirectHookPath, 'utf8');
+const authHashSessionHookSource = readFileSync(authHashSessionHookPath, 'utf8');
+const oauthCodeExchangeHookSource = readFileSync(oauthCodeExchangeHookPath, 'utf8');
 
 test('login page delegates localized copy and browser helpers to route-local modules', () => {
   assert.ok(existsSync(controllerPath), 'login controller hook should stay in a route-local hook module');
@@ -25,6 +31,9 @@ test('login page delegates localized copy and browser helpers to route-local mod
   assert.ok(existsSync(browserLocaleHookPath), 'login browser locale should stay in a route-local hook module');
   assert.ok(existsSync(modeQueryHookPath), 'login mode query sync should stay in a route-local hook module');
   assert.ok(existsSync(nextTargetHookPath), 'login next target state should stay in a route-local hook module');
+  assert.ok(existsSync(authenticatedRedirectHookPath), 'login authenticated redirect probes should stay in a route-local hook module');
+  assert.ok(existsSync(authHashSessionHookPath), 'login hash session handling should stay in a route-local hook module');
+  assert.ok(existsSync(oauthCodeExchangeHookPath), 'login OAuth code exchange should stay in a route-local hook module');
   assert.ok(existsSync(copyPath), 'login localized copy should stay in a route-local copy module');
   assert.ok(existsSync(helpersPath), 'login browser helpers should stay in a route-local helper module');
   assert.ok(existsSync(authSurfacePath), 'login form UI should stay in a route-local component module');
@@ -45,6 +54,9 @@ test('login page delegates localized copy and browser helpers to route-local mod
   assert.match(controllerSource, /from '\.\/useLoginBrowserLocale'/);
   assert.match(controllerSource, /from '\.\/useLoginModeFromQuery'/);
   assert.match(controllerSource, /from '\.\/useLoginNextTarget'/);
+  assert.match(controllerSource, /from '\.\/useLoginAuthenticatedRedirect'/);
+  assert.match(controllerSource, /from '\.\/useLoginAuthHashSession'/);
+  assert.match(controllerSource, /from '\.\/useLoginOAuthCodeExchange'/);
 });
 
 test('login page does not regain auth copy or browser helper ownership', () => {
@@ -79,8 +91,14 @@ test('login helper modules expose the expected route contract', () => {
   assert.match(nextTargetHookSource, /export function useLoginNextTarget/, 'next target resolution should live in its own hook');
   assert.match(nextTargetHookSource, /LOGIN_NEXT_STORAGE_KEY/, 'next target hook should own login target storage');
   assert.match(nextTargetHookSource, /LOGIN_LAST_TARGET_KEY/, 'next target hook should own last target storage');
-  assert.match(controllerSource, /exchangeCodeForSession\(oauthCode\)/, 'controller hook should own browser-side PKCE exchange');
-  assert.match(controllerSource, /startOAuthCookieRedirectFallback/, 'controller hook should own OAuth cookie fallback wiring');
+  assert.doesNotMatch(controllerSource, /exchangeCodeForSession\(oauthCode\)/, 'OAuth PKCE exchange belongs in useLoginOAuthCodeExchange');
+  assert.doesNotMatch(controllerSource, /startOAuthCookieRedirectFallback/, 'OAuth cookie fallback wiring belongs in useLoginOAuthCodeExchange');
+  assert.match(oauthCodeExchangeHookSource, /exchangeCodeForSession\(oauthCode\)/, 'OAuth code exchange hook should own browser-side PKCE exchange');
+  assert.match(oauthCodeExchangeHookSource, /startOAuthCookieRedirectFallback/, 'OAuth code exchange hook should own OAuth cookie fallback wiring');
+  assert.match(authenticatedRedirectHookSource, /export function useLoginAuthenticatedRedirect/, 'authenticated redirect hook should be exported');
+  assert.match(authenticatedRedirectHookSource, /async function redirectFromExistingBrowserSession\(target: string\): Promise<boolean>/, 'authenticated redirect hook should expose the Safari fallback redirect');
+  assert.match(authHashSessionHookSource, /export function useLoginAuthHashSession/, 'auth hash session hook should be exported');
+  assert.match(authHashSessionHookSource, /setSession\(\{/, 'auth hash session hook should own Supabase hash session hydration');
   assert.match(controllerSource, /signInWithOAuth/, 'controller hook should own Google OAuth submission');
   assert.match(copySource, /export const AUTH_COPY =/, 'copy module should export the auth copy dictionary');
   assert.match(copySource, /export type AuthMode =/, 'copy module should export the auth mode type');


### PR DESCRIPTION
## Summary
- split login authenticated redirect probing into a route-local hook
- split browser-side OAuth code exchange and cookie fallback wiring into a dedicated hook
- split hash-session hydration into a dedicated hook
- update login/auth architecture contracts so these responsibilities do not drift back into the controller

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/login-page-architecture.test.ts tests/auth-callback-redirect.test.ts tests/login-oauth-cookie-fallback.test.ts tests/login-hydration-contract.test.ts
- pnpm --dir frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run test:validate
- npm run lint:exposure
- npm run architecture:audit -- --min-lines 500
- git diff --check