### PR TITLE
Split upscale pricing context

### DIFF
--- a/frontend/src/server/tools/upscale-pricing-context.ts
+++ b/frontend/src/server/tools/upscale-pricing-context.ts
@@ -1,0 +1,106 @@
+import { computeBillingProductSnapshot } from '@/lib/billing-products';
+import {
+  UPSCALE_VIDEO_DYNAMIC_MARGIN_MULTIPLIER,
+  estimateImageUpscaleCostUsd,
+  estimateVideoUpscaleCostUsd,
+} from '@/lib/tools-upscale';
+import type { PricingSnapshot } from '@/types/engines';
+import type { UpscaleToolEngineDefinition, UpscaleToolRequest } from '@/types/tools-upscale';
+import {
+  UPSCALE_SURFACE,
+  cloneUpscalePricingWithDynamicTotal,
+  type VideoMetadata,
+} from './upscale-request-utils';
+import { UpscaleToolError } from './upscale-errors';
+
+export type UpscalePricingEstimate = {
+  megapixels?: number | null;
+  frames?: number | null;
+  durationSec?: number | null;
+};
+
+type ResolveUpscalePricingContextInput = {
+  billingProductKey: string;
+  engine: UpscaleToolEngineDefinition;
+  input: Pick<UpscaleToolRequest, 'imageHeight' | 'imageWidth' | 'mediaType'>;
+  targetResolution: UpscaleToolRequest['targetResolution'];
+  upscaleFactor: number;
+  videoMetadata: VideoMetadata | null;
+};
+
+export async function resolveUpscalePricingContext({
+  billingProductKey,
+  engine,
+  input,
+  targetResolution,
+  upscaleFactor,
+  videoMetadata,
+}: ResolveUpscalePricingContextInput): Promise<{
+  pricing: PricingSnapshot;
+  pricingEstimate: UpscalePricingEstimate;
+}> {
+  try {
+    let pricing = await computeBillingProductSnapshot({
+      productKey: billingProductKey,
+      quantity: 1,
+      engineId: engine.id,
+    });
+
+    if (input.mediaType === 'video' && videoMetadata) {
+      const estimate = estimateVideoUpscaleCostUsd({
+        engineId: engine.id,
+        width: videoMetadata.width,
+        height: videoMetadata.height,
+        durationSec: videoMetadata.durationSec,
+        fps: videoMetadata.fps,
+        targetResolution,
+        factor: upscaleFactor,
+      });
+      const dynamicCents = Math.max(1, Math.ceil(estimate.costUsd * 100 * UPSCALE_VIDEO_DYNAMIC_MARGIN_MULTIPLIER));
+      pricing = cloneUpscalePricingWithDynamicTotal(pricing, dynamicCents, {
+        surface: UPSCALE_SURFACE,
+        billingProductKey,
+        providerEstimateUsd: estimate.costUsd,
+        dynamicMultiplier: UPSCALE_VIDEO_DYNAMIC_MARGIN_MULTIPLIER,
+        videoMetadata,
+      });
+      return {
+        pricing,
+        pricingEstimate: {
+          megapixels: estimate.outputMegapixels,
+          frames: estimate.frames,
+          durationSec: videoMetadata.durationSec,
+        },
+      };
+    }
+
+    const estimateCostUsd = estimateImageUpscaleCostUsd({
+      engineId: engine.id,
+      width: input.imageWidth,
+      height: input.imageHeight,
+      factor: upscaleFactor,
+    });
+    pricing.meta = {
+      ...(pricing.meta ?? {}),
+      surface: UPSCALE_SURFACE,
+      billingProductKey,
+      providerEstimateUsd: estimateCostUsd,
+    };
+
+    return {
+      pricing,
+      pricingEstimate: {
+        megapixels:
+          typeof input.imageWidth === 'number' && typeof input.imageHeight === 'number'
+            ? Number(((input.imageWidth * input.imageHeight * upscaleFactor * upscaleFactor) / 1_000_000).toFixed(4))
+            : null,
+      },
+    };
+  } catch (error) {
+    throw new UpscaleToolError('Unable to compute upscale pricing.', {
+      status: 500,
+      code: 'pricing_error',
+      detail: error instanceof Error ? error.message : error,
+    });
+  }
+}

--- a/frontend/src/server/tools/upscale.ts
+++ b/frontend/src/server/tools/upscale.ts
@@ -3,17 +3,13 @@ import { ApiError, ValidationError } from '@fal-ai/client';
 import { getUpscaleToolEngine } from '@/config/tools-upscale-engines';
 import { query } from '@/lib/db';
 import { getFalClient } from '@/lib/fal-client';
-import { computeBillingProductSnapshot } from '@/lib/billing-products';
 import { buildStoredImageRenderEntries, resolveHeroThumbFromRenders } from '@/lib/image-renders';
 import { getPlatformFeeCents } from '@/lib/pricing';
 import { getUserPreferredCurrency } from '@/lib/currency';
 import { receiptsPriceOnlyEnabled } from '@/lib/env';
 import { ensureReusableAsset, upsertLegacyJobOutputs } from '@/server/media-library';
 import {
-  UPSCALE_VIDEO_DYNAMIC_MARGIN_MULTIPLIER,
   clampUpscaleFactor,
-  estimateImageUpscaleCostUsd,
-  estimateVideoUpscaleCostUsd,
   resolveUpscaleMode,
   resolveUpscaleOutputFormat,
   resolveUpscaleTargetResolution,
@@ -22,13 +18,11 @@ import type {
   UpscaleToolRequest,
   UpscaleToolResponse,
 } from '@/types/tools-upscale';
-import type { PricingSnapshot } from '@/types/engines';
 import {
   UPSCALE_SURFACE,
   buildUpscaleFalInput,
   buildUpscalePromptSummary,
   buildUpscaleSettingsSnapshot,
-  cloneUpscalePricingWithDynamicTotal,
   extractUpscaleActualCostUsd,
   extractUpscaleOutput,
   parseUpscaleRequestId,
@@ -38,6 +32,7 @@ import {
 import { UPSCALE_PLACEHOLDER_THUMB, UPSCALE_TOOL_EVENT_NAME } from './upscale-constants';
 import { UpscaleToolError } from './upscale-errors';
 export { UpscaleToolError } from './upscale-errors';
+import { resolveUpscalePricingContext } from './upscale-pricing-context';
 import {
   createAtomicInitialUpscaleJob,
   insertUpscaleToolEvent,
@@ -101,65 +96,14 @@ export async function runUpscaleToolBase(
       code: 'video_metadata_required',
     });
   }
-  let pricing: PricingSnapshot;
-  let pricingEstimate: { megapixels?: number | null; frames?: number | null; durationSec?: number | null } = {};
-  try {
-    pricing = await computeBillingProductSnapshot({
-      productKey: billingProductKey,
-      quantity: 1,
-      engineId: engine.id,
-    });
-
-    if (mediaType === 'video' && videoMetadata) {
-      const estimate = estimateVideoUpscaleCostUsd({
-        engineId: engine.id,
-        width: videoMetadata.width,
-        height: videoMetadata.height,
-        durationSec: videoMetadata.durationSec,
-        fps: videoMetadata.fps,
-        targetResolution,
-        factor: upscaleFactor,
-      });
-      pricingEstimate = {
-        megapixels: estimate.outputMegapixels,
-        frames: estimate.frames,
-        durationSec: videoMetadata.durationSec,
-      };
-      const dynamicCents = Math.max(1, Math.ceil(estimate.costUsd * 100 * UPSCALE_VIDEO_DYNAMIC_MARGIN_MULTIPLIER));
-      pricing = cloneUpscalePricingWithDynamicTotal(pricing, dynamicCents, {
-        surface: UPSCALE_SURFACE,
-        billingProductKey,
-        providerEstimateUsd: estimate.costUsd,
-        dynamicMultiplier: UPSCALE_VIDEO_DYNAMIC_MARGIN_MULTIPLIER,
-        videoMetadata,
-      });
-    } else {
-      const estimateCostUsd = estimateImageUpscaleCostUsd({
-        engineId: engine.id,
-        width: input.imageWidth,
-        height: input.imageHeight,
-        factor: upscaleFactor,
-      });
-      pricing.meta = {
-        ...(pricing.meta ?? {}),
-        surface: UPSCALE_SURFACE,
-        billingProductKey,
-        providerEstimateUsd: estimateCostUsd,
-      };
-      pricingEstimate = {
-        megapixels:
-          typeof input.imageWidth === 'number' && typeof input.imageHeight === 'number'
-            ? Number(((input.imageWidth * input.imageHeight * upscaleFactor * upscaleFactor) / 1_000_000).toFixed(4))
-            : null,
-      };
-    }
-  } catch (error) {
-    throw new UpscaleToolError('Unable to compute upscale pricing.', {
-      status: 500,
-      code: 'pricing_error',
-      detail: error instanceof Error ? error.message : error,
-    });
-  }
+  const { pricing, pricingEstimate } = await resolveUpscalePricingContext({
+    billingProductKey,
+    engine,
+    input,
+    targetResolution,
+    upscaleFactor,
+    videoMetadata,
+  });
 
   const chargedUsd = Number((pricing.totalCents / 100).toFixed(4));
   const chargedCredits = usdToCredits(chargedUsd) ?? 1;

--- a/tests/upscale-server-architecture.test.ts
+++ b/tests/upscale-server-architecture.test.ts
@@ -6,6 +6,7 @@ import test from 'node:test';
 const root = process.cwd();
 const serverPath = join(root, 'frontend/src/server/tools/upscale.ts');
 const requestUtilsPath = join(root, 'frontend/src/server/tools/upscale-request-utils.ts');
+const pricingContextPath = join(root, 'frontend/src/server/tools/upscale-pricing-context.ts');
 const jobPersistencePath = join(root, 'frontend/src/server/tools/upscale-job-persistence.ts');
 const outputPersistencePath = join(root, 'frontend/src/server/tools/upscale-output-persistence.ts');
 const errorsPath = join(root, 'frontend/src/server/tools/upscale-errors.ts');
@@ -13,6 +14,7 @@ const constantsPath = join(root, 'frontend/src/server/tools/upscale-constants.ts
 
 const serverSource = readFileSync(serverPath, 'utf8');
 const requestUtilsSource = readFileSync(requestUtilsPath, 'utf8');
+const pricingContextSource = readFileSync(pricingContextPath, 'utf8');
 const jobPersistenceSource = readFileSync(jobPersistencePath, 'utf8');
 const outputPersistenceSource = readFileSync(outputPersistencePath, 'utf8');
 const errorsSource = readFileSync(errorsPath, 'utf8');
@@ -20,6 +22,7 @@ const constantsSource = readFileSync(constantsPath, 'utf8');
 
 test('upscale server delegates request and provider normalization helpers', () => {
   assert.ok(existsSync(requestUtilsPath), 'upscale request helpers should live in a server-local utility module');
+  assert.ok(existsSync(pricingContextPath), 'upscale pricing context should live in a focused server module');
   assert.ok(existsSync(jobPersistencePath), 'upscale job persistence should live in a focused server module');
   assert.ok(existsSync(outputPersistencePath), 'upscale output persistence should live in a focused server module');
   assert.ok(existsSync(errorsPath), 'upscale errors should live in a small shared server module');
@@ -29,6 +32,7 @@ test('upscale server delegates request and provider normalization helpers', () =
     /from '\.\/upscale-request-utils'/,
     'upscale server orchestration should import request/provider helpers'
   );
+  assert.match(serverSource, /from '\.\/upscale-pricing-context'/);
   assert.match(serverSource, /from '\.\/upscale-job-persistence'/);
   assert.match(serverSource, /from '\.\/upscale-output-persistence'/);
   assert.match(serverSource, /from '\.\/upscale-errors'/);
@@ -46,6 +50,10 @@ test('upscale server delegates request and provider normalization helpers', () =
     'buildPromptSummary',
     'buildSettingsSnapshot',
     'clonePricingWithDynamicTotal',
+    'computeBillingProductSnapshot',
+    'estimateImageUpscaleCostUsd',
+    'estimateVideoUpscaleCostUsd',
+    'resolveUpscalePricingContext',
     'toValidationMessage',
     'recordUpscaleRefundReceipt',
     'insertProvisionalUpscaleJob',
@@ -62,7 +70,7 @@ test('upscale server delegates request and provider normalization helpers', () =
   }
 
   const lineCount = serverSource.split('\n').length;
-  assert.ok(lineCount <= 560, `upscale server orchestrator should stay below 560 lines after persistence extraction, got ${lineCount}`);
+  assert.ok(lineCount <= 460, `upscale server orchestrator should stay below 460 lines after pricing extraction, got ${lineCount}`);
 });
 
 test('upscale request utils expose the expected pure helper contract', () => {
@@ -92,6 +100,10 @@ test('upscale request utils expose the expected pure helper contract', () => {
 });
 
 test('upscale persistence modules expose job, event, output, and error contracts', () => {
+  assert.match(pricingContextSource, /export async function resolveUpscalePricingContext/);
+  assert.match(pricingContextSource, /computeBillingProductSnapshot/);
+  assert.match(pricingContextSource, /estimateImageUpscaleCostUsd/);
+  assert.match(pricingContextSource, /estimateVideoUpscaleCostUsd/);
   for (const exportName of ['recordUpscaleRefundReceipt', 'createAtomicInitialUpscaleJob', 'insertUpscaleToolEvent']) {
     assert.match(jobPersistenceSource, new RegExp(`export async function ${exportName}`));
   }


### PR DESCRIPTION
## Summary
- extract upscale pricing and estimate resolution from the main server orchestrator
- keep dynamic video pricing and image pricing metadata in a focused server module
- tighten the upscale server architecture contract around the pricing boundary

## Validation
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/upscale-server-architecture.test.ts tests/upscale-pricing-preview.test.ts tests/upscale-route-bundling.test.ts
- pnpm --dir frontend exec tsc --noEmit --pretty false
- npm --prefix frontend run lint
- npm run architecture:audit -- --min-lines 500
- npm run lint:exposure
- git diff --check
- npm run test:validate

Note: the first full test:validate run hit an unrelated audio routing timeout assertion, then the isolated audio suite and the full test:validate rerun both passed.