### PR TITLE
Split audio generation server helpers

### DIFF
--- a/frontend/src/server/audio/audio-generate-jobs.ts
+++ b/frontend/src/server/audio/audio-generate-jobs.ts
@@ -1,0 +1,191 @@
+import { AUDIO_SURFACE } from '@/lib/audio-generation';
+import { query, type QueryExecutor, withDbTransaction } from '@/lib/db';
+import { reserveWalletChargeInExecutor } from '@/lib/wallet';
+import { AudioGenerationError } from './audio-generate-validation';
+
+export const PLACEHOLDER_THUMB = '/assets/frames/thumb-16x9.svg';
+
+export type SourceJobRow = {
+  job_id: string;
+  video_url: string | null;
+  thumb_url: string | null;
+  prompt: string;
+  aspect_ratio: string | null;
+};
+
+export type AudioJobPatch = {
+  progress?: number;
+  status?: 'pending' | 'running' | 'completed' | 'failed';
+  message?: string | null;
+  videoUrl?: string | null;
+  audioUrl?: string | null;
+  thumbUrl?: string | null;
+  hasAudio?: boolean;
+  paymentStatus?: string;
+  settingsSnapshotJson?: string | null;
+};
+
+type InitialAudioJobParams = {
+  userId: string;
+  jobId: string;
+  amountCents: number;
+  currency: string;
+  description: string;
+  billingProductKey: string;
+  pricingSnapshotJson: string;
+  applicationFeeCents: number | null;
+  vendorAccountId: string | null;
+  engineId: string;
+  engineLabel: string;
+  durationSec: number;
+  promptSummary: string;
+  initialThumb: string;
+  aspectRatio: string | null;
+  settingsSnapshotJson: string;
+};
+
+export async function loadSourceJob(userId: string, sourceJobId: string): Promise<SourceJobRow | null> {
+  const rows = await query<SourceJobRow>(
+    `SELECT job_id, video_url, thumb_url, prompt, aspect_ratio
+       FROM app_jobs
+      WHERE job_id = $1
+        AND user_id = $2
+      LIMIT 1`,
+    [sourceJobId, userId]
+  );
+  return rows[0] ?? null;
+}
+
+export async function updateAudioJob(jobId: string, patch: AudioJobPatch): Promise<void> {
+  const assignments: string[] = [];
+  const params: unknown[] = [];
+
+  if (typeof patch.progress === 'number') {
+    params.push(Math.max(0, Math.min(100, Math.round(patch.progress))));
+    assignments.push(`progress = $${params.length}`);
+  }
+  if (patch.status) {
+    params.push(patch.status);
+    assignments.push(`status = $${params.length}`);
+  }
+  if (patch.message !== undefined) {
+    params.push(patch.message);
+    assignments.push(`message = $${params.length}`);
+  }
+  if (patch.videoUrl !== undefined) {
+    params.push(patch.videoUrl);
+    assignments.push(`video_url = $${params.length}`);
+  }
+  if (patch.audioUrl !== undefined) {
+    params.push(patch.audioUrl);
+    assignments.push(`audio_url = $${params.length}`);
+  }
+  if (patch.thumbUrl !== undefined) {
+    params.push(patch.thumbUrl);
+    assignments.push(`thumb_url = $${params.length}`);
+    assignments.push(`preview_frame = $${params.length}`);
+  }
+  if (typeof patch.hasAudio === 'boolean') {
+    params.push(patch.hasAudio);
+    assignments.push(`has_audio = $${params.length}`);
+  }
+  if (patch.paymentStatus) {
+    params.push(patch.paymentStatus);
+    assignments.push(`payment_status = $${params.length}`);
+  }
+  if (patch.settingsSnapshotJson !== undefined) {
+    params.push(patch.settingsSnapshotJson);
+    assignments.push(`settings_snapshot = $${params.length}::jsonb`);
+  }
+
+  if (!assignments.length) return;
+
+  params.push(jobId);
+  await query(`UPDATE app_jobs SET ${assignments.join(', ')}, updated_at = NOW() WHERE job_id = $${params.length}`, params);
+}
+
+async function insertInitialAudioJob(executor: QueryExecutor, params: InitialAudioJobParams): Promise<void> {
+  await executor.query(
+    `INSERT INTO app_jobs (
+       job_id,
+       user_id,
+       surface,
+       billing_product_key,
+       engine_id,
+       engine_label,
+       duration_sec,
+       prompt,
+       thumb_url,
+       video_url,
+       audio_url,
+       aspect_ratio,
+       has_audio,
+       preview_frame,
+       status,
+       progress,
+       final_price_cents,
+       pricing_snapshot,
+       settings_snapshot,
+       currency,
+       vendor_account_id,
+       payment_status,
+       visibility,
+       indexable,
+       provisional
+     )
+     VALUES (
+       $1,$2,$3,$4,$5,$6,$7,$8,$9,NULL,NULL,$10,FALSE,$11,'pending',0,$12,$13::jsonb,$14::jsonb,$15,NULL,'paid_wallet','private',FALSE,TRUE
+     )`,
+    [
+      params.jobId,
+      params.userId,
+      AUDIO_SURFACE,
+      params.billingProductKey,
+      params.engineId,
+      params.engineLabel,
+      params.durationSec,
+      params.promptSummary,
+      params.initialThumb,
+      params.aspectRatio,
+      params.initialThumb,
+      params.amountCents,
+      params.pricingSnapshotJson,
+      params.settingsSnapshotJson,
+      params.currency,
+    ]
+  );
+}
+
+export async function createInitialAudioJob(params: InitialAudioJobParams): Promise<void> {
+  await withDbTransaction(async (executor) => {
+    const reserveResult = await reserveWalletChargeInExecutor(executor, {
+      userId: params.userId,
+      amountCents: params.amountCents,
+      currency: params.currency,
+      description: params.description,
+      jobId: params.jobId,
+      surface: AUDIO_SURFACE,
+      billingProductKey: params.billingProductKey,
+      pricingSnapshotJson: params.pricingSnapshotJson,
+      applicationFeeCents: params.applicationFeeCents,
+      vendorAccountId: params.vendorAccountId,
+      stripePaymentIntentId: null,
+      stripeChargeId: null,
+    });
+
+    if (!reserveResult.ok) {
+      if (reserveResult.errorCode === 'currency_mismatch') {
+        throw new AudioGenerationError('Existing wallet balance uses a different currency.', {
+          status: 400,
+          code: 'wallet_currency_mismatch',
+        });
+      }
+      throw new AudioGenerationError('Insufficient wallet balance.', {
+        status: 402,
+        code: 'INSUFFICIENT_WALLET_FUNDS',
+      });
+    }
+
+    await insertInitialAudioJob(executor, params);
+  });
+}

--- a/frontend/src/server/audio/audio-generate-receipts.ts
+++ b/frontend/src/server/audio/audio-generate-receipts.ts
@@ -1,0 +1,43 @@
+import { AUDIO_SURFACE } from '@/lib/audio-generation';
+import { query } from '@/lib/db';
+
+export async function refundAudioCharge(params: {
+  userId: string;
+  jobId: string;
+  amountCents: number;
+  currency: string;
+  description: string;
+  billingProductKey: string;
+  pricingSnapshotJson: string;
+}): Promise<void> {
+  try {
+    await query(
+      `INSERT INTO app_receipts (
+         user_id,
+         type,
+         amount_cents,
+         currency,
+         description,
+         job_id,
+         surface,
+         billing_product_key,
+         pricing_snapshot,
+         application_fee_cents,
+         vendor_account_id
+       )
+       VALUES ($1, 'refund', $2, $3, $4, $5, $6, $7, $8::jsonb, 0, NULL)`,
+      [
+        params.userId,
+        params.amountCents,
+        params.currency,
+        params.description,
+        params.jobId,
+        AUDIO_SURFACE,
+        params.billingProductKey,
+        params.pricingSnapshotJson,
+      ]
+    );
+  } catch (error) {
+    console.warn('[audio] failed to record wallet refund', error);
+  }
+}

--- a/frontend/src/server/audio/audio-generate-snapshots.ts
+++ b/frontend/src/server/audio/audio-generate-snapshots.ts
@@ -1,0 +1,43 @@
+import {
+  getAudioPackConfig,
+  type AudioMood,
+  type AudioPackId,
+} from '@/lib/audio-generation';
+import type { AudioProviderError } from '@/server/audio/providers';
+
+export function buildPromptSummary(input: {
+  pack: AudioPackId;
+  prompt: string | null;
+  mood: AudioMood | null;
+  script: string | null;
+}): string {
+  const base = getAudioPackConfig(input.pack).label;
+  if (input.script) {
+    return `${base} • ${input.script.slice(0, 80).trim()}`;
+  }
+  if (input.prompt) {
+    return `${base} • ${input.prompt.slice(0, 80).trim()}`;
+  }
+  if (input.mood) {
+    return `${base} • ${input.mood}`;
+  }
+  return base;
+}
+
+export function buildProviderSnapshot(base: Record<string, unknown>, providers: Record<string, unknown>) {
+  return JSON.stringify({
+    ...base,
+    providers,
+  });
+}
+
+export function parseProviderFailures(error: unknown) {
+  if (error && typeof error === 'object' && 'failures' in (error as Record<string, unknown>)) {
+    return (error as AudioProviderError).failures;
+  }
+  return undefined;
+}
+
+export function isVideoBackedPack(pack: AudioPackId): boolean {
+  return !getAudioPackConfig(pack).audioOnly;
+}

--- a/frontend/src/server/audio/generate-audio.ts
+++ b/frontend/src/server/audio/generate-audio.ts
@@ -7,12 +7,9 @@ import {
   getAudioPackConfig,
   type AudioGenerateRequestBody,
   type AudioGenerateResponse,
-  type AudioMood,
-  type AudioPackId,
 } from '@/lib/audio-generation';
-import { isDatabaseConfigured, query, withDbTransaction } from '@/lib/db';
+import { isDatabaseConfigured } from '@/lib/db';
 import { ensureBillingSchema } from '@/lib/schema';
-import { reserveWalletChargeInExecutor } from '@/lib/wallet';
 import {
   mixAudioIntoVideo,
   mixAudioTracks,
@@ -26,13 +23,25 @@ import {
   generateMusicTrack,
   generateSoundDesignTrack,
   generateStandardVoiceTrack,
-  type AudioProviderError,
 } from '@/server/audio/providers';
 import {
   AudioGenerationError,
   resolveAudioRenderDuration,
   validateAudioGenerateRequest,
 } from '@/server/audio/audio-generate-validation';
+import {
+  createInitialAudioJob,
+  loadSourceJob,
+  PLACEHOLDER_THUMB,
+  updateAudioJob,
+} from '@/server/audio/audio-generate-jobs';
+import { refundAudioCharge } from '@/server/audio/audio-generate-receipts';
+import {
+  buildPromptSummary,
+  buildProviderSnapshot,
+  isVideoBackedPack,
+  parseProviderFailures,
+} from '@/server/audio/audio-generate-snapshots';
 
 export {
   AudioGenerationError,
@@ -40,159 +49,6 @@ export {
   validateAudioGenerateRequest,
 } from '@/server/audio/audio-generate-validation';
 export type { ValidatedAudioGenerateRequest } from '@/server/audio/audio-generate-validation';
-
-const PLACEHOLDER_THUMB = '/assets/frames/thumb-16x9.svg';
-
-type SourceJobRow = {
-  job_id: string;
-  video_url: string | null;
-  thumb_url: string | null;
-  prompt: string;
-  aspect_ratio: string | null;
-};
-
-function buildPromptSummary(input: { pack: AudioPackId; prompt: string | null; mood: AudioMood | null; script: string | null }): string {
-  const base = getAudioPackConfig(input.pack).label;
-  if (input.script) {
-    return `${base} • ${input.script.slice(0, 80).trim()}`;
-  }
-  if (input.prompt) {
-    return `${base} • ${input.prompt.slice(0, 80).trim()}`;
-  }
-  if (input.mood) {
-    return `${base} • ${input.mood}`;
-  }
-  return base;
-}
-
-async function loadSourceJob(userId: string, sourceJobId: string): Promise<SourceJobRow | null> {
-  const rows = await query<SourceJobRow>(
-    `SELECT job_id, video_url, thumb_url, prompt, aspect_ratio
-       FROM app_jobs
-      WHERE job_id = $1
-        AND user_id = $2
-      LIMIT 1`,
-    [sourceJobId, userId]
-  );
-  return rows[0] ?? null;
-}
-
-async function updateAudioJob(jobId: string, patch: {
-  progress?: number;
-  status?: 'pending' | 'running' | 'completed' | 'failed';
-  message?: string | null;
-  videoUrl?: string | null;
-  audioUrl?: string | null;
-  thumbUrl?: string | null;
-  hasAudio?: boolean;
-  paymentStatus?: string;
-  settingsSnapshotJson?: string | null;
-}): Promise<void> {
-  const assignments: string[] = [];
-  const params: unknown[] = [];
-
-  if (typeof patch.progress === 'number') {
-    params.push(Math.max(0, Math.min(100, Math.round(patch.progress))));
-    assignments.push(`progress = $${params.length}`);
-  }
-  if (patch.status) {
-    params.push(patch.status);
-    assignments.push(`status = $${params.length}`);
-  }
-  if (patch.message !== undefined) {
-    params.push(patch.message);
-    assignments.push(`message = $${params.length}`);
-  }
-  if (patch.videoUrl !== undefined) {
-    params.push(patch.videoUrl);
-    assignments.push(`video_url = $${params.length}`);
-  }
-  if (patch.audioUrl !== undefined) {
-    params.push(patch.audioUrl);
-    assignments.push(`audio_url = $${params.length}`);
-  }
-  if (patch.thumbUrl !== undefined) {
-    params.push(patch.thumbUrl);
-    assignments.push(`thumb_url = $${params.length}`);
-    assignments.push(`preview_frame = $${params.length}`);
-  }
-  if (typeof patch.hasAudio === 'boolean') {
-    params.push(patch.hasAudio);
-    assignments.push(`has_audio = $${params.length}`);
-  }
-  if (patch.paymentStatus) {
-    params.push(patch.paymentStatus);
-    assignments.push(`payment_status = $${params.length}`);
-  }
-  if (patch.settingsSnapshotJson !== undefined) {
-    params.push(patch.settingsSnapshotJson);
-    assignments.push(`settings_snapshot = $${params.length}::jsonb`);
-  }
-
-  if (!assignments.length) return;
-
-  params.push(jobId);
-  await query(`UPDATE app_jobs SET ${assignments.join(', ')}, updated_at = NOW() WHERE job_id = $${params.length}`, params);
-}
-
-async function refundAudioCharge(params: {
-  userId: string;
-  jobId: string;
-  amountCents: number;
-  currency: string;
-  description: string;
-  billingProductKey: string;
-  pricingSnapshotJson: string;
-}): Promise<void> {
-  try {
-    await query(
-      `INSERT INTO app_receipts (
-         user_id,
-         type,
-         amount_cents,
-         currency,
-         description,
-         job_id,
-         surface,
-         billing_product_key,
-         pricing_snapshot,
-         application_fee_cents,
-         vendor_account_id
-       )
-       VALUES ($1, 'refund', $2, $3, $4, $5, $6, $7, $8::jsonb, 0, NULL)`,
-      [
-        params.userId,
-        params.amountCents,
-        params.currency,
-        params.description,
-        params.jobId,
-        AUDIO_SURFACE,
-        params.billingProductKey,
-        params.pricingSnapshotJson,
-      ]
-    );
-  } catch (error) {
-    console.warn('[audio] failed to record wallet refund', error);
-  }
-}
-
-function buildProviderSnapshot(base: Record<string, unknown>, providers: Record<string, unknown>) {
-  return JSON.stringify({
-    ...base,
-    providers,
-  });
-}
-
-function parseProviderFailures(error: unknown) {
-  if (error && typeof error === 'object' && 'failures' in (error as Record<string, unknown>)) {
-    return (error as AudioProviderError).failures;
-  }
-  return undefined;
-}
-
-function isVideoBackedPack(pack: AudioPackId): boolean {
-  return !getAudioPackConfig(pack).audioOnly;
-}
 
 export async function generateAudioRun(params: {
   body: AudioGenerateRequestBody;
@@ -289,89 +145,24 @@ export async function generateAudioRun(params: {
   const amountCents = pricingSnapshot.totalCents;
   const initialThumb = sourceJob?.thumb_url ?? PLACEHOLDER_THUMB;
 
-  const walletReservation = await withDbTransaction(async (executor) => {
-    const reserveResult = await reserveWalletChargeInExecutor(executor, {
-      userId: params.userId,
-      amountCents,
-      currency: pricingSnapshot.currency,
-      description: packConfig.label,
-      jobId,
-      surface: AUDIO_SURFACE,
-      billingProductKey: packConfig.billingProductKey,
-      pricingSnapshotJson,
-      applicationFeeCents: pricingSnapshot.platformFeeCents ?? pricingSnapshot.margin.amountCents,
-      vendorAccountId: pricingSnapshot.vendorAccountId ?? null,
-      stripePaymentIntentId: null,
-      stripeChargeId: null,
-    });
-
-    if (!reserveResult.ok) {
-      if (reserveResult.errorCode === 'currency_mismatch') {
-        throw new AudioGenerationError('Existing wallet balance uses a different currency.', {
-          status: 400,
-          code: 'wallet_currency_mismatch',
-        });
-      }
-      throw new AudioGenerationError('Insufficient wallet balance.', {
-        status: 402,
-        code: 'INSUFFICIENT_WALLET_FUNDS',
-      });
-    }
-
-    await executor.query(
-      `INSERT INTO app_jobs (
-         job_id,
-         user_id,
-         surface,
-         billing_product_key,
-         engine_id,
-         engine_label,
-         duration_sec,
-         prompt,
-         thumb_url,
-         video_url,
-         audio_url,
-         aspect_ratio,
-         has_audio,
-         preview_frame,
-         status,
-         progress,
-         final_price_cents,
-         pricing_snapshot,
-         settings_snapshot,
-         currency,
-         vendor_account_id,
-         payment_status,
-         visibility,
-         indexable,
-         provisional
-       )
-       VALUES (
-         $1,$2,$3,$4,$5,$6,$7,$8,$9,NULL,NULL,$10,FALSE,$11,'pending',0,$12,$13::jsonb,$14::jsonb,$15,NULL,'paid_wallet','private',FALSE,TRUE
-       )`,
-      [
-        jobId,
-        params.userId,
-        AUDIO_SURFACE,
-        packConfig.billingProductKey,
-        packConfig.engineId,
-        packConfig.label,
-        durationSec,
-        promptSummary,
-        initialThumb,
-        aspectRatio,
-        initialThumb,
-        amountCents,
-        pricingSnapshotJson,
-        JSON.stringify(initialSettingsSnapshot),
-        pricingSnapshot.currency,
-      ]
-    );
-
-    return reserveResult;
+  await createInitialAudioJob({
+    userId: params.userId,
+    jobId,
+    amountCents,
+    currency: pricingSnapshot.currency,
+    description: packConfig.label,
+    billingProductKey: packConfig.billingProductKey,
+    pricingSnapshotJson,
+    applicationFeeCents: pricingSnapshot.platformFeeCents ?? pricingSnapshot.margin.amountCents,
+    vendorAccountId: pricingSnapshot.vendorAccountId ?? null,
+    engineId: packConfig.engineId,
+    engineLabel: packConfig.label,
+    durationSec,
+    promptSummary,
+    initialThumb,
+    aspectRatio,
+    settingsSnapshotJson: JSON.stringify(initialSettingsSnapshot),
   });
-
-  void walletReservation;
 
   await updateAudioJob(jobId, {
     status: 'running',

--- a/tests/audio-generate-server-architecture.test.ts
+++ b/tests/audio-generate-server-architecture.test.ts
@@ -6,9 +6,15 @@ import test from 'node:test';
 const root = process.cwd();
 const runnerPath = join(root, 'frontend/src/server/audio/generate-audio.ts');
 const validationPath = join(root, 'frontend/src/server/audio/audio-generate-validation.ts');
+const jobsPath = join(root, 'frontend/src/server/audio/audio-generate-jobs.ts');
+const receiptsPath = join(root, 'frontend/src/server/audio/audio-generate-receipts.ts');
+const snapshotsPath = join(root, 'frontend/src/server/audio/audio-generate-snapshots.ts');
 
 const runnerSource = readFileSync(runnerPath, 'utf8');
 const validationSource = readFileSync(validationPath, 'utf8');
+const jobsSource = readFileSync(jobsPath, 'utf8');
+const receiptsSource = readFileSync(receiptsPath, 'utf8');
+const snapshotsSource = readFileSync(snapshotsPath, 'utf8');
 
 test('audio generation runner delegates request validation and duration rules', () => {
   assert.ok(existsSync(validationPath), 'audio validation should live in a focused server module');
@@ -30,5 +36,45 @@ test('audio generation runner does not regain validation ownership', () => {
   assert.doesNotMatch(runnerSource, /export function resolveAudioRenderDuration\(/, 'duration resolution belongs in audio-generate-validation.ts');
 
   const lineCount = runnerSource.split('\n').length;
-  assert.ok(lineCount <= 670, `generate-audio.ts should stay below 670 lines after validation extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 460, `generate-audio.ts should stay below 460 lines after server helper extraction, got ${lineCount}`);
+});
+
+test('audio generation runner delegates job persistence, receipts, and snapshots', () => {
+  for (const [path, label] of [
+    [jobsPath, 'audio job helper'],
+    [receiptsPath, 'audio receipt helper'],
+    [snapshotsPath, 'audio snapshot helper'],
+  ] as const) {
+    assert.ok(existsSync(path), `${label} should live in a focused server module`);
+  }
+
+  assert.match(runnerSource, /from '@\/server\/audio\/audio-generate-jobs'/);
+  assert.match(runnerSource, /from '@\/server\/audio\/audio-generate-receipts'/);
+  assert.match(runnerSource, /from '@\/server\/audio\/audio-generate-snapshots'/);
+
+  for (const implementationPattern of [
+    /reserveWalletChargeInExecutor/,
+    /withDbTransaction/,
+    /async function loadSourceJob/,
+    /async function updateAudioJob/,
+    /async function refundAudioCharge/,
+    /function buildPromptSummary/,
+    /function buildProviderSnapshot/,
+    /function parseProviderFailures/,
+  ]) {
+    assert.doesNotMatch(runnerSource, implementationPattern, 'generate-audio.ts should stay focused on run orchestration');
+  }
+
+  assert.match(jobsSource, /export const PLACEHOLDER_THUMB/, 'audio job helper should own placeholder metadata');
+  assert.match(jobsSource, /export type SourceJobRow/, 'audio job helper should expose the source job row contract');
+  assert.match(jobsSource, /export async function loadSourceJob/, 'audio job helper should own source job loading');
+  assert.match(jobsSource, /export async function updateAudioJob/, 'audio job helper should own job patch persistence');
+  assert.match(jobsSource, /export async function createInitialAudioJob/, 'audio job helper should own initial job persistence');
+  assert.match(jobsSource, /reserveWalletChargeInExecutor/, 'audio job helper should own wallet reservation');
+  assert.match(jobsSource, /withDbTransaction/, 'audio job helper should own the initial job transaction boundary');
+  assert.match(receiptsSource, /export async function refundAudioCharge/, 'audio receipt helper should own refund receipts');
+  assert.match(snapshotsSource, /export function buildPromptSummary/, 'audio snapshot helper should own prompt summaries');
+  assert.match(snapshotsSource, /export function buildProviderSnapshot/, 'audio snapshot helper should own provider snapshots');
+  assert.match(snapshotsSource, /export function parseProviderFailures/, 'audio snapshot helper should own provider failure extraction');
+  assert.match(snapshotsSource, /export function isVideoBackedPack/, 'audio snapshot helper should own pack media classification');
 });


### PR DESCRIPTION
## Summary
- split audio generation job persistence, wallet reservation, refund receipts, and snapshot helpers out of the runner
- keep `generate-audio.ts` focused on orchestration and provider flow
- tighten audio architecture tests so the runner stays below the new bloat threshold

## Verification
- `pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/audio-generate-server-architecture.test.ts tests/audio-generate-validation.test.ts tests/audio-pricing.test.ts tests/audio-provider-routing.test.ts tests/audio-mix-graph.test.ts`
- `pnpm --dir frontend exec tsc --noEmit --pretty false`
- `npm --prefix frontend run lint`
- `npm run architecture:audit -- --min-lines 500`
- `npm run lint:exposure`
- `git diff --check`
- `npm run test:validate`