### PR TITLE
Split workspace media UI helpers

### DIFF
--- a/frontend/app/(core)/(workspace)/app/_lib/workspace-video-job-media.ts
+++ b/frontend/app/(core)/(workspace)/app/_lib/workspace-video-job-media.ts
@@ -1,0 +1,149 @@
+import type { SelectedVideoPreview } from '@/lib/video-preview-group';
+import type { SharedVideoPreview } from '@/lib/video-preview-group';
+import type { VideoGroup } from '@/types/video-groups';
+
+type VideoSettingsRecord = {
+  schemaVersion?: unknown;
+  surface?: unknown;
+  engineId?: unknown;
+  engineLabel?: unknown;
+  prompt?: unknown;
+  core?: unknown;
+};
+
+export type VideoJobPayload = {
+  ok?: boolean;
+  error?: string;
+  settingsSnapshot?: unknown;
+  videoUrl?: string;
+  previewVideoUrl?: string;
+  thumbUrl?: string;
+  aspectRatio?: string;
+  progress?: number;
+  status?: string;
+  pricing?: { totalCents?: number; currency?: string } | null;
+  finalPriceCents?: number;
+  currency?: string;
+  createdAt?: string;
+};
+
+export type VideoJobMediaPatch = {
+  videoUrl: string | null;
+  previewVideoUrl: string | null;
+  thumbUrl: string | null;
+  aspectRatio?: string;
+  progress?: number;
+  status?: string;
+};
+
+export type RequestedJobPreview = {
+  sharedVideo: SharedVideoPreview;
+  selectedPreview: SelectedVideoPreview;
+};
+
+function readRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function readFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+export function buildVideoJobMediaPatch(payload: VideoJobPayload): VideoJobMediaPatch | null {
+  const videoUrl = typeof payload.videoUrl === 'string' && payload.videoUrl.length ? payload.videoUrl : null;
+  const previewVideoUrl =
+    typeof payload.previewVideoUrl === 'string' && payload.previewVideoUrl.length ? payload.previewVideoUrl : null;
+  const thumbUrl = typeof payload.thumbUrl === 'string' && payload.thumbUrl.length ? payload.thumbUrl : null;
+  if (!videoUrl && !thumbUrl) return null;
+  return {
+    videoUrl,
+    previewVideoUrl,
+    thumbUrl,
+    aspectRatio: payload.aspectRatio,
+    progress: payload.progress,
+    status: payload.status,
+  };
+}
+
+export function applyVideoJobMediaPatchToSelectedPreview(
+  current: SelectedVideoPreview | null,
+  jobId: string,
+  patch: VideoJobMediaPatch
+): SelectedVideoPreview | null {
+  if (!current || (current.id !== jobId && current.localKey !== jobId)) return current;
+  return {
+    ...current,
+    videoUrl: patch.videoUrl ?? current.videoUrl,
+    previewVideoUrl: patch.previewVideoUrl ?? current.previewVideoUrl,
+    thumbUrl: patch.thumbUrl ?? current.thumbUrl,
+    aspectRatio: patch.aspectRatio ?? current.aspectRatio,
+    progress: typeof patch.progress === 'number' ? patch.progress : current.progress,
+    status: patch.status === 'failed' ? 'failed' : patch.status === 'pending' ? 'pending' : current.status,
+  };
+}
+
+export function applyVideoJobMediaPatchToCompositeOverride(
+  current: VideoGroup | null,
+  jobId: string,
+  patch: VideoJobMediaPatch
+): VideoGroup | null {
+  if (!current) return current;
+  let changed = false;
+  const items = current.items.map((item) => {
+    if (item.id !== jobId && item.jobId !== jobId) return item;
+    changed = true;
+    return {
+      ...item,
+      url: patch.videoUrl ?? item.url,
+      previewUrl: patch.previewVideoUrl ?? item.previewUrl,
+      thumb: patch.thumbUrl ?? item.thumb,
+      aspect: patch.aspectRatio === '9:16' || patch.aspectRatio === '1:1' ? patch.aspectRatio : item.aspect,
+    };
+  });
+  return changed ? { ...current, items } : current;
+}
+
+export function buildRequestedJobPreview(requestedJobId: string, payload: VideoJobPayload): RequestedJobPreview | null {
+  const snapshot = payload.settingsSnapshot as VideoSettingsRecord | null | undefined;
+  if (snapshot?.schemaVersion !== 1 || snapshot?.surface !== 'video') return null;
+  const core = readRecord(snapshot.core);
+  const durationSec = readFiniteNumber(core.durationSec) ?? 0;
+  const engineId = typeof snapshot.engineId === 'string' ? snapshot.engineId : 'unknown-engine';
+  const engineLabel = typeof snapshot.engineLabel === 'string' ? snapshot.engineLabel : engineId;
+  const prompt = typeof snapshot.prompt === 'string' ? snapshot.prompt : '';
+  const patch = buildVideoJobMediaPatch(payload);
+  if (!patch) return null;
+
+  return {
+    sharedVideo: {
+      id: requestedJobId,
+      engineId,
+      engineLabel,
+      durationSec,
+      prompt,
+      thumbUrl: patch.thumbUrl ?? undefined,
+      videoUrl: patch.videoUrl ?? undefined,
+      previewVideoUrl: patch.previewVideoUrl ?? undefined,
+      aspectRatio: payload.aspectRatio ?? undefined,
+      createdAt:
+        typeof payload.createdAt === 'string' && payload.createdAt.length ? payload.createdAt : new Date().toISOString(),
+    },
+    selectedPreview: {
+      id: requestedJobId,
+      videoUrl: patch.videoUrl ?? undefined,
+      previewVideoUrl: patch.previewVideoUrl ?? undefined,
+      thumbUrl: patch.thumbUrl ?? undefined,
+      aspectRatio: payload.aspectRatio ?? undefined,
+      progress: typeof payload.progress === 'number' ? payload.progress : undefined,
+      status:
+        payload.status === 'failed'
+          ? 'failed'
+          : payload.status === 'completed'
+            ? 'completed'
+            : ('pending' as const),
+      priceCents: payload.finalPriceCents ?? payload.pricing?.totalCents ?? undefined,
+      currency: payload.currency ?? payload.pricing?.currency ?? undefined,
+      prompt,
+    },
+  };
+}

--- a/frontend/app/(core)/(workspace)/app/_lib/workspace-video-settings.ts
+++ b/frontend/app/(core)/(workspace)/app/_lib/workspace-video-settings.ts
@@ -1,9 +1,8 @@
 import type { MultiPromptScene } from '@/components/Composer';
 import type { KlingElementAsset, KlingElementState } from '@/components/KlingElementsBuilder';
 import type { QuadPreviewTile } from '@/components/QuadPreviewPanel';
-import type { SharedVideoPreview, SelectedVideoPreview } from '@/lib/video-preview-group';
+import type { SharedVideoPreview } from '@/lib/video-preview-group';
 import type { EngineCaps, Mode } from '@/types/engines';
-import type { VideoGroup } from '@/types/video-groups';
 import type { ReferenceAsset } from './workspace-assets';
 import { coerceStoredExtraInputValues, type FormState } from './workspace-form-state';
 import {
@@ -74,36 +73,6 @@ export type ResolvedVideoSettingsSnapshot = {
   };
   inputAssets: Record<string, (ReferenceAsset | null)[]> | null;
   klingElements: KlingElementState[] | null;
-};
-
-export type VideoJobPayload = {
-  ok?: boolean;
-  error?: string;
-  settingsSnapshot?: unknown;
-  videoUrl?: string;
-  previewVideoUrl?: string;
-  thumbUrl?: string;
-  aspectRatio?: string;
-  progress?: number;
-  status?: string;
-  pricing?: { totalCents?: number; currency?: string } | null;
-  finalPriceCents?: number;
-  currency?: string;
-  createdAt?: string;
-};
-
-export type VideoJobMediaPatch = {
-  videoUrl: string | null;
-  previewVideoUrl: string | null;
-  thumbUrl: string | null;
-  aspectRatio?: string;
-  progress?: number;
-  status?: string;
-};
-
-export type RequestedJobPreview = {
-  sharedVideo: SharedVideoPreview;
-  selectedPreview: SelectedVideoPreview;
 };
 
 function readRecord(value: unknown): Record<string, unknown> {
@@ -423,101 +392,10 @@ export function buildVideoSettingsSnapshotFromSharedVideo(sharedVideo: SharedVid
   };
 }
 
-export function buildVideoJobMediaPatch(payload: VideoJobPayload): VideoJobMediaPatch | null {
-  const videoUrl = typeof payload.videoUrl === 'string' && payload.videoUrl.length ? payload.videoUrl : null;
-  const previewVideoUrl =
-    typeof payload.previewVideoUrl === 'string' && payload.previewVideoUrl.length ? payload.previewVideoUrl : null;
-  const thumbUrl = typeof payload.thumbUrl === 'string' && payload.thumbUrl.length ? payload.thumbUrl : null;
-  if (!videoUrl && !thumbUrl) return null;
-  return {
-    videoUrl,
-    previewVideoUrl,
-    thumbUrl,
-    aspectRatio: payload.aspectRatio,
-    progress: payload.progress,
-    status: payload.status,
-  };
-}
-
-export function applyVideoJobMediaPatchToSelectedPreview(
-  current: SelectedVideoPreview | null,
-  jobId: string,
-  patch: VideoJobMediaPatch
-): SelectedVideoPreview | null {
-  if (!current || (current.id !== jobId && current.localKey !== jobId)) return current;
-  return {
-    ...current,
-    videoUrl: patch.videoUrl ?? current.videoUrl,
-    previewVideoUrl: patch.previewVideoUrl ?? current.previewVideoUrl,
-    thumbUrl: patch.thumbUrl ?? current.thumbUrl,
-    aspectRatio: patch.aspectRatio ?? current.aspectRatio,
-    progress: typeof patch.progress === 'number' ? patch.progress : current.progress,
-    status: patch.status === 'failed' ? 'failed' : patch.status === 'pending' ? 'pending' : current.status,
-  };
-}
-
-export function applyVideoJobMediaPatchToCompositeOverride(
-  current: VideoGroup | null,
-  jobId: string,
-  patch: VideoJobMediaPatch
-): VideoGroup | null {
-  if (!current) return current;
-  let changed = false;
-  const items = current.items.map((item) => {
-    if (item.id !== jobId && item.jobId !== jobId) return item;
-    changed = true;
-    return {
-      ...item,
-      url: patch.videoUrl ?? item.url,
-      previewUrl: patch.previewVideoUrl ?? item.previewUrl,
-      thumb: patch.thumbUrl ?? item.thumb,
-      aspect: patch.aspectRatio === '9:16' || patch.aspectRatio === '1:1' ? patch.aspectRatio : item.aspect,
-    };
-  });
-  return changed ? { ...current, items } : current;
-}
-
-export function buildRequestedJobPreview(requestedJobId: string, payload: VideoJobPayload): RequestedJobPreview | null {
-  const snapshot = payload.settingsSnapshot as VideoSettingsRecord | null | undefined;
-  if (snapshot?.schemaVersion !== 1 || snapshot?.surface !== 'video') return null;
-  const core = readRecord(snapshot.core);
-  const durationSec = readFiniteNumber(core.durationSec) ?? 0;
-  const engineId = typeof snapshot.engineId === 'string' ? snapshot.engineId : 'unknown-engine';
-  const engineLabel = typeof snapshot.engineLabel === 'string' ? snapshot.engineLabel : engineId;
-  const prompt = typeof snapshot.prompt === 'string' ? snapshot.prompt : '';
-  const patch = buildVideoJobMediaPatch(payload);
-  if (!patch) return null;
-
-  return {
-    sharedVideo: {
-      id: requestedJobId,
-      engineId,
-      engineLabel,
-      durationSec,
-      prompt,
-      thumbUrl: patch.thumbUrl ?? undefined,
-      videoUrl: patch.videoUrl ?? undefined,
-      previewVideoUrl: patch.previewVideoUrl ?? undefined,
-      aspectRatio: payload.aspectRatio ?? undefined,
-      createdAt:
-        typeof payload.createdAt === 'string' && payload.createdAt.length ? payload.createdAt : new Date().toISOString(),
-    },
-    selectedPreview: {
-      id: requestedJobId,
-      videoUrl: patch.videoUrl ?? undefined,
-      previewVideoUrl: patch.previewVideoUrl ?? undefined,
-      thumbUrl: patch.thumbUrl ?? undefined,
-      aspectRatio: payload.aspectRatio ?? undefined,
-      progress: typeof payload.progress === 'number' ? payload.progress : undefined,
-      status:
-        payload.status === 'failed'
-          ? 'failed'
-          : payload.status === 'completed'
-            ? 'completed'
-            : ('pending' as const),
-      priceCents: payload.finalPriceCents ?? payload.pricing?.totalCents ?? undefined,
-      currency: payload.currency ?? payload.pricing?.currency ?? undefined,
-      prompt,
-    },
-  };
-}
+export {
+  applyVideoJobMediaPatchToCompositeOverride,
+  applyVideoJobMediaPatchToSelectedPreview,
+  buildRequestedJobPreview,
+  buildVideoJobMediaPatch,
+} from './workspace-video-job-media';
+export type { RequestedJobPreview, VideoJobMediaPatch, VideoJobPayload } from './workspace-video-job-media';

--- a/frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx
+++ b/frontend/app/(core)/(workspace)/app/image/ImageWorkspace.tsx
@@ -1,22 +1,11 @@
 'use client';
 
-/* eslint-disable @next/next/no-img-element */
-
-import clsx from 'clsx';
-import dynamic from 'next/dynamic';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { usePathname, useSearchParams } from 'next/navigation';
+import { useState } from 'react';
 import type { ImageGenerationMode } from '@/types/image-generation';
-import { useI18n } from '@/lib/i18n/I18nProvider';
-import { FEATURES } from '@/content/feature-flags';
-import { clampRequestedImageCount } from '@/lib/image/inputSchema';
-import {
-  parseGptImage2SizeKey,
-} from '@/lib/image/gptImage2';
-import { ImageAuthGateModal } from './_components/ImageAuthGateModal';
-import { ImageLibraryModal } from './_components/ImageLibraryModal';
 import { ImageWorkspaceComposerSurface } from './_components/ImageWorkspaceComposerSurface';
-import { ImageWorkspaceGalleryRail } from './_components/ImageWorkspaceGalleryRail';
+import { ImageWorkspaceEmptyState } from './_components/ImageWorkspaceEmptyState';
+import { ImageWorkspaceRuntimeModals } from './_components/ImageWorkspaceRuntimeModals';
+import { ImageWorkspaceShell } from './_components/ImageWorkspaceShell';
 import { useImageWorkspaceDisplayState } from './_hooks/useImageWorkspaceDisplayState';
 import { useImageGallerySelection } from './_hooks/useImageGallerySelection';
 import { useImageGenerationRunner } from './_hooks/useImageGenerationRunner';
@@ -30,11 +19,10 @@ import { useImageReferenceSlots } from './_hooks/useImageReferenceSlots';
 import { useImageComposerPersistence } from './_hooks/useImageComposerPersistence';
 import { useImageWorkspaceReferenceAssets } from './_hooks/useImageWorkspaceReferenceAssets';
 import { useImageWorkspaceViewer } from './_hooks/useImageWorkspaceViewer';
-import {
-  DEFAULT_COPY,
-  mergeCopy,
-  type ImageWorkspaceCopy,
-} from './_lib/image-workspace-copy';
+import { useImageWorkspaceRouteContext } from './_hooks/useImageWorkspaceRouteContext';
+import { useImageWorkspaceModeSync } from './_hooks/useImageWorkspaceModeSync';
+import { useImageWorkspacePresetHandlers } from './_hooks/useImageWorkspacePresetHandlers';
+import { useImageWorkspaceSelectedEngine } from './_hooks/useImageWorkspaceSelectedEngine';
 import {
   type HistoryEntry,
   type ImageEngineOption,
@@ -42,29 +30,18 @@ import {
 
 export type { ImageEngineOption } from './_lib/image-workspace-types';
 
-const GroupViewerModal = dynamic(
-  () => import('@/components/groups/GroupViewerModal').then((mod) => mod.GroupViewerModal),
-  { ssr: false }
-);
-
 interface ImageWorkspaceProps {
   engines: ImageEngineOption[];
 }
 
 export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
-  const toolsEnabled = FEATURES.workflows.toolsSection;
-  const { t } = useI18n();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const rawCopy = t('workspace.image', DEFAULT_COPY);
-  const resolvedCopy = useMemo<ImageWorkspaceCopy>(() => {
-    return mergeCopy(DEFAULT_COPY, (rawCopy ?? {}) as Partial<ImageWorkspaceCopy>);
-  }, [rawCopy]);
-  const loginRedirectTarget = useMemo(() => {
-    const params = searchParams?.toString() ?? '';
-    const base = pathname ?? '/app/image';
-    return params ? `${base}?${params}` : base;
-  }, [pathname, searchParams]);
+  const {
+    advancedSettingsTitle,
+    loginRedirectTarget,
+    resolvedCopy,
+    searchParams,
+    toolsEnabled,
+  } = useImageWorkspaceRouteContext();
   const [engineId, setEngineId] = useState(() => engines[0]?.id ?? '');
   const [mode, setMode] = useState<ImageGenerationMode>('t2i');
   const [prompt, setPrompt] = useState('');
@@ -93,15 +70,12 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
     handleSaveVariantToLibrary,
     viewerGroup,
   } = useImageWorkspaceViewer();
-  const engineCapsList = useMemo(() => engines.map((engine) => engine.engineCaps), [engines]);
-  const selectedEngine = useMemo(
-    () => engines.find((engine) => engine.id === engineId) ?? engines[0],
-    [engineId, engines]
-  );
-  const autoModeFromReferences = Boolean(
-    selectedEngine && selectedEngine.modes.includes('t2i') && selectedEngine.modes.includes('i2i')
-  );
-  const selectedEngineCaps = selectedEngine?.engineCaps ?? engines[0]?.engineCaps;
+  const {
+    autoModeFromReferences,
+    engineCapsList,
+    selectedEngine,
+    selectedEngineCaps,
+  } = useImageWorkspaceSelectedEngine(engines, engineId);
   const {
     aspectRatioField,
     aspectRatioSelectOptions,
@@ -212,18 +186,13 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
 
   const referenceNoteText = resolvedCopy.composer.referenceNote;
 
-  useEffect(() => {
-    if (!selectedEngine || !autoModeFromReferences) return;
-    const desiredMode: ImageGenerationMode =
-      hasAnyReferenceSelection && selectedEngine.modes.includes('i2i')
-        ? 'i2i'
-        : selectedEngine.modes.includes('t2i')
-          ? 't2i'
-          : (selectedEngine.modes[0] as ImageGenerationMode);
-    if (mode !== desiredMode) {
-      setMode(desiredMode);
-    }
-  }, [autoModeFromReferences, hasAnyReferenceSelection, mode, selectedEngine]);
+  useImageWorkspaceModeSync({
+    autoModeFromReferences,
+    hasAnyReferenceSelection,
+    mode,
+    selectedEngine,
+    setMode,
+  });
 
   useImageComposerPersistence({
     engines,
@@ -287,18 +256,14 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
     setThinkingLevel,
   });
 
-  const setNumImagesPreset = useCallback((value: number) => {
-    setNumImages(clampRequestedImageCount(selectedEngineCaps ?? null, mode, value));
-  }, [selectedEngineCaps, mode]);
-
-  const setResolutionPreset = useCallback((value: string) => {
-    setResolution(value);
-    const parsedSize = parseGptImage2SizeKey(value);
-    if (parsedSize) {
-      setCustomImageWidth(String(parsedSize.width));
-      setCustomImageHeight(String(parsedSize.height));
-    }
-  }, []);
+  const { setNumImagesPreset, setResolutionPreset } = useImageWorkspacePresetHandlers({
+    mode,
+    selectedEngineCaps,
+    setCustomImageHeight,
+    setCustomImageWidth,
+    setNumImages,
+    setResolution,
+  });
 
   const handleRun = useImageGenerationRunner({
     aspectRatio,
@@ -385,20 +350,13 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
     canUseWorkspace,
     genericError: resolvedCopy.errors.generic,
     previewEntry,
-    removedFromLibraryMessage: t(
-      'workspace.image.messages.removedFromLibrary',
-      DEFAULT_COPY.messages.removedFromLibrary
-    ) as string,
-    savedToLibraryMessage: t(
-      'workspace.image.messages.savedToLibrary',
-      DEFAULT_COPY.messages.savedToLibrary
-    ) as string,
+    removedFromLibraryMessage: resolvedCopy.messages.removedFromLibrary,
+    savedToLibraryMessage: resolvedCopy.messages.savedToLibrary,
     selectedPreviewImageIndex,
     setError,
     setStatusMessage,
   });
 
-  const advancedSettingsTitle = t('workspace.generate.controls.advancedTitle', 'Advanced settings') as string;
   const {
     composerReferenceAssets,
     referenceAssetFields,
@@ -416,19 +374,22 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
   });
 
   if (!selectedEngine || !selectedEngineCaps) {
-    return (
-      <main className="flex flex-1 items-center justify-center bg-bg text-text-secondary">
-        {resolvedCopy.general.emptyEngines}
-      </main>
-    );
+    return <ImageWorkspaceEmptyState message={resolvedCopy.general.emptyEngines} />;
   }
 
   return (
     <>
-      <div className={clsx('flex w-full flex-1 min-w-0', isDesktopLayout ? 'flex-row' : 'flex-col')}>
-        <div className="flex w-full flex-1 min-w-0 flex-col overflow-hidden">
-          <main className="flex w-full flex-1 min-w-0 flex-col gap-[var(--stack-gap-lg)] p-4 sm:p-6">
-            <ImageWorkspaceComposerSurface
+      <ImageWorkspaceShell
+        isDesktopLayout={isDesktopLayout}
+        galleryRailProps={{
+          activeGroups: pendingGroups,
+          engineCapsList,
+          isImageJob,
+          onOpenGroup: handleSelectGalleryGroup,
+          selectedEngineCaps,
+        }}
+      >
+        <ImageWorkspaceComposerSurface
               advancedSettingsTitle={advancedSettingsTitle}
               aspectRatio={aspectRatio}
               aspectRatioSelectOptions={aspectRatioSelectOptions}
@@ -511,60 +472,26 @@ export default function ImageWorkspace({ engines }: ImageWorkspaceProps) {
               statusMessage={statusMessage}
               thinkingLevel={thinkingLevel}
               thinkingLevelSelectOptions={thinkingLevelSelectOptions}
-            />
-          </main>
-        </div>
-        {isDesktopLayout ? (
-          <ImageWorkspaceGalleryRail
-            activeGroups={pendingGroups}
-            engineCapsList={engineCapsList}
-            isImageJob={isImageJob}
-            onOpenGroup={handleSelectGalleryGroup}
-            selectedEngineCaps={selectedEngineCaps}
-            variant="desktop"
-          />
-        ) : null}
-      </div>
-      {!isDesktopLayout ? (
-        <ImageWorkspaceGalleryRail
-          activeGroups={pendingGroups}
-          engineCapsList={engineCapsList}
-          isImageJob={isImageJob}
-          onOpenGroup={handleSelectGalleryGroup}
-          selectedEngineCaps={selectedEngineCaps}
-          variant="mobile"
         />
-      ) : null}
-      {viewerGroup ? (
-        <GroupViewerModal
-          group={viewerGroup}
-          onClose={closeViewer}
-          onSaveToLibrary={handleSaveVariantToLibrary}
-        />
-      ) : null}
-      <ImageAuthGateModal
-        open={authModalOpen}
-        copy={resolvedCopy.authGate}
+      </ImageWorkspaceShell>
+      <ImageWorkspaceRuntimeModals
+        authModalOpen={authModalOpen}
+        characterSelectionLimit={characterSelectionLimit}
+        closeLibraryModal={closeLibraryModal}
+        closeViewer={closeViewer}
+        handleLibrarySelect={handleLibrarySelect}
+        handleSaveVariantToLibrary={handleSaveVariantToLibrary}
+        libraryModal={libraryModal}
         loginRedirectTarget={loginRedirectTarget}
-        onClose={() => setAuthModalOpen(false)}
+        resolvedCopy={resolvedCopy}
+        selectedCharacterReferences={selectedCharacterReferences}
+        setAuthModalOpen={setAuthModalOpen}
+        supportedReferenceFormats={supportedReferenceFormats}
+        supportedReferenceFormatsLabel={supportedReferenceFormatsLabel}
+        toggleCharacterReference={toggleCharacterReference}
+        toolsEnabled={toolsEnabled}
+        viewerGroup={viewerGroup}
       />
-      {libraryModal.open ? (
-        <ImageLibraryModal
-          open={libraryModal.open}
-          onClose={closeLibraryModal}
-          onSelect={handleLibrarySelect}
-          onToggleCharacter={toggleCharacterReference}
-          selectedCharacterReferences={selectedCharacterReferences}
-          characterSelectionLimit={characterSelectionLimit}
-          copy={resolvedCopy.library}
-          characterCopy={resolvedCopy.characterPicker}
-          selectionMode={libraryModal.selectionMode}
-          initialSource={libraryModal.initialSource}
-          supportedFormats={supportedReferenceFormats}
-          supportedFormatsLabel={supportedReferenceFormatsLabel}
-          toolsEnabled={toolsEnabled}
-        />
-      ) : null}
     </>
   );
 }

--- a/frontend/app/(core)/(workspace)/app/image/_components/ImageWorkspaceEmptyState.tsx
+++ b/frontend/app/(core)/(workspace)/app/image/_components/ImageWorkspaceEmptyState.tsx
@@ -1,0 +1,11 @@
+type ImageWorkspaceEmptyStateProps = {
+  message: string;
+};
+
+export function ImageWorkspaceEmptyState({ message }: ImageWorkspaceEmptyStateProps) {
+  return (
+    <main className="flex flex-1 items-center justify-center bg-bg text-text-secondary">
+      {message}
+    </main>
+  );
+}

--- a/frontend/app/(core)/(workspace)/app/image/_components/ImageWorkspaceRuntimeModals.tsx
+++ b/frontend/app/(core)/(workspace)/app/image/_components/ImageWorkspaceRuntimeModals.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import type { Dispatch, SetStateAction } from 'react';
+import type { MediaLightboxEntry } from '@/components/MediaLightbox';
+import type { CharacterReferenceSelection } from '@/types/image-generation';
+import type { VideoGroup } from '@/types/video-groups';
+import { ImageAuthGateModal } from './ImageAuthGateModal';
+import { ImageLibraryModal } from './ImageLibraryModal';
+import type { ImageWorkspaceCopy } from '../_lib/image-workspace-copy';
+import type {
+  ImageLibraryModalState,
+  LibraryAsset,
+} from '../_lib/image-workspace-types';
+
+const GroupViewerModal = dynamic(
+  () => import('@/components/groups/GroupViewerModal').then((mod) => mod.GroupViewerModal),
+  { ssr: false }
+);
+
+type ImageWorkspaceRuntimeModalsProps = {
+  authModalOpen: boolean;
+  characterSelectionLimit: number;
+  closeLibraryModal: () => void;
+  closeViewer: () => void;
+  handleLibrarySelect: (asset: LibraryAsset) => void;
+  handleSaveVariantToLibrary: (entry: MediaLightboxEntry) => Promise<void>;
+  libraryModal: ImageLibraryModalState;
+  loginRedirectTarget: string;
+  resolvedCopy: ImageWorkspaceCopy;
+  selectedCharacterReferences: CharacterReferenceSelection[];
+  setAuthModalOpen: Dispatch<SetStateAction<boolean>>;
+  supportedReferenceFormats: string[];
+  supportedReferenceFormatsLabel: string;
+  toggleCharacterReference: (reference: CharacterReferenceSelection) => void;
+  toolsEnabled: boolean;
+  viewerGroup: VideoGroup | null;
+};
+
+export function ImageWorkspaceRuntimeModals({
+  authModalOpen,
+  characterSelectionLimit,
+  closeLibraryModal,
+  closeViewer,
+  handleLibrarySelect,
+  handleSaveVariantToLibrary,
+  libraryModal,
+  loginRedirectTarget,
+  resolvedCopy,
+  selectedCharacterReferences,
+  setAuthModalOpen,
+  supportedReferenceFormats,
+  supportedReferenceFormatsLabel,
+  toggleCharacterReference,
+  toolsEnabled,
+  viewerGroup,
+}: ImageWorkspaceRuntimeModalsProps) {
+  return (
+    <>
+      {viewerGroup ? (
+        <GroupViewerModal
+          group={viewerGroup}
+          onClose={closeViewer}
+          onSaveToLibrary={handleSaveVariantToLibrary}
+        />
+      ) : null}
+      <ImageAuthGateModal
+        open={authModalOpen}
+        copy={resolvedCopy.authGate}
+        loginRedirectTarget={loginRedirectTarget}
+        onClose={() => setAuthModalOpen(false)}
+      />
+      {libraryModal.open ? (
+        <ImageLibraryModal
+          open={libraryModal.open}
+          onClose={closeLibraryModal}
+          onSelect={handleLibrarySelect}
+          onToggleCharacter={toggleCharacterReference}
+          selectedCharacterReferences={selectedCharacterReferences}
+          characterSelectionLimit={characterSelectionLimit}
+          copy={resolvedCopy.library}
+          characterCopy={resolvedCopy.characterPicker}
+          selectionMode={libraryModal.selectionMode}
+          initialSource={libraryModal.initialSource}
+          supportedFormats={supportedReferenceFormats}
+          supportedFormatsLabel={supportedReferenceFormatsLabel}
+          toolsEnabled={toolsEnabled}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/frontend/app/(core)/(workspace)/app/image/_components/ImageWorkspaceShell.tsx
+++ b/frontend/app/(core)/(workspace)/app/image/_components/ImageWorkspaceShell.tsx
@@ -1,0 +1,44 @@
+import clsx from 'clsx';
+import type { ReactNode } from 'react';
+import type { EngineCaps } from '@/types/engines';
+import type { GroupSummary } from '@/types/groups';
+import type { Job } from '@/types/jobs';
+import { ImageWorkspaceGalleryRail } from './ImageWorkspaceGalleryRail';
+
+type ImageWorkspaceGalleryRailBaseProps = {
+  activeGroups: GroupSummary[];
+  engineCapsList: EngineCaps[];
+  isImageJob: (job: Job) => boolean;
+  onOpenGroup: (group: GroupSummary) => void;
+  selectedEngineCaps: EngineCaps;
+};
+
+type ImageWorkspaceShellProps = {
+  children: ReactNode;
+  galleryRailProps: ImageWorkspaceGalleryRailBaseProps;
+  isDesktopLayout: boolean;
+};
+
+export function ImageWorkspaceShell({
+  children,
+  galleryRailProps,
+  isDesktopLayout,
+}: ImageWorkspaceShellProps) {
+  return (
+    <>
+      <div className={clsx('flex w-full flex-1 min-w-0', isDesktopLayout ? 'flex-row' : 'flex-col')}>
+        <div className="flex w-full flex-1 min-w-0 flex-col overflow-hidden">
+          <main className="flex w-full flex-1 min-w-0 flex-col gap-[var(--stack-gap-lg)] p-4 sm:p-6">
+            {children}
+          </main>
+        </div>
+        {isDesktopLayout ? (
+          <ImageWorkspaceGalleryRail {...galleryRailProps} variant="desktop" />
+        ) : null}
+      </div>
+      {!isDesktopLayout ? (
+        <ImageWorkspaceGalleryRail {...galleryRailProps} variant="mobile" />
+      ) : null}
+    </>
+  );
+}

--- a/frontend/app/(core)/(workspace)/app/image/_hooks/useImageReferenceSlots.ts
+++ b/frontend/app/(core)/(workspace)/app/image/_hooks/useImageReferenceSlots.ts
@@ -12,12 +12,19 @@ import { getReferenceConstraints } from '@/lib/image/inputSchema';
 import { createCharacterReferenceSlot } from '../_lib/image-workspace-character-references';
 import { formatTemplate, type ImageWorkspaceCopy } from '../_lib/image-workspace-copy';
 import {
+  buildPersistableReferenceSlots,
+  cleanupSlotPreview,
+  countRegularReferenceSelections,
+  getReadyReferenceSlots,
+  getReferenceSizeSignature,
+  getSelectedCharacterReferences,
+} from '../_lib/image-reference-slot-state';
+import {
   DEFAULT_UPLOAD_LIMIT_MB,
   DEFAULT_VISIBLE_REFERENCE_SLOTS,
   MAX_REFERENCE_SLOTS,
   type ImageLibraryModalState,
   type LibraryAsset,
-  type PersistedReferenceSlot,
   type ReferenceSlotValue,
   type UploadFailure,
 } from '../_lib/image-workspace-types';
@@ -32,14 +39,6 @@ type UseImageReferenceSlotsParams = {
   supportedReferenceFormatsLabel: string;
   toolsEnabled: boolean;
 };
-
-function cleanupSlotPreview(slot: ReferenceSlotValue | null) {
-  if (slot?.previewUrl && slot.previewUrl.startsWith('blob:')) {
-    try {
-      URL.revokeObjectURL(slot.previewUrl);
-    } catch {}
-  }
-}
 
 export function useImageReferenceSlots({
   autoModeFromReferences,
@@ -84,25 +83,15 @@ export function useImageReferenceSlots({
     [baseReferenceSlotLimit, referenceSlots]
   );
   const referenceSizeSignature = useMemo(
-    () =>
-      visibleReferenceSlots
-        .filter((slot): slot is ReferenceSlotValue => Boolean(slot && slot.status === 'ready'))
-        .map((slot) => `${slot.width ?? ''}x${slot.height ?? ''}`)
-        .join('|'),
+    () => getReferenceSizeSignature(visibleReferenceSlots),
     [visibleReferenceSlots]
   );
   const selectedCharacterReferences = useMemo(
-    () =>
-      visibleReferenceSlots.reduce<CharacterReferenceSelection[]>((acc, slot) => {
-        if (slot?.characterReference) {
-          acc.push(slot.characterReference);
-        }
-        return acc;
-      }, []),
+    () => getSelectedCharacterReferences(visibleReferenceSlots),
     [visibleReferenceSlots]
   );
   const totalRegularReferenceSelections = useMemo(
-    () => visibleReferenceSlots.filter((slot) => Boolean(slot && !slot.characterReference)).length,
+    () => countRegularReferenceSelections(visibleReferenceSlots),
     [visibleReferenceSlots]
   );
   const characterSelectionLimit = useMemo(
@@ -147,17 +136,11 @@ export function useImageReferenceSlots({
     ]
   );
   const readyReferenceUrls = useMemo(
-    () =>
-      visibleReferenceSlots
-        .filter((slot): slot is ReferenceSlotValue => Boolean(slot && slot.status === 'ready'))
-        .map((slot) => slot.url),
+    () => getReadyReferenceSlots(visibleReferenceSlots).map((slot) => slot.url),
     [visibleReferenceSlots]
   );
   const readyReferenceSizes = useMemo(
-    () =>
-      visibleReferenceSlots
-        .filter((slot): slot is ReferenceSlotValue => Boolean(slot && slot.status === 'ready'))
-        .map((slot) => ({ width: slot.width ?? null, height: slot.height ?? null })),
+    () => getReadyReferenceSlots(visibleReferenceSlots).map((slot) => ({ width: slot.width ?? null, height: slot.height ?? null })),
     [visibleReferenceSlots]
   );
   const combinedReferenceUrls = readyReferenceUrls;
@@ -165,32 +148,8 @@ export function useImageReferenceSlots({
     () => visibleReferenceSlots.some((slot) => Boolean(slot)),
     [visibleReferenceSlots]
   );
-  const persistableReferenceSlots = useMemo<PersistedReferenceSlot[]>(
-    () =>
-      referenceSlots.slice(0, MAX_REFERENCE_SLOTS).map((slot) => {
-        if (!slot || slot.status !== 'ready') return null;
-        const url = slot.url?.trim?.() ?? '';
-        if (!url || url.startsWith('blob:')) return null;
-        return {
-          url,
-          source: slot.source,
-          width: slot.width ?? null,
-          height: slot.height ?? null,
-          characterReference: slot.characterReference
-            ? {
-                id: slot.characterReference.id,
-                jobId: slot.characterReference.jobId,
-                imageUrl: slot.characterReference.imageUrl,
-                thumbUrl: slot.characterReference.thumbUrl ?? null,
-                prompt: slot.characterReference.prompt ?? null,
-                createdAt: slot.characterReference.createdAt ?? null,
-                engineLabel: slot.characterReference.engineLabel ?? null,
-                outputMode: slot.characterReference.outputMode ?? null,
-                action: slot.characterReference.action ?? null,
-              }
-            : null,
-        };
-      }),
+  const persistableReferenceSlots = useMemo(
+    () => buildPersistableReferenceSlots(referenceSlots.slice(0, MAX_REFERENCE_SLOTS)),
     [referenceSlots]
   );
 

--- a/frontend/app/(core)/(workspace)/app/image/_hooks/useImageWorkspaceModeSync.ts
+++ b/frontend/app/(core)/(workspace)/app/image/_hooks/useImageWorkspaceModeSync.ts
@@ -1,0 +1,32 @@
+import { useEffect, type Dispatch, type SetStateAction } from 'react';
+import type { ImageGenerationMode } from '@/types/image-generation';
+import type { ImageEngineOption } from '../_lib/image-workspace-types';
+
+type UseImageWorkspaceModeSyncArgs = {
+  autoModeFromReferences: boolean;
+  hasAnyReferenceSelection: boolean;
+  mode: ImageGenerationMode;
+  selectedEngine?: ImageEngineOption;
+  setMode: Dispatch<SetStateAction<ImageGenerationMode>>;
+};
+
+export function useImageWorkspaceModeSync({
+  autoModeFromReferences,
+  hasAnyReferenceSelection,
+  mode,
+  selectedEngine,
+  setMode,
+}: UseImageWorkspaceModeSyncArgs) {
+  useEffect(() => {
+    if (!selectedEngine || !autoModeFromReferences) return;
+    const desiredMode: ImageGenerationMode =
+      hasAnyReferenceSelection && selectedEngine.modes.includes('i2i')
+        ? 'i2i'
+        : selectedEngine.modes.includes('t2i')
+          ? 't2i'
+          : (selectedEngine.modes[0] as ImageGenerationMode);
+    if (mode !== desiredMode) {
+      setMode(desiredMode);
+    }
+  }, [autoModeFromReferences, hasAnyReferenceSelection, mode, selectedEngine, setMode]);
+}

--- a/frontend/app/(core)/(workspace)/app/image/_hooks/useImageWorkspacePresetHandlers.ts
+++ b/frontend/app/(core)/(workspace)/app/image/_hooks/useImageWorkspacePresetHandlers.ts
@@ -1,0 +1,41 @@
+import { useCallback, type Dispatch, type SetStateAction } from 'react';
+import type { ImageGenerationMode } from '@/types/image-generation';
+import type { EngineCaps } from '@/types/engines';
+import { clampRequestedImageCount } from '@/lib/image/inputSchema';
+import { parseGptImage2SizeKey } from '@/lib/image/gptImage2';
+
+type UseImageWorkspacePresetHandlersArgs = {
+  mode: ImageGenerationMode;
+  selectedEngineCaps?: EngineCaps;
+  setCustomImageHeight: Dispatch<SetStateAction<string>>;
+  setCustomImageWidth: Dispatch<SetStateAction<string>>;
+  setNumImages: Dispatch<SetStateAction<number>>;
+  setResolution: Dispatch<SetStateAction<string | null>>;
+};
+
+export function useImageWorkspacePresetHandlers({
+  mode,
+  selectedEngineCaps,
+  setCustomImageHeight,
+  setCustomImageWidth,
+  setNumImages,
+  setResolution,
+}: UseImageWorkspacePresetHandlersArgs) {
+  const setNumImagesPreset = useCallback((value: number) => {
+    setNumImages(clampRequestedImageCount(selectedEngineCaps ?? null, mode, value));
+  }, [mode, selectedEngineCaps, setNumImages]);
+
+  const setResolutionPreset = useCallback((value: string) => {
+    setResolution(value);
+    const parsedSize = parseGptImage2SizeKey(value);
+    if (parsedSize) {
+      setCustomImageWidth(String(parsedSize.width));
+      setCustomImageHeight(String(parsedSize.height));
+    }
+  }, [setCustomImageHeight, setCustomImageWidth, setResolution]);
+
+  return {
+    setNumImagesPreset,
+    setResolutionPreset,
+  };
+}

--- a/frontend/app/(core)/(workspace)/app/image/_hooks/useImageWorkspaceRouteContext.ts
+++ b/frontend/app/(core)/(workspace)/app/image/_hooks/useImageWorkspaceRouteContext.ts
@@ -1,0 +1,33 @@
+import { useMemo } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { FEATURES } from '@/content/feature-flags';
+import { useI18n } from '@/lib/i18n/I18nProvider';
+import {
+  DEFAULT_COPY,
+  mergeCopy,
+  type ImageWorkspaceCopy,
+} from '../_lib/image-workspace-copy';
+
+export function useImageWorkspaceRouteContext() {
+  const { t } = useI18n();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const rawCopy = t('workspace.image', DEFAULT_COPY);
+  const resolvedCopy = useMemo<ImageWorkspaceCopy>(() => {
+    return mergeCopy(DEFAULT_COPY, (rawCopy ?? {}) as Partial<ImageWorkspaceCopy>);
+  }, [rawCopy]);
+  const advancedSettingsTitle = t('workspace.generate.controls.advancedTitle', 'Advanced settings') as string;
+  const loginRedirectTarget = useMemo(() => {
+    const params = searchParams?.toString() ?? '';
+    const base = pathname ?? '/app/image';
+    return params ? `${base}?${params}` : base;
+  }, [pathname, searchParams]);
+
+  return {
+    advancedSettingsTitle,
+    loginRedirectTarget,
+    resolvedCopy,
+    searchParams,
+    toolsEnabled: FEATURES.workflows.toolsSection,
+  };
+}

--- a/frontend/app/(core)/(workspace)/app/image/_hooks/useImageWorkspaceSelectedEngine.ts
+++ b/frontend/app/(core)/(workspace)/app/image/_hooks/useImageWorkspaceSelectedEngine.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+import type { ImageEngineOption } from '../_lib/image-workspace-types';
+
+export function useImageWorkspaceSelectedEngine(engines: ImageEngineOption[], engineId: string) {
+  const engineCapsList = useMemo(() => engines.map((engine) => engine.engineCaps), [engines]);
+  const selectedEngine = useMemo(
+    () => engines.find((engine) => engine.id === engineId) ?? engines[0],
+    [engineId, engines]
+  );
+  const autoModeFromReferences = Boolean(
+    selectedEngine && selectedEngine.modes.includes('t2i') && selectedEngine.modes.includes('i2i')
+  );
+  const selectedEngineCaps = selectedEngine?.engineCaps ?? engines[0]?.engineCaps;
+
+  return {
+    autoModeFromReferences,
+    engineCapsList,
+    selectedEngine,
+    selectedEngineCaps,
+  };
+}

--- a/frontend/app/(core)/(workspace)/app/image/_lib/image-reference-slot-state.ts
+++ b/frontend/app/(core)/(workspace)/app/image/_lib/image-reference-slot-state.ts
@@ -1,0 +1,67 @@
+import type { CharacterReferenceSelection } from '@/types/image-generation';
+import type {
+  PersistedReferenceSlot,
+  ReferenceSlotValue,
+} from './image-workspace-types';
+
+export function cleanupSlotPreview(slot: ReferenceSlotValue | null) {
+  if (slot?.previewUrl && slot.previewUrl.startsWith('blob:')) {
+    try {
+      URL.revokeObjectURL(slot.previewUrl);
+    } catch {}
+  }
+}
+
+export function getReadyReferenceSlots(slots: (ReferenceSlotValue | null)[]): ReferenceSlotValue[] {
+  return slots.filter((slot): slot is ReferenceSlotValue => Boolean(slot && slot.status === 'ready'));
+}
+
+export function getReferenceSizeSignature(slots: (ReferenceSlotValue | null)[]): string {
+  return getReadyReferenceSlots(slots)
+    .map((slot) => `${slot.width ?? ''}x${slot.height ?? ''}`)
+    .join('|');
+}
+
+export function getSelectedCharacterReferences(
+  slots: (ReferenceSlotValue | null)[]
+): CharacterReferenceSelection[] {
+  return slots.reduce<CharacterReferenceSelection[]>((acc, slot) => {
+    if (slot?.characterReference) {
+      acc.push(slot.characterReference);
+    }
+    return acc;
+  }, []);
+}
+
+export function countRegularReferenceSelections(slots: (ReferenceSlotValue | null)[]): number {
+  return slots.filter((slot) => Boolean(slot && !slot.characterReference)).length;
+}
+
+export function buildPersistableReferenceSlots(
+  slots: (ReferenceSlotValue | null)[]
+): PersistedReferenceSlot[] {
+  return slots.map((slot) => {
+    if (!slot || slot.status !== 'ready') return null;
+    const url = slot.url?.trim?.() ?? '';
+    if (!url || url.startsWith('blob:')) return null;
+    return {
+      url,
+      source: slot.source,
+      width: slot.width ?? null,
+      height: slot.height ?? null,
+      characterReference: slot.characterReference
+        ? {
+            id: slot.characterReference.id,
+            jobId: slot.characterReference.jobId,
+            imageUrl: slot.characterReference.imageUrl,
+            thumbUrl: slot.characterReference.thumbUrl ?? null,
+            prompt: slot.characterReference.prompt ?? null,
+            createdAt: slot.characterReference.createdAt ?? null,
+            engineLabel: slot.characterReference.engineLabel ?? null,
+            outputMode: slot.characterReference.outputMode ?? null,
+            action: slot.characterReference.action ?? null,
+          }
+        : null,
+    };
+  });
+}

--- a/frontend/src/components/ui/EngineSelect.tsx
+++ b/frontend/src/components/ui/EngineSelect.tsx
@@ -1,36 +1,30 @@
 'use client';
 
 import clsx from 'clsx';
-import { createPortal } from 'react-dom';
-import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 import {
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
-  useRef,
   useState,
   useId
 } from 'react';
-import type { EngineAvailability, EngineCaps, Mode } from '@/types/engines';
+import type { EngineCaps, Mode } from '@/types/engines';
 import { Card } from './Card';
 import { Chip } from './Chip';
 import { EngineIcon } from '@/components/ui/EngineIcon';
 import { useI18n } from '@/lib/i18n/I18nProvider';
 import { BrowseEnginesModal } from './engine-select/BrowseEnginesModal';
+import { EngineSelectDropdown } from './engine-select/EngineSelectDropdown';
 import { DEFAULT_ENGINE_SELECT_COPY, type EngineSelectCopy } from './engine-select/engine-select-copy';
 import {
-  compareEnginesByDefaultPriority,
   DEFAULT_MODE_OPTIONS,
-  ENGINE_LEGACY_STORAGE_KEY,
   ENGINE_VARIANT_LABEL_OVERRIDES,
-  ensureEngineRegistryMeta,
   formatAvgDuration,
-  getCachedEngineRegistryMeta,
-  getModeDisplayOrder,
   getModeLabel,
 } from './engine-select/engine-select-helpers';
-import type { DropdownPosition, EngineRegistryMeta, EngineSelectProps } from './engine-select/engine-select-types';
+import { useEngineSelectDropdownState } from './engine-select/useEngineSelectDropdownState';
+import { useEngineSelectRegistry } from './engine-select/useEngineSelectRegistry';
+import type { EngineSelectProps } from './engine-select/engine-select-types';
 
 export function EngineSelect({
   engines,
@@ -49,88 +43,23 @@ export function EngineSelect({
 }: EngineSelectProps) {
   const { t, locale } = useI18n();
   const copy = t('workspace.generate.engineSelect', DEFAULT_ENGINE_SELECT_COPY) as EngineSelectCopy;
-  const [registryMeta, setRegistryMeta] = useState<EngineRegistryMeta | null>(() => getCachedEngineRegistryMeta());
   const [open, setOpen] = useState(false);
-  const [position, setPosition] = useState<DropdownPosition | null>(null);
-  const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
-  const [portalElement, setPortalElement] = useState<HTMLDivElement | null>(null);
   const [browseOpen, setBrowseOpen] = useState(false);
-  const [showLegacy, setShowLegacy] = useState(false);
-  const [legacyHydrated, setLegacyHydrated] = useState(false);
-
-  const containerRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const contentRef = useRef<HTMLDivElement>(null);
-  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   const triggerId = useId();
   const legacyToggleId = useId();
 
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    try {
-      const stored = window.localStorage.getItem(ENGINE_LEGACY_STORAGE_KEY);
-      if (stored === 'true') {
-        setShowLegacy(true);
-      }
-    } catch {
-      // ignore storage failures
-    } finally {
-      setLegacyHydrated(true);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!legacyHydrated) return;
-    try {
-      window.localStorage.setItem(ENGINE_LEGACY_STORAGE_KEY, showLegacy ? 'true' : 'false');
-    } catch {
-      // ignore storage failures
-    }
-  }, [legacyHydrated, showLegacy]);
-
-  const availableEngines = useMemo(() => {
-    const sorted = engines.slice();
-    sorted.sort((a, b) => compareEnginesByDefaultPriority(a, b, registryMeta));
-    return sorted.filter((entry) => entry.availability !== 'paused');
-  }, [engines, registryMeta]);
-
-  const selectedEngine = useMemo(() => {
-    const candidate = availableEngines.find((entry) => entry.id === engineId);
-    return candidate ?? availableEngines[0] ?? engines[0];
-  }, [availableEngines, engineId, engines]);
-
-  const selectedMeta = useMemo(
-    () => (selectedEngine ? registryMeta?.meta.get(selectedEngine.id) : undefined),
-    [registryMeta, selectedEngine]
-  );
-
-  const visibleEngines = useMemo(() => {
-    return availableEngines.filter((engine) => {
-      const meta = registryMeta?.meta.get(engine.id);
-      if (!meta?.isLegacy) return true;
-      if (showLegacy) return true;
-      return engine.id === selectedEngine?.id;
-    });
-  }, [availableEngines, registryMeta, selectedEngine, showLegacy]);
-  const hasLegacyEngines = useMemo(
-    () => availableEngines.some((engine) => Boolean(registryMeta?.meta.get(engine.id)?.isLegacy)),
-    [availableEngines, registryMeta]
-  );
-  const legacyToggleLabel = copy.modal.legacyToggleLabel ?? DEFAULT_ENGINE_SELECT_COPY.modal.legacyToggleLabel;
-
-  const variantEngines = useMemo(() => {
-    if (!selectedEngine) return [];
-    const selectedVariantGroup = selectedMeta?.surfaces.app.variantGroup;
-    if (selectedVariantGroup) {
-      return availableEngines.filter(
-        (entry) => registryMeta?.meta.get(entry.id)?.surfaces.app.variantGroup === selectedVariantGroup
-      );
-    }
-    return [];
-  }, [availableEngines, registryMeta, selectedEngine, selectedMeta]);
-
-  const showVariantSelector = variantEngines.length > 1;
+  const {
+    hasLegacyEngines,
+    registryMeta,
+    selectedEngine,
+    selectedMeta,
+    setShowLegacy,
+    showLegacy,
+    showVariantSelector,
+    variantEngines,
+    visibleEngines,
+  } = useEngineSelectRegistry({ browseOpen, engineId, engines, open });
 
   const formatEngineShort = useCallback((engine: EngineCaps | null | undefined) => {
     if (!engine) return '';
@@ -147,50 +76,7 @@ export function EngineSelect({
     [registryMeta]
   );
 
-  useEffect(() => {
-    if (registryMeta) return;
-    if (typeof window === 'undefined') return;
-    let active = true;
-    const timer = window.setTimeout(() => {
-      ensureEngineRegistryMeta()
-        .then((meta) => {
-          if (active) setRegistryMeta(meta);
-        })
-        .catch(() => undefined);
-    }, 1200);
-    return () => {
-      active = false;
-      window.clearTimeout(timer);
-    };
-  }, [registryMeta]);
-
-  useEffect(() => {
-    if (registryMeta) return;
-    if (!open && !browseOpen) return;
-    let active = true;
-    ensureEngineRegistryMeta()
-      .then((meta) => {
-        if (active) setRegistryMeta(meta);
-      })
-      .catch(() => undefined);
-    return () => {
-      active = false;
-    };
-  }, [browseOpen, open, registryMeta]);
-
-  useEffect(() => {
-    const element = document.createElement('div');
-    element.dataset.engineSelectPortal = 'true';
-    document.body.appendChild(element);
-    setPortalElement(element);
-    return () => {
-      try {
-        if (element.parentNode) {
-          element.parentNode.removeChild(element);
-        }
-      } catch {}
-    };
-  }, []);
+  const legacyToggleLabel = copy.modal.legacyToggleLabel ?? DEFAULT_ENGINE_SELECT_COPY.modal.legacyToggleLabel;
 
   useEffect(() => {
     if (!selectedEngine) return;
@@ -214,130 +100,24 @@ export function EngineSelect({
 
   const showModeVariantSelector = modeVariantOptions.length > 1;
 
-  const updatePosition = useCallback(() => {
-    if (!triggerRef.current) return;
-    const rect = triggerRef.current.getBoundingClientRect();
-    setPosition({
-      top: rect.bottom + 8,
-      left: rect.left,
-      width: rect.width
-    });
-  }, []);
-
-  const toggleOpen = () => {
-    setOpen((previous) => {
-      const next = !previous;
-      if (next) {
-        updatePosition();
-      } else {
-        setHighlightedIndex(-1);
-      }
-      return next;
-    });
-  };
-
-  useLayoutEffect(() => {
-    if (!open) return;
-    updatePosition();
-
-    function handleResize() {
-      updatePosition();
-    }
-
-    window.addEventListener('resize', handleResize, { passive: true });
-    window.addEventListener('scroll', handleResize, { passive: true, capture: true });
-    return () => {
-      window.removeEventListener('resize', handleResize);
-      window.removeEventListener('scroll', handleResize, true);
-    };
-  }, [open, updatePosition]);
-
-  useEffect(() => {
-    if (!open) return;
-    if (!visibleEngines.length) {
-      setHighlightedIndex(-1);
-      return;
-    }
-    const currentIndex = visibleEngines.findIndex((candidate) => candidate.id === selectedEngine?.id);
-    setHighlightedIndex(currentIndex >= 0 ? currentIndex : 0);
-  }, [open, visibleEngines, selectedEngine]);
-
-  useEffect(() => {
-    if (!open) return;
-    function handlePointer(event: MouseEvent | TouchEvent) {
-      const target = event.target as Node;
-      if (triggerRef.current?.contains(target)) return;
-      if (contentRef.current?.contains(target)) return;
-      setOpen(false);
-      setHighlightedIndex(-1);
-    }
-
-    function handleKey(event: KeyboardEvent) {
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        setOpen(false);
-        setHighlightedIndex(-1);
-        triggerRef.current?.focus();
-        return;
-      }
-
-      if (!visibleEngines.length) {
-        return;
-      }
-
-      if (event.key === 'ArrowDown') {
-        event.preventDefault();
-        setHighlightedIndex((previous) => {
-          const next = previous + 1 >= visibleEngines.length ? 0 : previous + 1;
-          return next;
-        });
-      }
-
-      if (event.key === 'ArrowUp') {
-        event.preventDefault();
-        setHighlightedIndex((previous) => {
-          const next = previous - 1 < 0 ? visibleEngines.length - 1 : previous - 1;
-          return next;
-        });
-      }
-
-      if (event.key === 'Enter' || event.key === ' ') {
-        if (highlightedIndex >= 0 && highlightedIndex < visibleEngines.length) {
-          event.preventDefault();
-          onEngineChange(visibleEngines[highlightedIndex].id);
-          setOpen(false);
-          setHighlightedIndex(-1);
-          triggerRef.current?.focus();
-        }
-      }
-    }
-
-    document.addEventListener('mousedown', handlePointer);
-    document.addEventListener('touchstart', handlePointer, { passive: true });
-    document.addEventListener('keydown', handleKey);
-    return () => {
-      document.removeEventListener('mousedown', handlePointer);
-      document.removeEventListener('touchstart', handlePointer);
-      document.removeEventListener('keydown', handleKey);
-    };
-  }, [open, engines, highlightedIndex, onEngineChange, visibleEngines]);
-
-  useEffect(() => {
-    if (!open) return;
-    const item = itemRefs.current[highlightedIndex];
-    item?.focus({ preventScroll: true });
-    item?.scrollIntoView({ block: 'nearest' });
-  }, [open, highlightedIndex]);
-
-  const handleTriggerKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>) => {
-    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-      event.preventDefault();
-      if (!open) {
-        updatePosition();
-      }
-      setOpen(true);
-    }
-  };
+  const {
+    containerRef,
+    contentRef,
+    handleTriggerKeyDown,
+    highlightedIndex,
+    itemRefs,
+    portalElement,
+    position,
+    setHighlightedIndex,
+    toggleOpen,
+    triggerRef,
+  } = useEngineSelectDropdownState({
+    onEngineChange,
+    open,
+    selectedEngineId: selectedEngine?.id,
+    setOpen,
+    visibleEngines,
+  });
 
   if (!selectedEngine) {
     return null;
@@ -512,120 +292,43 @@ export function EngineSelect({
             </p>
           )}
 
-          {open && portalElement && position &&
-            createPortal(
-              <div
-                ref={contentRef}
-                className="fixed z-[9999]"
-                style={{ top: position.top, left: position.left, minWidth: Math.max(position.width, 280) }}
-              >
-                <div className="overflow-hidden rounded-card border border-border bg-surface shadow-float">
-                  <div className="flex items-center justify-between gap-4 border-b border-hairline px-3 py-2 text-[12px] text-text-muted">
-                    <span>Engines</span>
-                    <div className="flex items-center gap-3">
-                      {hasLegacyEngines ? (
-                        <label
-                          htmlFor={legacyToggleId}
-                          className="inline-flex items-center gap-2 whitespace-nowrap text-[11px] font-medium text-text-secondary"
-                        >
-                          <input
-                            id={legacyToggleId}
-                            type="checkbox"
-                            checked={showLegacy}
-                            onChange={(event) => setShowLegacy(event.currentTarget.checked)}
-                            className="h-4 w-4 rounded border border-border accent-brand"
-                          />
-                          <span>{legacyToggleLabel}</span>
-                        </label>
-                      ) : null}
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setOpen(false);
-                          setHighlightedIndex(-1);
-                          setBrowseOpen(true);
-                        }}
-                        className="rounded-input border border-transparent px-2 py-1 text-[11px] font-medium text-brand transition hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                      >
-                        {copy.browse}
-                      </button>
-                    </div>
-                  </div>
-                  <ul
-                    className="max-h-72 overflow-y-auto py-1"
-                    role="listbox"
-                    aria-labelledby={triggerId}
-                    aria-activedescendant={activeOptionId}
-                  >
-                    {visibleEngines.map((engine, index) => {
-                      const active = engine.id === selectedEngine.id;
-                      const highlighted = index === highlightedIndex;
-                      const meta = registryMeta?.meta.get(engine.id);
-                      const avgDurationLabel = formatAvgDuration(engine.avgDurationMs);
-                      const availability: EngineAvailability = meta?.availability ?? engine.availability ?? 'available';
-                      const disabled = availability === 'paused';
-                      return (
-                        <li key={engine.id}>
-                          <button
-                            ref={(node) => {
-                              itemRefs.current[index] = node;
-                            }}
-                            type="button"
-                            onClick={() => {
-                              if (disabled) return;
-                              onEngineChange(engine.id);
-                              setOpen(false);
-                              setHighlightedIndex(-1);
-                              triggerRef.current?.focus();
-                            }}
-                            onMouseEnter={() => setHighlightedIndex(index)}
-                            onFocus={() => setHighlightedIndex(index)}
-                            className={clsx(
-                              'flex w-full items-start gap-4 px-4 py-3 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-                              'hover:bg-surface-2',
-                              active && 'bg-surface-2',
-                              highlighted && !active && 'bg-surface-2',
-                              disabled && 'cursor-not-allowed opacity-60'
-                            )}
-                            role="option"
-                            id={`${engine.id}-option`}
-                            aria-selected={active}
-                            aria-disabled={disabled}
-                            disabled={disabled}
-                            tabIndex={-1}
-                          >
-                            <EngineIcon engine={engine} size={32} className="mt-0.5 shrink-0" />
-                            <div className="flex min-w-0 flex-1 items-start justify-between gap-4">
-                              <div className="min-w-0 space-y-1">
-                                <p className="truncate text-sm font-medium text-text-primary">{meta?.marketingName ?? formatEngineShort(engine)}</p>
-                                <p className="truncate text-[12px] text-text-muted">
-                                  {engine.provider} - {meta?.versionLabel ?? engine.version ?? '-'}
-                                </p>
-                                <div className="flex flex-wrap gap-1 text-[10px]">
-                                  {getModeDisplayOrder(engine.id, engine.modes).map((engineMode) => (
-                                    <Chip key={engineMode} variant="outline" className="px-1.5 py-0.5 text-[10px]">
-                                      {getModeLabel(engine.id, engineMode, locale, modeLabelOverrides)}
-                                    </Chip>
-                                  ))}
-                                  {engine.isLab && (
-                                    <Chip variant="ghost" className="px-1.5 py-0.5 text-[10px]">Lab</Chip>
-                                  )}
-                                </div>
-                              </div>
-                              <div className="flex flex-col items-end gap-1 text-[11px] text-text-muted">
-                                {avgDurationLabel && <span>{copy.avgDuration.replace('{value}', avgDurationLabel)}</span>}
-                                {engine.status && <span className="uppercase tracking-micro">{engine.status}</span>}
-                              </div>
-                            </div>
-                          </button>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                </div>
-              </div>,
-              portalElement
-            )}
+          {open && portalElement && position ? (
+            <EngineSelectDropdown
+              activeOptionId={activeOptionId}
+              contentRef={contentRef}
+              copy={copy}
+              formatEngineShort={formatEngineShort}
+              hasLegacyEngines={hasLegacyEngines}
+              highlightedIndex={highlightedIndex}
+              legacyToggleId={legacyToggleId}
+              legacyToggleLabel={legacyToggleLabel}
+              locale={locale}
+              modeLabelOverrides={modeLabelOverrides}
+              onBrowse={() => {
+                setOpen(false);
+                setHighlightedIndex(-1);
+                setBrowseOpen(true);
+              }}
+              onHighlight={setHighlightedIndex}
+              onItemRef={(index, node) => {
+                itemRefs.current[index] = node;
+              }}
+              onSelectEngine={(nextEngineId) => {
+                onEngineChange(nextEngineId);
+                setOpen(false);
+                setHighlightedIndex(-1);
+                triggerRef.current?.focus();
+              }}
+              onToggleLegacy={setShowLegacy}
+              portalElement={portalElement}
+              position={position}
+              registryMeta={registryMeta}
+              selectedEngine={selectedEngine}
+              showLegacy={showLegacy}
+              triggerId={triggerId}
+              visibleEngines={visibleEngines}
+            />
+          ) : null}
         </div>
 
         {shouldShowModes ? (

--- a/frontend/src/components/ui/engine-select/EngineSelectDropdown.tsx
+++ b/frontend/src/components/ui/engine-select/EngineSelectDropdown.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import clsx from 'clsx';
+import { createPortal } from 'react-dom';
+import type { RefObject } from 'react';
+import type { EngineAvailability, EngineCaps, Mode } from '@/types/engines';
+import { Chip } from '../Chip';
+import { EngineIcon } from '@/components/ui/EngineIcon';
+import type { EngineSelectCopy } from './engine-select-copy';
+import {
+  formatAvgDuration,
+  getModeDisplayOrder,
+  getModeLabel,
+} from './engine-select-helpers';
+import type { DropdownPosition, EngineRegistryMeta } from './engine-select-types';
+
+type EngineSelectDropdownProps = {
+  activeOptionId?: string;
+  contentRef: RefObject<HTMLDivElement>;
+  copy: EngineSelectCopy;
+  formatEngineShort: (engine: EngineCaps | null | undefined) => string;
+  hasLegacyEngines: boolean;
+  highlightedIndex: number;
+  legacyToggleId: string;
+  legacyToggleLabel: string;
+  locale?: string;
+  modeLabelOverrides?: Partial<Record<Mode, string>>;
+  onBrowse: () => void;
+  onHighlight: (index: number) => void;
+  onItemRef: (index: number, node: HTMLButtonElement | null) => void;
+  onSelectEngine: (engineId: string) => void;
+  onToggleLegacy: (checked: boolean) => void;
+  portalElement: HTMLDivElement;
+  position: DropdownPosition;
+  registryMeta: EngineRegistryMeta | null;
+  selectedEngine: EngineCaps;
+  showLegacy: boolean;
+  triggerId: string;
+  visibleEngines: EngineCaps[];
+};
+
+export function EngineSelectDropdown({
+  activeOptionId,
+  contentRef,
+  copy,
+  formatEngineShort,
+  hasLegacyEngines,
+  highlightedIndex,
+  legacyToggleId,
+  legacyToggleLabel,
+  locale,
+  modeLabelOverrides,
+  onBrowse,
+  onHighlight,
+  onItemRef,
+  onSelectEngine,
+  onToggleLegacy,
+  portalElement,
+  position,
+  registryMeta,
+  selectedEngine,
+  showLegacy,
+  triggerId,
+  visibleEngines,
+}: EngineSelectDropdownProps) {
+  return createPortal(
+    <div
+      ref={contentRef}
+      className="fixed z-[9999]"
+      style={{ top: position.top, left: position.left, minWidth: Math.max(position.width, 280) }}
+    >
+      <div className="overflow-hidden rounded-card border border-border bg-surface shadow-float">
+        <div className="flex items-center justify-between gap-4 border-b border-hairline px-3 py-2 text-[12px] text-text-muted">
+          <span>Engines</span>
+          <div className="flex items-center gap-3">
+            {hasLegacyEngines ? (
+              <label
+                htmlFor={legacyToggleId}
+                className="inline-flex items-center gap-2 whitespace-nowrap text-[11px] font-medium text-text-secondary"
+              >
+                <input
+                  id={legacyToggleId}
+                  type="checkbox"
+                  checked={showLegacy}
+                  onChange={(event) => onToggleLegacy(event.currentTarget.checked)}
+                  className="h-4 w-4 rounded border border-border accent-brand"
+                />
+                <span>{legacyToggleLabel}</span>
+              </label>
+            ) : null}
+            <button
+              type="button"
+              onClick={onBrowse}
+              className="rounded-input border border-transparent px-2 py-1 text-[11px] font-medium text-brand transition hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {copy.browse}
+            </button>
+          </div>
+        </div>
+        <ul
+          className="max-h-72 overflow-y-auto py-1"
+          role="listbox"
+          aria-labelledby={triggerId}
+          aria-activedescendant={activeOptionId}
+        >
+          {visibleEngines.map((engine, index) => {
+            const active = engine.id === selectedEngine.id;
+            const highlighted = index === highlightedIndex;
+            const meta = registryMeta?.meta.get(engine.id);
+            const avgDurationLabel = formatAvgDuration(engine.avgDurationMs);
+            const availability: EngineAvailability = meta?.availability ?? engine.availability ?? 'available';
+            const disabled = availability === 'paused';
+            return (
+              <li key={engine.id}>
+                <button
+                  ref={(node) => onItemRef(index, node)}
+                  type="button"
+                  onClick={() => {
+                    if (disabled) return;
+                    onSelectEngine(engine.id);
+                  }}
+                  onMouseEnter={() => onHighlight(index)}
+                  onFocus={() => onHighlight(index)}
+                  className={clsx(
+                    'flex w-full items-start gap-4 px-4 py-3 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                    'hover:bg-surface-2',
+                    active && 'bg-surface-2',
+                    highlighted && !active && 'bg-surface-2',
+                    disabled && 'cursor-not-allowed opacity-60'
+                  )}
+                  role="option"
+                  id={`${engine.id}-option`}
+                  aria-selected={active}
+                  aria-disabled={disabled}
+                  disabled={disabled}
+                  tabIndex={-1}
+                >
+                  <EngineIcon engine={engine} size={32} className="mt-0.5 shrink-0" />
+                  <div className="flex min-w-0 flex-1 items-start justify-between gap-4">
+                    <div className="min-w-0 space-y-1">
+                      <p className="truncate text-sm font-medium text-text-primary">
+                        {meta?.marketingName ?? formatEngineShort(engine)}
+                      </p>
+                      <p className="truncate text-[12px] text-text-muted">
+                        {engine.provider} - {meta?.versionLabel ?? engine.version ?? '-'}
+                      </p>
+                      <div className="flex flex-wrap gap-1 text-[10px]">
+                        {getModeDisplayOrder(engine.id, engine.modes).map((engineMode) => (
+                          <Chip key={engineMode} variant="outline" className="px-1.5 py-0.5 text-[10px]">
+                            {getModeLabel(engine.id, engineMode, locale, modeLabelOverrides)}
+                          </Chip>
+                        ))}
+                        {engine.isLab && (
+                          <Chip variant="ghost" className="px-1.5 py-0.5 text-[10px]">Lab</Chip>
+                        )}
+                      </div>
+                    </div>
+                    <div className="flex flex-col items-end gap-1 text-[11px] text-text-muted">
+                      {avgDurationLabel && <span>{copy.avgDuration.replace('{value}', avgDurationLabel)}</span>}
+                      {engine.status && <span className="uppercase tracking-micro">{engine.status}</span>}
+                    </div>
+                  </div>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>,
+    portalElement
+  );
+}

--- a/frontend/src/components/ui/engine-select/useEngineSelectDropdownState.ts
+++ b/frontend/src/components/ui/engine-select/useEngineSelectDropdownState.ts
@@ -1,0 +1,181 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type SetStateAction,
+} from 'react';
+import type { EngineCaps } from '@/types/engines';
+import type { DropdownPosition } from './engine-select-types';
+
+type UseEngineSelectDropdownStateArgs = {
+  onEngineChange: (engineId: string) => void;
+  open: boolean;
+  selectedEngineId?: string;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+  visibleEngines: EngineCaps[];
+};
+
+export function useEngineSelectDropdownState({
+  onEngineChange,
+  open,
+  selectedEngineId,
+  setOpen,
+  visibleEngines,
+}: UseEngineSelectDropdownStateArgs) {
+  const [position, setPosition] = useState<DropdownPosition | null>(null);
+  const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
+  const [portalElement, setPortalElement] = useState<HTMLDivElement | null>(null);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const updatePosition = useCallback(() => {
+    if (!triggerRef.current) return;
+    const rect = triggerRef.current.getBoundingClientRect();
+    setPosition({
+      top: rect.bottom + 8,
+      left: rect.left,
+      width: rect.width,
+    });
+  }, []);
+
+  const toggleOpen = () => {
+    setOpen((previous) => {
+      const next = !previous;
+      if (next) {
+        updatePosition();
+      } else {
+        setHighlightedIndex(-1);
+      }
+      return next;
+    });
+  };
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    updatePosition();
+
+    function handleResize() {
+      updatePosition();
+    }
+
+    window.addEventListener('resize', handleResize, { passive: true });
+    window.addEventListener('scroll', handleResize, { passive: true, capture: true });
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      window.removeEventListener('scroll', handleResize, true);
+    };
+  }, [open, updatePosition]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (!visibleEngines.length) {
+      setHighlightedIndex(-1);
+      return;
+    }
+    const currentIndex = visibleEngines.findIndex((candidate) => candidate.id === selectedEngineId);
+    setHighlightedIndex(currentIndex >= 0 ? currentIndex : 0);
+  }, [open, visibleEngines, selectedEngineId]);
+
+  useEffect(() => {
+    if (!open) return;
+    function handlePointer(event: MouseEvent | TouchEvent) {
+      const target = event.target as Node;
+      if (triggerRef.current?.contains(target)) return;
+      if (contentRef.current?.contains(target)) return;
+      setOpen(false);
+      setHighlightedIndex(-1);
+    }
+
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setOpen(false);
+        setHighlightedIndex(-1);
+        triggerRef.current?.focus();
+        return;
+      }
+
+      if (!visibleEngines.length) return;
+
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        setHighlightedIndex((previous) => (previous + 1 >= visibleEngines.length ? 0 : previous + 1));
+      }
+
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        setHighlightedIndex((previous) => (previous - 1 < 0 ? visibleEngines.length - 1 : previous - 1));
+      }
+
+      if (event.key === 'Enter' || event.key === ' ') {
+        if (highlightedIndex >= 0 && highlightedIndex < visibleEngines.length) {
+          event.preventDefault();
+          onEngineChange(visibleEngines[highlightedIndex].id);
+          setOpen(false);
+          setHighlightedIndex(-1);
+          triggerRef.current?.focus();
+        }
+      }
+    }
+
+    document.addEventListener('mousedown', handlePointer);
+    document.addEventListener('touchstart', handlePointer, { passive: true });
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handlePointer);
+      document.removeEventListener('touchstart', handlePointer);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [highlightedIndex, onEngineChange, open, setOpen, visibleEngines]);
+
+  useEffect(() => {
+    if (!open) return;
+    const item = itemRefs.current[highlightedIndex];
+    item?.focus({ preventScroll: true });
+    item?.scrollIntoView({ block: 'nearest' });
+  }, [open, highlightedIndex]);
+
+  useEffect(() => {
+    const element = document.createElement('div');
+    element.dataset.engineSelectPortal = 'true';
+    document.body.appendChild(element);
+    setPortalElement(element);
+    return () => {
+      try {
+        if (element.parentNode) {
+          element.parentNode.removeChild(element);
+        }
+      } catch {}
+    };
+  }, []);
+
+  const handleTriggerKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (!open) {
+        updatePosition();
+      }
+      setOpen(true);
+    }
+  };
+
+  return {
+    containerRef,
+    contentRef,
+    handleTriggerKeyDown,
+    highlightedIndex,
+    itemRefs,
+    portalElement,
+    position,
+    setHighlightedIndex,
+    toggleOpen,
+    triggerRef,
+  };
+}

--- a/frontend/src/components/ui/engine-select/useEngineSelectRegistry.ts
+++ b/frontend/src/components/ui/engine-select/useEngineSelectRegistry.ts
@@ -1,0 +1,135 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { EngineCaps } from '@/types/engines';
+import {
+  compareEnginesByDefaultPriority,
+  ENGINE_LEGACY_STORAGE_KEY,
+  ensureEngineRegistryMeta,
+  getCachedEngineRegistryMeta,
+} from './engine-select-helpers';
+import type { EngineRegistryMeta } from './engine-select-types';
+
+type UseEngineSelectRegistryArgs = {
+  browseOpen: boolean;
+  engineId: string;
+  engines: EngineCaps[];
+  open: boolean;
+};
+
+export function useEngineSelectRegistry({
+  browseOpen,
+  engineId,
+  engines,
+  open,
+}: UseEngineSelectRegistryArgs) {
+  const [registryMeta, setRegistryMeta] = useState<EngineRegistryMeta | null>(() => getCachedEngineRegistryMeta());
+  const [showLegacy, setShowLegacy] = useState(false);
+  const [legacyHydrated, setLegacyHydrated] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = window.localStorage.getItem(ENGINE_LEGACY_STORAGE_KEY);
+      if (stored === 'true') {
+        setShowLegacy(true);
+      }
+    } catch {
+      // ignore storage failures
+    } finally {
+      setLegacyHydrated(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!legacyHydrated) return;
+    try {
+      window.localStorage.setItem(ENGINE_LEGACY_STORAGE_KEY, showLegacy ? 'true' : 'false');
+    } catch {
+      // ignore storage failures
+    }
+  }, [legacyHydrated, showLegacy]);
+
+  const availableEngines = useMemo(() => {
+    const sorted = engines.slice();
+    sorted.sort((a, b) => compareEnginesByDefaultPriority(a, b, registryMeta));
+    return sorted.filter((entry) => entry.availability !== 'paused');
+  }, [engines, registryMeta]);
+
+  const selectedEngine = useMemo(() => {
+    const candidate = availableEngines.find((entry) => entry.id === engineId);
+    return candidate ?? availableEngines[0] ?? engines[0];
+  }, [availableEngines, engineId, engines]);
+
+  const selectedMeta = useMemo(
+    () => (selectedEngine ? registryMeta?.meta.get(selectedEngine.id) : undefined),
+    [registryMeta, selectedEngine]
+  );
+
+  const visibleEngines = useMemo(() => {
+    return availableEngines.filter((engine) => {
+      const meta = registryMeta?.meta.get(engine.id);
+      if (!meta?.isLegacy) return true;
+      if (showLegacy) return true;
+      return engine.id === selectedEngine?.id;
+    });
+  }, [availableEngines, registryMeta, selectedEngine, showLegacy]);
+
+  const hasLegacyEngines = useMemo(
+    () => availableEngines.some((engine) => Boolean(registryMeta?.meta.get(engine.id)?.isLegacy)),
+    [availableEngines, registryMeta]
+  );
+
+  const variantEngines = useMemo(() => {
+    if (!selectedEngine) return [];
+    const selectedVariantGroup = selectedMeta?.surfaces.app.variantGroup;
+    if (selectedVariantGroup) {
+      return availableEngines.filter(
+        (entry) => registryMeta?.meta.get(entry.id)?.surfaces.app.variantGroup === selectedVariantGroup
+      );
+    }
+    return [];
+  }, [availableEngines, registryMeta, selectedEngine, selectedMeta]);
+
+  useEffect(() => {
+    if (registryMeta) return;
+    if (typeof window === 'undefined') return;
+    let active = true;
+    const timer = window.setTimeout(() => {
+      ensureEngineRegistryMeta()
+        .then((meta) => {
+          if (active) setRegistryMeta(meta);
+        })
+        .catch(() => undefined);
+    }, 1200);
+    return () => {
+      active = false;
+      window.clearTimeout(timer);
+    };
+  }, [registryMeta]);
+
+  useEffect(() => {
+    if (registryMeta) return;
+    if (!open && !browseOpen) return;
+    let active = true;
+    ensureEngineRegistryMeta()
+      .then((meta) => {
+        if (active) setRegistryMeta(meta);
+      })
+      .catch(() => undefined);
+    return () => {
+      active = false;
+    };
+  }, [browseOpen, open, registryMeta]);
+
+  return {
+    availableEngines,
+    hasLegacyEngines,
+    registryMeta,
+    selectedEngine,
+    selectedMeta,
+    setShowLegacy,
+    showLegacy,
+    showVariantSelector: variantEngines.length > 1,
+    variantEngines,
+    visibleEngines,
+  };
+}

--- a/tests/engine-select-architecture.test.ts
+++ b/tests/engine-select-architecture.test.ts
@@ -5,12 +5,18 @@ import test from 'node:test';
 
 const root = process.cwd();
 const engineSelectPath = join(root, 'frontend/src/components/ui/EngineSelect.tsx');
+const dropdownPath = join(root, 'frontend/src/components/ui/engine-select/EngineSelectDropdown.tsx');
+const dropdownStateHookPath = join(root, 'frontend/src/components/ui/engine-select/useEngineSelectDropdownState.ts');
+const registryHookPath = join(root, 'frontend/src/components/ui/engine-select/useEngineSelectRegistry.ts');
 const modalPath = join(root, 'frontend/src/components/ui/engine-select/BrowseEnginesModal.tsx');
 const helpersPath = join(root, 'frontend/src/components/ui/engine-select/engine-select-helpers.ts');
 const copyPath = join(root, 'frontend/src/components/ui/engine-select/engine-select-copy.ts');
 const typesPath = join(root, 'frontend/src/components/ui/engine-select/engine-select-types.ts');
 
 const engineSelectSource = readFileSync(engineSelectPath, 'utf8');
+const dropdownSource = readFileSync(dropdownPath, 'utf8');
+const dropdownStateHookSource = readFileSync(dropdownStateHookPath, 'utf8');
+const registryHookSource = readFileSync(registryHookPath, 'utf8');
 const modalSource = readFileSync(modalPath, 'utf8');
 const helpersSource = readFileSync(helpersPath, 'utf8');
 const copySource = readFileSync(copyPath, 'utf8');
@@ -18,11 +24,17 @@ const typesSource = readFileSync(typesPath, 'utf8');
 
 test('engine select delegates modal rendering, copy, helpers, and contracts', () => {
   assert.ok(existsSync(modalPath), 'browse engines modal should live in a focused module');
+  assert.ok(existsSync(dropdownPath), 'engine dropdown rendering should live in a focused module');
+  assert.ok(existsSync(dropdownStateHookPath), 'engine dropdown state should live in a focused hook');
+  assert.ok(existsSync(registryHookPath), 'engine registry state should live in a focused hook');
   assert.ok(existsSync(helpersPath), 'engine select helpers should live in a focused module');
   assert.ok(existsSync(copyPath), 'engine select default copy should live in a focused module');
   assert.ok(existsSync(typesPath), 'engine select contracts should live in a focused module');
 
   assert.match(engineSelectSource, /from '\.\/engine-select\/BrowseEnginesModal'/);
+  assert.match(engineSelectSource, /from '\.\/engine-select\/EngineSelectDropdown'/);
+  assert.match(engineSelectSource, /from '\.\/engine-select\/useEngineSelectDropdownState'/);
+  assert.match(engineSelectSource, /from '\.\/engine-select\/useEngineSelectRegistry'/);
   assert.match(engineSelectSource, /from '\.\/engine-select\/engine-select-helpers'/);
   assert.match(engineSelectSource, /from '\.\/engine-select\/engine-select-copy'/);
   assert.match(engineSelectSource, /from '\.\/engine-select\/engine-select-types'/);
@@ -30,16 +42,26 @@ test('engine select delegates modal rendering, copy, helpers, and contracts', ()
 
 test('engine select does not regain extracted ownership', () => {
   assert.doesNotMatch(engineSelectSource, /function BrowseEnginesModal\(/, 'browse modal belongs in BrowseEnginesModal.tsx');
+  assert.doesNotMatch(engineSelectSource, /createPortal/, 'dropdown portal rendering belongs in EngineSelectDropdown.tsx');
+  assert.doesNotMatch(engineSelectSource, /localStorage\.getItem\(ENGINE_LEGACY_STORAGE_KEY\)/, 'legacy preference hydration belongs in useEngineSelectRegistry.ts');
+  assert.doesNotMatch(engineSelectSource, /document\.addEventListener\('mousedown'/, 'dropdown dismissal belongs in useEngineSelectDropdownState.ts');
   assert.doesNotMatch(engineSelectSource, /function compareEnginesByDefaultPriority\(/, 'engine ordering belongs in engine-select-helpers.ts');
   assert.doesNotMatch(engineSelectSource, /const DEFAULT_ENGINE_SELECT_COPY =/, 'default copy belongs in engine-select-copy.ts');
   assert.doesNotMatch(engineSelectSource, /type EngineRegistryMeta =/, 'engine registry contracts belong in engine-select-types.ts');
   assert.doesNotMatch(engineSelectSource, /listFalEngines/, 'registry loading belongs in engine-select-helpers.ts');
 
   const lineCount = engineSelectSource.split('\n').length;
-  assert.ok(lineCount <= 760, `EngineSelect should stay below 760 lines after modal/helper extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 430, `EngineSelect should stay below 430 lines after state hook extraction, got ${lineCount}`);
 });
 
 test('engine select modules expose the expected contracts', () => {
+  assert.match(dropdownSource, /export function EngineSelectDropdown/);
+  assert.match(dropdownSource, /createPortal/);
+  assert.match(dropdownSource, /getModeDisplayOrder/);
+  assert.match(dropdownStateHookSource, /export function useEngineSelectDropdownState/);
+  assert.match(dropdownStateHookSource, /document\.addEventListener\('mousedown'/);
+  assert.match(registryHookSource, /export function useEngineSelectRegistry/);
+  assert.match(registryHookSource, /ENGINE_LEGACY_STORAGE_KEY/);
   assert.match(modalSource, /export function BrowseEnginesModal/);
   assert.match(helpersSource, /export async function ensureEngineRegistryMeta/);
   assert.match(helpersSource, /export function compareEnginesByDefaultPriority/);

--- a/tests/image-reference-slots-hook-contract.test.ts
+++ b/tests/image-reference-slots-hook-contract.test.ts
@@ -7,12 +7,15 @@ const root = process.cwd();
 const imageDir = path.join(root, 'frontend/app/(core)/(workspace)/app/image');
 const workspacePath = path.join(imageDir, 'ImageWorkspace.tsx');
 const hookPath = path.join(imageDir, '_hooks/useImageReferenceSlots.ts');
+const slotStatePath = path.join(imageDir, '_lib/image-reference-slot-state.ts');
 
 test('image reference slots are owned by a route-local hook', () => {
   statSync(hookPath);
+  statSync(slotStatePath);
 
   const workspaceSource = readFileSync(workspacePath, 'utf8');
   const hookSource = readFileSync(hookPath, 'utf8');
+  const slotStateSource = readFileSync(slotStatePath, 'utf8');
 
   assert.match(workspaceSource, /from '\.\/_hooks\/useImageReferenceSlots'/);
   assert.match(workspaceSource, /useImageReferenceSlots\(/);
@@ -28,4 +31,11 @@ test('image reference slots are owned by a route-local hook', () => {
   assert.match(hookSource, /handleLibrarySelect/);
   assert.match(hookSource, /toggleCharacterReference/);
   assert.match(hookSource, /prepareImageFileForUpload/);
+  assert.match(hookSource, /from '\.\.\/_lib\/image-reference-slot-state'/);
+  assert.match(slotStateSource, /export function buildPersistableReferenceSlots/);
+  assert.match(slotStateSource, /export function getReferenceSizeSignature/);
+  assert.match(slotStateSource, /export function getSelectedCharacterReferences/);
+
+  const lineCount = hookSource.split('\n').length;
+  assert.ok(lineCount <= 500, `useImageReferenceSlots should stay below 500 lines after selector extraction, got ${lineCount}`);
 });

--- a/tests/image-workspace-split-contract.test.ts
+++ b/tests/image-workspace-split-contract.test.ts
@@ -15,10 +15,17 @@ const referenceAssetsHookPath = path.join(imageDir, '_hooks/useImageWorkspaceRef
 const viewerHookPath = path.join(imageDir, '_hooks/useImageWorkspaceViewer.ts');
 const composerSurfacePath = path.join(imageDir, '_components/ImageWorkspaceComposerSurface.tsx');
 const galleryRailPath = path.join(imageDir, '_components/ImageWorkspaceGalleryRail.tsx');
+const runtimeModalsPath = path.join(imageDir, '_components/ImageWorkspaceRuntimeModals.tsx');
+const shellPath = path.join(imageDir, '_components/ImageWorkspaceShell.tsx');
+const emptyStatePath = path.join(imageDir, '_components/ImageWorkspaceEmptyState.tsx');
+const routeContextHookPath = path.join(imageDir, '_hooks/useImageWorkspaceRouteContext.ts');
 
 const splitFiles = [
   '_components/ImageAuthGateModal.tsx',
   '_components/ImageLibraryModal.tsx',
+  '_components/ImageWorkspaceRuntimeModals.tsx',
+  '_components/ImageWorkspaceShell.tsx',
+  '_components/ImageWorkspaceEmptyState.tsx',
   '_components/ImageWorkspaceGalleryRail.tsx',
   '_components/ImageWorkspaceComposerSurface.tsx',
   '_hooks/useImageComposerPersistence.ts',
@@ -29,6 +36,10 @@ const splitFiles = [
   '_hooks/useImageWorkspacePricing.ts',
   '_hooks/useImageWorkspaceDesktopLayout.ts',
   '_hooks/useImageWorkspaceQueryHydration.ts',
+  '_hooks/useImageWorkspaceRouteContext.ts',
+  '_hooks/useImageWorkspaceModeSync.ts',
+  '_hooks/useImageWorkspacePresetHandlers.ts',
+  '_hooks/useImageWorkspaceSelectedEngine.ts',
   '_hooks/useImageGenerationRunner.ts',
   '_hooks/useImageGallerySelection.ts',
   '_lib/image-workspace-character-references.ts',
@@ -54,15 +65,19 @@ test('image workspace foundations are split from the route orchestrator', () => 
   const viewerHookSource = readFileSync(viewerHookPath, 'utf8');
   const composerSurfaceSource = readFileSync(composerSurfacePath, 'utf8');
   const galleryRailSource = readFileSync(galleryRailPath, 'utf8');
+  const runtimeModalsSource = readFileSync(runtimeModalsPath, 'utf8');
+  const shellSource = readFileSync(shellPath, 'utf8');
+  const emptyStateSource = readFileSync(emptyStatePath, 'utf8');
+  const routeContextHookSource = readFileSync(routeContextHookPath, 'utf8');
 
   for (const file of splitFiles) {
     statSync(path.join(imageDir, file));
   }
 
-  assert.match(source, /from '\.\/_components\/ImageLibraryModal'/);
-  assert.match(source, /from '\.\/_components\/ImageAuthGateModal'/);
   assert.match(source, /from '\.\/_components\/ImageWorkspaceComposerSurface'/);
-  assert.match(source, /from '\.\/_components\/ImageWorkspaceGalleryRail'/);
+  assert.match(source, /from '\.\/_components\/ImageWorkspaceRuntimeModals'/);
+  assert.match(source, /from '\.\/_components\/ImageWorkspaceShell'/);
+  assert.match(source, /from '\.\/_components\/ImageWorkspaceEmptyState'/);
   assert.match(source, /from '\.\/_hooks\/useImageComposerPersistence'/);
   assert.match(source, /from '\.\/_hooks\/useImageWorkspaceDisplayState'/);
   assert.match(source, /from '\.\/_hooks\/useImageWorkspaceReferenceAssets'/);
@@ -71,9 +86,12 @@ test('image workspace foundations are split from the route orchestrator', () => 
   assert.match(source, /from '\.\/_hooks\/useImageWorkspacePricing'/);
   assert.match(source, /from '\.\/_hooks\/useImageWorkspaceDesktopLayout'/);
   assert.match(source, /from '\.\/_hooks\/useImageWorkspaceQueryHydration'/);
+  assert.match(source, /from '\.\/_hooks\/useImageWorkspaceRouteContext'/);
+  assert.match(source, /from '\.\/_hooks\/useImageWorkspaceModeSync'/);
+  assert.match(source, /from '\.\/_hooks\/useImageWorkspacePresetHandlers'/);
+  assert.match(source, /from '\.\/_hooks\/useImageWorkspaceSelectedEngine'/);
   assert.match(source, /from '\.\/_hooks\/useImageGenerationRunner'/);
   assert.match(source, /from '\.\/_hooks\/useImageGallerySelection'/);
-  assert.match(source, /from '\.\/_lib\/image-workspace-copy'/);
 
   assert.doesNotMatch(source, /const DEFAULT_COPY: ImageWorkspaceCopy =/);
   assert.doesNotMatch(source, /function ImageLibraryModal\(/);
@@ -147,7 +165,15 @@ test('image workspace foundations are split from the route orchestrator', () => 
   assert.match(viewerHookSource, /saveImageToLibrary/);
   assert.match(galleryRailSource, /export function ImageWorkspaceGalleryRail/);
   assert.match(galleryRailSource, /<GalleryRail\b/);
+  assert.match(runtimeModalsSource, /export function ImageWorkspaceRuntimeModals/);
+  assert.match(runtimeModalsSource, /<ImageAuthGateModal\b/);
+  assert.match(runtimeModalsSource, /<ImageLibraryModal\b/);
+  assert.match(runtimeModalsSource, /GroupViewerModal/);
+  assert.match(shellSource, /export function ImageWorkspaceShell/);
+  assert.match(shellSource, /<ImageWorkspaceGalleryRail\b/);
+  assert.match(emptyStateSource, /export function ImageWorkspaceEmptyState/);
+  assert.match(routeContextHookSource, /mergeCopy/);
 
   const lineCount = source.split('\n').length;
-  assert.ok(lineCount <= 590, `ImageWorkspace should stay below 590 lines after display/reference/viewer extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 500, `ImageWorkspace should stay below 500 lines after shell extraction, got ${lineCount}`);
 });

--- a/tests/workspace-gallery-rail-contract.test.ts
+++ b/tests/workspace-gallery-rail-contract.test.ts
@@ -67,6 +67,10 @@ test('composite preview preserves preview urls but plays canonical video urls', 
     path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/_lib/workspace-video-settings.ts'),
     'utf8'
   );
+  const videoJobMediaSource = fs.readFileSync(
+    path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/_lib/workspace-video-job-media.ts'),
+    'utf8'
+  );
   const galleryActionsHookSource = fs.readFileSync(
     path.join(process.cwd(), 'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceGalleryActions.ts'),
     'utf8'
@@ -77,8 +81,9 @@ test('composite preview preserves preview urls but plays canonical video urls', 
   );
 
   assert.match(galleryActionsHookSource, /previewVideoUrl:\s*tile\.previewVideoUrl/);
-  assert.match(videoSettingsSource, /previewVideoUrl:\s*patch\.previewVideoUrl\s*\?\?\s*current\.previewVideoUrl/);
-  assert.match(videoSettingsSource, /previewUrl:\s*patch\.previewVideoUrl\s*\?\?\s*item\.previewUrl/);
+  assert.match(videoSettingsSource, /from '\.\/workspace-video-job-media'/);
+  assert.match(videoJobMediaSource, /previewVideoUrl:\s*patch\.previewVideoUrl\s*\?\?\s*current\.previewVideoUrl/);
+  assert.match(videoJobMediaSource, /previewUrl:\s*patch\.previewVideoUrl\s*\?\?\s*item\.previewUrl/);
   assert.match(renderGroupSource, /previewVideoUrl:\s*gatingActive\s*\?\s*null\s*:\s*item\.previewVideoUrl\s*\?\?\s*null/);
   assert.match(dockUtilsSource, /function getInlinePreviewUrl\(item: VideoItem\): string \{\s*return item\.url;\s*\}/);
   assert.doesNotMatch(dockUtilsSource, /return item\.previewUrl \?\? item\.url/);

--- a/tests/workspace-video-settings-hook-contract.test.ts
+++ b/tests/workspace-video-settings-hook-contract.test.ts
@@ -12,9 +12,20 @@ test('workspace video settings hydration is owned by a route-local hook', () => 
     process.cwd(),
     'frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceVideoSettings.ts'
   );
+  const settingsPath = path.join(
+    process.cwd(),
+    'frontend/app/(core)/(workspace)/app/_lib/workspace-video-settings.ts'
+  );
+  const jobMediaPath = path.join(
+    process.cwd(),
+    'frontend/app/(core)/(workspace)/app/_lib/workspace-video-job-media.ts'
+  );
   assert.equal(fs.existsSync(hookPath), true);
+  assert.equal(fs.existsSync(jobMediaPath), true);
 
   const hookSource = fs.readFileSync(hookPath, 'utf8');
+  const settingsSource = fs.readFileSync(settingsPath, 'utf8');
+  const jobMediaSource = fs.readFileSync(jobMediaPath, 'utf8');
 
   assert.match(appSource, /import \{ useWorkspaceVideoSettings \} from '\.\/_hooks\/useWorkspaceVideoSettings';/);
   assert.match(appSource, /useWorkspaceVideoSettings\(\{/);
@@ -28,4 +39,11 @@ test('workspace video settings hydration is owned by a route-local hook', () => 
   assert.match(hookSource, /const applyVideoSettingsFromTile = useCallback/);
   assert.match(hookSource, /buildVideoSettingsSnapshotFromSharedVideo/);
   assert.match(hookSource, /buildRequestedJobPreview/);
+
+  assert.match(settingsSource, /from '\.\/workspace-video-job-media'/);
+  assert.match(jobMediaSource, /export function buildVideoJobMediaPatch/);
+  assert.match(jobMediaSource, /export function buildRequestedJobPreview/);
+
+  const settingsLineCount = settingsSource.split('\n').length;
+  assert.ok(settingsLineCount <= 430, `workspace-video-settings should stay below 430 lines after job media extraction, got ${settingsLineCount}`);
 });


### PR DESCRIPTION
## Summary
- split image workspace shell, runtime modals, route context, selected-engine, mode sync, and preset handlers out of ImageWorkspace
- split image reference-slot selectors and video job media patch helpers into focused modules
- split EngineSelect dropdown rendering plus registry/dropdown state into focused modules
- update architecture contracts for the new ownership boundaries

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/image-workspace-split-contract.test.ts tests/image-reference-slots-hook-contract.test.ts tests/workspace-video-settings-hook-contract.test.ts tests/engine-select-architecture.test.ts
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/workspace-gallery-rail-contract.test.ts tests/image-workspace-split-contract.test.ts tests/engine-select-architecture.test.ts tests/workspace-video-settings-hook-contract.test.ts
- pnpm --dir frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run architecture:audit -- --min-lines 500
- npm run lint:exposure
- npm run test:validate
- git diff --check