### PR TITLE
Split angle server helpers

### DIFF
--- a/frontend/src/server/tools/angle-error.ts
+++ b/frontend/src/server/tools/angle-error.ts
@@ -1,0 +1,13 @@
+export class AngleToolError extends Error {
+  status: number;
+  code: string;
+  detail?: unknown;
+
+  constructor(message: string, options?: { status?: number; code?: string; detail?: unknown }) {
+    super(message);
+    this.name = 'AngleToolError';
+    this.status = options?.status ?? 500;
+    this.code = options?.code ?? 'angle_tool_error';
+    this.detail = options?.detail;
+  }
+}

--- a/frontend/src/server/tools/angle-event-log.ts
+++ b/frontend/src/server/tools/angle-event-log.ts
@@ -1,0 +1,33 @@
+import { isDatabaseConfigured, query } from '@/lib/db';
+import { getResultProviderMode } from '@/lib/result-provider';
+import { ensureBillingSchema } from '@/lib/schema';
+import type { AngleToolEngineId } from '@/types/tools-angle';
+
+export const TOOL_EVENT_NAME = 'tool_angle_generate';
+
+export async function insertAngleToolEvent(params: {
+  jobId: string;
+  engineId: AngleToolEngineId;
+  providerJobId?: string | null;
+  payload: Record<string, unknown>;
+}) {
+  if (!isDatabaseConfigured()) return;
+
+  try {
+    await ensureBillingSchema();
+    await query(
+      `INSERT INTO fal_queue_log (job_id, provider, provider_job_id, engine_id, status, payload)
+       VALUES ($1,$2,$3,$4,$5,$6::jsonb)`,
+      [
+        params.jobId,
+        getResultProviderMode(),
+        params.providerJobId ?? null,
+        params.engineId,
+        TOOL_EVENT_NAME,
+        JSON.stringify(params.payload),
+      ]
+    );
+  } catch (error) {
+    console.warn('[tools/angle] failed to persist event log', error);
+  }
+}

--- a/frontend/src/server/tools/angle-initial-job.ts
+++ b/frontend/src/server/tools/angle-initial-job.ts
@@ -1,0 +1,167 @@
+import { type QueryExecutor, withDbTransaction } from '@/lib/db';
+import { reserveWalletChargeInExecutor } from '@/lib/wallet';
+import type { Currency } from '@/lib/currency';
+import type { AngleToolEngineId } from '@/types/tools-angle';
+import { ANGLE_SURFACE } from './angle-request-utils';
+import { AngleToolError } from './angle-error';
+
+export const PLACEHOLDER_THUMB = '/assets/frames/thumb-1x1.svg';
+
+type ProvisionalAngleJobInsert = {
+  jobId: string;
+  userId: string;
+  billingProductKey: string;
+  engineId: AngleToolEngineId;
+  engineLabel: string;
+  durationSec: number;
+  promptSummary: string;
+  finalPriceCents: number;
+  pricingSnapshotJson: string;
+  settingsSnapshotJson: string;
+  currency: string;
+  vendorAccountId: string | null;
+};
+
+export type CreateAngleInitialJobParams = {
+  userId: string;
+  jobId: string;
+  description: string;
+  amountCents: number;
+  currency: string;
+  billingProductKey: string;
+  pricingSnapshotJson: string;
+  applicationFeeCents: number | null;
+  vendorAccountId: string | null;
+  engineId: AngleToolEngineId;
+  engineLabel: string;
+  requestedOutputCount: number;
+  promptSummary: string;
+  settingsSnapshotJson: string;
+  preferredCurrency: Currency | null;
+};
+
+async function insertProvisionalAngleJob(executor: QueryExecutor, params: ProvisionalAngleJobInsert) {
+  await executor.query(
+    `INSERT INTO app_jobs (
+       job_id,
+       user_id,
+       surface,
+       billing_product_key,
+       engine_id,
+       engine_label,
+       duration_sec,
+       prompt,
+       thumb_url,
+       preview_frame,
+       status,
+       progress,
+       final_price_cents,
+       pricing_snapshot,
+       settings_snapshot,
+       currency,
+       vendor_account_id,
+       payment_status,
+       visibility,
+       indexable,
+       provisional
+     )
+     VALUES (
+       $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,'pending',0,$11,$12::jsonb,$13::jsonb,$14,$15,'paid_wallet','private',FALSE,TRUE
+     )`,
+    [
+      params.jobId,
+      params.userId,
+      ANGLE_SURFACE,
+      params.billingProductKey,
+      params.engineId,
+      params.engineLabel,
+      params.durationSec,
+      params.promptSummary,
+      PLACEHOLDER_THUMB,
+      PLACEHOLDER_THUMB,
+      params.finalPriceCents,
+      params.pricingSnapshotJson,
+      params.settingsSnapshotJson,
+      params.currency,
+      params.vendorAccountId,
+    ]
+  );
+}
+
+export async function createAngleInitialJobInExecutor(
+  executor: QueryExecutor,
+  params: CreateAngleInitialJobParams
+): Promise<void> {
+  const reserveResult = await reserveWalletChargeInExecutor(
+    executor,
+    {
+      userId: params.userId,
+      amountCents: params.amountCents,
+      currency: params.currency,
+      description: params.description,
+      jobId: params.jobId,
+      surface: ANGLE_SURFACE,
+      billingProductKey: params.billingProductKey,
+      pricingSnapshotJson: params.pricingSnapshotJson,
+      applicationFeeCents: params.applicationFeeCents,
+      vendorAccountId: params.vendorAccountId,
+      stripePaymentIntentId: null,
+      stripeChargeId: null,
+    },
+    { preferredCurrency: params.preferredCurrency }
+  );
+
+  if (!reserveResult.ok) {
+    if (reserveResult.errorCode === 'currency_mismatch') {
+      const lockedCurrency = (reserveResult.preferredCurrency ?? 'usd').toUpperCase();
+      throw new AngleToolError(`Wallet currency locked to ${lockedCurrency}. Contact support to request a change.`, {
+        status: 409,
+        code: 'wallet_currency_mismatch',
+        detail: { lockedCurrency },
+      });
+    }
+
+    throw new AngleToolError('Insufficient wallet balance for this angle run.', {
+      status: 402,
+      code: 'insufficient_wallet_funds',
+      detail: {
+        balanceCents: reserveResult.balanceCents,
+        requiredCents: Math.max(0, params.amountCents - reserveResult.balanceCents),
+      },
+    });
+  }
+
+  await insertProvisionalAngleJob(executor, {
+    jobId: params.jobId,
+    userId: params.userId,
+    billingProductKey: params.billingProductKey,
+    engineId: params.engineId,
+    engineLabel: params.engineLabel,
+    durationSec: params.requestedOutputCount,
+    promptSummary: params.promptSummary,
+    finalPriceCents: params.amountCents,
+    pricingSnapshotJson: params.pricingSnapshotJson,
+    settingsSnapshotJson: params.settingsSnapshotJson,
+    currency: params.currency,
+    vendorAccountId: params.vendorAccountId,
+  });
+}
+
+export async function createAtomicInitialAngleJob(params: CreateAngleInitialJobParams): Promise<void> {
+  try {
+    await withDbTransaction(async (executor) => {
+      await executor.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [params.jobId]);
+      await createAngleInitialJobInExecutor(executor, params);
+    });
+  } catch (error) {
+    if (error instanceof AngleToolError) {
+      throw error;
+    }
+
+    throw new AngleToolError('Failed to save angle job.', {
+      status: 500,
+      code: 'job_persist_failed',
+      detail: error instanceof Error ? error.message : error,
+    });
+  }
+}

--- a/frontend/src/server/tools/angle-receipts.ts
+++ b/frontend/src/server/tools/angle-receipts.ts
@@ -1,0 +1,56 @@
+import { query } from '@/lib/db';
+import type { PricingSnapshot } from '@/types/engines';
+import { ANGLE_SURFACE } from './angle-request-utils';
+
+export type PendingAngleReceipt = {
+  userId: string;
+  amountCents: number;
+  currency: string;
+  description: string;
+  jobId: string;
+  surface: typeof ANGLE_SURFACE;
+  billingProductKey: string;
+  snapshot: PricingSnapshot;
+  applicationFeeCents: number | null;
+  vendorAccountId: string | null;
+};
+
+export async function recordAngleRefundReceipt(receipt: PendingAngleReceipt, label: string, priceOnly: boolean) {
+  try {
+    await query(
+      `INSERT INTO app_receipts (
+         user_id,
+         type,
+         amount_cents,
+         currency,
+         description,
+         job_id,
+         surface,
+         billing_product_key,
+         pricing_snapshot,
+         application_fee_cents,
+         vendor_account_id,
+         platform_revenue_cents,
+         destination_acct
+       )
+       VALUES ($1,'refund',$2,$3,$4,$5,$6,$7,$8::jsonb,$9,$10,$11,$12)
+       ON CONFLICT DO NOTHING`,
+      [
+        receipt.userId,
+        receipt.amountCents,
+        receipt.currency,
+        label,
+        receipt.jobId,
+        receipt.surface,
+        receipt.billingProductKey,
+        JSON.stringify(receipt.snapshot),
+        priceOnly ? null : 0,
+        priceOnly ? null : receipt.vendorAccountId,
+        priceOnly ? null : 0,
+        priceOnly ? null : receipt.vendorAccountId,
+      ]
+    );
+  } catch (error) {
+    console.warn('[tools/angle] failed to record refund receipt', error);
+  }
+}

--- a/frontend/src/server/tools/angle.ts
+++ b/frontend/src/server/tools/angle.ts
@@ -1,14 +1,11 @@
 import { randomUUID } from 'crypto';
 import { ApiError, ValidationError } from '@fal-ai/client';
 import { getAngleToolEngine } from '@/config/tools-angle-engines';
-import { isDatabaseConfigured, query, type QueryExecutor, withDbTransaction } from '@/lib/db';
+import { query } from '@/lib/db';
 import { getFalClient } from '@/lib/fal-client';
-import { getResultProviderMode } from '@/lib/result-provider';
-import { ensureBillingSchema } from '@/lib/schema';
 import { computeBillingProductSnapshot } from '@/lib/billing-products';
 import { getPlatformFeeCents } from '@/lib/pricing';
-import { getUserPreferredCurrency, type Currency } from '@/lib/currency';
-import { reserveWalletChargeInExecutor } from '@/lib/wallet';
+import { getUserPreferredCurrency } from '@/lib/currency';
 import { receiptsPriceOnlyEnabled } from '@/lib/env';
 import { createImageThumbnailBatch } from '@/server/image-thumbnails';
 import { buildStoredImageRenderEntries, resolveHeroThumbFromRenders } from '@/lib/image-renders';
@@ -23,7 +20,6 @@ import type {
   AngleToolOutput,
   AngleToolRequest,
   AngleToolResponse,
-  AngleToolEngineId,
 } from '@/types/tools-angle';
 import type { PricingSnapshot } from '@/types/engines';
 import {
@@ -39,270 +35,24 @@ import {
   toAngleValidationMessage,
 } from './angle-request-utils';
 import { persistAngleOutputs } from './angle-output-persistence';
+import { AngleToolError } from './angle-error';
+import {
+  createAtomicInitialAngleJob,
+  PLACEHOLDER_THUMB,
+} from './angle-initial-job';
+import { insertAngleToolEvent, TOOL_EVENT_NAME } from './angle-event-log';
+import { recordAngleRefundReceipt, type PendingAngleReceipt } from './angle-receipts';
 
-const TOOL_EVENT_NAME = 'tool_angle_generate';
-const PLACEHOLDER_THUMB = '/assets/frames/thumb-1x1.svg';
-
-function usdToCredits(value: number | null | undefined): number | null {
-  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return null;
-  return Math.max(1, Math.round(value * 100));
-}
-
-export class AngleToolError extends Error {
-  status: number;
-  code: string;
-  detail?: unknown;
-
-  constructor(message: string, options?: { status?: number; code?: string; detail?: unknown }) {
-    super(message);
-    this.name = 'AngleToolError';
-    this.status = options?.status ?? 500;
-    this.code = options?.code ?? 'angle_tool_error';
-    this.detail = options?.detail;
-  }
-}
+export { AngleToolError } from './angle-error';
+export { createAngleInitialJobInExecutor } from './angle-initial-job';
 
 type RunAngleToolInput = AngleToolRequest & {
   userId: string;
 };
 
-type PendingAngleReceipt = {
-  userId: string;
-  amountCents: number;
-  currency: string;
-  description: string;
-  jobId: string;
-  surface: typeof ANGLE_SURFACE;
-  billingProductKey: string;
-  snapshot: PricingSnapshot;
-  applicationFeeCents: number | null;
-  vendorAccountId: string | null;
-};
-
-type ProvisionalAngleJobInsert = {
-  jobId: string;
-  userId: string;
-  billingProductKey: string;
-  engineId: AngleToolEngineId;
-  engineLabel: string;
-  durationSec: number;
-  promptSummary: string;
-  finalPriceCents: number;
-  pricingSnapshotJson: string;
-  settingsSnapshotJson: string;
-  currency: string;
-  vendorAccountId: string | null;
-};
-
-type CreateAngleInitialJobParams = {
-  userId: string;
-  jobId: string;
-  description: string;
-  amountCents: number;
-  currency: string;
-  billingProductKey: string;
-  pricingSnapshotJson: string;
-  applicationFeeCents: number | null;
-  vendorAccountId: string | null;
-  engineId: AngleToolEngineId;
-  engineLabel: string;
-  requestedOutputCount: number;
-  promptSummary: string;
-  settingsSnapshotJson: string;
-  preferredCurrency: Currency | null;
-};
-
-async function recordAngleRefundReceipt(receipt: PendingAngleReceipt, label: string, priceOnly: boolean) {
-  try {
-    await query(
-      `INSERT INTO app_receipts (
-         user_id,
-         type,
-         amount_cents,
-         currency,
-         description,
-         job_id,
-         surface,
-         billing_product_key,
-         pricing_snapshot,
-         application_fee_cents,
-         vendor_account_id,
-         platform_revenue_cents,
-         destination_acct
-       )
-       VALUES ($1,'refund',$2,$3,$4,$5,$6,$7,$8::jsonb,$9,$10,$11,$12)
-       ON CONFLICT DO NOTHING`,
-      [
-        receipt.userId,
-        receipt.amountCents,
-        receipt.currency,
-        label,
-        receipt.jobId,
-        receipt.surface,
-        receipt.billingProductKey,
-        JSON.stringify(receipt.snapshot),
-        priceOnly ? null : 0,
-        priceOnly ? null : receipt.vendorAccountId,
-        priceOnly ? null : 0,
-        priceOnly ? null : receipt.vendorAccountId,
-      ]
-    );
-  } catch (error) {
-    console.warn('[tools/angle] failed to record refund receipt', error);
-  }
-}
-
-async function insertProvisionalAngleJob(executor: QueryExecutor, params: ProvisionalAngleJobInsert) {
-  await executor.query(
-    `INSERT INTO app_jobs (
-       job_id,
-       user_id,
-       surface,
-       billing_product_key,
-       engine_id,
-       engine_label,
-       duration_sec,
-       prompt,
-       thumb_url,
-       preview_frame,
-       status,
-       progress,
-       final_price_cents,
-       pricing_snapshot,
-       settings_snapshot,
-       currency,
-       vendor_account_id,
-       payment_status,
-       visibility,
-       indexable,
-       provisional
-     )
-     VALUES (
-       $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,'pending',0,$11,$12::jsonb,$13::jsonb,$14,$15,'paid_wallet','private',FALSE,TRUE
-     )`,
-    [
-      params.jobId,
-      params.userId,
-      ANGLE_SURFACE,
-      params.billingProductKey,
-      params.engineId,
-      params.engineLabel,
-      params.durationSec,
-      params.promptSummary,
-      PLACEHOLDER_THUMB,
-      PLACEHOLDER_THUMB,
-      params.finalPriceCents,
-      params.pricingSnapshotJson,
-      params.settingsSnapshotJson,
-      params.currency,
-      params.vendorAccountId,
-    ]
-  );
-}
-
-export async function createAngleInitialJobInExecutor(
-  executor: QueryExecutor,
-  params: CreateAngleInitialJobParams
-): Promise<void> {
-  const reserveResult = await reserveWalletChargeInExecutor(
-    executor,
-    {
-      userId: params.userId,
-      amountCents: params.amountCents,
-      currency: params.currency,
-      description: params.description,
-      jobId: params.jobId,
-      surface: ANGLE_SURFACE,
-      billingProductKey: params.billingProductKey,
-      pricingSnapshotJson: params.pricingSnapshotJson,
-      applicationFeeCents: params.applicationFeeCents,
-      vendorAccountId: params.vendorAccountId,
-      stripePaymentIntentId: null,
-      stripeChargeId: null,
-    },
-    { preferredCurrency: params.preferredCurrency }
-  );
-
-  if (!reserveResult.ok) {
-    if (reserveResult.errorCode === 'currency_mismatch') {
-      const lockedCurrency = (reserveResult.preferredCurrency ?? 'usd').toUpperCase();
-      throw new AngleToolError(`Wallet currency locked to ${lockedCurrency}. Contact support to request a change.`, {
-        status: 409,
-        code: 'wallet_currency_mismatch',
-        detail: { lockedCurrency },
-      });
-    }
-
-    throw new AngleToolError('Insufficient wallet balance for this angle run.', {
-      status: 402,
-      code: 'insufficient_wallet_funds',
-      detail: {
-        balanceCents: reserveResult.balanceCents,
-        requiredCents: Math.max(0, params.amountCents - reserveResult.balanceCents),
-      },
-    });
-  }
-
-  await insertProvisionalAngleJob(executor, {
-    jobId: params.jobId,
-    userId: params.userId,
-    billingProductKey: params.billingProductKey,
-    engineId: params.engineId,
-    engineLabel: params.engineLabel,
-    durationSec: params.requestedOutputCount,
-    promptSummary: params.promptSummary,
-    finalPriceCents: params.amountCents,
-    pricingSnapshotJson: params.pricingSnapshotJson,
-    settingsSnapshotJson: params.settingsSnapshotJson,
-    currency: params.currency,
-    vendorAccountId: params.vendorAccountId,
-  });
-}
-
-async function createAtomicInitialAngleJob(params: CreateAngleInitialJobParams): Promise<void> {
-  try {
-    await withDbTransaction(async (executor) => {
-      await executor.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [params.jobId]);
-      await createAngleInitialJobInExecutor(executor, params);
-    });
-  } catch (error) {
-    if (error instanceof AngleToolError) {
-      throw error;
-    }
-
-    throw new AngleToolError('Failed to save angle job.', {
-      status: 500,
-      code: 'job_persist_failed',
-      detail: error instanceof Error ? error.message : error,
-    });
-  }
-}
-
-async function insertToolEvent(params: {
-  jobId: string;
-  engineId: AngleToolEngineId;
-  providerJobId?: string | null;
-  payload: Record<string, unknown>;
-}) {
-  if (!isDatabaseConfigured()) return;
-
-  try {
-    await ensureBillingSchema();
-    await query(
-      `INSERT INTO fal_queue_log (job_id, provider, provider_job_id, engine_id, status, payload)
-       VALUES ($1,$2,$3,$4,$5,$6::jsonb)`,
-      [
-        params.jobId,
-        getResultProviderMode(),
-        params.providerJobId ?? null,
-        params.engineId,
-        TOOL_EVENT_NAME,
-        JSON.stringify(params.payload),
-      ]
-    );
-  } catch (error) {
-    console.warn('[tools/angle] failed to persist event log', error);
-  }
+function usdToCredits(value: number | null | undefined): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return null;
+  return Math.max(1, Math.round(value * 100));
 }
 
 export async function runAngleTool(input: RunAngleToolInput): Promise<AngleToolResponse> {
@@ -523,7 +273,7 @@ export async function runAngleTool(input: RunAngleToolInput): Promise<AngleToolR
       )
     );
 
-    await insertToolEvent({
+    await insertAngleToolEvent({
       jobId,
       engineId: engine.id,
       providerJobId: requestId,
@@ -628,7 +378,7 @@ export async function runAngleTool(input: RunAngleToolInput): Promise<AngleToolR
       console.warn('[tools/angle] failed to mark job as failed', updateError);
     }
 
-    await insertToolEvent({
+    await insertAngleToolEvent({
       jobId,
       engineId: engine.id,
       providerJobId,

--- a/tests/angle-server-architecture.test.ts
+++ b/tests/angle-server-architecture.test.ts
@@ -7,10 +7,18 @@ const root = process.cwd();
 const serverPath = join(root, 'frontend/src/server/tools/angle.ts');
 const requestUtilsPath = join(root, 'frontend/src/server/tools/angle-request-utils.ts');
 const outputPersistencePath = join(root, 'frontend/src/server/tools/angle-output-persistence.ts');
+const angleErrorPath = join(root, 'frontend/src/server/tools/angle-error.ts');
+const angleReceiptsPath = join(root, 'frontend/src/server/tools/angle-receipts.ts');
+const angleInitialJobPath = join(root, 'frontend/src/server/tools/angle-initial-job.ts');
+const angleEventLogPath = join(root, 'frontend/src/server/tools/angle-event-log.ts');
 
 const serverSource = readFileSync(serverPath, 'utf8');
 const requestUtilsSource = readFileSync(requestUtilsPath, 'utf8');
 const outputPersistenceSource = readFileSync(outputPersistencePath, 'utf8');
+const angleErrorSource = readFileSync(angleErrorPath, 'utf8');
+const angleReceiptsSource = readFileSync(angleReceiptsPath, 'utf8');
+const angleInitialJobSource = readFileSync(angleInitialJobPath, 'utf8');
+const angleEventLogSource = readFileSync(angleEventLogPath, 'utf8');
 
 test('angle server delegates request and provider normalization helpers', () => {
   assert.ok(existsSync(requestUtilsPath), 'angle request helpers should live in a server-local utility module');
@@ -42,7 +50,7 @@ test('angle server delegates request and provider normalization helpers', () => 
   assert.doesNotMatch(serverSource, /normalizeMediaUrl/, 'Fal output URL normalization belongs in angle-request-utils.ts');
 
   const lineCount = serverSource.split('\n').length;
-  assert.ok(lineCount <= 700, `angle server orchestrator should stay below 700 lines after helper extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 460, `angle server orchestrator should stay below 460 lines after helper extraction, got ${lineCount}`);
 });
 
 test('angle server delegates output persistence to a focused helper', () => {
@@ -96,4 +104,68 @@ test('angle request utils expose the expected pure helper contract', () => {
 
   assert.match(requestUtilsSource, /function normalizeFalUrl\(/, 'Fal URL normalization should be private to request helpers');
   assert.match(requestUtilsSource, /function toAngleOutput\(/, 'provider output mapping should be private to request helpers');
+});
+
+test('angle server delegates wallet, receipt, and event-log responsibilities', () => {
+  for (const [path, label] of [
+    [angleErrorPath, 'angle error helper'],
+    [angleReceiptsPath, 'angle receipt helper'],
+    [angleInitialJobPath, 'angle initial job helper'],
+    [angleEventLogPath, 'angle event log helper'],
+  ] as const) {
+    assert.ok(existsSync(path), `${label} should live in a server-local helper module`);
+  }
+
+  for (const importName of ['angle-error', 'angle-receipts', 'angle-initial-job', 'angle-event-log']) {
+    assert.match(serverSource, new RegExp(`from '\\./${importName}'`), `angle server should import ${importName}`);
+  }
+
+  assert.match(serverSource, /export \{ AngleToolError \} from '\.\/angle-error'/, 'legacy error export should stay stable');
+  assert.match(
+    serverSource,
+    /export \{ createAngleInitialJobInExecutor \} from '\.\/angle-initial-job'/,
+    'legacy initial-job export should stay stable'
+  );
+
+  for (const implementationPattern of [
+    /export class AngleToolError/,
+    /reserveWalletChargeInExecutor/,
+    /withDbTransaction/,
+    /async function insertProvisionalAngleJob/,
+    /async function recordAngleRefundReceipt/,
+    /async function insertToolEvent/,
+  ]) {
+    assert.doesNotMatch(serverSource, implementationPattern, 'angle.ts should stay focused on run orchestration');
+  }
+
+  assert.match(angleErrorSource, /export class AngleToolError/, 'angle-error should own the public error class');
+  assert.match(angleReceiptsSource, /export type PendingAngleReceipt/, 'angle-receipts should export pending receipt data');
+  assert.match(
+    angleReceiptsSource,
+    /export async function recordAngleRefundReceipt/,
+    'angle-receipts should own refund receipt persistence'
+  );
+  assert.match(angleInitialJobSource, /export const PLACEHOLDER_THUMB/, 'angle-initial-job should own placeholder metadata');
+  assert.match(
+    angleInitialJobSource,
+    /export async function createAngleInitialJobInExecutor/,
+    'angle-initial-job should export the testable transaction inner contract'
+  );
+  assert.match(
+    angleInitialJobSource,
+    /export async function createAtomicInitialAngleJob/,
+    'angle-initial-job should export atomic initial-job persistence'
+  );
+  assert.match(
+    angleInitialJobSource,
+    /reserveWalletChargeInExecutor/,
+    'angle-initial-job should own wallet reservation preflight'
+  );
+  assert.match(angleInitialJobSource, /withDbTransaction/, 'angle-initial-job should own the transaction boundary');
+  assert.match(angleEventLogSource, /export const TOOL_EVENT_NAME/, 'angle-event-log should own the event name');
+  assert.match(
+    angleEventLogSource,
+    /export async function insertAngleToolEvent/,
+    'angle-event-log should own Fal queue event persistence'
+  );
 });


### PR DESCRIPTION
## Summary
- split Angle tool error, wallet initial job, refund receipt, and event-log responsibilities into focused server helpers
- keep `angle.ts` as the run orchestrator while preserving legacy public exports used by tests
- tighten Angle architecture contracts so the server file stays below the new bloat threshold

## Verification
- `pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/angle-server-architecture.test.ts tests/angle-atomic.test.ts`
- `pnpm --dir frontend exec tsc --noEmit --pretty false`
- `npm --prefix frontend run lint`
- `npm run architecture:audit -- --min-lines 500`
- `npm run lint:exposure`
- `git diff --check`
- `npm run test:validate`