### PR TITLE
Split image generation request context

### DIFF
--- a/frontend/src/server/images/execute-image-generation.ts
+++ b/frontend/src/server/images/execute-image-generation.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from 'crypto';
-import { listFalEngines } from '@/config/falEngines';
 import type {
   ImageGenerationMode,
   ImageGenerationRequest,
@@ -21,17 +20,10 @@ import {
 } from '@/server/storage';
 import { createImageThumbnailBatch } from '@/server/image-thumbnails';
 import {
-  formatSupportedImageFormatsLabel,
-  getSupportedImageFormats,
-} from '@/lib/image/formats';
-import {
   canonicalizeImageFieldValue,
-  clampRequestedImageCount,
   getImageFieldValues,
   getImageInputField,
-  getReferenceConstraints,
   normalizeFalImageResolution,
-  resolveRequestedAspectRatio,
   resolveRequestedResolution,
 } from '@/app/api/images/utils';
 import {
@@ -43,27 +35,21 @@ import {
 import { computeBillingProductSnapshot } from '@/lib/billing-products';
 import type { BillingProductKey, JobSurface } from '@/types/billing';
 import { buildResponseFromExistingJob } from './existing-image-job-response';
-import {
-  getStoredAssetInfoByUrl,
-  isReferenceImageSupported,
-  normalizeReferenceImageForEngine,
-  type StoredAssetInfo,
-} from './image-reference-normalization';
 import { ImageGenerationExecutionError } from './image-generation-error';
 import { createAtomicInitialImageJob } from './image-initial-job';
 import { persistCompletedImageGeneration } from './image-generation-completion';
 import { persistFailedImageGeneration } from './image-generation-failure';
 import {
-  buildCharacterReferencePrompt,
   extractImages,
   parseRequestId,
-  sanitizeCharacterReferences,
 } from './image-provider-payload';
 import {
   buildReceiptSnapshot,
   type PendingReceipt,
 } from './image-generation-receipts';
 import { buildDefaultSettingsSnapshot } from './image-generation-settings-snapshot';
+import { resolveImageGenerationRequestContext } from './image-generation-request-context';
+import { prepareImageGenerationReferences } from './image-generation-references';
 
 export { buildResponseFromExistingJob } from './existing-image-job-response';
 export { ImageGenerationExecutionError } from './image-generation-error';
@@ -81,31 +67,8 @@ type ExecuteImageGenerationOptions = {
   billingQuantityMultiplier?: number;
 };
 
-type ImageEngineEntry = (typeof IMAGE_ENGINE_REGISTRY)[number];
-
-const IMAGE_ENGINE_REGISTRY = listFalEngines().filter((entry) => (entry.category ?? 'video') === 'image');
-const IMAGE_ENGINE_MAP = new Map(IMAGE_ENGINE_REGISTRY.map((entry) => [entry.id, entry]));
-const DEFAULT_IMAGE_ENGINE_ID = IMAGE_ENGINE_REGISTRY[0]?.id ?? null;
-
 function normalizeOptionalBoolean(value: unknown): boolean | null {
   return typeof value === 'boolean' ? value : null;
-}
-
-function getImageEngine(engineId?: string | null): ImageEngineEntry | null {
-  if (engineId && IMAGE_ENGINE_MAP.has(engineId)) {
-    return IMAGE_ENGINE_MAP.get(engineId) ?? null;
-  }
-  if (DEFAULT_IMAGE_ENGINE_ID && IMAGE_ENGINE_MAP.has(DEFAULT_IMAGE_ENGINE_ID)) {
-    return IMAGE_ENGINE_MAP.get(DEFAULT_IMAGE_ENGINE_ID) ?? null;
-  }
-  return null;
-}
-
-function normalizeMode(value: unknown, fallback: ImageGenerationMode = 't2i'): ImageGenerationMode {
-  if (value === 't2i' || value === 'i2i') return value;
-  if (value === 'generate') return 't2i';
-  if (value === 'edit') return 'i2i';
-  return fallback;
 }
 
 function fail(
@@ -138,180 +101,33 @@ export async function executeImageGeneration({
     fail('t2i', 'db_unavailable', 'Database unavailable.', 503);
   }
 
-  const engineEntry = getImageEngine(body.engineId);
-  if (!engineEntry) {
-    fail('t2i', 'engine_unavailable', 'Image engine unavailable.', 503);
-  }
-
-  const engine = engineEntry.engine;
-  const fallbackMode = (engineEntry.modes[0]?.mode as ImageGenerationMode | undefined) ?? 't2i';
-  const mode = normalizeMode(body.mode, fallbackMode);
-  const modeConfig = engineEntry.modes.find((entry) => entry.mode === mode);
-  if (!modeConfig?.falModelId) {
-    fail(mode, 'mode_unsupported', 'Selected engine does not support this mode.', 400, null, {
-      engineId: engineEntry.id,
-      engineLabel: engineEntry.marketingName,
-    });
-  }
-
-  const aspectRatioResult = resolveRequestedAspectRatio(
+  const {
+    engineEntry,
     engine,
     mode,
-    typeof body.aspectRatio === 'string' ? body.aspectRatio : null
-  );
-  if (!aspectRatioResult.ok) {
-    fail(
-      mode,
-      'aspect_ratio_invalid',
-      'Selected aspect ratio is not available for this engine.',
-      400,
-      { allowed: aspectRatioResult.allowed },
-      {
-        engineId: engineEntry.id,
-        engineLabel: engineEntry.marketingName,
-      }
-    );
-  }
-  const resolvedAspectRatio = aspectRatioResult.value || null;
+    modeConfig,
+    resolvedAspectRatio,
+    prompt,
+    numImages,
+    durationSec,
+  } = resolveImageGenerationRequestContext(body);
 
-  const prompt = typeof body.prompt === 'string' ? body.prompt.trim() : '';
-  if (!prompt.length) {
-    fail(mode, 'invalid_prompt', 'Prompt is required.', 400, null, {
-      engineId: engineEntry.id,
-      engineLabel: engineEntry.marketingName,
-    });
-  }
-
-  const requestedImages =
-    typeof body.numImages === 'number' && Number.isFinite(body.numImages) ? Math.round(body.numImages) : 1;
-  const numImages = clampRequestedImageCount(engine, mode, requestedImages);
-
-  const rawImageUrls = Array.isArray(body.imageUrls) ? body.imageUrls : [];
-  const imageUrls = rawImageUrls
-    .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
-    .filter((entry) => entry.length);
-  let characterReferences = sanitizeCharacterReferences(body.characterReferences);
-  const characterReferenceUrls = characterReferences.map((entry) => entry.imageUrl);
-  let normalizedImageUrls = imageUrls.filter((url) => !characterReferenceUrls.includes(url));
-  let combinedImageUrls = [...characterReferenceUrls, ...normalizedImageUrls];
-  const effectivePrompt = buildCharacterReferencePrompt(prompt, characterReferences);
-  const invalidImageUrl = combinedImageUrls.find((entry) => !/^https?:\/\//i.test(entry));
-  if (invalidImageUrl) {
-    fail(
-      mode,
-      'invalid_image_url',
-      'Reference images must be absolute URLs (https://...).',
-      400,
-      { url: invalidImageUrl },
-      {
-        engineId: engineEntry.id,
-        engineLabel: engineEntry.marketingName,
-      }
-    );
-  }
-
-  const supportedReferenceFormats = getSupportedImageFormats(engine);
-  let storedAssetInfoByUrl = new Map<string, StoredAssetInfo>();
-  if (supportedReferenceFormats.length && combinedImageUrls.length) {
-    storedAssetInfoByUrl = await getStoredAssetInfoByUrl(userId, combinedImageUrls);
-    const normalizedReferenceByUrl = new Map<string, { url: string; mime: string }>();
-
-    for (const referenceUrl of [...new Set(combinedImageUrls)]) {
-      if (isReferenceImageSupported(supportedReferenceFormats, referenceUrl, storedAssetInfoByUrl)) {
-        continue;
-      }
-
-      try {
-        const normalizedReference = await normalizeReferenceImageForEngine({
-          userId,
-          url: referenceUrl,
-          supportedFormats: supportedReferenceFormats,
-          engineId: engine.id,
-        });
-        normalizedReferenceByUrl.set(referenceUrl, normalizedReference);
-        storedAssetInfoByUrl.set(normalizedReference.url, { mime: normalizedReference.mime });
-      } catch (error) {
-        const reason = error instanceof Error && error.message ? error.message : 'Unable to normalize reference image.';
-        console.warn('[images] failed to normalize reference image for engine', {
-          engineId: engine.id,
-          url: referenceUrl,
-          reason,
-        });
-        fail(
-          mode,
-          'image_normalization_failed',
-          'Reference image could not be converted to a format supported by this engine.',
-          422,
-          { allowed: supportedReferenceFormats, url: referenceUrl, reason },
-          {
-            engineId: engineEntry.id,
-            engineLabel: engineEntry.marketingName,
-          }
-        );
-      }
-    }
-
-    if (normalizedReferenceByUrl.size) {
-      characterReferences = characterReferences.map((entry) => ({
-        ...entry,
-        imageUrl: normalizedReferenceByUrl.get(entry.imageUrl)?.url ?? entry.imageUrl,
-      }));
-      normalizedImageUrls = normalizedImageUrls.map(
-        (entry) => normalizedReferenceByUrl.get(entry)?.url ?? entry
-      );
-      const currentCharacterReferenceUrls = new Set(characterReferences.map((entry) => entry.imageUrl));
-      combinedImageUrls = [
-        ...characterReferences.map((entry) => entry.imageUrl),
-        ...normalizedImageUrls.filter((url) => !currentCharacterReferenceUrls.has(url)),
-      ];
-    }
-
-    const invalidImageFormatUrl = combinedImageUrls.find(
-      (entry) => !isReferenceImageSupported(supportedReferenceFormats, entry, storedAssetInfoByUrl)
-    );
-    if (invalidImageFormatUrl) {
-      fail(
-        mode,
-        'image_format_invalid',
-        `Reference images must use ${formatSupportedImageFormatsLabel(supportedReferenceFormats)}.`,
-        400,
-        { allowed: supportedReferenceFormats, url: invalidImageFormatUrl },
-        {
-          engineId: engineEntry.id,
-          engineLabel: engineEntry.marketingName,
-        }
-      );
-    }
-  }
-
-  const referenceConstraints = getReferenceConstraints(engine, mode);
-  if (referenceConstraints.min > 0 && combinedImageUrls.length < referenceConstraints.min) {
-    const message =
-      referenceConstraints.min === 1
-        ? 'At least one reference image is required for this request.'
-        : `Provide at least ${referenceConstraints.min} reference images for this request.`;
-    fail(mode, 'missing_image_urls', message, 400, { minRequired: referenceConstraints.min }, {
-      engineId: engineEntry.id,
-      engineLabel: engineEntry.marketingName,
-    });
-  }
-  if (combinedImageUrls.length > referenceConstraints.max) {
-    fail(
-      mode,
-      'too_many_image_urls',
-      `You can attach up to ${referenceConstraints.max} reference images.`,
-      400,
-      { maxAllowed: referenceConstraints.max },
-      {
-        engineId: engineEntry.id,
-        engineLabel: engineEntry.marketingName,
-      }
-    );
-  }
+  const {
+    characterReferences,
+    normalizedImageUrls,
+    combinedImageUrls,
+    effectivePrompt,
+    storedAssetInfoByUrl,
+  } = await prepareImageGenerationReferences({
+    userId,
+    body,
+    engineEntry,
+    mode,
+    prompt,
+  });
 
   const requestId = typeof body.jobId === 'string' && body.jobId.trim().length ? body.jobId.trim() : null;
   const jobId = requestId ?? `img_${randomUUID()}`;
-  const durationSec = numImages;
 
   const resolutionResult = resolveRequestedResolution(
     engine,

--- a/frontend/src/server/images/image-generation-references.ts
+++ b/frontend/src/server/images/image-generation-references.ts
@@ -1,0 +1,186 @@
+import type {
+  CharacterReferenceSelection,
+  ImageGenerationMode,
+  ImageGenerationRequest,
+  ImageGenerationResponse,
+} from '@/types/image-generation';
+import { formatSupportedImageFormatsLabel, getSupportedImageFormats } from '@/lib/image/formats';
+import { getReferenceConstraints } from '@/app/api/images/utils';
+import {
+  getStoredAssetInfoByUrl,
+  isReferenceImageSupported,
+  normalizeReferenceImageForEngine,
+  type StoredAssetInfo,
+} from './image-reference-normalization';
+import { ImageGenerationExecutionError } from './image-generation-error';
+import {
+  buildCharacterReferencePrompt,
+  sanitizeCharacterReferences,
+} from './image-provider-payload';
+import type { ImageEngineEntry } from './image-generation-request-context';
+
+export type ImageGenerationReferenceContext = {
+  characterReferences: CharacterReferenceSelection[];
+  normalizedImageUrls: string[];
+  combinedImageUrls: string[];
+  effectivePrompt: string;
+  storedAssetInfoByUrl: Map<string, StoredAssetInfo>;
+};
+
+export async function prepareImageGenerationReferences({
+  userId,
+  body,
+  engineEntry,
+  mode,
+  prompt,
+}: {
+  userId: string;
+  body: Partial<ImageGenerationRequest>;
+  engineEntry: ImageEngineEntry;
+  mode: ImageGenerationMode;
+  prompt: string;
+}): Promise<ImageGenerationReferenceContext> {
+  const engine = engineEntry.engine;
+  const rawImageUrls = Array.isArray(body.imageUrls) ? body.imageUrls : [];
+  const imageUrls = rawImageUrls
+    .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+    .filter((entry) => entry.length);
+  let characterReferences = sanitizeCharacterReferences(body.characterReferences);
+  const characterReferenceUrls = characterReferences.map((entry) => entry.imageUrl);
+  let normalizedImageUrls = imageUrls.filter((url) => !characterReferenceUrls.includes(url));
+  let combinedImageUrls = [...characterReferenceUrls, ...normalizedImageUrls];
+  const effectivePrompt = buildCharacterReferencePrompt(prompt, characterReferences);
+
+  const invalidImageUrl = combinedImageUrls.find((entry) => !/^https?:\/\//i.test(entry));
+  if (invalidImageUrl) {
+    fail(
+      mode,
+      'invalid_image_url',
+      'Reference images must be absolute URLs (https://...).',
+      400,
+      { url: invalidImageUrl },
+      {
+        engineId: engineEntry.id,
+        engineLabel: engineEntry.marketingName,
+      }
+    );
+  }
+
+  const supportedReferenceFormats = getSupportedImageFormats(engine);
+  let storedAssetInfoByUrl = new Map<string, StoredAssetInfo>();
+  if (supportedReferenceFormats.length && combinedImageUrls.length) {
+    storedAssetInfoByUrl = await getStoredAssetInfoByUrl(userId, combinedImageUrls);
+    const normalizedReferenceByUrl = new Map<string, { url: string; mime: string }>();
+
+    for (const referenceUrl of [...new Set(combinedImageUrls)]) {
+      if (isReferenceImageSupported(supportedReferenceFormats, referenceUrl, storedAssetInfoByUrl)) {
+        continue;
+      }
+
+      try {
+        const normalizedReference = await normalizeReferenceImageForEngine({
+          userId,
+          url: referenceUrl,
+          supportedFormats: supportedReferenceFormats,
+          engineId: engine.id,
+        });
+        normalizedReferenceByUrl.set(referenceUrl, normalizedReference);
+        storedAssetInfoByUrl.set(normalizedReference.url, { mime: normalizedReference.mime });
+      } catch (error) {
+        const reason = error instanceof Error && error.message ? error.message : 'Unable to normalize reference image.';
+        console.warn('[images] failed to normalize reference image for engine', {
+          engineId: engine.id,
+          url: referenceUrl,
+          reason,
+        });
+        fail(
+          mode,
+          'image_normalization_failed',
+          'Reference image could not be converted to a format supported by this engine.',
+          422,
+          { allowed: supportedReferenceFormats, url: referenceUrl, reason },
+          {
+            engineId: engineEntry.id,
+            engineLabel: engineEntry.marketingName,
+          }
+        );
+      }
+    }
+
+    if (normalizedReferenceByUrl.size) {
+      characterReferences = characterReferences.map((entry) => ({
+        ...entry,
+        imageUrl: normalizedReferenceByUrl.get(entry.imageUrl)?.url ?? entry.imageUrl,
+      }));
+      normalizedImageUrls = normalizedImageUrls.map(
+        (entry) => normalizedReferenceByUrl.get(entry)?.url ?? entry
+      );
+      const currentCharacterReferenceUrls = new Set(characterReferences.map((entry) => entry.imageUrl));
+      combinedImageUrls = [
+        ...characterReferences.map((entry) => entry.imageUrl),
+        ...normalizedImageUrls.filter((url) => !currentCharacterReferenceUrls.has(url)),
+      ];
+    }
+
+    const invalidImageFormatUrl = combinedImageUrls.find(
+      (entry) => !isReferenceImageSupported(supportedReferenceFormats, entry, storedAssetInfoByUrl)
+    );
+    if (invalidImageFormatUrl) {
+      fail(
+        mode,
+        'image_format_invalid',
+        `Reference images must use ${formatSupportedImageFormatsLabel(supportedReferenceFormats)}.`,
+        400,
+        { allowed: supportedReferenceFormats, url: invalidImageFormatUrl },
+        {
+          engineId: engineEntry.id,
+          engineLabel: engineEntry.marketingName,
+        }
+      );
+    }
+  }
+
+  const referenceConstraints = getReferenceConstraints(engine, mode);
+  if (referenceConstraints.min > 0 && combinedImageUrls.length < referenceConstraints.min) {
+    const message =
+      referenceConstraints.min === 1
+        ? 'At least one reference image is required for this request.'
+        : `Provide at least ${referenceConstraints.min} reference images for this request.`;
+    fail(mode, 'missing_image_urls', message, 400, { minRequired: referenceConstraints.min }, {
+      engineId: engineEntry.id,
+      engineLabel: engineEntry.marketingName,
+    });
+  }
+  if (combinedImageUrls.length > referenceConstraints.max) {
+    fail(
+      mode,
+      'too_many_image_urls',
+      `You can attach up to ${referenceConstraints.max} reference images.`,
+      400,
+      { maxAllowed: referenceConstraints.max },
+      {
+        engineId: engineEntry.id,
+        engineLabel: engineEntry.marketingName,
+      }
+    );
+  }
+
+  return {
+    characterReferences,
+    normalizedImageUrls,
+    combinedImageUrls,
+    effectivePrompt,
+    storedAssetInfoByUrl,
+  };
+}
+
+function fail(
+  mode: ImageGenerationMode,
+  code: string,
+  message: string,
+  status: number,
+  detail?: unknown,
+  extras?: Partial<ImageGenerationResponse>
+): never {
+  throw new ImageGenerationExecutionError(message, { mode, code, status, detail, extras });
+}

--- a/frontend/src/server/images/image-generation-request-context.ts
+++ b/frontend/src/server/images/image-generation-request-context.ts
@@ -1,0 +1,118 @@
+import { listFalEngines, type FalEngineEntry } from '@/config/falEngines';
+import type {
+  ImageGenerationMode,
+  ImageGenerationRequest,
+  ImageGenerationResponse,
+} from '@/types/image-generation';
+import {
+  clampRequestedImageCount,
+  resolveRequestedAspectRatio,
+} from '@/app/api/images/utils';
+import { ImageGenerationExecutionError } from './image-generation-error';
+
+export type ImageEngineEntry = FalEngineEntry;
+
+export type ImageGenerationRequestContext = {
+  engineEntry: ImageEngineEntry;
+  engine: ImageEngineEntry['engine'];
+  mode: ImageGenerationMode;
+  modeConfig: ImageEngineEntry['modes'][number];
+  resolvedAspectRatio: string | null;
+  prompt: string;
+  numImages: number;
+  durationSec: number;
+};
+
+const IMAGE_ENGINE_REGISTRY = listFalEngines().filter((entry) => (entry.category ?? 'video') === 'image');
+const IMAGE_ENGINE_MAP = new Map(IMAGE_ENGINE_REGISTRY.map((entry) => [entry.id, entry]));
+const DEFAULT_IMAGE_ENGINE_ID = IMAGE_ENGINE_REGISTRY[0]?.id ?? null;
+
+export function resolveImageGenerationRequestContext(
+  body: Partial<ImageGenerationRequest>
+): ImageGenerationRequestContext {
+  const engineEntry = getImageEngine(body.engineId);
+  if (!engineEntry) {
+    fail('t2i', 'engine_unavailable', 'Image engine unavailable.', 503);
+  }
+
+  const engine = engineEntry.engine;
+  const fallbackMode = (engineEntry.modes[0]?.mode as ImageGenerationMode | undefined) ?? 't2i';
+  const mode = normalizeMode(body.mode, fallbackMode);
+  const modeConfig = engineEntry.modes.find((entry) => entry.mode === mode);
+  if (!modeConfig?.falModelId) {
+    fail(mode, 'mode_unsupported', 'Selected engine does not support this mode.', 400, null, {
+      engineId: engineEntry.id,
+      engineLabel: engineEntry.marketingName,
+    });
+  }
+
+  const aspectRatioResult = resolveRequestedAspectRatio(
+    engine,
+    mode,
+    typeof body.aspectRatio === 'string' ? body.aspectRatio : null
+  );
+  if (!aspectRatioResult.ok) {
+    fail(
+      mode,
+      'aspect_ratio_invalid',
+      'Selected aspect ratio is not available for this engine.',
+      400,
+      { allowed: aspectRatioResult.allowed },
+      {
+        engineId: engineEntry.id,
+        engineLabel: engineEntry.marketingName,
+      }
+    );
+  }
+
+  const prompt = typeof body.prompt === 'string' ? body.prompt.trim() : '';
+  if (!prompt.length) {
+    fail(mode, 'invalid_prompt', 'Prompt is required.', 400, null, {
+      engineId: engineEntry.id,
+      engineLabel: engineEntry.marketingName,
+    });
+  }
+
+  const requestedImages =
+    typeof body.numImages === 'number' && Number.isFinite(body.numImages) ? Math.round(body.numImages) : 1;
+  const numImages = clampRequestedImageCount(engine, mode, requestedImages);
+
+  return {
+    engineEntry,
+    engine,
+    mode,
+    modeConfig,
+    resolvedAspectRatio: aspectRatioResult.value || null,
+    prompt,
+    numImages,
+    durationSec: numImages,
+  };
+}
+
+function getImageEngine(engineId?: string | null): ImageEngineEntry | null {
+  if (engineId && IMAGE_ENGINE_MAP.has(engineId)) {
+    return IMAGE_ENGINE_MAP.get(engineId) ?? null;
+  }
+  if (DEFAULT_IMAGE_ENGINE_ID && IMAGE_ENGINE_MAP.has(DEFAULT_IMAGE_ENGINE_ID)) {
+    return IMAGE_ENGINE_MAP.get(DEFAULT_IMAGE_ENGINE_ID) ?? null;
+  }
+  return null;
+}
+
+function normalizeMode(value: unknown, fallback: ImageGenerationMode = 't2i'): ImageGenerationMode {
+  if (value === 't2i' || value === 'i2i') return value;
+  if (value === 'generate') return 't2i';
+  if (value === 'edit') return 'i2i';
+  return fallback;
+}
+
+function fail(
+  mode: ImageGenerationMode,
+  code: string,
+  message: string,
+  status: number,
+  detail?: unknown,
+  extras?: Partial<ImageGenerationResponse>
+): never {
+  throw new ImageGenerationExecutionError(message, { mode, code, status, detail, extras });
+}

--- a/tests/image-generation-server-architecture.test.ts
+++ b/tests/image-generation-server-architecture.test.ts
@@ -7,6 +7,8 @@ const root = process.cwd();
 const executorPath = join(root, 'frontend/src/server/images/execute-image-generation.ts');
 const existingJobResponsePath = join(root, 'frontend/src/server/images/existing-image-job-response.ts');
 const referenceNormalizationPath = join(root, 'frontend/src/server/images/image-reference-normalization.ts');
+const requestContextPath = join(root, 'frontend/src/server/images/image-generation-request-context.ts');
+const referencesPath = join(root, 'frontend/src/server/images/image-generation-references.ts');
 const initialJobPath = join(root, 'frontend/src/server/images/image-initial-job.ts');
 const errorPath = join(root, 'frontend/src/server/images/image-generation-error.ts');
 const providerPayloadPath = join(root, 'frontend/src/server/images/image-provider-payload.ts');
@@ -18,6 +20,8 @@ const settingsSnapshotPath = join(root, 'frontend/src/server/images/image-genera
 const executorSource = readFileSync(executorPath, 'utf8');
 const existingJobResponseSource = readFileSync(existingJobResponsePath, 'utf8');
 const referenceNormalizationSource = readFileSync(referenceNormalizationPath, 'utf8');
+const requestContextSource = readFileSync(requestContextPath, 'utf8');
+const referencesSource = readFileSync(referencesPath, 'utf8');
 const initialJobSource = readFileSync(initialJobPath, 'utf8');
 const errorSource = readFileSync(errorPath, 'utf8');
 const providerPayloadSource = readFileSync(providerPayloadPath, 'utf8');
@@ -29,6 +33,8 @@ const settingsSnapshotSource = readFileSync(settingsSnapshotPath, 'utf8');
 test('image generation executor delegates focused server helpers', () => {
   assert.ok(existsSync(existingJobResponsePath), 'existing image job response helpers should live in a focused module');
   assert.ok(existsSync(referenceNormalizationPath), 'image reference normalization should live in a focused module');
+  assert.ok(existsSync(requestContextPath), 'image request context validation should live in a focused module');
+  assert.ok(existsSync(referencesPath), 'image reference preparation should live in a focused module');
   assert.ok(existsSync(initialJobPath), 'atomic initial image job creation should live in a focused module');
   assert.ok(existsSync(errorPath), 'image generation execution error should live in a focused module');
   assert.ok(existsSync(providerPayloadPath), 'provider payload parsing should live in a focused module');
@@ -37,7 +43,8 @@ test('image generation executor delegates focused server helpers', () => {
   assert.ok(existsSync(receiptsPath), 'image generation receipt helpers should live in a focused module');
   assert.ok(existsSync(settingsSnapshotPath), 'image settings snapshot helpers should live in a focused module');
   assert.match(executorSource, /from '\.\/existing-image-job-response'/);
-  assert.match(executorSource, /from '\.\/image-reference-normalization'/);
+  assert.match(executorSource, /from '\.\/image-generation-request-context'/);
+  assert.match(executorSource, /from '\.\/image-generation-references'/);
   assert.match(executorSource, /from '\.\/image-initial-job'/);
   assert.match(executorSource, /from '\.\/image-generation-error'/);
   assert.match(executorSource, /from '\.\/image-provider-payload'/);
@@ -53,6 +60,12 @@ test('image generation executor does not regain extracted server ownership', () 
   assert.doesNotMatch(executorSource, /function buildImagesFromExistingJob\(/, 'stored render parsing belongs in existing-image-job-response.ts');
   assert.doesNotMatch(executorSource, /function parseResolutionFromSettingsSnapshot\(/, 'settings snapshot resolution parsing belongs in existing-image-job-response.ts');
   assert.doesNotMatch(executorSource, /parseStoredImageRenders/, 'stored render parsing belongs in existing-image-job-response.ts');
+  assert.doesNotMatch(executorSource, /function getImageEngine\(/, 'engine resolution belongs in image-generation-request-context.ts');
+  assert.doesNotMatch(executorSource, /function normalizeMode\(/, 'mode normalization belongs in image-generation-request-context.ts');
+  assert.doesNotMatch(executorSource, /clampRequestedImageCount/, 'image count clamping belongs in image-generation-request-context.ts');
+  assert.doesNotMatch(executorSource, /resolveRequestedAspectRatio/, 'aspect ratio validation belongs in image-generation-request-context.ts');
+  assert.doesNotMatch(executorSource, /sanitizeCharacterReferences/, 'character reference sanitizing belongs in image-generation-references.ts');
+  assert.doesNotMatch(executorSource, /getReferenceConstraints/, 'reference count validation belongs in image-generation-references.ts');
   assert.doesNotMatch(executorSource, /function pickNormalizedReferenceMime\(/, 'reference mime selection belongs in image-reference-normalization.ts');
   assert.doesNotMatch(executorSource, /function isReferenceImageSupported\(/, 'reference format checks belong in image-reference-normalization.ts');
   assert.doesNotMatch(executorSource, /async function normalizeReferenceImageForEngine\(/, 'reference normalization belongs in image-reference-normalization.ts');
@@ -78,7 +91,7 @@ test('image generation executor does not regain extracted server ownership', () 
   assert.doesNotMatch(executorSource, /referenceImageHosts/, 'failed provider log metadata belongs in image-generation-failure.ts');
 
   const lineCount = executorSource.split('\n').length;
-  assert.ok(lineCount <= 790, `image generation executor should stay below 790 lines after failure extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 640, `image generation executor should stay below 640 lines after context extraction, got ${lineCount}`);
 });
 
 test('existing image job response module exposes the expected contract', () => {
@@ -91,6 +104,14 @@ test('existing image job response module exposes the expected contract', () => {
   assert.match(referenceNormalizationSource, /export function isReferenceImageSupported/);
   assert.match(referenceNormalizationSource, /export function pickNormalizedReferenceMime/);
   assert.match(referenceNormalizationSource, /export async function normalizeReferenceImageForEngine/);
+  assert.match(requestContextSource, /export type ImageEngineEntry/);
+  assert.match(requestContextSource, /export function resolveImageGenerationRequestContext/);
+  assert.match(requestContextSource, /function getImageEngine/);
+  assert.match(requestContextSource, /function normalizeMode/);
+  assert.match(referencesSource, /export async function prepareImageGenerationReferences/);
+  assert.match(referencesSource, /getStoredAssetInfoByUrl/);
+  assert.match(referencesSource, /normalizeReferenceImageForEngine/);
+  assert.match(referencesSource, /getReferenceConstraints/);
   assert.match(initialJobSource, /export const PLACEHOLDER_THUMB/);
   assert.match(initialJobSource, /export async function createAtomicInitialImageJob/);
   assert.match(initialJobSource, /async function insertProvisionalImageJob/);


### PR DESCRIPTION
## Summary
- extract image engine/mode/aspect ratio/prompt/count resolution into a focused request context module
- extract image reference validation, conversion, and count constraints into a focused references module
- keep pricing, wallet reservation, provider execution, and persistence in the executor for a smaller-risk backend batch
- tighten image generation architecture coverage around the new modules and lower the executor line limit

## Verification
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/image-generation-server-architecture.test.ts tests/image-generation-atomic.test.ts
- pnpm --dir frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run architecture:audit -- --min-lines 500
- npm run lint:exposure
- git diff --check
- npm run test:validate