### PR TITLE
Split SEO signal helpers

### DIFF
--- a/frontend/lib/seo/content-momentum-format.ts
+++ b/frontend/lib/seo/content-momentum-format.ts
@@ -1,0 +1,91 @@
+import type { ContentMomentumItem, ContentMomentumType, SeoSourceMetrics } from './internal-seo-types';
+import { stripOrigin } from './seo-opportunity-engine';
+
+export function formatContentMomentumMarkdown(item: ContentMomentumItem): string {
+  return [
+    'Title:',
+    buildMomentumTitle(item),
+    '',
+    'Target:',
+    item.pageUrl ? stripOrigin(item.pageUrl) : item.queryCluster ?? item.family,
+    '',
+    'Source:',
+    item.queryCluster ? `GSC query cluster: "${item.queryCluster}"` : `GSC family/page momentum: ${item.family}`,
+    `Current: ${formatMetrics(item.current)}`,
+    `Previous: ${formatMetrics(item.previous)}`,
+    `Delta: ${formatDelta(item.clickDelta, 'clicks')}, ${formatDelta(item.impressionDelta, 'impressions')}, ${formatSignedPercent(item.ctrDelta)} CTR, ${formatSignedNumber(item.positionDelta)} position`,
+    '',
+    'Observed trend:',
+    item.observedTrend,
+    '',
+    'Recommended action:',
+    item.recommendedAction,
+    '',
+    'Why it matters:',
+    item.whyItMatters,
+    '',
+    'Acceptance criteria:',
+    ...item.acceptanceCriteria.map((criterion) => `- ${criterion}`),
+  ].join('\n');
+}
+
+export function formatContentMomentumSectionMarkdown(items: ContentMomentumItem[]): string {
+  if (!items.length) {
+    return ['# Content Momentum', '', 'No Content Momentum items generated for this snapshot.'].join('\n');
+  }
+
+  return [
+    '# Content Momentum',
+    '',
+    `Generated items: ${items.length}`,
+    '',
+    ...items.map((item, index) => [`## ${index + 1}. ${buildMomentumTitle(item)}`, '', formatContentMomentumMarkdown(item)].join('\n')),
+  ].join('\n\n');
+}
+
+export function labelizeMomentumType(value: ContentMomentumType) {
+  if (value === 'gaining_page') return 'Gaining page';
+  if (value === 'declining_page') return 'Declining page';
+  if (value === 'gaining_cluster') return 'Gaining cluster';
+  if (value === 'declining_cluster') return 'Declining cluster';
+  if (value === 'rising_family') return 'Rising family';
+  if (value === 'declining_family') return 'Declining family';
+  if (value === 'mixed_family_momentum') return 'Mixed family momentum';
+  if (value === 'refresh_candidate') return 'Refresh candidate';
+  if (value === 'protect_winner') return 'Protect winner';
+  if (value === 'outdated_model_attention') return 'Older model attention';
+  return 'Watchlist';
+}
+
+function buildMomentumTitle(item: ContentMomentumItem) {
+  if (item.type === 'protect_winner') return `Protect growing SEO winner: ${item.pageUrl ? stripOrigin(item.pageUrl) : item.queryCluster}`;
+  if (item.type === 'refresh_candidate') return `Refresh declining SEO page: ${item.pageUrl ? stripOrigin(item.pageUrl) : item.queryCluster}`;
+  if (item.type === 'outdated_model_attention') return `Reposition older ${item.family} demand`;
+  if (item.type === 'rising_family') return `${item.family} family is gaining momentum`;
+  if (item.type === 'declining_family') return `${item.family} family is losing momentum`;
+  if (item.type === 'mixed_family_momentum') return `${item.family} family has mixed momentum`;
+  return `${labelizeMomentumType(item.type)}: ${item.queryCluster ?? item.pageUrl ?? item.family}`;
+}
+
+function formatMetrics(metrics: SeoSourceMetrics) {
+  return [
+    `${metrics.clicks} clicks`,
+    `${metrics.impressions} impressions`,
+    `${(metrics.ctr * 100).toFixed(2)}% CTR`,
+    `avg position ${metrics.averagePosition.toFixed(1)}`,
+  ].join(', ');
+}
+
+export function formatDelta(value: number, label: string) {
+  return `${formatSignedNumber(value)} ${label}`;
+}
+
+export function formatSignedNumber(value: number) {
+  if (!Number.isFinite(value)) return '0';
+  return `${value > 0 ? '+' : ''}${value.toFixed(Number.isInteger(value) ? 0 : 1)}`;
+}
+
+export function formatSignedPercent(value: number) {
+  if (!Number.isFinite(value)) return '+0.00%';
+  return `${value > 0 ? '+' : ''}${(value * 100).toFixed(2)}%`;
+}

--- a/frontend/lib/seo/content-momentum-scoring.ts
+++ b/frontend/lib/seo/content-momentum-scoring.ts
@@ -1,0 +1,135 @@
+import type { SeoActionPriority, SeoSourceMetrics } from './internal-seo-types';
+import { classifyMissingContentIntent } from './missing-content';
+import { getBusinessPriorityWeight, getSeoFamilyStatus, normalizeSeoQuery } from './seo-intents';
+import type { MomentumDraft } from './content-momentum';
+
+const STRATEGIC_FAMILIES = new Set(['Seedance', 'Kling', 'Veo', 'LTX']);
+
+export function scoreMomentumDraft(
+  draft: MomentumDraft,
+  clickDelta: number,
+  impressionDelta: number,
+  ctrDelta: number
+) {
+  const maxImpressions = Math.max(draft.current.impressions, draft.previous.impressions);
+  const deltaMagnitude = Math.abs(impressionDelta) + Math.abs(clickDelta) * 8;
+  const volumeScore = Math.min(34, Math.log10(Math.max(maxImpressions, 1)) * 14);
+  const deltaScore = Math.min(34, Math.log10(Math.max(deltaMagnitude, 1)) * 16);
+  const positionScore = draft.current.averagePosition <= 6 ? 14 : draft.current.averagePosition <= 12 ? 10 : draft.current.averagePosition <= 30 ? 3 : -10;
+  const ctrScore = draft.type.includes('declining') || draft.type === 'refresh_candidate' ? Math.min(10, Math.max(0, -ctrDelta * 220)) : Math.min(8, Math.max(0, ctrDelta * 180));
+  return Math.round((volumeScore + deltaScore + positionScore + ctrScore + draft.scoreBoost) * getBusinessPriorityWeight(draft.family));
+}
+
+export function calibrateScore(draft: MomentumDraft, rawScore: number) {
+  const status = getSeoFamilyStatus(draft.family);
+  const maxImpressions = Math.max(draft.current.impressions, draft.previous.impressions);
+  const impressionDelta = Math.abs(draft.current.impressions - draft.previous.impressions);
+  const currentImpressions = draft.current.impressions;
+  const clickDelta = Math.abs(draft.current.clicks - draft.previous.clicks);
+  if (draft.family === 'Brand') {
+    return Math.min(rawScore, isBrandTypoMomentum(draft) ? 75 : 103);
+  }
+  if (maxImpressions < 35 || impressionDelta < 20) return Math.min(rawScore, 48);
+  if (draft.type === 'mixed_family_momentum') return Math.min(rawScore, 48);
+  if ((draft.type === 'declining_cluster' || draft.type === 'declining_page') && currentImpressions < 20 && maxImpressions < 80) {
+    return Math.min(rawScore, 48);
+  }
+  if (currentImpressions < 50 && maxImpressions < 90) return Math.min(rawScore, 75);
+  if (draft.current.averagePosition >= 30 && maxImpressions < 250) return Math.min(rawScore, 48);
+  if (draft.type === 'watchlist') return Math.min(rawScore, 48);
+  if (draft.type === 'outdated_model_attention') return Math.min(rawScore, 48);
+  if (draft.family === 'Sora') return Math.min(rawScore, 48);
+  if (status === 'emerging' && maxImpressions < 120) return Math.min(rawScore, 48);
+  if (status === 'emerging') return Math.min(rawScore, 62);
+  if ((draft.type === 'rising_family' || draft.type === 'declining_family') && maxImpressions < 100) return Math.min(rawScore, 58);
+  if (rawScore >= 104 && !isCriticalEligible(draft, impressionDelta, clickDelta)) return Math.min(rawScore, 103);
+  return rawScore;
+}
+
+export function scoreToPriority(score: number): SeoActionPriority {
+  if (score >= 104) return 'critical';
+  if (score >= 76) return 'high';
+  if (score >= 52) return 'medium';
+  return 'low';
+}
+
+export function classifyTrend(current: SeoSourceMetrics, previous: SeoSourceMetrics): 'gaining' | 'declining' | null {
+  const maxImpressions = Math.max(current.impressions, previous.impressions);
+  const impressionDelta = current.impressions - previous.impressions;
+  const clickDelta = current.clicks - previous.clicks;
+  const relativeImpressionDelta = previous.impressions ? impressionDelta / previous.impressions : current.impressions ? 1 : 0;
+  const relativeClickDelta = previous.clicks ? clickDelta / previous.clicks : current.clicks ? 1 : 0;
+
+  if (maxImpressions < 20) return null;
+  if (Math.abs(impressionDelta) < 20 && Math.abs(clickDelta) < 4) return null;
+
+  if (
+    (impressionDelta >= 40 && relativeImpressionDelta >= 0.25) ||
+    (clickDelta >= 5 && relativeClickDelta >= 0.25)
+  ) {
+    return 'gaining';
+  }
+  if (
+    (impressionDelta <= -40 && relativeImpressionDelta <= -0.25) ||
+    (clickDelta <= -5 && relativeClickDelta <= -0.25)
+  ) {
+    return 'declining';
+  }
+  return null;
+}
+
+export function classifyMixedFamilyMomentum(current: SeoSourceMetrics, previous: SeoSourceMetrics): boolean {
+  const impressionDelta = current.impressions - previous.impressions;
+  const clickDelta = current.clicks - previous.clicks;
+  const positionDelta = current.averagePosition - previous.averagePosition;
+  const clicksRising = clickDelta >= 5;
+  const impressionsFalling = impressionDelta <= -40;
+  const positionWorse = positionDelta >= 3 && current.averagePosition > 12;
+  const clicksFalling = clickDelta <= -5;
+  const impressionsRising = impressionDelta >= 40;
+  return (clicksRising && (impressionsFalling || positionWorse)) || (clicksFalling && impressionsRising);
+}
+
+export function isWorthMomentumItem(draft: MomentumDraft) {
+  const maxImpressions = Math.max(draft.current.impressions, draft.previous.impressions);
+  const impressionDelta = Math.abs(draft.current.impressions - draft.previous.impressions);
+  const clickDelta = Math.abs(draft.current.clicks - draft.previous.clicks);
+  const status = getSeoFamilyStatus(draft.family);
+
+  if (draft.type === 'outdated_model_attention') return draft.current.impressions >= 50;
+  if (maxImpressions < 20) return false;
+  if (impressionDelta < 20 && clickDelta < 4) return false;
+  if (status === 'emerging') return maxImpressions >= 35 && impressionDelta >= 15;
+  if (draft.type === 'mixed_family_momentum') return maxImpressions >= 80 && (impressionDelta >= 40 || clickDelta >= 5);
+  if (draft.type === 'rising_family' || draft.type === 'declining_family') return maxImpressions >= 80 && impressionDelta >= 50;
+  return true;
+}
+
+export function isJunkMomentumDraft(draft: MomentumDraft) {
+  const text = normalizeSeoQuery([
+    draft.pageUrl,
+    draft.queryCluster,
+    draft.family,
+    ...draft.representativeQueries,
+  ].filter(Boolean).join(' '));
+  if (isAdultOrJunkText(text)) return true;
+  return draft.representativeQueries.some((query) => classifyMissingContentIntent(query) === 'irrelevant_junk');
+}
+
+function isCriticalEligible(draft: MomentumDraft, impressionDelta: number, clickDelta: number) {
+  const hasAbsoluteSignal = draft.current.impressions >= 250 || impressionDelta >= 150;
+  const hasClickSignal = draft.current.clicks >= 20 || clickDelta >= 15;
+  const nearPageOne = draft.current.averagePosition > 0 && draft.current.averagePosition <= 12;
+  const strategic = STRATEGIC_FAMILIES.has(draft.family);
+  if (hasAbsoluteSignal && hasClickSignal && nearPageOne) return true;
+  return strategic && nearPageOne && draft.current.impressions >= 120 && impressionDelta >= 80 && hasClickSignal;
+}
+
+function isBrandTypoMomentum(draft: MomentumDraft) {
+  const text = normalizeSeoQuery([draft.queryCluster, ...draft.representativeQueries].filter(Boolean).join(' '));
+  return /\bmaxvedio\b|\bmaxvideos\b|\bmax videoa\b|\bmaxvideai\b|\bmax vidio\b/.test(text);
+}
+
+function isAdultOrJunkText(value: string) {
+  return /\b(?:porn|porno|nsfw|nude|naked|sex|sexy|xxx|onlyfans|casino|gambling|torrent|crack|hack)\b/.test(value);
+}

--- a/frontend/lib/seo/content-momentum.ts
+++ b/frontend/lib/seo/content-momentum.ts
@@ -6,14 +6,32 @@ import type {
   SeoSourceMetrics,
   StrategicSeoFamily,
 } from './internal-seo-types';
-import { classifyMissingContentIntent } from './missing-content';
 import {
   detectStrategicModelFamily,
-  getBusinessPriorityWeight,
   getSeoFamilyStatus,
-  normalizeSeoQuery,
 } from './seo-intents';
 import { clusterGscQueries, stripOrigin, summarizeRows } from './seo-opportunity-engine';
+import {
+  formatContentMomentumMarkdown,
+  formatDelta,
+  formatSignedNumber,
+  formatSignedPercent,
+} from './content-momentum-format';
+import {
+  calibrateScore,
+  classifyMixedFamilyMomentum,
+  classifyTrend,
+  isJunkMomentumDraft,
+  isWorthMomentumItem,
+  scoreMomentumDraft,
+  scoreToPriority,
+} from './content-momentum-scoring';
+
+export {
+  formatContentMomentumMarkdown,
+  formatContentMomentumSectionMarkdown,
+  labelizeMomentumType,
+} from './content-momentum-format';
 
 const MAX_MOMENTUM_ITEMS = 80;
 const STRATEGIC_FAMILIES = new Set(['Seedance', 'Kling', 'Veo', 'LTX']);
@@ -23,7 +41,7 @@ type BuildContentMomentumOptions = {
   previousRows: GscPerformanceRow[];
 };
 
-type MomentumDraft = {
+export type MomentumDraft = {
   type: ContentMomentumType;
   pageUrl: string | null;
   queryCluster: string | null;
@@ -52,62 +70,6 @@ export function buildContentMomentumItems(options: BuildContentMomentumOptions):
   )
     .sort((a, b) => priorityRank(a.priority) - priorityRank(b.priority) || b.score - a.score)
     .slice(0, MAX_MOMENTUM_ITEMS);
-}
-
-export function formatContentMomentumMarkdown(item: ContentMomentumItem): string {
-  return [
-    'Title:',
-    buildMomentumTitle(item),
-    '',
-    'Target:',
-    item.pageUrl ? stripOrigin(item.pageUrl) : item.queryCluster ?? item.family,
-    '',
-    'Source:',
-    item.queryCluster ? `GSC query cluster: "${item.queryCluster}"` : `GSC family/page momentum: ${item.family}`,
-    `Current: ${formatMetrics(item.current)}`,
-    `Previous: ${formatMetrics(item.previous)}`,
-    `Delta: ${formatDelta(item.clickDelta, 'clicks')}, ${formatDelta(item.impressionDelta, 'impressions')}, ${formatSignedPercent(item.ctrDelta)} CTR, ${formatSignedNumber(item.positionDelta)} position`,
-    '',
-    'Observed trend:',
-    item.observedTrend,
-    '',
-    'Recommended action:',
-    item.recommendedAction,
-    '',
-    'Why it matters:',
-    item.whyItMatters,
-    '',
-    'Acceptance criteria:',
-    ...item.acceptanceCriteria.map((criterion) => `- ${criterion}`),
-  ].join('\n');
-}
-
-export function formatContentMomentumSectionMarkdown(items: ContentMomentumItem[]): string {
-  if (!items.length) {
-    return ['# Content Momentum', '', 'No Content Momentum items generated for this snapshot.'].join('\n');
-  }
-
-  return [
-    '# Content Momentum',
-    '',
-    `Generated items: ${items.length}`,
-    '',
-    ...items.map((item, index) => [`## ${index + 1}. ${buildMomentumTitle(item)}`, '', formatContentMomentumMarkdown(item)].join('\n')),
-  ].join('\n\n');
-}
-
-export function labelizeMomentumType(value: ContentMomentumType) {
-  if (value === 'gaining_page') return 'Gaining page';
-  if (value === 'declining_page') return 'Declining page';
-  if (value === 'gaining_cluster') return 'Gaining cluster';
-  if (value === 'declining_cluster') return 'Declining cluster';
-  if (value === 'rising_family') return 'Rising family';
-  if (value === 'declining_family') return 'Declining family';
-  if (value === 'mixed_family_momentum') return 'Mixed family momentum';
-  if (value === 'refresh_candidate') return 'Refresh candidate';
-  if (value === 'protect_winner') return 'Protect winner';
-  if (value === 'outdated_model_attention') return 'Older model attention';
-  return 'Watchlist';
 }
 
 function buildPageMomentumDrafts(currentRows: GscPerformanceRow[], previousRows: GscPerformanceRow[]): MomentumDraft[] {
@@ -291,117 +253,6 @@ function finalizeMomentumItem(draft: MomentumDraft): ContentMomentumItem {
   };
 }
 
-function scoreMomentumDraft(
-  draft: MomentumDraft,
-  clickDelta: number,
-  impressionDelta: number,
-  ctrDelta: number
-) {
-  const maxImpressions = Math.max(draft.current.impressions, draft.previous.impressions);
-  const deltaMagnitude = Math.abs(impressionDelta) + Math.abs(clickDelta) * 8;
-  const volumeScore = Math.min(34, Math.log10(Math.max(maxImpressions, 1)) * 14);
-  const deltaScore = Math.min(34, Math.log10(Math.max(deltaMagnitude, 1)) * 16);
-  const positionScore = draft.current.averagePosition <= 6 ? 14 : draft.current.averagePosition <= 12 ? 10 : draft.current.averagePosition <= 30 ? 3 : -10;
-  const ctrScore = draft.type.includes('declining') || draft.type === 'refresh_candidate' ? Math.min(10, Math.max(0, -ctrDelta * 220)) : Math.min(8, Math.max(0, ctrDelta * 180));
-  return Math.round((volumeScore + deltaScore + positionScore + ctrScore + draft.scoreBoost) * getBusinessPriorityWeight(draft.family));
-}
-
-function calibrateScore(draft: MomentumDraft, rawScore: number) {
-  const status = getSeoFamilyStatus(draft.family);
-  const maxImpressions = Math.max(draft.current.impressions, draft.previous.impressions);
-  const impressionDelta = Math.abs(draft.current.impressions - draft.previous.impressions);
-  const currentImpressions = draft.current.impressions;
-  const clickDelta = Math.abs(draft.current.clicks - draft.previous.clicks);
-  if (draft.family === 'Brand') {
-    return Math.min(rawScore, isBrandTypoMomentum(draft) ? 75 : 103);
-  }
-  if (maxImpressions < 35 || impressionDelta < 20) return Math.min(rawScore, 48);
-  if (draft.type === 'mixed_family_momentum') return Math.min(rawScore, 48);
-  if ((draft.type === 'declining_cluster' || draft.type === 'declining_page') && currentImpressions < 20 && maxImpressions < 80) {
-    return Math.min(rawScore, 48);
-  }
-  if (currentImpressions < 50 && maxImpressions < 90) return Math.min(rawScore, 75);
-  if (draft.current.averagePosition >= 30 && maxImpressions < 250) return Math.min(rawScore, 48);
-  if (draft.type === 'watchlist') return Math.min(rawScore, 48);
-  if (draft.type === 'outdated_model_attention') return Math.min(rawScore, 48);
-  if (draft.family === 'Sora') return Math.min(rawScore, 48);
-  if (status === 'emerging' && maxImpressions < 120) return Math.min(rawScore, 48);
-  if (status === 'emerging') return Math.min(rawScore, 62);
-  if ((draft.type === 'rising_family' || draft.type === 'declining_family') && maxImpressions < 100) return Math.min(rawScore, 58);
-  if (rawScore >= 104 && !isCriticalEligible(draft, impressionDelta, clickDelta)) return Math.min(rawScore, 103);
-  return rawScore;
-}
-
-function scoreToPriority(score: number): SeoActionPriority {
-  if (score >= 104) return 'critical';
-  if (score >= 76) return 'high';
-  if (score >= 52) return 'medium';
-  return 'low';
-}
-
-function classifyTrend(current: SeoSourceMetrics, previous: SeoSourceMetrics): 'gaining' | 'declining' | null {
-  const maxImpressions = Math.max(current.impressions, previous.impressions);
-  const impressionDelta = current.impressions - previous.impressions;
-  const clickDelta = current.clicks - previous.clicks;
-  const relativeImpressionDelta = previous.impressions ? impressionDelta / previous.impressions : current.impressions ? 1 : 0;
-  const relativeClickDelta = previous.clicks ? clickDelta / previous.clicks : current.clicks ? 1 : 0;
-
-  if (maxImpressions < 20) return null;
-  if (Math.abs(impressionDelta) < 20 && Math.abs(clickDelta) < 4) return null;
-
-  if (
-    (impressionDelta >= 40 && relativeImpressionDelta >= 0.25) ||
-    (clickDelta >= 5 && relativeClickDelta >= 0.25)
-  ) {
-    return 'gaining';
-  }
-  if (
-    (impressionDelta <= -40 && relativeImpressionDelta <= -0.25) ||
-    (clickDelta <= -5 && relativeClickDelta <= -0.25)
-  ) {
-    return 'declining';
-  }
-  return null;
-}
-
-function classifyMixedFamilyMomentum(current: SeoSourceMetrics, previous: SeoSourceMetrics): boolean {
-  const impressionDelta = current.impressions - previous.impressions;
-  const clickDelta = current.clicks - previous.clicks;
-  const positionDelta = current.averagePosition - previous.averagePosition;
-  const clicksRising = clickDelta >= 5;
-  const impressionsFalling = impressionDelta <= -40;
-  const positionWorse = positionDelta >= 3 && current.averagePosition > 12;
-  const clicksFalling = clickDelta <= -5;
-  const impressionsRising = impressionDelta >= 40;
-  return (clicksRising && (impressionsFalling || positionWorse)) || (clicksFalling && impressionsRising);
-}
-
-function isWorthMomentumItem(draft: MomentumDraft) {
-  const maxImpressions = Math.max(draft.current.impressions, draft.previous.impressions);
-  const impressionDelta = Math.abs(draft.current.impressions - draft.previous.impressions);
-  const clickDelta = Math.abs(draft.current.clicks - draft.previous.clicks);
-  const status = getSeoFamilyStatus(draft.family);
-
-  if (draft.type === 'outdated_model_attention') return draft.current.impressions >= 50;
-  if (maxImpressions < 20) return false;
-  if (impressionDelta < 20 && clickDelta < 4) return false;
-  if (status === 'emerging') return maxImpressions >= 35 && impressionDelta >= 15;
-  if (draft.type === 'mixed_family_momentum') return maxImpressions >= 80 && (impressionDelta >= 40 || clickDelta >= 5);
-  if (draft.type === 'rising_family' || draft.type === 'declining_family') return maxImpressions >= 80 && impressionDelta >= 50;
-  return true;
-}
-
-function isJunkMomentumDraft(draft: MomentumDraft) {
-  const text = normalizeSeoQuery([
-    draft.pageUrl,
-    draft.queryCluster,
-    draft.family,
-    ...draft.representativeQueries,
-  ].filter(Boolean).join(' '));
-  if (isAdultOrJunkText(text)) return true;
-  return draft.representativeQueries.some((query) => classifyMissingContentIntent(query) === 'irrelevant_junk');
-}
-
 function buildObservedTrend(
   draft: MomentumDraft,
   clickDelta: number,
@@ -485,16 +336,6 @@ function buildAcceptanceCriteria(draft: MomentumDraft) {
     criteria.push('Underlying query/page clusters are reviewed before assigning implementation work');
   }
   return criteria;
-}
-
-function buildMomentumTitle(item: ContentMomentumItem) {
-  if (item.type === 'protect_winner') return `Protect growing SEO winner: ${item.pageUrl ? stripOrigin(item.pageUrl) : item.queryCluster}`;
-  if (item.type === 'refresh_candidate') return `Refresh declining SEO page: ${item.pageUrl ? stripOrigin(item.pageUrl) : item.queryCluster}`;
-  if (item.type === 'outdated_model_attention') return `Reposition older ${item.family} demand`;
-  if (item.type === 'rising_family') return `${item.family} family is gaining momentum`;
-  if (item.type === 'declining_family') return `${item.family} family is losing momentum`;
-  if (item.type === 'mixed_family_momentum') return `${item.family} family has mixed momentum`;
-  return `${labelizeMomentumType(item.type)}: ${item.queryCluster ?? item.pageUrl ?? item.family}`;
 }
 
 function groupRowsByPage(rows: GscPerformanceRow[]) {
@@ -599,49 +440,8 @@ function priorityRank(priority: SeoActionPriority) {
   return 4;
 }
 
-function isCriticalEligible(draft: MomentumDraft, impressionDelta: number, clickDelta: number) {
-  const hasAbsoluteSignal = draft.current.impressions >= 250 || impressionDelta >= 150;
-  const hasClickSignal = draft.current.clicks >= 20 || clickDelta >= 15;
-  const nearPageOne = draft.current.averagePosition > 0 && draft.current.averagePosition <= 12;
-  const strategic = STRATEGIC_FAMILIES.has(draft.family);
-  if (hasAbsoluteSignal && hasClickSignal && nearPageOne) return true;
-  return strategic && nearPageOne && draft.current.impressions >= 120 && impressionDelta >= 80 && hasClickSignal;
-}
-
-function isBrandTypoMomentum(draft: MomentumDraft) {
-  const text = normalizeSeoQuery([draft.queryCluster, ...draft.representativeQueries].filter(Boolean).join(' '));
-  return /\bmaxvedio\b|\bmaxvideos\b|\bmax videoa\b|\bmaxvideai\b|\bmax vidio\b/.test(text);
-}
-
 function targetLabel(draft: MomentumDraft) {
   return draft.queryCluster ?? draft.pageUrl ?? draft.family;
-}
-
-function formatMetrics(metrics: SeoSourceMetrics) {
-  return [
-    `${metrics.clicks} clicks`,
-    `${metrics.impressions} impressions`,
-    `${(metrics.ctr * 100).toFixed(2)}% CTR`,
-    `avg position ${metrics.averagePosition.toFixed(1)}`,
-  ].join(', ');
-}
-
-function formatDelta(value: number, label: string) {
-  return `${formatSignedNumber(value)} ${label}`;
-}
-
-function formatSignedNumber(value: number) {
-  if (!Number.isFinite(value)) return '0';
-  return `${value > 0 ? '+' : ''}${value.toFixed(Number.isInteger(value) ? 0 : 1)}`;
-}
-
-function formatSignedPercent(value: number) {
-  if (!Number.isFinite(value)) return '+0.00%';
-  return `${value > 0 ? '+' : ''}${(value * 100).toFixed(2)}%`;
-}
-
-function isAdultOrJunkText(value: string) {
-  return /\b(?:porn|porno|nsfw|nude|naked|sex|sexy|xxx|onlyfans|casino|gambling|torrent|crack|hack)\b/.test(value);
 }
 
 function stableId(value: string) {

--- a/frontend/lib/seo/internal-link-builder-format.ts
+++ b/frontend/lib/seo/internal-link-builder-format.ts
@@ -1,0 +1,58 @@
+import type { InternalLinkRecommendationType, InternalLinkSuggestion, SeoPageType } from './internal-seo-types';
+import { formatMetrics } from './internal-link-builder-helpers';
+
+export function formatInternalLinkMarkdown(item: InternalLinkSuggestion): string {
+  return [
+    'Title:',
+    `Add or verify internal link from ${item.sourceUrl} to ${item.targetUrl}`,
+    '',
+    'Source:',
+    `GSC query cluster: ${item.representativeQueries.map((query) => `"${query}"`).join(', ')}`,
+    `Metrics: ${formatMetrics(item.currentMetrics)}`,
+    '',
+    'Recommended link:',
+    `Source page: ${item.sourceUrl}`,
+    `Target page: ${item.targetUrl}`,
+    `Anchor text: ${item.suggestedAnchor}`,
+    '',
+    'Reason:',
+    item.reason,
+    '',
+    'Implementation note:',
+    item.verifyExistingLinkFirst
+      ? 'Verify whether this internal link already exists first. If it exists with clear anchor text, refine only if needed instead of adding a duplicate link.'
+      : 'Add the link where it naturally helps users move between related MaxVideoAI pages.',
+    '',
+    'Acceptance criteria:',
+    ...item.acceptanceCriteria.map((criterion) => `- ${criterion}`),
+  ].join('\n');
+}
+
+export function formatInternalLinkSectionMarkdown(items: InternalLinkSuggestion[]): string {
+  if (!items.length) {
+    return ['# Internal Link Suggestions', '', 'No internal link suggestions generated for this snapshot.'].join('\n');
+  }
+
+  return [
+    '# Internal Link Suggestions',
+    '',
+    `Generated suggestions: ${items.length}`,
+    '',
+    ...items.map((item, index) => [`## ${index + 1}. ${item.sourceUrl} -> ${item.targetUrl}`, '', formatInternalLinkMarkdown(item)].join('\n')),
+  ].join('\n\n');
+}
+
+export function labelizeInternalLinkType(value: InternalLinkRecommendationType) {
+  if (value === 'family_hub_to_model') return 'Family hub to model';
+  if (value === 'model_to_examples') return 'Model to examples';
+  if (value === 'compare_to_model') return 'Compare to model';
+  if (value === 'examples_to_model') return 'Examples to model';
+  if (value === 'pricing_to_model') return 'Pricing to model';
+  return 'Hub to opportunity';
+}
+
+export function labelizePageType(value: SeoPageType) {
+  return value
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}

--- a/frontend/lib/seo/internal-link-builder-helpers.ts
+++ b/frontend/lib/seo/internal-link-builder-helpers.ts
@@ -1,0 +1,204 @@
+import type {
+  InternalLinkRecommendationType,
+  SeoIntentType,
+  SeoPageType,
+  SeoQueryCluster,
+  SeoSourceMetrics,
+  StrategicSeoFamily,
+} from './internal-seo-types';
+import { getSeoFamilyDictionary, normalizeSeoQuery } from './seo-intents';
+import { stripOrigin } from './seo-opportunity-engine';
+
+type InternalLinkDraftLike = {
+  recommendationType: InternalLinkRecommendationType;
+  sourceUrl: string;
+  targetUrl: string;
+  sourceType: SeoPageType;
+  family: StrategicSeoFamily;
+};
+
+const STRATEGIC_FAMILIES = new Set(['Seedance', 'Kling', 'Veo', 'LTX']);
+
+export function inferModelSlug(
+  cluster: SeoQueryCluster,
+  familyEntry: ReturnType<typeof getSeoFamilyDictionary>[number] | undefined
+) {
+  const targetPath = normalizePath(stripOrigin(cluster.targetUrl));
+  if (targetPath.startsWith('/models/')) return targetPath.split('/').filter(Boolean)[1] ?? null;
+  if (!familyEntry) return null;
+
+  const haystack = normalizeSeoQuery(`${cluster.representativeQueries.join(' ')} ${targetPath}`);
+  const modelSlug = familyEntry.modelSlugs
+    .slice()
+    .sort((a, b) => b.length - a.length)
+    .find((slug) => aliasInHaystack(slug, haystack) || aliasInHaystack(humanizeModelSlug(slug), haystack));
+
+  return preferCurrentModelSlug(modelSlug ?? null, familyEntry);
+}
+
+function preferCurrentModelSlug(
+  candidateSlug: string | null,
+  familyEntry: ReturnType<typeof getSeoFamilyDictionary>[number]
+) {
+  const currentSlugs = familyEntry.currentModelSlugs.length
+    ? familyEntry.currentModelSlugs
+    : familyEntry.defaultModelSlug
+      ? [familyEntry.defaultModelSlug]
+      : [];
+  if (!candidateSlug) return currentSlugs[0] ?? familyEntry.defaultModelSlug;
+  if (currentSlugs.includes(candidateSlug)) return candidateSlug;
+
+  const defaultSlug = familyEntry.defaultModelSlug;
+  if (defaultSlug && currentSlugs.includes(defaultSlug) && defaultSlug.startsWith(candidateSlug)) {
+    return defaultSlug;
+  }
+
+  return currentSlugs.find((slug) => slug.startsWith(candidateSlug)) ?? candidateSlug;
+}
+
+export function buildExamplesToModelAnchor(cluster: SeoQueryCluster, family: StrategicSeoFamily, modelSlug: string) {
+  const modelName = chooseModelName(cluster, modelSlug);
+  if (cluster.intent === 'prompt_examples' || cluster.intent === 'prompt_guide') return `${modelName} prompt examples and specs`;
+  if (cluster.intent === 'examples') return `${modelName} examples and specs`;
+  return `${family} model specs`;
+}
+
+export function buildModelToExamplesAnchor(cluster: SeoQueryCluster, family: StrategicSeoFamily, modelSlug: string) {
+  const modelName = chooseModelName(cluster, modelSlug);
+  if (cluster.intent === 'prompt_examples' || cluster.intent === 'prompt_guide') return `${modelName} prompt examples`;
+  if (cluster.intent === 'examples') return `${modelName} examples`;
+  return `${family} examples`;
+}
+
+export function buildHubAnchor(cluster: SeoQueryCluster, modelSlug: string) {
+  const modelName = chooseModelName(cluster, modelSlug);
+  if (cluster.intent === 'prompt_examples' || cluster.intent === 'prompt_guide') return `${modelName} prompt examples`;
+  if (cluster.intent === 'comparison') return `${modelName} comparison`;
+  if (cluster.intent === 'pricing' || cluster.intent === 'pricing_specs') return `${modelName} pricing and specs`;
+  return `${modelName} model details`;
+}
+
+function chooseModelName(cluster: SeoQueryCluster, modelSlug: string) {
+  const queryText = cluster.representativeQueries.join(' ');
+  const versionMatch = queryText.match(/\b(?:ltx|seedance|veo|kling|pika|wan|sora|happy horse|hailuo|minimax|luma|ray)\s+(?:v)?\d+(?:[.\s-]\d+){0,2}(?:\s+(?:fast|lite|pro|standard|flash))?\b/i);
+  if (versionMatch) return titleize(versionMatch[0]);
+  return humanizeModelSlug(modelSlug);
+}
+
+export function humanizeModelSlug(slug: string) {
+  return slug
+    .split('-')
+    .map((part) => {
+      if (/^\d+$/.test(part)) return part;
+      if (part === 'ltx') return 'LTX';
+      if (part === 'veo') return 'Veo';
+      if (part === 'wan') return 'Wan';
+      if (part === 'pika') return 'Pika';
+      if (part === 'sora') return 'Sora';
+      if (part === 'kling') return 'Kling';
+      if (part === 'seedance') return 'Seedance';
+      if (part === 'minimax') return 'MiniMax';
+      if (part === 'hailuo') return 'Hailuo';
+      if (part === 'luma') return 'Luma';
+      return part.charAt(0).toUpperCase() + part.slice(1);
+    })
+    .join(' ')
+    .replace(/\b2 3\b/g, '2.3')
+    .replace(/\b3 1\b/g, '3.1')
+    .replace(/\b2 0\b/g, '2.0')
+    .replace(/\b1 5\b/g, '1.5')
+    .replace(/\b1 0\b/g, '1.0');
+}
+
+export function isPromptOrExamplesIntent(intent: SeoIntentType) {
+  return intent === 'prompt_examples' || intent === 'prompt_guide' || intent === 'examples';
+}
+
+export function isModelPageIntent(intent: SeoIntentType) {
+  return isPromptOrExamplesIntent(intent) || intent === 'model_page' || intent === 'pricing_specs' || intent === 'specs';
+}
+
+export function isLinkableIntent(intent: SeoIntentType) {
+  return (
+    isPromptOrExamplesIntent(intent) ||
+    intent === 'comparison' ||
+    intent === 'pricing' ||
+    intent === 'pricing_specs' ||
+    intent === 'pay_as_you_go' ||
+    intent === 'specs' ||
+    intent === 'max_length' ||
+    intent === 'image_to_video' ||
+    intent === 'text_to_video' ||
+    intent === 'model_page'
+  );
+}
+
+export function isExpectedExistingLinkPattern(draft: InternalLinkDraftLike) {
+  if (draft.recommendationType === 'compare_to_model' && draft.sourceType === 'compare_page') return true;
+  if (draft.recommendationType === 'model_to_examples' && draft.sourceType === 'model_page') return true;
+  if (
+    (draft.recommendationType === 'examples_to_model' || draft.recommendationType === 'hub_to_opportunity') &&
+    (draft.sourceType === 'family_examples' || draft.sourceType === 'examples_hub' || draft.sourceType === 'models_hub') &&
+    getSeoFamilyDictionary().some(
+      (entry) =>
+        entry.label === draft.family &&
+        entry.currentModelSlugs.includes(draft.targetUrl.replace('/models/', ''))
+    )
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export function isStrategicInternalLinkFamily(family: StrategicSeoFamily) {
+  return STRATEGIC_FAMILIES.has(family);
+}
+
+export function normalizePath(value: string | null) {
+  if (!value || value === 'No target URL') return '';
+  return value.split('?')[0].replace(/\/$/, '') || '/';
+}
+
+function aliasInHaystack(alias: string, haystack: string) {
+  const normalized = normalizeSeoQuery(alias);
+  if (!normalized) return false;
+  const escaped = normalized.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\ /g, '[\\s./-]+');
+  return new RegExp(`(^|[\\s/.-])${escaped}($|[\\s/.-])`, 'i').test(haystack);
+}
+
+function titleize(value: string) {
+  return value
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+    .replace(/\bLtx\b/g, 'LTX');
+}
+
+export function signalKey(targetUrl: string | null, cluster: string) {
+  return `${normalizePath(stripOrigin(targetUrl))}|${normalizeSeoQuery(cluster)}`;
+}
+
+export function formatMetrics(metrics: SeoSourceMetrics) {
+  return [
+    `${metrics.clicks} clicks`,
+    `${metrics.impressions} impressions`,
+    `${(metrics.ctr * 100).toFixed(2)}% CTR`,
+    `avg position ${metrics.averagePosition.toFixed(1)}`,
+  ].join(', ');
+}
+
+export function priorityRank(priority: 'critical' | 'high' | 'medium' | 'low') {
+  if (priority === 'critical') return 1;
+  if (priority === 'high') return 2;
+  if (priority === 'medium') return 3;
+  return 4;
+}
+
+export function stableId(value: string) {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(index);
+    hash |= 0;
+  }
+  return Math.abs(hash).toString(36);
+}

--- a/frontend/lib/seo/internal-link-builder.ts
+++ b/frontend/lib/seo/internal-link-builder.ts
@@ -1,15 +1,10 @@
 import type { GscPerformanceRow } from './gsc-analysis';
 import type {
   CtrDoctorItem,
-  InternalLinkRecommendationType,
   InternalLinkSuggestion,
   MissingContentItem,
   SeoActionPriority,
-  SeoIntentType,
-  SeoPageType,
   SeoQueryCluster,
-  SeoSourceMetrics,
-  StrategicSeoFamily,
   StrategicSeoOpportunity,
 } from './internal-seo-types';
 import { classifyMissingContentIntent } from './missing-content';
@@ -17,13 +12,36 @@ import {
   getBusinessPriorityWeight,
   getSeoFamilyDictionary,
   getSeoFamilyStatus,
-  normalizeSeoQuery,
 } from './seo-intents';
 import { clusterGscQueries, stripOrigin } from './seo-opportunity-engine';
+import {
+  buildExamplesToModelAnchor,
+  buildHubAnchor,
+  buildModelToExamplesAnchor,
+  formatMetrics,
+  humanizeModelSlug,
+  inferModelSlug,
+  isExpectedExistingLinkPattern,
+  isLinkableIntent,
+  isModelPageIntent,
+  isPromptOrExamplesIntent,
+  isStrategicInternalLinkFamily,
+  normalizePath,
+  priorityRank,
+  signalKey,
+  stableId,
+} from './internal-link-builder-helpers';
+import { formatInternalLinkMarkdown } from './internal-link-builder-format';
+
+export {
+  formatInternalLinkMarkdown,
+  formatInternalLinkSectionMarkdown,
+  labelizeInternalLinkType,
+  labelizePageType,
+} from './internal-link-builder-format';
 
 const MIN_LINK_IMPRESSIONS = 25;
 const MAX_SUGGESTIONS = 80;
-const STRATEGIC_FAMILIES = new Set(['Seedance', 'Kling', 'Veo', 'LTX']);
 
 type BuildInternalLinkOptions = {
   rows: GscPerformanceRow[];
@@ -55,62 +73,6 @@ export function buildInternalLinkSuggestions(options: BuildInternalLinkOptions):
   )
     .sort((a, b) => priorityRank(a.priority) - priorityRank(b.priority) || b.score - a.score)
     .slice(0, MAX_SUGGESTIONS);
-}
-
-export function formatInternalLinkMarkdown(item: InternalLinkSuggestion): string {
-  return [
-    'Title:',
-    `Add or verify internal link from ${item.sourceUrl} to ${item.targetUrl}`,
-    '',
-    'Source:',
-    `GSC query cluster: ${item.representativeQueries.map((query) => `"${query}"`).join(', ')}`,
-    `Metrics: ${formatMetrics(item.currentMetrics)}`,
-    '',
-    'Recommended link:',
-    `Source page: ${item.sourceUrl}`,
-    `Target page: ${item.targetUrl}`,
-    `Anchor text: ${item.suggestedAnchor}`,
-    '',
-    'Reason:',
-    item.reason,
-    '',
-    'Implementation note:',
-    item.verifyExistingLinkFirst
-      ? 'Verify whether this internal link already exists first. If it exists with clear anchor text, refine only if needed instead of adding a duplicate link.'
-      : 'Add the link where it naturally helps users move between related MaxVideoAI pages.',
-    '',
-    'Acceptance criteria:',
-    ...item.acceptanceCriteria.map((criterion) => `- ${criterion}`),
-  ].join('\n');
-}
-
-export function formatInternalLinkSectionMarkdown(items: InternalLinkSuggestion[]): string {
-  if (!items.length) {
-    return ['# Internal Link Suggestions', '', 'No internal link suggestions generated for this snapshot.'].join('\n');
-  }
-
-  return [
-    '# Internal Link Suggestions',
-    '',
-    `Generated suggestions: ${items.length}`,
-    '',
-    ...items.map((item, index) => [`## ${index + 1}. ${item.sourceUrl} -> ${item.targetUrl}`, '', formatInternalLinkMarkdown(item)].join('\n')),
-  ].join('\n\n');
-}
-
-export function labelizeInternalLinkType(value: InternalLinkRecommendationType) {
-  if (value === 'family_hub_to_model') return 'Family hub to model';
-  if (value === 'model_to_examples') return 'Model to examples';
-  if (value === 'compare_to_model') return 'Compare to model';
-  if (value === 'examples_to_model') return 'Examples to model';
-  if (value === 'pricing_to_model') return 'Pricing to model';
-  return 'Hub to opportunity';
-}
-
-export function labelizePageType(value: SeoPageType) {
-  return value
-    .replace(/_/g, ' ')
-    .replace(/\b\w/g, (letter) => letter.toUpperCase());
 }
 
 function buildSignalContext(options: BuildInternalLinkOptions) {
@@ -221,7 +183,7 @@ function buildClusterLinkDrafts(cluster: SeoQueryCluster): LinkDraft[] {
     }
   }
 
-  if (modelPath && modelSlug && STRATEGIC_FAMILIES.has(cluster.modelFamily) && cluster.metrics.impressions >= 90 && isLinkableIntent(cluster.intent)) {
+  if (modelPath && modelSlug && isStrategicInternalLinkFamily(cluster.modelFamily) && cluster.metrics.impressions >= 90 && isLinkableIntent(cluster.intent)) {
     const sourceUrl = isPromptOrExamplesIntent(cluster.intent) ? '/examples' : '/models';
     drafts.push({
       recommendationType: 'hub_to_opportunity',
@@ -329,137 +291,6 @@ function scoreToPriority(score: number): SeoActionPriority {
   return 'low';
 }
 
-function inferModelSlug(
-  cluster: SeoQueryCluster,
-  familyEntry: ReturnType<typeof getSeoFamilyDictionary>[number] | undefined
-) {
-  const targetPath = normalizePath(stripOrigin(cluster.targetUrl));
-  if (targetPath.startsWith('/models/')) return targetPath.split('/').filter(Boolean)[1] ?? null;
-  if (!familyEntry) return null;
-
-  const haystack = normalizeSeoQuery(`${cluster.representativeQueries.join(' ')} ${targetPath}`);
-  const modelSlug = familyEntry.modelSlugs
-    .slice()
-    .sort((a, b) => b.length - a.length)
-    .find((slug) => aliasInHaystack(slug, haystack) || aliasInHaystack(humanizeModelSlug(slug), haystack));
-
-  return preferCurrentModelSlug(modelSlug ?? null, familyEntry);
-}
-
-function preferCurrentModelSlug(
-  candidateSlug: string | null,
-  familyEntry: ReturnType<typeof getSeoFamilyDictionary>[number]
-) {
-  const currentSlugs = familyEntry.currentModelSlugs.length
-    ? familyEntry.currentModelSlugs
-    : familyEntry.defaultModelSlug
-      ? [familyEntry.defaultModelSlug]
-      : [];
-  if (!candidateSlug) return currentSlugs[0] ?? familyEntry.defaultModelSlug;
-  if (currentSlugs.includes(candidateSlug)) return candidateSlug;
-
-  const defaultSlug = familyEntry.defaultModelSlug;
-  if (defaultSlug && currentSlugs.includes(defaultSlug) && defaultSlug.startsWith(candidateSlug)) {
-    return defaultSlug;
-  }
-
-  return currentSlugs.find((slug) => slug.startsWith(candidateSlug)) ?? candidateSlug;
-}
-
-function buildExamplesToModelAnchor(cluster: SeoQueryCluster, family: StrategicSeoFamily, modelSlug: string) {
-  const modelName = chooseModelName(cluster, modelSlug);
-  if (cluster.intent === 'prompt_examples' || cluster.intent === 'prompt_guide') return `${modelName} prompt examples and specs`;
-  if (cluster.intent === 'examples') return `${modelName} examples and specs`;
-  return `${family} model specs`;
-}
-
-function buildModelToExamplesAnchor(cluster: SeoQueryCluster, family: StrategicSeoFamily, modelSlug: string) {
-  const modelName = chooseModelName(cluster, modelSlug);
-  if (cluster.intent === 'prompt_examples' || cluster.intent === 'prompt_guide') return `${modelName} prompt examples`;
-  if (cluster.intent === 'examples') return `${modelName} examples`;
-  return `${family} examples`;
-}
-
-function buildHubAnchor(cluster: SeoQueryCluster, modelSlug: string) {
-  const modelName = chooseModelName(cluster, modelSlug);
-  if (cluster.intent === 'prompt_examples' || cluster.intent === 'prompt_guide') return `${modelName} prompt examples`;
-  if (cluster.intent === 'comparison') return `${modelName} comparison`;
-  if (cluster.intent === 'pricing' || cluster.intent === 'pricing_specs') return `${modelName} pricing and specs`;
-  return `${modelName} model details`;
-}
-
-function chooseModelName(cluster: SeoQueryCluster, modelSlug: string) {
-  const queryText = cluster.representativeQueries.join(' ');
-  const versionMatch = queryText.match(/\b(?:ltx|seedance|veo|kling|pika|wan|sora|happy horse|hailuo|minimax|luma|ray)\s+(?:v)?\d+(?:[.\s-]\d+){0,2}(?:\s+(?:fast|lite|pro|standard|flash))?\b/i);
-  if (versionMatch) return titleize(versionMatch[0]);
-  return humanizeModelSlug(modelSlug);
-}
-
-function humanizeModelSlug(slug: string) {
-  return slug
-    .split('-')
-    .map((part) => {
-      if (/^\d+$/.test(part)) return part;
-      if (part === 'ltx') return 'LTX';
-      if (part === 'veo') return 'Veo';
-      if (part === 'wan') return 'Wan';
-      if (part === 'pika') return 'Pika';
-      if (part === 'sora') return 'Sora';
-      if (part === 'kling') return 'Kling';
-      if (part === 'seedance') return 'Seedance';
-      if (part === 'minimax') return 'MiniMax';
-      if (part === 'hailuo') return 'Hailuo';
-      if (part === 'luma') return 'Luma';
-      return part.charAt(0).toUpperCase() + part.slice(1);
-    })
-    .join(' ')
-    .replace(/\b2 3\b/g, '2.3')
-    .replace(/\b3 1\b/g, '3.1')
-    .replace(/\b2 0\b/g, '2.0')
-    .replace(/\b1 5\b/g, '1.5')
-    .replace(/\b1 0\b/g, '1.0');
-}
-
-function isPromptOrExamplesIntent(intent: SeoIntentType) {
-  return intent === 'prompt_examples' || intent === 'prompt_guide' || intent === 'examples';
-}
-
-function isModelPageIntent(intent: SeoIntentType) {
-  return isPromptOrExamplesIntent(intent) || intent === 'model_page' || intent === 'pricing_specs' || intent === 'specs';
-}
-
-function isLinkableIntent(intent: SeoIntentType) {
-  return (
-    isPromptOrExamplesIntent(intent) ||
-    intent === 'comparison' ||
-    intent === 'pricing' ||
-    intent === 'pricing_specs' ||
-    intent === 'pay_as_you_go' ||
-    intent === 'specs' ||
-    intent === 'max_length' ||
-    intent === 'image_to_video' ||
-    intent === 'text_to_video' ||
-    intent === 'model_page'
-  );
-}
-
-function isExpectedExistingLinkPattern(draft: LinkDraft) {
-  if (draft.recommendationType === 'compare_to_model' && draft.sourceType === 'compare_page') return true;
-  if (draft.recommendationType === 'model_to_examples' && draft.sourceType === 'model_page') return true;
-  if (
-    (draft.recommendationType === 'examples_to_model' || draft.recommendationType === 'hub_to_opportunity') &&
-    (draft.sourceType === 'family_examples' || draft.sourceType === 'examples_hub' || draft.sourceType === 'models_hub') &&
-    getSeoFamilyDictionary().some(
-      (entry) =>
-        entry.label === draft.family &&
-        entry.currentModelSlugs.includes(draft.targetUrl.replace('/models/', ''))
-    )
-  ) {
-    return true;
-  }
-  return false;
-}
-
 function dedupeSuggestions(items: InternalLinkSuggestion[]) {
   const best = new Map<string, InternalLinkSuggestion>();
   for (const item of items) {
@@ -506,53 +337,4 @@ function buildAcceptanceCriteria(item: LinkDraft) {
     criteria.push('Model and examples pages reinforce each other without turning either page into a link list');
   }
   return criteria;
-}
-
-function normalizePath(value: string | null) {
-  if (!value || value === 'No target URL') return '';
-  return value.split('?')[0].replace(/\/$/, '') || '/';
-}
-
-function aliasInHaystack(alias: string, haystack: string) {
-  const normalized = normalizeSeoQuery(alias);
-  if (!normalized) return false;
-  const escaped = normalized.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\ /g, '[\\s./-]+');
-  return new RegExp(`(^|[\\s/.-])${escaped}($|[\\s/.-])`, 'i').test(haystack);
-}
-
-function titleize(value: string) {
-  return value
-    .replace(/\s+/g, ' ')
-    .trim()
-    .replace(/\b\w/g, (letter) => letter.toUpperCase())
-    .replace(/\bLtx\b/g, 'LTX');
-}
-
-function signalKey(targetUrl: string | null, cluster: string) {
-  return `${normalizePath(stripOrigin(targetUrl))}|${normalizeSeoQuery(cluster)}`;
-}
-
-function formatMetrics(metrics: SeoSourceMetrics) {
-  return [
-    `${metrics.clicks} clicks`,
-    `${metrics.impressions} impressions`,
-    `${(metrics.ctr * 100).toFixed(2)}% CTR`,
-    `avg position ${metrics.averagePosition.toFixed(1)}`,
-  ].join(', ');
-}
-
-function priorityRank(priority: SeoActionPriority) {
-  if (priority === 'critical') return 1;
-  if (priority === 'high') return 2;
-  if (priority === 'medium') return 3;
-  return 4;
-}
-
-function stableId(value: string) {
-  let hash = 0;
-  for (let index = 0; index < value.length; index += 1) {
-    hash = (hash << 5) - hash + value.charCodeAt(index);
-    hash |= 0;
-  }
-  return Math.abs(hash).toString(36);
 }

--- a/frontend/lib/seo/seo-opportunity-engine.ts
+++ b/frontend/lib/seo/seo-opportunity-engine.ts
@@ -14,6 +14,9 @@ import {
   isStrategicIntent,
   normalizeSeoQuery,
 } from './seo-intents';
+import { stripOrigin } from './seo-url';
+
+export { stripOrigin } from './seo-url';
 
 const MIN_CLUSTER_IMPRESSIONS = 50;
 const MIN_STRATEGIC_IMPRESSIONS = 20;
@@ -83,16 +86,6 @@ export function summarizeRows(rows: GscPerformanceRow[]) {
     ctr: impressions ? clicks / impressions : 0,
     averagePosition,
   };
-}
-
-export function stripOrigin(url: string | null): string {
-  if (!url) return 'No target URL';
-  try {
-    const parsed = new URL(url);
-    return `${parsed.pathname}${parsed.search}`;
-  } catch {
-    return url;
-  }
 }
 
 function detectIssueTypes(cluster: SeoQueryCluster): StrategicSeoIssueType[];

--- a/frontend/lib/seo/seo-url.ts
+++ b/frontend/lib/seo/seo-url.ts
@@ -1,0 +1,9 @@
+export function stripOrigin(url: string | null): string {
+  if (!url) return 'No target URL';
+  try {
+    const parsed = new URL(url);
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return url;
+  }
+}

--- a/frontend/lib/seo/unified-action-brief-format.ts
+++ b/frontend/lib/seo/unified-action-brief-format.ts
@@ -1,0 +1,62 @@
+import type { UnifiedActionSourceModule, UnifiedPageActionBrief } from './internal-seo-types';
+
+export function formatUnifiedActionBriefMarkdown(brief: UnifiedPageActionBrief): string {
+  return [
+    'Title:',
+    titleForBrief(brief),
+    '',
+    'Target:',
+    brief.targetUrl,
+    '',
+    'Source signals:',
+    ...brief.combinedSignals.map((signal) => `- ${labelizeModule(signal.module)}: ${signal.summary}`),
+    '',
+    'Problem:',
+    brief.observedProblem,
+    '',
+    'Recommended implementation:',
+    brief.recommendedImplementation,
+    '',
+    'Supporting actions:',
+    ...brief.supportingActions.map((action) => `- ${action}`),
+    '',
+    'Risks / caveats:',
+    ...brief.risks.map((risk) => `- ${risk}`),
+    '',
+    'Acceptance criteria:',
+    ...brief.acceptanceCriteria.map((criterion) => `- ${criterion}`),
+  ].join('\n');
+}
+
+export function formatUnifiedActionBriefsMarkdown(briefs: UnifiedPageActionBrief[]): string {
+  if (!briefs.length) return ['# Recommended Page Actions', '', 'No unified page action briefs generated for this snapshot.'].join('\n');
+  return [
+    '# Recommended Page Actions',
+    '',
+    `Generated briefs: ${briefs.length}`,
+    '',
+    ...briefs.map((brief, index) => [`## ${index + 1}. ${titleForBrief(brief)}`, '', formatUnifiedActionBriefMarkdown(brief)].join('\n')),
+  ].join('\n\n');
+}
+
+export function titleForBrief(brief: Pick<UnifiedPageActionBrief, 'queryCluster' | 'targetUrl' | 'intent'>) {
+  if (brief.intent === 'prompt_examples' || brief.intent === 'prompt_guide' || brief.intent === 'examples') {
+    return `Strengthen ${brief.targetUrl} for ${brief.queryCluster}`;
+  }
+  if (brief.intent === 'comparison') return `Expand/defend ${brief.queryCluster} on ${brief.targetUrl}`;
+  if (brief.intent === 'brand_typo') return `Defend brand typo demand on ${brief.targetUrl}`;
+  return `Improve ${brief.targetUrl} for ${brief.queryCluster}`;
+}
+
+function labelizeModule(module: UnifiedActionSourceModule) {
+  if (module === 'opportunity_finder') return 'Opportunity Finder';
+  if (module === 'ctr_doctor') return 'CTR Doctor';
+  if (module === 'missing_content') return 'Missing Content';
+  if (module === 'internal_links') return 'Internal Links';
+  if (module === 'url_inspection') return 'URL Inspection';
+  return 'Momentum';
+}
+
+export function labelizeIssue(value: string) {
+  return value.replace(/_/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase());
+}

--- a/frontend/lib/seo/unified-action-briefs.ts
+++ b/frontend/lib/seo/unified-action-briefs.ts
@@ -16,6 +16,9 @@ import type {
 } from './internal-seo-types';
 import { compactIntentLabel } from './seo-intents';
 import { stripOrigin } from './seo-opportunity-engine';
+import { formatUnifiedActionBriefMarkdown, labelizeIssue } from './unified-action-brief-format';
+
+export { formatUnifiedActionBriefMarkdown, formatUnifiedActionBriefsMarkdown } from './unified-action-brief-format';
 
 type BuildUnifiedActionBriefsOptions = {
   opportunities?: StrategicSeoOpportunity[];
@@ -213,45 +216,6 @@ export function buildUnifiedActionBriefs(options: BuildUnifiedActionBriefsOption
     .map(finalizeBrief)
     .filter((brief) => shouldKeepBrief(brief))
     .sort((a, b) => priorityWeight[b.priority] - priorityWeight[a.priority] || b.score - a.score || a.targetUrl.localeCompare(b.targetUrl));
-}
-
-export function formatUnifiedActionBriefMarkdown(brief: UnifiedPageActionBrief): string {
-  return [
-    'Title:',
-    titleForBrief(brief),
-    '',
-    'Target:',
-    brief.targetUrl,
-    '',
-    'Source signals:',
-    ...brief.combinedSignals.map((signal) => `- ${labelizeModule(signal.module)}: ${signal.summary}`),
-    '',
-    'Problem:',
-    brief.observedProblem,
-    '',
-    'Recommended implementation:',
-    brief.recommendedImplementation,
-    '',
-    'Supporting actions:',
-    ...brief.supportingActions.map((action) => `- ${action}`),
-    '',
-    'Risks / caveats:',
-    ...brief.risks.map((risk) => `- ${risk}`),
-    '',
-    'Acceptance criteria:',
-    ...brief.acceptanceCriteria.map((criterion) => `- ${criterion}`),
-  ].join('\n');
-}
-
-export function formatUnifiedActionBriefsMarkdown(briefs: UnifiedPageActionBrief[]): string {
-  if (!briefs.length) return ['# Recommended Page Actions', '', 'No unified page action briefs generated for this snapshot.'].join('\n');
-  return [
-    '# Recommended Page Actions',
-    '',
-    `Generated briefs: ${briefs.length}`,
-    '',
-    ...briefs.map((brief, index) => [`## ${index + 1}. ${titleForBrief(brief)}`, '', formatUnifiedActionBriefMarkdown(brief)].join('\n')),
-  ].join('\n\n');
 }
 
 function getDraft(
@@ -496,26 +460,4 @@ function briefKey(targetUrl: string, queryCluster: string, family: string, inten
 
 function stableId(parts: string[]) {
   return `brief-${parts.join('|').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 96)}`;
-}
-
-function titleForBrief(brief: Pick<UnifiedPageActionBrief, 'queryCluster' | 'targetUrl' | 'intent'>) {
-  if (brief.intent === 'prompt_examples' || brief.intent === 'prompt_guide' || brief.intent === 'examples') {
-    return `Strengthen ${brief.targetUrl} for ${brief.queryCluster}`;
-  }
-  if (brief.intent === 'comparison') return `Expand/defend ${brief.queryCluster} on ${brief.targetUrl}`;
-  if (brief.intent === 'brand_typo') return `Defend brand typo demand on ${brief.targetUrl}`;
-  return `Improve ${brief.targetUrl} for ${brief.queryCluster}`;
-}
-
-function labelizeModule(module: UnifiedActionSourceModule) {
-  if (module === 'opportunity_finder') return 'Opportunity Finder';
-  if (module === 'ctr_doctor') return 'CTR Doctor';
-  if (module === 'missing_content') return 'Missing Content';
-  if (module === 'internal_links') return 'Internal Links';
-  if (module === 'url_inspection') return 'URL Inspection';
-  return 'Momentum';
-}
-
-function labelizeIssue(value: string) {
-  return value.replace(/_/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase());
 }

--- a/tests/seo-signal-architecture.test.ts
+++ b/tests/seo-signal-architecture.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const seoSignalFiles = [
+  'frontend/lib/seo/content-momentum.ts',
+  'frontend/lib/seo/content-momentum-format.ts',
+  'frontend/lib/seo/content-momentum-scoring.ts',
+  'frontend/lib/seo/internal-link-builder.ts',
+  'frontend/lib/seo/internal-link-builder-format.ts',
+  'frontend/lib/seo/internal-link-builder-helpers.ts',
+  'frontend/lib/seo/seo-opportunity-engine.ts',
+  'frontend/lib/seo/seo-url.ts',
+  'frontend/lib/seo/unified-action-briefs.ts',
+  'frontend/lib/seo/unified-action-brief-format.ts',
+];
+
+function source(path: string) {
+  return readFileSync(path, 'utf8');
+}
+
+function lineCount(path: string) {
+  return source(path).split('\n').length;
+}
+
+test('SEO signal helpers stay split across focused modules', () => {
+  seoSignalFiles.forEach((path) => {
+    assert.equal(existsSync(path), true, `${path} should exist`);
+    assert.ok(lineCount(path) < 500, `${path} should stay under 500 lines`);
+  });
+
+  const momentumSource = source('frontend/lib/seo/content-momentum.ts');
+  const internalLinksSource = source('frontend/lib/seo/internal-link-builder.ts');
+  const opportunitySource = source('frontend/lib/seo/seo-opportunity-engine.ts');
+  const unifiedSource = source('frontend/lib/seo/unified-action-briefs.ts');
+
+  assert.match(momentumSource, /content-momentum-format/);
+  assert.match(momentumSource, /content-momentum-scoring/);
+  assert.match(internalLinksSource, /internal-link-builder-format/);
+  assert.match(internalLinksSource, /internal-link-builder-helpers/);
+  assert.match(opportunitySource, /export \{ stripOrigin \} from '\.\/seo-url';/);
+  assert.match(unifiedSource, /unified-action-brief-format/);
+});


### PR DESCRIPTION
## Summary
- split content momentum formatting and scoring out of the builder facade
- split internal link formatting and helper logic out of the suggestion builder
- split unified action brief formatting and shared SEO URL helper while keeping public imports stable
- add architecture contract coverage for SEO signal helper boundaries

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/seo-signal-architecture.test.ts tests/seo-phase2a.test.ts tests/seo-internal-links.test.ts tests/seo-momentum.test.ts tests/seo-unified-action-briefs.test.ts
- pnpm --dir frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm --prefix frontend run seo:check
- npm run test:validate
- npm run architecture:audit -- --min-lines 500
- npm run lint:exposure
- git diff --check
