### PR TITLE
Split video watch page sections

### DIFF
--- a/frontend/app/(core)/video/[id]/_components/VideoWatchCard.tsx
+++ b/frontend/app/(core)/video/[id]/_components/VideoWatchCard.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+
+export function VideoWatchCard({
+  children,
+  className = '',
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <section className={`rounded-card border border-hairline bg-surface shadow-card ${className}`}>
+      {children}
+    </section>
+  );
+}

--- a/frontend/app/(core)/video/[id]/_components/VideoWatchContent.tsx
+++ b/frontend/app/(core)/video/[id]/_components/VideoWatchContent.tsx
@@ -1,22 +1,16 @@
-import type { CSSProperties, ReactNode } from 'react';
-import Image from 'next/image';
+import type { CSSProperties } from 'react';
 import Link from 'next/link';
 import {
   ArrowRight,
-  BadgeDollarSign,
   Box,
-  CalendarDays,
   Clock3,
   ExternalLink,
   Film,
-  GalleryHorizontal,
   Monitor,
   Sparkles,
   Tag,
   TextCursorInput,
   Volume2,
-  WandSparkles,
-  Waves,
   type LucideIcon,
 } from 'lucide-react';
 import { CopyPromptButton } from '@/components/CopyPromptButton';
@@ -35,102 +29,11 @@ import {
   serializeJsonLd,
   toAbsoluteUrl,
   toDurationIso,
-  type DetailRow,
   type WatchPageData,
 } from '../_lib/video-watch-page-utils';
-
-type HighlightTone = 'blue' | 'green' | 'rose' | 'amber' | 'slate';
-
-function getDetailIcon(key: string): LucideIcon {
-  switch (key) {
-    case 'engine':
-      return Film;
-    case 'mode':
-      return WandSparkles;
-    case 'duration':
-      return Clock3;
-    case 'aspectRatio':
-      return Monitor;
-    case 'resolution':
-      return GalleryHorizontal;
-    case 'audio':
-      return Volume2;
-    case 'cost':
-      return BadgeDollarSign;
-    case 'created':
-      return CalendarDays;
-    default:
-      return Box;
-  }
-}
-
-function buildHighlightItems(signals: WatchPageData['signals']): Array<{
-  title: string;
-  body: string;
-  tone: HighlightTone;
-  Icon: LucideIcon;
-}> {
-  const items = signals.whatThisShows.slice(0, 5).map((item) => {
-    const lower = item.toLowerCase();
-    const isAudio = lower.includes('audio');
-    const isCamera = lower.includes('camera') || lower.includes('push') || lower.includes('tracking') || lower.includes('drone');
-    const isFrame = lower.includes('frame') || lower.includes('image');
-    const isStyle = lower.includes('style') || lower.includes('scene');
-    return {
-      title: item,
-      body: isCamera
-        ? 'Camera and movement cue'
-        : isAudio
-          ? 'Audio-driven atmosphere'
-          : isFrame
-            ? 'Source or framing control'
-            : isStyle
-              ? 'Visual direction'
-              : 'Generation signal',
-      tone: (isCamera ? 'blue' : isAudio ? 'slate' : isFrame ? 'green' : isStyle ? 'amber' : 'rose') as HighlightTone,
-      Icon: isCamera ? Waves : isAudio ? Volume2 : isFrame ? GalleryHorizontal : isStyle ? Sparkles : WandSparkles,
-    };
-  });
-
-  if (items.length) return items;
-
-  return signals.capabilityTags.slice(0, 5).map((tag) => ({
-    title: humanizeTag(tag),
-    body: 'Detected workflow signal',
-    tone: 'blue' as HighlightTone,
-    Icon: WandSparkles,
-  }));
-}
-
-function getHighlightToneClass(tone: HighlightTone): string {
-  switch (tone) {
-    case 'green':
-      return 'bg-success-bg text-success';
-    case 'rose':
-      return 'bg-error-bg text-error';
-    case 'amber':
-      return 'bg-warning-bg text-warning';
-    case 'slate':
-      return 'bg-surface-3 text-text-secondary';
-    case 'blue':
-    default:
-      return 'bg-[var(--brand-soft)] text-brand';
-  }
-}
-
-function WatchCard({
-  children,
-  className = '',
-}: {
-  children: ReactNode;
-  className?: string;
-}) {
-  return (
-    <section className={`rounded-card border border-hairline bg-surface shadow-card ${className}`}>
-      {children}
-    </section>
-  );
-}
+import { VideoWatchCard } from './VideoWatchCard';
+import { VideoWatchRelatedExamples } from './VideoWatchRelatedExamples';
+import { VideoWatchSidebar } from './VideoWatchSidebar';
 
 export function VideoWatchContent({ page }: { page: WatchPageData }) {
   const { video, signals, related, isEligible } = page;
@@ -202,10 +105,6 @@ export function VideoWatchContent({ page }: { page: WatchPageData }) {
   const audioLabel = getDetailValue(detailRows, 'audio') ?? (signals.hasAudio ? 'Enabled' : 'Off');
   const costLabel = getDetailValue(detailRows, 'cost');
   const createdLabel = formatWatchDate(video.createdAt);
-  const sidebarDetailRows: DetailRow[] = detailRows.some((row) => row.key === 'created')
-    ? detailRows
-    : [...detailRows, { key: 'created', label: 'Created', value: createdLabel }];
-  const highlightItems = buildHighlightItems(signals);
   const cameraHighlights = signals.capabilityTags
     .filter((tag) => ['push-in', 'tracking', 'drone', 'close-up', 'transition', 'camera-lock'].includes(tag))
     .map(humanizeTag);
@@ -257,7 +156,7 @@ export function VideoWatchContent({ page }: { page: WatchPageData }) {
 
       <article className="grid items-start gap-6 lg:grid-cols-[minmax(0,1fr)_340px] xl:grid-cols-[minmax(0,1fr)_360px]">
         <div className="min-w-0 space-y-5">
-          <WatchCard className="overflow-hidden">
+          <VideoWatchCard className="overflow-hidden">
             <WatchVideoPlayer
               src={videoUrl}
               poster={playbackPoster}
@@ -316,9 +215,9 @@ export function VideoWatchContent({ page }: { page: WatchPageData }) {
                 ) : null}
               </div>
             </div>
-          </WatchCard>
+          </VideoWatchCard>
 
-          <WatchCard className="p-5 sm:p-6">
+          <VideoWatchCard className="p-5 sm:p-6">
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div>
                 <div className="inline-flex items-center gap-2">
@@ -360,9 +259,9 @@ export function VideoWatchContent({ page }: { page: WatchPageData }) {
               </summary>
               <p id={fullPromptId} className="mt-3 whitespace-pre-line text-sm leading-6 text-text-secondary">{signals.promptText}</p>
             </details>
-          </WatchCard>
+          </VideoWatchCard>
 
-          <WatchCard className="p-5 sm:p-6">
+          <VideoWatchCard className="p-5 sm:p-6">
             <h2 className="text-lg font-semibold text-text-primary">Why {signals.engineLabel} fits this shot</h2>
             <p className="mt-2 text-sm leading-6 text-text-secondary">{signals.engineDescription}</p>
             <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
@@ -375,9 +274,9 @@ export function VideoWatchContent({ page }: { page: WatchPageData }) {
                 </div>
               ))}
             </div>
-          </WatchCard>
+          </VideoWatchCard>
 
-          <WatchCard className="p-5 sm:p-6">
+          <VideoWatchCard className="p-5 sm:p-6">
             <div className="flex items-center justify-between gap-3">
               <h2 className="text-lg font-semibold text-text-primary">Key frames</h2>
               <ArrowRight className="h-4 w-4 text-text-muted" aria-hidden />
@@ -389,131 +288,12 @@ export function VideoWatchContent({ page }: { page: WatchPageData }) {
               durationSec={signals.durationSec ?? video.durationSec}
               keyframeUrls={video.keyframeUrls}
             />
-          </WatchCard>
+          </VideoWatchCard>
 
-          {related.length ? (
-            <WatchCard className="p-5 sm:p-6 [content-visibility:auto] [contain-intrinsic-size:360px]">
-              <div className="flex items-center justify-between gap-3">
-                <h2 className="text-lg font-semibold text-text-primary">Related examples</h2>
-                <Link href="/examples" prefetch={false} className="inline-flex items-center gap-2 text-sm font-semibold text-text-primary hover:text-brand">
-                  View all examples
-                  <ArrowRight className="h-4 w-4" aria-hidden />
-                </Link>
-              </div>
-              <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-                {related.map((item) => (
-                  <article key={item.id} className="overflow-hidden rounded-input border border-hairline bg-surface-2 transition hover:-translate-y-0.5 hover:shadow-card">
-                    <Link href={item.href} prefetch={false} className="block">
-                      <div className="relative aspect-video bg-surface-on-media-dark-5">
-                        {item.thumbUrl ? (
-                          <Image
-                            src={item.thumbUrl}
-                            alt={item.title}
-                            fill
-                            className="object-cover"
-                            sizes="(min-width: 1280px) 190px, (min-width: 640px) 45vw, 100vw"
-                          />
-                        ) : (
-                          <div className="flex h-full w-full items-center justify-center text-xs font-semibold uppercase tracking-micro text-text-secondary">
-                            No preview
-                          </div>
-                        )}
-                        <span className="absolute left-2 top-2 rounded-pill bg-surface-on-media-dark-70 px-2 py-1 text-[10px] font-semibold text-on-inverse">
-                          {signals.engineLabel}
-                        </span>
-                      </div>
-                      <div className="space-y-1 px-3 py-3">
-                        <h3 className="line-clamp-1 text-sm font-semibold text-text-primary">{item.title}</h3>
-                        <p className="line-clamp-2 text-xs leading-5 text-text-secondary">{item.subtitle}</p>
-                      </div>
-                    </Link>
-                  </article>
-                ))}
-              </div>
-            </WatchCard>
-          ) : null}
+          <VideoWatchRelatedExamples engineLabel={signals.engineLabel} related={related} />
         </div>
 
-        <aside className="space-y-5 lg:sticky lg:top-[calc(var(--header-height)+24px)] lg:self-start">
-          <WatchCard className="p-5">
-            <h2 className="text-lg font-semibold text-text-primary">Render details</h2>
-            <div className="mt-5 divide-y divide-hairline">
-              {sidebarDetailRows.map((row) => {
-                const DetailIcon = getDetailIcon(row.key);
-                const label = row.key === 'mode' ? 'Workflow' : row.label;
-                const value = row.key === 'created' ? createdLabel : row.value;
-                return (
-                  <div key={row.key} className="flex items-center justify-between gap-4 py-3 first:pt-0 last:pb-0">
-                    <div className="inline-flex min-w-0 items-center gap-3 text-sm text-text-secondary">
-                      <DetailIcon className="h-4 w-4 shrink-0 text-text-muted" aria-hidden />
-                      <span>{label}</span>
-                    </div>
-                    <span className="text-right text-sm font-semibold text-text-primary">{value}</span>
-                  </div>
-                );
-              })}
-            </div>
-            <div className="mt-5 space-y-2">
-              <ButtonLink href={signals.recreatePath} prefetch={false} className="w-full bg-text-primary text-bg hover:bg-text-primary/90">
-                <Sparkles className="h-4 w-4" aria-hidden />
-                Recreate in workspace
-              </ButtonLink>
-              <ButtonLink href={signals.recreatePath} variant="outline" prefetch={false} className="w-full">
-                <ExternalLink className="h-4 w-4" aria-hidden />
-                Open in workspace
-              </ButtonLink>
-            </div>
-          </WatchCard>
-
-          <WatchCard className="p-5">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-micro text-text-secondary">About this engine</p>
-                <h2 className="mt-3 text-lg font-semibold text-text-primary">{signals.engineLabel}</h2>
-              </div>
-              <span className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-input bg-[var(--brand-soft)] text-brand">
-                <Film className="h-5 w-5" aria-hidden />
-              </span>
-            </div>
-            <p className="mt-3 text-sm leading-6 text-text-secondary">{signals.engineDescription}</p>
-            {signals.engineBadges.length ? (
-              <div className="mt-4 flex flex-wrap gap-2">
-                {signals.engineBadges.slice(0, 4).map((badge) => (
-                  <span key={badge} className="rounded-pill border border-hairline bg-surface-2 px-2.5 py-1 text-[11px] font-semibold text-text-secondary">
-                    {badge}
-                  </span>
-                ))}
-              </div>
-            ) : null}
-            {signals.modelPath ? (
-              <Link
-                href={signals.modelPath}
-                prefetch={false}
-                className="mt-5 inline-flex w-full items-center justify-between rounded-input bg-surface-2 px-4 py-3 text-sm font-semibold text-text-primary transition hover:bg-surface-hover"
-              >
-                Learn more about this engine
-                <ArrowRight className="h-4 w-4" aria-hidden />
-              </Link>
-            ) : null}
-          </WatchCard>
-
-          <WatchCard className="p-5">
-            <h2 className="text-lg font-semibold text-text-primary">Shot highlights</h2>
-            <div className="mt-4 space-y-3">
-              {highlightItems.map(({ title, body, tone, Icon }) => (
-                <div key={title} className="flex gap-3">
-                  <span className={`inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-input ${getHighlightToneClass(tone)}`}>
-                    <Icon className="h-4 w-4" aria-hidden />
-                  </span>
-                  <div className="min-w-0">
-                    <p className="text-sm font-semibold text-text-primary">{title}</p>
-                    <p className="mt-0.5 text-xs leading-5 text-text-secondary">{body}</p>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </WatchCard>
-        </aside>
+        <VideoWatchSidebar createdLabel={createdLabel} signals={signals} />
       </article>
 
       {videoJsonLd ? (

--- a/frontend/app/(core)/video/[id]/_components/VideoWatchRelatedExamples.tsx
+++ b/frontend/app/(core)/video/[id]/_components/VideoWatchRelatedExamples.tsx
@@ -1,0 +1,56 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import type { WatchPageData } from '../_lib/video-watch-page-utils';
+import { VideoWatchCard } from './VideoWatchCard';
+
+type VideoWatchRelatedExamplesProps = {
+  engineLabel: string;
+  related: WatchPageData['related'];
+};
+
+export function VideoWatchRelatedExamples({ engineLabel, related }: VideoWatchRelatedExamplesProps) {
+  if (!related.length) return null;
+
+  return (
+    <VideoWatchCard className="p-5 sm:p-6 [content-visibility:auto] [contain-intrinsic-size:360px]">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-lg font-semibold text-text-primary">Related examples</h2>
+        <Link href="/examples" prefetch={false} className="inline-flex items-center gap-2 text-sm font-semibold text-text-primary hover:text-brand">
+          View all examples
+          <ArrowRight className="h-4 w-4" aria-hidden />
+        </Link>
+      </div>
+      <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {related.map((item) => (
+          <article key={item.id} className="overflow-hidden rounded-input border border-hairline bg-surface-2 transition hover:-translate-y-0.5 hover:shadow-card">
+            <Link href={item.href} prefetch={false} className="block">
+              <div className="relative aspect-video bg-surface-on-media-dark-5">
+                {item.thumbUrl ? (
+                  <Image
+                    src={item.thumbUrl}
+                    alt={item.title}
+                    fill
+                    className="object-cover"
+                    sizes="(min-width: 1280px) 190px, (min-width: 640px) 45vw, 100vw"
+                  />
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center text-xs font-semibold uppercase tracking-micro text-text-secondary">
+                    No preview
+                  </div>
+                )}
+                <span className="absolute left-2 top-2 rounded-pill bg-surface-on-media-dark-70 px-2 py-1 text-[10px] font-semibold text-on-inverse">
+                  {engineLabel}
+                </span>
+              </div>
+              <div className="space-y-1 px-3 py-3">
+                <h3 className="line-clamp-1 text-sm font-semibold text-text-primary">{item.title}</h3>
+                <p className="line-clamp-2 text-xs leading-5 text-text-secondary">{item.subtitle}</p>
+              </div>
+            </Link>
+          </article>
+        ))}
+      </div>
+    </VideoWatchCard>
+  );
+}

--- a/frontend/app/(core)/video/[id]/_components/VideoWatchSidebar.tsx
+++ b/frontend/app/(core)/video/[id]/_components/VideoWatchSidebar.tsx
@@ -1,0 +1,195 @@
+import Link from 'next/link';
+import {
+  ArrowRight,
+  BadgeDollarSign,
+  Box,
+  CalendarDays,
+  Clock3,
+  ExternalLink,
+  Film,
+  GalleryHorizontal,
+  Monitor,
+  Sparkles,
+  Volume2,
+  WandSparkles,
+  Waves,
+  type LucideIcon,
+} from 'lucide-react';
+import { ButtonLink } from '@/components/ui/Button';
+import { humanizeTag, type WatchPageData } from '../_lib/video-watch-page-utils';
+import { VideoWatchCard } from './VideoWatchCard';
+
+type HighlightTone = 'blue' | 'green' | 'rose' | 'amber' | 'slate';
+
+function getDetailIcon(key: string): LucideIcon {
+  switch (key) {
+    case 'engine':
+      return Film;
+    case 'mode':
+      return WandSparkles;
+    case 'duration':
+      return Clock3;
+    case 'aspectRatio':
+      return Monitor;
+    case 'resolution':
+      return GalleryHorizontal;
+    case 'audio':
+      return Volume2;
+    case 'cost':
+      return BadgeDollarSign;
+    case 'created':
+      return CalendarDays;
+    default:
+      return Box;
+  }
+}
+
+function buildHighlightItems(signals: WatchPageData['signals']): Array<{
+  title: string;
+  body: string;
+  tone: HighlightTone;
+  Icon: LucideIcon;
+}> {
+  const items = signals.whatThisShows.slice(0, 5).map((item) => {
+    const lower = item.toLowerCase();
+    const isAudio = lower.includes('audio');
+    const isCamera = lower.includes('camera') || lower.includes('push') || lower.includes('tracking') || lower.includes('drone');
+    const isFrame = lower.includes('frame') || lower.includes('image');
+    const isStyle = lower.includes('style') || lower.includes('scene');
+    return {
+      title: item,
+      body: isCamera
+        ? 'Camera and movement cue'
+        : isAudio
+          ? 'Audio-driven atmosphere'
+          : isFrame
+            ? 'Source or framing control'
+            : isStyle
+              ? 'Visual direction'
+              : 'Generation signal',
+      tone: (isCamera ? 'blue' : isAudio ? 'slate' : isFrame ? 'green' : isStyle ? 'amber' : 'rose') as HighlightTone,
+      Icon: isCamera ? Waves : isAudio ? Volume2 : isFrame ? GalleryHorizontal : isStyle ? Sparkles : WandSparkles,
+    };
+  });
+
+  if (items.length) return items;
+
+  return signals.capabilityTags.slice(0, 5).map((tag) => ({
+    title: humanizeTag(tag),
+    body: 'Detected workflow signal',
+    tone: 'blue' as HighlightTone,
+    Icon: WandSparkles,
+  }));
+}
+
+function getHighlightToneClass(tone: HighlightTone): string {
+  switch (tone) {
+    case 'green':
+      return 'bg-success-bg text-success';
+    case 'rose':
+      return 'bg-error-bg text-error';
+    case 'amber':
+      return 'bg-warning-bg text-warning';
+    case 'slate':
+      return 'bg-surface-3 text-text-secondary';
+    case 'blue':
+    default:
+      return 'bg-[var(--brand-soft)] text-brand';
+  }
+}
+
+export function VideoWatchSidebar({
+  createdLabel,
+  signals,
+}: {
+  createdLabel: string;
+  signals: WatchPageData['signals'];
+}) {
+  const sidebarDetailRows = signals.detailRows.some((row) => row.key === 'created')
+    ? signals.detailRows
+    : [...signals.detailRows, { key: 'created', label: 'Created', value: createdLabel }];
+  const highlightItems = buildHighlightItems(signals);
+
+  return (
+    <aside className="space-y-5 lg:sticky lg:top-[calc(var(--header-height)+24px)] lg:self-start">
+      <VideoWatchCard className="p-5">
+        <h2 className="text-lg font-semibold text-text-primary">Render details</h2>
+        <div className="mt-5 divide-y divide-hairline">
+          {sidebarDetailRows.map((row) => {
+            const DetailIcon = getDetailIcon(row.key);
+            const label = row.key === 'mode' ? 'Workflow' : row.label;
+            const value = row.key === 'created' ? createdLabel : row.value;
+            return (
+              <div key={row.key} className="flex items-center justify-between gap-4 py-3 first:pt-0 last:pb-0">
+                <div className="inline-flex min-w-0 items-center gap-3 text-sm text-text-secondary">
+                  <DetailIcon className="h-4 w-4 shrink-0 text-text-muted" aria-hidden />
+                  <span>{label}</span>
+                </div>
+                <span className="text-right text-sm font-semibold text-text-primary">{value}</span>
+              </div>
+            );
+          })}
+        </div>
+        <div className="mt-5 space-y-2">
+          <ButtonLink href={signals.recreatePath} prefetch={false} className="w-full bg-text-primary text-bg hover:bg-text-primary/90">
+            <Sparkles className="h-4 w-4" aria-hidden />
+            Recreate in workspace
+          </ButtonLink>
+          <ButtonLink href={signals.recreatePath} variant="outline" prefetch={false} className="w-full">
+            <ExternalLink className="h-4 w-4" aria-hidden />
+            Open in workspace
+          </ButtonLink>
+        </div>
+      </VideoWatchCard>
+
+      <VideoWatchCard className="p-5">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-micro text-text-secondary">About this engine</p>
+            <h2 className="mt-3 text-lg font-semibold text-text-primary">{signals.engineLabel}</h2>
+          </div>
+          <span className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-input bg-[var(--brand-soft)] text-brand">
+            <Film className="h-5 w-5" aria-hidden />
+          </span>
+        </div>
+        <p className="mt-3 text-sm leading-6 text-text-secondary">{signals.engineDescription}</p>
+        {signals.engineBadges.length ? (
+          <div className="mt-4 flex flex-wrap gap-2">
+            {signals.engineBadges.slice(0, 4).map((badge) => (
+              <span key={badge} className="rounded-pill border border-hairline bg-surface-2 px-2.5 py-1 text-[11px] font-semibold text-text-secondary">
+                {badge}
+              </span>
+            ))}
+          </div>
+        ) : null}
+        {signals.modelPath ? (
+          <Link
+            href={signals.modelPath}
+            prefetch={false}
+            className="mt-5 inline-flex w-full items-center justify-between rounded-input bg-surface-2 px-4 py-3 text-sm font-semibold text-text-primary transition hover:bg-surface-hover"
+          >
+            Learn more about this engine
+            <ArrowRight className="h-4 w-4" aria-hidden />
+          </Link>
+        ) : null}
+      </VideoWatchCard>
+
+      <VideoWatchCard className="p-5">
+        <h2 className="text-lg font-semibold text-text-primary">Shot highlights</h2>
+        <div className="mt-4 space-y-3">
+          {highlightItems.map(({ title, body, tone, Icon }) => (
+            <div key={title} className="flex gap-3">
+              <span className={`inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-input ${getHighlightToneClass(tone)}`}>
+                <Icon className="h-4 w-4" aria-hidden />
+              </span>
+              <div className="min-w-0">
+                <p className="text-sm font-semibold text-text-primary">{title}</p>
+                <p className="mt-0.5 text-xs leading-5 text-text-secondary">{body}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </VideoWatchCard>
+    </aside>
+  );
+}

--- a/tests/video-page-architecture.test.ts
+++ b/tests/video-page-architecture.test.ts
@@ -6,17 +6,26 @@ import test from 'node:test';
 const root = process.cwd();
 const pagePath = join(root, 'frontend/app/(core)/video/[id]/page.tsx');
 const contentPath = join(root, 'frontend/app/(core)/video/[id]/_components/VideoWatchContent.tsx');
+const cardPath = join(root, 'frontend/app/(core)/video/[id]/_components/VideoWatchCard.tsx');
+const relatedPath = join(root, 'frontend/app/(core)/video/[id]/_components/VideoWatchRelatedExamples.tsx');
+const sidebarPath = join(root, 'frontend/app/(core)/video/[id]/_components/VideoWatchSidebar.tsx');
 const unavailablePath = join(root, 'frontend/app/(core)/video/[id]/_components/VideoUnavailableState.tsx');
 const utilsPath = join(root, 'frontend/app/(core)/video/[id]/_lib/video-watch-page-utils.ts');
 
 const pageSource = readFileSync(pagePath, 'utf8');
 const contentSource = readFileSync(contentPath, 'utf8');
+const cardSource = readFileSync(cardPath, 'utf8');
+const relatedSource = readFileSync(relatedPath, 'utf8');
+const sidebarSource = readFileSync(sidebarPath, 'utf8');
 const unavailableSource = readFileSync(unavailablePath, 'utf8');
 const utilsSource = readFileSync(utilsPath, 'utf8');
 
 test('video watch page stays a route orchestrator', () => {
   assert.ok(existsSync(pagePath), 'video watch page should exist');
   assert.ok(existsSync(contentPath), 'video watch content component should exist');
+  assert.ok(existsSync(cardPath), 'video watch card shell should exist');
+  assert.ok(existsSync(relatedPath), 'video watch related examples component should exist');
+  assert.ok(existsSync(sidebarPath), 'video watch sidebar component should exist');
   assert.ok(existsSync(unavailablePath), 'video unavailable component should exist');
   assert.ok(existsSync(utilsPath), 'video watch helper module should exist');
 
@@ -43,8 +52,18 @@ test('video watch modules own rendering and helper contracts', () => {
   assert.match(contentSource, /WatchKeyFrames/, 'content component should own keyframe rendering');
   assert.match(contentSource, /CopyPromptButton/, 'content component should own prompt copy UI');
   assert.match(contentSource, /dangerouslySetInnerHTML/, 'content component should own JSON-LD script rendering');
-  assert.match(contentSource, /function WatchCard/, 'content component should own watch card UI');
-  assert.match(contentSource, /buildHighlightItems/, 'content component should own highlight view model');
+  assert.match(contentSource, /from '\.\/VideoWatchCard'/, 'content component should compose the watch card shell');
+  assert.match(contentSource, /from '\.\/VideoWatchRelatedExamples'/, 'content component should compose related examples');
+  assert.match(contentSource, /from '\.\/VideoWatchSidebar'/, 'content component should compose the sidebar');
+  assert.doesNotMatch(contentSource, /function WatchCard/, 'watch card UI belongs in VideoWatchCard');
+  assert.doesNotMatch(contentSource, /function buildHighlightItems/, 'highlight view model belongs in VideoWatchSidebar');
+  assert.doesNotMatch(contentSource, /Related examples/, 'related examples markup belongs in VideoWatchRelatedExamples');
+  assert.ok(contentSource.split('\n').length <= 360, `video watch content should stay below 360 lines, got ${contentSource.split('\n').length}`);
+  assert.match(cardSource, /export function VideoWatchCard/, 'watch card shell should be exported');
+  assert.match(relatedSource, /export function VideoWatchRelatedExamples/, 'related examples component should be exported');
+  assert.match(sidebarSource, /export function VideoWatchSidebar/, 'sidebar component should be exported');
+  assert.match(sidebarSource, /function buildHighlightItems/, 'sidebar should own highlight view model');
+  assert.match(sidebarSource, /function getDetailIcon/, 'sidebar should own detail icon mapping');
   assert.match(unavailableSource, /export function VideoUnavailableState/, 'unavailable component should be exported');
   assert.match(utilsSource, /export function buildMetaTitle/, 'helper module should own metadata title building');
   assert.match(utilsSource, /export function parseAspectRatio/, 'helper module should own aspect parsing');


### PR DESCRIPTION
## Summary
- split the video watch card shell into a route-local component
- move related examples rendering into VideoWatchRelatedExamples
- move sidebar details, engine summary, and highlight view model into VideoWatchSidebar
- update video page architecture tests to keep VideoWatchContent lean

## Validation
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/video-page-architecture.test.ts tests/watch-page-signals-architecture.test.ts
- pnpm --dir frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run architecture:audit -- --min-lines 500
- npm run lint:exposure
- git diff --check
- npm run test:validate