### PR TITLE
Split BytePlus provider helpers

### DIFF
--- a/frontend/scripts/qa/byteplus-provider-test.ts
+++ b/frontend/scripts/qa/byteplus-provider-test.ts
@@ -389,7 +389,7 @@ assert.equal(
 
 assert.equal(
   getBytePlusUserSafeErrorMessage('The request failed because the input image may contain real person. Request id: abc'),
-  'BytePlus rejected one of the input images. Try an image without identifiable people or private content.'
+  'The render service rejected one of the input images. Try an image without identifiable people or private content.'
 );
 
 assert.deepEqual(

--- a/frontend/server/byteplus-accounting.ts
+++ b/frontend/server/byteplus-accounting.ts
@@ -1,0 +1,98 @@
+import {
+  BYTEPLUS_SEEDANCE_ASPECT_RATIOS,
+  PUBLIC_SEEDANCE_ENGINE_ID,
+} from '@/server/video-providers/byteplus-modelark';
+import { isRecord } from './byteplus-record-utils';
+import type { BytePlusPendingJob } from './byteplus-poll-types';
+
+const BYTEPLUS_FAST_UNIT_PRICE_USD_PER_1K_TOKENS = 0.0056;
+const BYTEPLUS_STANDARD_UNIT_PRICE_USD_PER_1K_TOKENS = 0.007;
+
+const BYTEPLUS_TOKEN_DIMENSIONS: Record<string, Record<string, { width: number; height: number }>> = {
+  '480p': {
+    '21:9': { width: 1120, height: 480 },
+    '16:9': { width: 854, height: 480 },
+    '4:3': { width: 640, height: 480 },
+    '1:1': { width: 480, height: 480 },
+    '3:4': { width: 480, height: 640 },
+    '9:16': { width: 480, height: 854 },
+  },
+  '720p': {
+    '21:9': { width: 1680, height: 720 },
+    '16:9': { width: 1280, height: 720 },
+    '4:3': { width: 960, height: 720 },
+    '1:1': { width: 720, height: 720 },
+    '3:4': { width: 720, height: 960 },
+    '9:16': { width: 720, height: 1280 },
+  },
+  '1080p': {
+    '21:9': { width: 2520, height: 1080 },
+    '16:9': { width: 1920, height: 1080 },
+    '4:3': { width: 1440, height: 1080 },
+    '1:1': { width: 1080, height: 1080 },
+    '3:4': { width: 1080, height: 1440 },
+    '9:16': { width: 1080, height: 1920 },
+  },
+};
+
+export function expectedBytePlusTokens(job: Pick<BytePlusPendingJob, 'duration_sec' | 'settings_snapshot'>): number {
+  const settings = isRecord(job.settings_snapshot) ? job.settings_snapshot : {};
+  const core = isRecord(settings.core) ? settings.core : {};
+  const resolution = typeof core.resolution === 'string' ? core.resolution : '720p';
+  const aspectRatio =
+    typeof core.aspectRatio === 'string' && BYTEPLUS_SEEDANCE_ASPECT_RATIOS.includes(core.aspectRatio as never)
+      ? core.aspectRatio
+      : '16:9';
+  const dimensions = BYTEPLUS_TOKEN_DIMENSIONS[resolution]?.[aspectRatio] ?? BYTEPLUS_TOKEN_DIMENSIONS['720p']['16:9'];
+  return (dimensions.width * dimensions.height * Math.max(1, Math.round(job.duration_sec)) * 24) / 1024;
+}
+
+export function getBytePlusAccounting(job: Pick<BytePlusPendingJob, 'settings_snapshot' | 'has_audio'>) {
+  const settings = isRecord(job.settings_snapshot) ? job.settings_snapshot : {};
+  const refs = isRecord(settings.refs) ? settings.refs : {};
+  const mode =
+    settings.inputMode === 'extend'
+      ? 'extend'
+      : settings.inputMode === 'v2v'
+        ? 'v2v'
+        : settings.inputMode === 'ref2v'
+          ? 'ref2v'
+          : settings.inputMode === 'i2v'
+            ? 'i2v'
+            : 't2v';
+  const hasStartImage = mode === 'i2v' && typeof refs.imageUrl === 'string' && refs.imageUrl.trim().length > 0;
+  const hasEndImage = mode === 'i2v' && typeof refs.endImageUrl === 'string' && refs.endImageUrl.trim().length > 0;
+  const hasReferenceImages = Array.isArray(refs.referenceImages) && refs.referenceImages.length > 0;
+  const hasReferenceVideos = Array.isArray(refs.videoUrls) && refs.videoUrls.length > 0;
+  const hasReferenceAudio = typeof refs.audioUrl === 'string' || (Array.isArray(refs.audioUrls) && refs.audioUrls.length > 0);
+  const inputType =
+    mode === 'extend'
+      ? 'video_extension'
+      : mode === 'v2v'
+        ? 'video_edit'
+        : mode === 'ref2v'
+          ? 'reference_generation'
+          : hasEndImage
+            ? 'first_last_frame'
+            : hasStartImage
+              ? 'image_input'
+              : 'text_input';
+
+  return {
+    mode,
+    inputType,
+    hasStartImage,
+    hasEndImage,
+    hasReferenceImages,
+    hasReferenceVideos,
+    hasReferenceAudio,
+    generateAudio: job.has_audio === true,
+    byteplusBillingInputType: hasReferenceVideos ? 'video_input' : 'no_video_input',
+  };
+}
+
+export function getBytePlusUnitPriceUsdPer1kTokens(engineId: string | null | undefined): number {
+  return engineId === PUBLIC_SEEDANCE_ENGINE_ID
+    ? BYTEPLUS_STANDARD_UNIT_PRICE_USD_PER_1K_TOKENS
+    : BYTEPLUS_FAST_UNIT_PRICE_USD_PER_1K_TOKENS;
+}

--- a/frontend/server/byteplus-poll-types.ts
+++ b/frontend/server/byteplus-poll-types.ts
@@ -1,0 +1,21 @@
+export type BytePlusPendingJob = {
+  job_id: string;
+  user_id: string | null;
+  engine_id: string;
+  engine_label: string;
+  provider_job_id: string;
+  status: string;
+  duration_sec: number;
+  thumb_url: string | null;
+  preview_video_url: string | null;
+  keyframe_urls: unknown;
+  aspect_ratio: string | null;
+  has_audio: boolean | null;
+  final_price_cents: number | null;
+  pricing_snapshot: unknown;
+  settings_snapshot: unknown;
+  currency: string | null;
+  payment_status: string | null;
+  updated_at: string;
+  created_at: string;
+};

--- a/frontend/server/byteplus-poll.ts
+++ b/frontend/server/byteplus-poll.ts
@@ -7,212 +7,44 @@ import { generateAndPersistJobKeyframes } from '@/server/video-keyframes';
 import { generateAndPersistJobPreviewVideo } from '@/server/video-preview';
 import {
   BYTEPLUS_MODELARK_PROVIDER,
-  BYTEPLUS_SEEDANCE_ASPECT_RATIOS,
   PUBLIC_SEEDANCE_ENGINE_ID,
   getBytePlusArkConfig,
   getBytePlusModelArkClient,
   isBytePlusModelArkEnabled,
   scrubBytePlusError,
 } from '@/server/video-providers/byteplus-modelark';
+import {
+  expectedBytePlusTokens,
+  getBytePlusAccounting,
+  getBytePlusUnitPriceUsdPer1kTokens,
+} from './byteplus-accounting';
+import type { BytePlusPendingJob } from './byteplus-poll-types';
+import { isRecord } from './byteplus-record-utils';
+import {
+  buildNextBytePlusStorageCopyState,
+  getBytePlusStorageCopyState,
+  isBytePlusStorageCopyRetryDue,
+  resolveBytePlusStorageCopyMaxAttempts,
+  shouldRetryBytePlusStorageCopy,
+  type BytePlusStorageCopyState,
+} from './byteplus-storage-copy';
 
-type BytePlusPendingJob = {
-  job_id: string;
-  user_id: string | null;
-  engine_id: string;
-  engine_label: string;
-  provider_job_id: string;
-  status: string;
-  duration_sec: number;
-  thumb_url: string | null;
-  preview_video_url: string | null;
-  keyframe_urls: unknown;
-  aspect_ratio: string | null;
-  has_audio: boolean | null;
-  final_price_cents: number | null;
-  pricing_snapshot: unknown;
-  settings_snapshot: unknown;
-  currency: string | null;
-  payment_status: string | null;
-  updated_at: string;
-  created_at: string;
-};
+export {
+  getBytePlusAccounting,
+  getBytePlusUnitPriceUsdPer1kTokens,
+} from './byteplus-accounting';
+export type { BytePlusStorageCopyState } from './byteplus-storage-copy';
+export {
+  buildNextBytePlusStorageCopyState,
+  getBytePlusStorageCopyState,
+  isBytePlusStorageCopyRetryDue,
+  resolveBytePlusStorageCopyMaxAttempts,
+  shouldRetryBytePlusStorageCopy,
+} from './byteplus-storage-copy';
 
 const POLL_INITIAL_DELAY_MS = 5_000;
 const POLL_MAX_DURATION_MS = 35 * 60_000;
-const BYTEPLUS_OUTPUT_COPY_WINDOW_MS = 3 * 60 * 60_000;
-const DEFAULT_PROVIDER_VIDEO_COPY_MAX_ATTEMPTS = 6;
-const BYTEPLUS_STORAGE_COPY_RETRY_DELAYS_MS = [2, 5, 15, 45, 90].map((minutes) => minutes * 60_000);
-const BYTEPLUS_FAST_UNIT_PRICE_USD_PER_1K_TOKENS = 0.0056;
-const BYTEPLUS_STANDARD_UNIT_PRICE_USD_PER_1K_TOKENS = 0.007;
-// Live V1a smoke test: 720p / 16:9 / 5.041667s returned 108,900 tokens, $0.60984 provider cost.
 const ACTIVE_JOB_STATUSES = ['pending', 'queued', 'running', 'processing', 'in_progress'];
-
-const BYTEPLUS_TOKEN_DIMENSIONS: Record<string, Record<string, { width: number; height: number }>> = {
-  '480p': {
-    '21:9': { width: 1120, height: 480 },
-    '16:9': { width: 854, height: 480 },
-    '4:3': { width: 640, height: 480 },
-    '1:1': { width: 480, height: 480 },
-    '3:4': { width: 480, height: 640 },
-    '9:16': { width: 480, height: 854 },
-  },
-  '720p': {
-    '21:9': { width: 1680, height: 720 },
-    '16:9': { width: 1280, height: 720 },
-    '4:3': { width: 960, height: 720 },
-    '1:1': { width: 720, height: 720 },
-    '3:4': { width: 720, height: 960 },
-    '9:16': { width: 720, height: 1280 },
-  },
-  '1080p': {
-    '21:9': { width: 2520, height: 1080 },
-    '16:9': { width: 1920, height: 1080 },
-    '4:3': { width: 1440, height: 1080 },
-    '1:1': { width: 1080, height: 1080 },
-    '3:4': { width: 1080, height: 1440 },
-    '9:16': { width: 1080, height: 1920 },
-  },
-};
-
-function expectedBytePlusTokens(job: Pick<BytePlusPendingJob, 'duration_sec' | 'settings_snapshot'>): number {
-  const settings = isRecord(job.settings_snapshot) ? job.settings_snapshot : {};
-  const core = isRecord(settings.core) ? settings.core : {};
-  const resolution = typeof core.resolution === 'string' ? core.resolution : '720p';
-  const aspectRatio =
-    typeof core.aspectRatio === 'string' && BYTEPLUS_SEEDANCE_ASPECT_RATIOS.includes(core.aspectRatio as never)
-      ? core.aspectRatio
-      : '16:9';
-  const dimensions = BYTEPLUS_TOKEN_DIMENSIONS[resolution]?.[aspectRatio] ?? BYTEPLUS_TOKEN_DIMENSIONS['720p']['16:9'];
-  return (dimensions.width * dimensions.height * Math.max(1, Math.round(job.duration_sec)) * 24) / 1024;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
-}
-
-export type BytePlusStorageCopyState = {
-  attempts: number;
-  firstFailedAt: string | null;
-  lastFailedAt: string | null;
-  lastProviderStatus?: string | null;
-  lastReason?: string | null;
-  nextRetryAt?: string | null;
-};
-
-export function resolveBytePlusStorageCopyMaxAttempts(raw = process.env.PROVIDER_VIDEO_COPY_MAX_ATTEMPTS ?? process.env.BYTEPLUS_STORAGE_COPY_MAX_ATTEMPTS): number {
-  const parsed = Number.parseInt(String(raw ?? ''), 10);
-  return Number.isFinite(parsed) && parsed > 0 ? Math.min(parsed, 50) : DEFAULT_PROVIDER_VIDEO_COPY_MAX_ATTEMPTS;
-}
-
-export function getBytePlusStorageCopyState(settingsSnapshot: unknown): BytePlusStorageCopyState {
-  const settings = isRecord(settingsSnapshot) ? settingsSnapshot : {};
-  const raw = isRecord(settings.byteplusStorageCopy) ? settings.byteplusStorageCopy : {};
-  const attempts = Number(raw.attempts);
-  return {
-    attempts: Number.isFinite(attempts) && attempts > 0 ? Math.floor(attempts) : 0,
-    firstFailedAt: typeof raw.firstFailedAt === 'string' && raw.firstFailedAt.length ? raw.firstFailedAt : null,
-    lastFailedAt: typeof raw.lastFailedAt === 'string' && raw.lastFailedAt.length ? raw.lastFailedAt : null,
-    lastProviderStatus: typeof raw.lastProviderStatus === 'string' ? raw.lastProviderStatus : null,
-    lastReason: typeof raw.lastReason === 'string' ? raw.lastReason : null,
-    nextRetryAt: typeof raw.nextRetryAt === 'string' && raw.nextRetryAt.length ? raw.nextRetryAt : null,
-  };
-}
-
-export function buildNextBytePlusStorageCopyState(
-  settingsSnapshot: unknown,
-  params: { nowIso?: string; providerStatus?: string | null; reason?: string | null; maxAttempts?: number } = {}
-): BytePlusStorageCopyState {
-  const previous = getBytePlusStorageCopyState(settingsSnapshot);
-  const nowIso = params.nowIso ?? new Date().toISOString();
-  const attempts = previous.attempts + 1;
-  const maxAttempts = params.maxAttempts ?? resolveBytePlusStorageCopyMaxAttempts();
-  const retryDelayMs = attempts < maxAttempts ? BYTEPLUS_STORAGE_COPY_RETRY_DELAYS_MS[attempts - 1] : null;
-  const nowMs = Date.parse(nowIso);
-  return {
-    attempts,
-    firstFailedAt: previous.firstFailedAt ?? nowIso,
-    lastFailedAt: nowIso,
-    lastProviderStatus: params.providerStatus ?? previous.lastProviderStatus ?? null,
-    lastReason: params.reason ?? previous.lastReason ?? null,
-    nextRetryAt:
-      retryDelayMs !== null && Number.isFinite(nowMs) ? new Date(nowMs + retryDelayMs).toISOString() : null,
-  };
-}
-
-export function isBytePlusStorageCopyRetryDue(
-  state: Pick<BytePlusStorageCopyState, 'nextRetryAt'>,
-  nowMs = Date.now()
-): boolean {
-  if (!state.nextRetryAt) return true;
-  const nextRetryAtMs = Date.parse(state.nextRetryAt);
-  if (!Number.isFinite(nextRetryAtMs)) return true;
-  return nowMs >= nextRetryAtMs;
-}
-
-export function shouldRetryBytePlusStorageCopy(params: {
-  state: Pick<BytePlusStorageCopyState, 'attempts'>;
-  createdAt: string;
-  nowMs?: number;
-  maxAttempts?: number;
-  copyWindowMs?: number;
-}): boolean {
-  const maxAttempts = params.maxAttempts ?? resolveBytePlusStorageCopyMaxAttempts();
-  if (params.state.attempts >= maxAttempts) return false;
-  const createdAtMs = Date.parse(params.createdAt);
-  if (!Number.isFinite(createdAtMs)) return true;
-  const copyWindowMs = params.copyWindowMs ?? BYTEPLUS_OUTPUT_COPY_WINDOW_MS;
-  return (params.nowMs ?? Date.now()) - createdAtMs < copyWindowMs;
-}
-
-export function getBytePlusAccounting(job: Pick<BytePlusPendingJob, 'settings_snapshot' | 'has_audio'>) {
-  const settings = isRecord(job.settings_snapshot) ? job.settings_snapshot : {};
-  const refs = isRecord(settings.refs) ? settings.refs : {};
-  const mode =
-    settings.inputMode === 'extend'
-      ? 'extend'
-      : settings.inputMode === 'v2v'
-        ? 'v2v'
-        : settings.inputMode === 'ref2v'
-          ? 'ref2v'
-          : settings.inputMode === 'i2v'
-            ? 'i2v'
-            : 't2v';
-  const hasStartImage = mode === 'i2v' && typeof refs.imageUrl === 'string' && refs.imageUrl.trim().length > 0;
-  const hasEndImage = mode === 'i2v' && typeof refs.endImageUrl === 'string' && refs.endImageUrl.trim().length > 0;
-  const hasReferenceImages = Array.isArray(refs.referenceImages) && refs.referenceImages.length > 0;
-  const hasReferenceVideos = Array.isArray(refs.videoUrls) && refs.videoUrls.length > 0;
-  const hasReferenceAudio = typeof refs.audioUrl === 'string' || (Array.isArray(refs.audioUrls) && refs.audioUrls.length > 0);
-  const inputType =
-    mode === 'extend'
-      ? 'video_extension'
-      : mode === 'v2v'
-        ? 'video_edit'
-        : mode === 'ref2v'
-      ? 'reference_generation'
-      : hasEndImage
-        ? 'first_last_frame'
-        : hasStartImage
-          ? 'image_input'
-          : 'text_input';
-
-  return {
-    mode,
-    inputType,
-    hasStartImage,
-    hasEndImage,
-    hasReferenceImages,
-    hasReferenceVideos,
-    hasReferenceAudio,
-    generateAudio: job.has_audio === true,
-    byteplusBillingInputType: hasReferenceVideos ? 'video_input' : 'no_video_input',
-  };
-}
-
-export function getBytePlusUnitPriceUsdPer1kTokens(engineId: string | null | undefined): number {
-  return engineId === PUBLIC_SEEDANCE_ENGINE_ID
-    ? BYTEPLUS_STANDARD_UNIT_PRICE_USD_PER_1K_TOKENS
-    : BYTEPLUS_FAST_UNIT_PRICE_USD_PER_1K_TOKENS;
-}
 
 async function recordPollEvent(
   job: Pick<BytePlusPendingJob, 'job_id' | 'provider_job_id' | 'engine_id'>,

--- a/frontend/server/byteplus-record-utils.ts
+++ b/frontend/server/byteplus-record-utils.ts
@@ -1,0 +1,3 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}

--- a/frontend/server/byteplus-storage-copy.ts
+++ b/frontend/server/byteplus-storage-copy.ts
@@ -1,0 +1,79 @@
+import { isRecord } from './byteplus-record-utils';
+
+const BYTEPLUS_OUTPUT_COPY_WINDOW_MS = 3 * 60 * 60_000;
+const DEFAULT_PROVIDER_VIDEO_COPY_MAX_ATTEMPTS = 6;
+const BYTEPLUS_STORAGE_COPY_RETRY_DELAYS_MS = [2, 5, 15, 45, 90].map((minutes) => minutes * 60_000);
+
+export type BytePlusStorageCopyState = {
+  attempts: number;
+  firstFailedAt: string | null;
+  lastFailedAt: string | null;
+  lastProviderStatus?: string | null;
+  lastReason?: string | null;
+  nextRetryAt?: string | null;
+};
+
+export function resolveBytePlusStorageCopyMaxAttempts(raw = process.env.PROVIDER_VIDEO_COPY_MAX_ATTEMPTS ?? process.env.BYTEPLUS_STORAGE_COPY_MAX_ATTEMPTS): number {
+  const parsed = Number.parseInt(String(raw ?? ''), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.min(parsed, 50) : DEFAULT_PROVIDER_VIDEO_COPY_MAX_ATTEMPTS;
+}
+
+export function getBytePlusStorageCopyState(settingsSnapshot: unknown): BytePlusStorageCopyState {
+  const settings = isRecord(settingsSnapshot) ? settingsSnapshot : {};
+  const raw = isRecord(settings.byteplusStorageCopy) ? settings.byteplusStorageCopy : {};
+  const attempts = Number(raw.attempts);
+  return {
+    attempts: Number.isFinite(attempts) && attempts > 0 ? Math.floor(attempts) : 0,
+    firstFailedAt: typeof raw.firstFailedAt === 'string' && raw.firstFailedAt.length ? raw.firstFailedAt : null,
+    lastFailedAt: typeof raw.lastFailedAt === 'string' && raw.lastFailedAt.length ? raw.lastFailedAt : null,
+    lastProviderStatus: typeof raw.lastProviderStatus === 'string' ? raw.lastProviderStatus : null,
+    lastReason: typeof raw.lastReason === 'string' ? raw.lastReason : null,
+    nextRetryAt: typeof raw.nextRetryAt === 'string' && raw.nextRetryAt.length ? raw.nextRetryAt : null,
+  };
+}
+
+export function buildNextBytePlusStorageCopyState(
+  settingsSnapshot: unknown,
+  params: { nowIso?: string; providerStatus?: string | null; reason?: string | null; maxAttempts?: number } = {}
+): BytePlusStorageCopyState {
+  const previous = getBytePlusStorageCopyState(settingsSnapshot);
+  const nowIso = params.nowIso ?? new Date().toISOString();
+  const attempts = previous.attempts + 1;
+  const maxAttempts = params.maxAttempts ?? resolveBytePlusStorageCopyMaxAttempts();
+  const retryDelayMs = attempts < maxAttempts ? BYTEPLUS_STORAGE_COPY_RETRY_DELAYS_MS[attempts - 1] : null;
+  const nowMs = Date.parse(nowIso);
+  return {
+    attempts,
+    firstFailedAt: previous.firstFailedAt ?? nowIso,
+    lastFailedAt: nowIso,
+    lastProviderStatus: params.providerStatus ?? previous.lastProviderStatus ?? null,
+    lastReason: params.reason ?? previous.lastReason ?? null,
+    nextRetryAt:
+      retryDelayMs !== null && Number.isFinite(nowMs) ? new Date(nowMs + retryDelayMs).toISOString() : null,
+  };
+}
+
+export function isBytePlusStorageCopyRetryDue(
+  state: Pick<BytePlusStorageCopyState, 'nextRetryAt'>,
+  nowMs = Date.now()
+): boolean {
+  if (!state.nextRetryAt) return true;
+  const nextRetryAtMs = Date.parse(state.nextRetryAt);
+  if (!Number.isFinite(nextRetryAtMs)) return true;
+  return nowMs >= nextRetryAtMs;
+}
+
+export function shouldRetryBytePlusStorageCopy(params: {
+  state: Pick<BytePlusStorageCopyState, 'attempts'>;
+  createdAt: string;
+  nowMs?: number;
+  maxAttempts?: number;
+  copyWindowMs?: number;
+}): boolean {
+  const maxAttempts = params.maxAttempts ?? resolveBytePlusStorageCopyMaxAttempts();
+  if (params.state.attempts >= maxAttempts) return false;
+  const createdAtMs = Date.parse(params.createdAt);
+  if (!Number.isFinite(createdAtMs)) return true;
+  const copyWindowMs = params.copyWindowMs ?? BYTEPLUS_OUTPUT_COPY_WINDOW_MS;
+  return (params.nowMs ?? Date.now()) - createdAtMs < copyWindowMs;
+}

--- a/frontend/src/server/video-providers/byteplus-modelark-constants.ts
+++ b/frontend/src/server/video-providers/byteplus-modelark-constants.ts
@@ -1,0 +1,14 @@
+import type { AspectRatio, Mode, Resolution } from '@/types/engines';
+
+export const BYTEPLUS_MODELARK_PROVIDER = 'byteplus_modelark';
+export const PUBLIC_SEEDANCE_ENGINE_ID = 'seedance-2-0';
+export const PUBLIC_SEEDANCE_FAST_ENGINE_ID = 'seedance-2-0-fast';
+export const BYTEPLUS_SEEDANCE_FAST_ENGINE_ID = 'seedance-2-0-fast-byteplus';
+export const BYTEPLUS_SEEDANCE_DEFAULT_MODEL_ID = 'dreamina-seedance-2-0-260128';
+export const BYTEPLUS_SEEDANCE_FAST_DEFAULT_MODEL_ID = 'dreamina-seedance-2-0-fast-260128';
+export const BYTEPLUS_SEEDANCE_FAST_DEFAULT_BASE_URL = 'https://ark.ap-southeast.bytepluses.com/api/v3';
+export const BYTEPLUS_SEEDANCE_MODES: Mode[] = ['t2v', 'i2v', 'ref2v', 'v2v', 'extend'];
+export const BYTEPLUS_SEEDANCE_RESOLUTIONS: Resolution[] = ['480p', '720p', '1080p'];
+export const BYTEPLUS_SEEDANCE_FAST_RESOLUTIONS: Resolution[] = ['480p', '720p'];
+export const BYTEPLUS_SEEDANCE_ASPECT_RATIOS: AspectRatio[] = ['21:9', '16:9', '4:3', '1:1', '3:4', '9:16'];
+export const BYTEPLUS_SEEDANCE_DURATION_OPTIONS = [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] as const;

--- a/frontend/src/server/video-providers/byteplus-modelark-error.ts
+++ b/frontend/src/server/video-providers/byteplus-modelark-error.ts
@@ -1,0 +1,13 @@
+export class BytePlusModelArkError extends Error {
+  status: number | null;
+  code: string | null;
+  providerMessage: string | null;
+
+  constructor(message: string, options: { status?: number | null; code?: string | null; providerMessage?: string | null } = {}) {
+    super(message);
+    this.name = 'BytePlusModelArkError';
+    this.status = options.status ?? null;
+    this.code = options.code ?? null;
+    this.providerMessage = options.providerMessage ?? null;
+  }
+}

--- a/frontend/src/server/video-providers/byteplus-modelark-payload.ts
+++ b/frontend/src/server/video-providers/byteplus-modelark-payload.ts
@@ -1,0 +1,184 @@
+import type { AspectRatio, Mode, Resolution } from '@/types/engines';
+import {
+  BYTEPLUS_SEEDANCE_ASPECT_RATIOS,
+  BYTEPLUS_SEEDANCE_FAST_RESOLUTIONS,
+  BYTEPLUS_SEEDANCE_MODES,
+} from './byteplus-modelark-constants';
+import { BytePlusModelArkError } from './byteplus-modelark-error';
+
+type BytePlusContentItem =
+  | { type: 'text'; text: string }
+  | {
+      type: 'image_url';
+      image_url: { url: string };
+      role: 'reference_image';
+    }
+  | {
+      type: 'video_url';
+      video_url: { url: string };
+      role: 'reference_video';
+    }
+  | {
+      type: 'audio_url';
+      audio_url: { url: string };
+      role: 'reference_audio';
+    };
+
+export type BytePlusSeedanceFastPayload = {
+  model: string;
+  content: BytePlusContentItem[];
+  resolution: '480p' | '720p' | '1080p';
+  ratio: '21:9' | '16:9' | '4:3' | '1:1' | '3:4' | '9:16';
+  duration: number;
+  generate_audio: boolean;
+  watermark: false;
+};
+
+export type BytePlusSeedancePayload = BytePlusSeedanceFastPayload;
+
+function uniqueNonEmptyUrls(values: Array<string | null | undefined> | undefined): string[] {
+  return Array.from(
+    new Set(
+      (values ?? [])
+        .map((value) => (typeof value === 'string' ? value.trim() : ''))
+        .filter(Boolean)
+    )
+  );
+}
+
+export function buildBytePlusSeedancePayload(params: {
+  modelId: string;
+  prompt: string;
+  durationSec: number;
+  mode?: Extract<Mode, 't2v' | 'i2v' | 'ref2v' | 'v2v' | 'extend'>;
+  imageUrl?: string | null;
+  endImageUrl?: string | null;
+  referenceImageUrls?: string[];
+  referenceVideoUrls?: string[];
+  referenceAudioUrls?: string[];
+  resolution?: string | null;
+  ratio?: string | null;
+  generateAudio?: boolean;
+  allowedResolutions?: Resolution[];
+}): BytePlusSeedancePayload {
+  const prompt = params.prompt.trim();
+  const duration = Math.trunc(params.durationSec);
+  const mode = params.mode ?? 't2v';
+  const imageUrl = typeof params.imageUrl === 'string' ? params.imageUrl.trim() : '';
+  const endImageUrl = typeof params.endImageUrl === 'string' ? params.endImageUrl.trim() : '';
+  const referenceImageUrls = uniqueNonEmptyUrls(params.referenceImageUrls);
+  const referenceVideoUrls = uniqueNonEmptyUrls(params.referenceVideoUrls);
+  const referenceAudioUrls = uniqueNonEmptyUrls(params.referenceAudioUrls);
+  const allowedResolutions = params.allowedResolutions?.length ? params.allowedResolutions : BYTEPLUS_SEEDANCE_FAST_RESOLUTIONS;
+  const requestedResolution = (typeof params.resolution === 'string' && params.resolution.trim()
+    ? params.resolution.trim()
+    : '720p') as Resolution;
+  const requestedRatio = (typeof params.ratio === 'string' && params.ratio.trim() ? params.ratio.trim() : '16:9') as AspectRatio;
+  if (!prompt) {
+    throw new BytePlusModelArkError('Prompt is required for BytePlus Seedance.', { code: 'PROMPT_REQUIRED' });
+  }
+  if (!BYTEPLUS_SEEDANCE_MODES.includes(mode)) {
+    throw new BytePlusModelArkError('BytePlus Seedance supports only configured T2V, I2V, reference, video edit, and extension modes.', {
+      code: 'BYTEPLUS_MODE_UNSUPPORTED',
+    });
+  }
+  if (mode === 'i2v' && !imageUrl) {
+    throw new BytePlusModelArkError('Image URL is required for BytePlus Seedance image-to-video.', {
+      code: 'IMAGE_URL_REQUIRED',
+    });
+  }
+  if (mode === 'ref2v' && referenceImageUrls.length + referenceVideoUrls.length + referenceAudioUrls.length === 0) {
+    throw new BytePlusModelArkError('At least one reference image, video, or audio URL is required for BytePlus Seedance reference-to-video.', {
+      code: 'REFERENCE_URL_REQUIRED',
+    });
+  }
+  if (mode === 'ref2v' && referenceImageUrls.length + referenceVideoUrls.length === 0) {
+    throw new BytePlusModelArkError('At least one reference image or video URL is required for BytePlus Seedance reference-to-video.', {
+      code: 'REFERENCE_MEDIA_REQUIRED',
+    });
+  }
+  if ((mode === 'v2v' || mode === 'extend') && referenceVideoUrls.length === 0) {
+    throw new BytePlusModelArkError('At least one source video URL is required for BytePlus Seedance video edit and extension modes.', {
+      code: 'VIDEO_URL_REQUIRED',
+    });
+  }
+  if (!Number.isFinite(duration) || duration < 5 || duration > 15) {
+    throw new BytePlusModelArkError('BytePlus Seedance duration must be between 5 and 15 seconds.', {
+      code: 'BYTEPLUS_DURATION_UNSUPPORTED',
+    });
+  }
+  if (!params.modelId.trim()) {
+    throw new BytePlusModelArkError('BytePlus Seedance model id is not configured.', {
+      code: 'BYTEPLUS_MODEL_MISSING',
+    });
+  }
+  if (!allowedResolutions.includes(requestedResolution)) {
+    throw new BytePlusModelArkError('BytePlus Seedance resolution is not supported by this model.', {
+      code: 'BYTEPLUS_RESOLUTION_UNSUPPORTED',
+    });
+  }
+  if (!BYTEPLUS_SEEDANCE_ASPECT_RATIOS.includes(requestedRatio)) {
+    throw new BytePlusModelArkError('BytePlus Seedance aspect ratio is not supported.', {
+      code: 'BYTEPLUS_RATIO_UNSUPPORTED',
+    });
+  }
+
+  const text =
+    mode === 'i2v' && endImageUrl
+      ? `Use Image 1 as the opening frame and Image 2 as the final frame. ${prompt}`
+      : mode === 'i2v'
+        ? `Use Image 1 as the opening frame. ${prompt}`
+        : prompt;
+  const content: BytePlusContentItem[] = [{ type: 'text', text }];
+  if (mode === 'i2v') {
+    content.push({
+      type: 'image_url',
+      image_url: { url: imageUrl },
+      role: 'reference_image',
+    });
+    if (endImageUrl) {
+      content.push({
+        type: 'image_url',
+        image_url: { url: endImageUrl },
+        role: 'reference_image',
+      });
+    }
+  }
+  if (mode === 'ref2v' || mode === 'v2v' || mode === 'extend') {
+    for (const url of referenceImageUrls) {
+      content.push({
+        type: 'image_url',
+        image_url: { url },
+        role: 'reference_image',
+      });
+    }
+    for (const url of referenceVideoUrls) {
+      content.push({
+        type: 'video_url',
+        video_url: { url },
+        role: 'reference_video',
+      });
+    }
+    for (const url of referenceAudioUrls) {
+      content.push({
+        type: 'audio_url',
+        audio_url: { url },
+        role: 'reference_audio',
+      });
+    }
+  }
+
+  return {
+    model: params.modelId.trim(),
+    content,
+    resolution: requestedResolution as BytePlusSeedancePayload['resolution'],
+    ratio: requestedRatio as BytePlusSeedancePayload['ratio'],
+    duration,
+    generate_audio: params.generateAudio === true,
+    watermark: false,
+  };
+}
+
+export function buildBytePlusSeedanceFastPayload(params: Parameters<typeof buildBytePlusSeedancePayload>[0]): BytePlusSeedanceFastPayload {
+  return buildBytePlusSeedancePayload(params);
+}

--- a/frontend/src/server/video-providers/byteplus-modelark-response.ts
+++ b/frontend/src/server/video-providers/byteplus-modelark-response.ts
@@ -1,0 +1,123 @@
+import type { NormalizedVideoProviderTask, NormalizedVideoProviderUsage } from '@/server/video-providers/types';
+
+export type BytePlusTaskResponse = Record<string, unknown>;
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function firstString(value: unknown, keys: string[]): string | null {
+  if (!isRecord(value)) return null;
+  for (const key of keys) {
+    const candidate = value[key];
+    if (typeof candidate === 'string' && candidate.trim().length) {
+      return candidate.trim();
+    }
+  }
+  return null;
+}
+
+function firstRecord(value: unknown, keys: string[]): Record<string, unknown> | null {
+  if (!isRecord(value)) return null;
+  for (const key of keys) {
+    const candidate = value[key];
+    if (isRecord(candidate)) return candidate;
+  }
+  return null;
+}
+
+function extractUsage(value: unknown): NormalizedVideoProviderUsage | null {
+  const content = firstRecord(value, ['content', 'result', 'output', 'data']);
+  const usage = firstRecord(value, ['usage']) ?? firstRecord(content, ['usage']);
+  if (!usage) return null;
+  const totalRaw = usage.total_tokens ?? usage.totalTokens;
+  const completionRaw = usage.completion_tokens ?? usage.completionTokens;
+  const totalTokens = typeof totalRaw === 'number' && Number.isFinite(totalRaw) ? totalRaw : null;
+  const completionTokens = typeof completionRaw === 'number' && Number.isFinite(completionRaw) ? completionRaw : null;
+  return totalTokens == null && completionTokens == null ? null : { totalTokens, completionTokens };
+}
+
+function extractVideoUrl(value: unknown): string | null {
+  const content = firstRecord(value, ['content', 'result', 'output', 'data']);
+  const direct = firstString(value, ['video_url', 'videoUrl', 'url']);
+  if (direct) return direct;
+  const contentDirect = firstString(content, ['video_url', 'videoUrl', 'url']);
+  if (contentDirect) return contentDirect;
+  const video = firstRecord(content, ['video']) ?? firstRecord(value, ['video']);
+  return firstString(video, ['url', 'video_url', 'videoUrl']);
+}
+
+function extractErrorMessage(value: unknown): string | null {
+  const error = firstRecord(value, ['error']);
+  return (
+    firstString(error, ['message', 'msg', 'detail']) ??
+    firstString(value, ['message', 'error_message', 'errorMessage']) ??
+    null
+  );
+}
+
+export function normalizeBytePlusTask(task: unknown): NormalizedVideoProviderTask {
+  const root = firstRecord(task, ['data', 'task']) ?? task;
+  const providerJobId = firstString(root, ['id', 'task_id', 'taskId']) ?? '';
+  const rawStatus = firstString(root, ['status', 'state'])?.toLowerCase() ?? null;
+  const status =
+    rawStatus === 'succeeded' || rawStatus === 'success'
+      ? 'completed'
+      : rawStatus === 'failed' || rawStatus === 'expired' || rawStatus === 'cancelled' || rawStatus === 'canceled'
+        ? 'failed'
+        : rawStatus === 'running' || rawStatus === 'processing' || rawStatus === 'in_progress'
+          ? 'running'
+          : 'queued';
+
+  return {
+    providerJobId,
+    status,
+    rawStatus,
+    videoUrl: extractVideoUrl(root) ?? extractVideoUrl(task),
+    message: extractErrorMessage(root) ?? extractErrorMessage(task),
+    usage: extractUsage(root) ?? extractUsage(task),
+    raw: task,
+  };
+}
+
+export function scrubBytePlusError(error: unknown): string {
+  const nestedError = isRecord(error) && isRecord(error.error) ? error.error : null;
+  const raw =
+    error instanceof Error
+      ? error.message
+      : isRecord(error) && typeof error.message === 'string'
+        ? error.message
+        : nestedError && typeof nestedError.message === 'string'
+          ? nestedError.message
+          : typeof error === 'string'
+            ? error
+            : 'BytePlus ModelArk request failed.';
+  return raw
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [redacted]')
+    .replace(/ark-[A-Za-z0-9._~+/=-]+/gi, '[redacted-api-key]')
+    .replace(/([?&](?:X-Amz-Signature|Signature|Expires|X-Amz-Credential)=)[^&\s]+/gi, '$1[redacted]');
+}
+
+export function getBytePlusUserSafeErrorMessage(providerMessage: string): string {
+  const normalized = providerMessage.toLowerCase();
+  if (
+    normalized.includes('real person') ||
+    normalized.includes('private information') ||
+    normalized.includes('sensitive') ||
+    normalized.includes('policy')
+  ) {
+    return 'The render service rejected one of the input images. Try an image without identifiable people or private content.';
+  }
+  return 'The render could not start. Please retry later.';
+}
+
+export async function parseJsonResponse(response: Response): Promise<BytePlusTaskResponse> {
+  const text = await response.text();
+  if (!text.trim()) return {};
+  try {
+    const parsed = JSON.parse(text);
+    return isRecord(parsed) ? parsed : { value: parsed };
+  } catch {
+    return { message: text };
+  }
+}

--- a/frontend/src/server/video-providers/byteplus-modelark.ts
+++ b/frontend/src/server/video-providers/byteplus-modelark.ts
@@ -1,65 +1,57 @@
 import { ENV } from '@/lib/env';
-import type { NormalizedVideoProviderTask, NormalizedVideoProviderUsage } from '@/server/video-providers/types';
-import type { AspectRatio, EngineCaps, EngineInputField, Mode, Resolution } from '@/types/engines';
+import type { NormalizedVideoProviderTask } from '@/server/video-providers/types';
+import type { EngineCaps, EngineInputField, Mode, Resolution } from '@/types/engines';
+import {
+  BYTEPLUS_MODELARK_PROVIDER,
+  BYTEPLUS_SEEDANCE_ASPECT_RATIOS,
+  BYTEPLUS_SEEDANCE_DEFAULT_MODEL_ID,
+  BYTEPLUS_SEEDANCE_DURATION_OPTIONS,
+  BYTEPLUS_SEEDANCE_FAST_DEFAULT_BASE_URL,
+  BYTEPLUS_SEEDANCE_FAST_DEFAULT_MODEL_ID,
+  BYTEPLUS_SEEDANCE_FAST_ENGINE_ID,
+  BYTEPLUS_SEEDANCE_FAST_RESOLUTIONS,
+  BYTEPLUS_SEEDANCE_MODES,
+  BYTEPLUS_SEEDANCE_RESOLUTIONS,
+  PUBLIC_SEEDANCE_ENGINE_ID,
+  PUBLIC_SEEDANCE_FAST_ENGINE_ID,
+} from './byteplus-modelark-constants';
+import { BytePlusModelArkError } from './byteplus-modelark-error';
+import type { BytePlusSeedanceFastPayload } from './byteplus-modelark-payload';
+import {
+  firstString,
+  normalizeBytePlusTask,
+  parseJsonResponse,
+  scrubBytePlusError,
+} from './byteplus-modelark-response';
 
-export const BYTEPLUS_MODELARK_PROVIDER = 'byteplus_modelark';
-export const PUBLIC_SEEDANCE_ENGINE_ID = 'seedance-2-0';
-export const PUBLIC_SEEDANCE_FAST_ENGINE_ID = 'seedance-2-0-fast';
-export const BYTEPLUS_SEEDANCE_FAST_ENGINE_ID = 'seedance-2-0-fast-byteplus';
-export const BYTEPLUS_SEEDANCE_DEFAULT_MODEL_ID = 'dreamina-seedance-2-0-260128';
-export const BYTEPLUS_SEEDANCE_FAST_DEFAULT_MODEL_ID = 'dreamina-seedance-2-0-fast-260128';
-export const BYTEPLUS_SEEDANCE_FAST_DEFAULT_BASE_URL = 'https://ark.ap-southeast.bytepluses.com/api/v3';
-export const BYTEPLUS_SEEDANCE_MODES: Mode[] = ['t2v', 'i2v', 'ref2v', 'v2v', 'extend'];
-export const BYTEPLUS_SEEDANCE_RESOLUTIONS: Resolution[] = ['480p', '720p', '1080p'];
-export const BYTEPLUS_SEEDANCE_FAST_RESOLUTIONS: Resolution[] = ['480p', '720p'];
-export const BYTEPLUS_SEEDANCE_ASPECT_RATIOS: AspectRatio[] = ['21:9', '16:9', '4:3', '1:1', '3:4', '9:16'];
-export const BYTEPLUS_SEEDANCE_DURATION_OPTIONS = [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] as const;
-
-type BytePlusContentItem =
-  | { type: 'text'; text: string }
-  | {
-      type: 'image_url';
-      image_url: { url: string };
-      role: 'reference_image';
-    }
-  | {
-      type: 'video_url';
-      video_url: { url: string };
-      role: 'reference_video';
-    }
-  | {
-      type: 'audio_url';
-      audio_url: { url: string };
-      role: 'reference_audio';
-    };
-
-export type BytePlusSeedanceFastPayload = {
-  model: string;
-  content: BytePlusContentItem[];
-  resolution: '480p' | '720p' | '1080p';
-  ratio: '21:9' | '16:9' | '4:3' | '1:1' | '3:4' | '9:16';
-  duration: number;
-  generate_audio: boolean;
-  watermark: false;
-};
-
-export type BytePlusSeedancePayload = BytePlusSeedanceFastPayload;
-
-type BytePlusTaskResponse = Record<string, unknown>;
-
-export class BytePlusModelArkError extends Error {
-  status: number | null;
-  code: string | null;
-  providerMessage: string | null;
-
-  constructor(message: string, options: { status?: number | null; code?: string | null; providerMessage?: string | null } = {}) {
-    super(message);
-    this.name = 'BytePlusModelArkError';
-    this.status = options.status ?? null;
-    this.code = options.code ?? null;
-    this.providerMessage = options.providerMessage ?? null;
-  }
-}
+export {
+  BYTEPLUS_MODELARK_PROVIDER,
+  BYTEPLUS_SEEDANCE_ASPECT_RATIOS,
+  BYTEPLUS_SEEDANCE_DEFAULT_MODEL_ID,
+  BYTEPLUS_SEEDANCE_DURATION_OPTIONS,
+  BYTEPLUS_SEEDANCE_FAST_DEFAULT_BASE_URL,
+  BYTEPLUS_SEEDANCE_FAST_DEFAULT_MODEL_ID,
+  BYTEPLUS_SEEDANCE_FAST_ENGINE_ID,
+  BYTEPLUS_SEEDANCE_FAST_RESOLUTIONS,
+  BYTEPLUS_SEEDANCE_MODES,
+  BYTEPLUS_SEEDANCE_RESOLUTIONS,
+  PUBLIC_SEEDANCE_ENGINE_ID,
+  PUBLIC_SEEDANCE_FAST_ENGINE_ID,
+} from './byteplus-modelark-constants';
+export { BytePlusModelArkError } from './byteplus-modelark-error';
+export {
+  buildBytePlusSeedanceFastPayload,
+  buildBytePlusSeedancePayload,
+} from './byteplus-modelark-payload';
+export type {
+  BytePlusSeedanceFastPayload,
+  BytePlusSeedancePayload,
+} from './byteplus-modelark-payload';
+export {
+  getBytePlusUserSafeErrorMessage,
+  normalizeBytePlusTask,
+  scrubBytePlusError,
+} from './byteplus-modelark-response';
 
 function trimTrailingSlash(value: string): string {
   return value.replace(/\/+$/, '');
@@ -74,16 +66,6 @@ function splitCsvEnv(value: string | undefined): string[] {
     .split(',')
     .map((entry) => entry.trim().toLowerCase())
     .filter(Boolean);
-}
-
-function uniqueNonEmptyUrls(values: Array<string | null | undefined> | undefined): string[] {
-  return Array.from(
-    new Set(
-      (values ?? [])
-        .map((value) => (typeof value === 'string' ? value.trim() : ''))
-        .filter(Boolean)
-    )
-  );
 }
 
 function allowedBytePlusModes(value: string | undefined): Mode[] {
@@ -304,263 +286,6 @@ export function getBytePlusArkConfig() {
     seedanceModelId: ENV.BYTEPLUS_ARK_SEEDANCE_MODEL_ID ?? BYTEPLUS_SEEDANCE_DEFAULT_MODEL_ID,
     seedanceFastModelId: ENV.BYTEPLUS_ARK_SEEDANCE_FAST_MODEL_ID ?? BYTEPLUS_SEEDANCE_FAST_DEFAULT_MODEL_ID,
   };
-}
-
-export function buildBytePlusSeedancePayload(params: {
-  modelId: string;
-  prompt: string;
-  durationSec: number;
-  mode?: Extract<Mode, 't2v' | 'i2v' | 'ref2v' | 'v2v' | 'extend'>;
-  imageUrl?: string | null;
-  endImageUrl?: string | null;
-  referenceImageUrls?: string[];
-  referenceVideoUrls?: string[];
-  referenceAudioUrls?: string[];
-  resolution?: string | null;
-  ratio?: string | null;
-  generateAudio?: boolean;
-  allowedResolutions?: Resolution[];
-}): BytePlusSeedancePayload {
-  const prompt = params.prompt.trim();
-  const duration = Math.trunc(params.durationSec);
-  const mode = params.mode ?? 't2v';
-  const imageUrl = typeof params.imageUrl === 'string' ? params.imageUrl.trim() : '';
-  const endImageUrl = typeof params.endImageUrl === 'string' ? params.endImageUrl.trim() : '';
-  const referenceImageUrls = uniqueNonEmptyUrls(params.referenceImageUrls);
-  const referenceVideoUrls = uniqueNonEmptyUrls(params.referenceVideoUrls);
-  const referenceAudioUrls = uniqueNonEmptyUrls(params.referenceAudioUrls);
-  const allowedResolutions = params.allowedResolutions?.length ? params.allowedResolutions : BYTEPLUS_SEEDANCE_FAST_RESOLUTIONS;
-  const requestedResolution = (typeof params.resolution === 'string' && params.resolution.trim()
-    ? params.resolution.trim()
-    : '720p') as Resolution;
-  const requestedRatio = (typeof params.ratio === 'string' && params.ratio.trim() ? params.ratio.trim() : '16:9') as AspectRatio;
-  if (!prompt) {
-    throw new BytePlusModelArkError('Prompt is required for BytePlus Seedance.', { code: 'PROMPT_REQUIRED' });
-  }
-  if (!BYTEPLUS_SEEDANCE_MODES.includes(mode)) {
-    throw new BytePlusModelArkError('BytePlus Seedance supports only configured T2V, I2V, reference, video edit, and extension modes.', {
-      code: 'BYTEPLUS_MODE_UNSUPPORTED',
-    });
-  }
-  if (mode === 'i2v' && !imageUrl) {
-    throw new BytePlusModelArkError('Image URL is required for BytePlus Seedance image-to-video.', {
-      code: 'IMAGE_URL_REQUIRED',
-    });
-  }
-  if (mode === 'ref2v' && referenceImageUrls.length + referenceVideoUrls.length + referenceAudioUrls.length === 0) {
-    throw new BytePlusModelArkError('At least one reference image, video, or audio URL is required for BytePlus Seedance reference-to-video.', {
-      code: 'REFERENCE_URL_REQUIRED',
-    });
-  }
-  if (mode === 'ref2v' && referenceImageUrls.length + referenceVideoUrls.length === 0) {
-    throw new BytePlusModelArkError('At least one reference image or video URL is required for BytePlus Seedance reference-to-video.', {
-      code: 'REFERENCE_MEDIA_REQUIRED',
-    });
-  }
-  if ((mode === 'v2v' || mode === 'extend') && referenceVideoUrls.length === 0) {
-    throw new BytePlusModelArkError('At least one source video URL is required for BytePlus Seedance video edit and extension modes.', {
-      code: 'VIDEO_URL_REQUIRED',
-    });
-  }
-  if (!Number.isFinite(duration) || duration < 5 || duration > 15) {
-    throw new BytePlusModelArkError('BytePlus Seedance duration must be between 5 and 15 seconds.', {
-      code: 'BYTEPLUS_DURATION_UNSUPPORTED',
-    });
-  }
-  if (!params.modelId.trim()) {
-    throw new BytePlusModelArkError('BytePlus Seedance model id is not configured.', {
-      code: 'BYTEPLUS_MODEL_MISSING',
-    });
-  }
-  if (!allowedResolutions.includes(requestedResolution)) {
-    throw new BytePlusModelArkError('BytePlus Seedance resolution is not supported by this model.', {
-      code: 'BYTEPLUS_RESOLUTION_UNSUPPORTED',
-    });
-  }
-  if (!BYTEPLUS_SEEDANCE_ASPECT_RATIOS.includes(requestedRatio)) {
-    throw new BytePlusModelArkError('BytePlus Seedance aspect ratio is not supported.', {
-      code: 'BYTEPLUS_RATIO_UNSUPPORTED',
-    });
-  }
-
-  const text =
-    mode === 'i2v' && endImageUrl
-      ? `Use Image 1 as the opening frame and Image 2 as the final frame. ${prompt}`
-      : mode === 'i2v'
-        ? `Use Image 1 as the opening frame. ${prompt}`
-        : prompt;
-  const content: BytePlusContentItem[] = [{ type: 'text', text }];
-  if (mode === 'i2v') {
-    content.push({
-      type: 'image_url',
-      image_url: { url: imageUrl },
-      role: 'reference_image',
-    });
-    if (endImageUrl) {
-      content.push({
-        type: 'image_url',
-        image_url: { url: endImageUrl },
-        role: 'reference_image',
-      });
-    }
-  }
-  if (mode === 'ref2v' || mode === 'v2v' || mode === 'extend') {
-    for (const url of referenceImageUrls) {
-      content.push({
-        type: 'image_url',
-        image_url: { url },
-        role: 'reference_image',
-      });
-    }
-    for (const url of referenceVideoUrls) {
-      content.push({
-        type: 'video_url',
-        video_url: { url },
-        role: 'reference_video',
-      });
-    }
-    for (const url of referenceAudioUrls) {
-      content.push({
-        type: 'audio_url',
-        audio_url: { url },
-        role: 'reference_audio',
-      });
-    }
-  }
-
-  return {
-    model: params.modelId.trim(),
-    content,
-    resolution: requestedResolution as BytePlusSeedancePayload['resolution'],
-    ratio: requestedRatio as BytePlusSeedancePayload['ratio'],
-    duration,
-    generate_audio: params.generateAudio === true,
-    watermark: false,
-  };
-}
-
-export function buildBytePlusSeedanceFastPayload(params: Parameters<typeof buildBytePlusSeedancePayload>[0]): BytePlusSeedanceFastPayload {
-  return buildBytePlusSeedancePayload(params);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
-}
-
-function firstString(value: unknown, keys: string[]): string | null {
-  if (!isRecord(value)) return null;
-  for (const key of keys) {
-    const candidate = value[key];
-    if (typeof candidate === 'string' && candidate.trim().length) {
-      return candidate.trim();
-    }
-  }
-  return null;
-}
-
-function firstRecord(value: unknown, keys: string[]): Record<string, unknown> | null {
-  if (!isRecord(value)) return null;
-  for (const key of keys) {
-    const candidate = value[key];
-    if (isRecord(candidate)) return candidate;
-  }
-  return null;
-}
-
-function extractUsage(value: unknown): NormalizedVideoProviderUsage | null {
-  const content = firstRecord(value, ['content', 'result', 'output', 'data']);
-  const usage = firstRecord(value, ['usage']) ?? firstRecord(content, ['usage']);
-  if (!usage) return null;
-  const totalRaw = usage.total_tokens ?? usage.totalTokens;
-  const completionRaw = usage.completion_tokens ?? usage.completionTokens;
-  const totalTokens = typeof totalRaw === 'number' && Number.isFinite(totalRaw) ? totalRaw : null;
-  const completionTokens = typeof completionRaw === 'number' && Number.isFinite(completionRaw) ? completionRaw : null;
-  return totalTokens == null && completionTokens == null ? null : { totalTokens, completionTokens };
-}
-
-function extractVideoUrl(value: unknown): string | null {
-  const content = firstRecord(value, ['content', 'result', 'output', 'data']);
-  const direct = firstString(value, ['video_url', 'videoUrl', 'url']);
-  if (direct) return direct;
-  const contentDirect = firstString(content, ['video_url', 'videoUrl', 'url']);
-  if (contentDirect) return contentDirect;
-  const video = firstRecord(content, ['video']) ?? firstRecord(value, ['video']);
-  return firstString(video, ['url', 'video_url', 'videoUrl']);
-}
-
-function extractErrorMessage(value: unknown): string | null {
-  const error = firstRecord(value, ['error']);
-  return (
-    firstString(error, ['message', 'msg', 'detail']) ??
-    firstString(value, ['message', 'error_message', 'errorMessage']) ??
-    null
-  );
-}
-
-export function normalizeBytePlusTask(task: unknown): NormalizedVideoProviderTask {
-  const root = firstRecord(task, ['data', 'task']) ?? task;
-  const providerJobId = firstString(root, ['id', 'task_id', 'taskId']) ?? '';
-  const rawStatus = firstString(root, ['status', 'state'])?.toLowerCase() ?? null;
-  const status =
-    rawStatus === 'succeeded' || rawStatus === 'success'
-      ? 'completed'
-      : rawStatus === 'failed' || rawStatus === 'expired' || rawStatus === 'cancelled' || rawStatus === 'canceled'
-        ? 'failed'
-        : rawStatus === 'running' || rawStatus === 'processing' || rawStatus === 'in_progress'
-          ? 'running'
-          : 'queued';
-
-  return {
-    providerJobId,
-    status,
-    rawStatus,
-    videoUrl: extractVideoUrl(root) ?? extractVideoUrl(task),
-    message: extractErrorMessage(root) ?? extractErrorMessage(task),
-    usage: extractUsage(root) ?? extractUsage(task),
-    raw: task,
-  };
-}
-
-export function scrubBytePlusError(error: unknown): string {
-  const nestedError = isRecord(error) && isRecord(error.error) ? error.error : null;
-  const raw =
-    error instanceof Error
-      ? error.message
-      : isRecord(error) && typeof error.message === 'string'
-        ? error.message
-        : nestedError && typeof nestedError.message === 'string'
-          ? nestedError.message
-        : typeof error === 'string'
-          ? error
-          : 'BytePlus ModelArk request failed.';
-  return raw
-    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [redacted]')
-    .replace(/ark-[A-Za-z0-9._~+/=-]+/gi, '[redacted-api-key]')
-    .replace(/([?&](?:X-Amz-Signature|Signature|Expires|X-Amz-Credential)=)[^&\s]+/gi, '$1[redacted]');
-}
-
-export function getBytePlusUserSafeErrorMessage(providerMessage: string): string {
-  const normalized = providerMessage.toLowerCase();
-  if (
-    normalized.includes('real person') ||
-    normalized.includes('private information') ||
-    normalized.includes('sensitive') ||
-    normalized.includes('policy')
-  ) {
-    return 'The render service rejected one of the input images. Try an image without identifiable people or private content.';
-  }
-  return 'The render could not start. Please retry later.';
-}
-
-async function parseJsonResponse(response: Response): Promise<BytePlusTaskResponse> {
-  const text = await response.text();
-  if (!text.trim()) return {};
-  try {
-    const parsed = JSON.parse(text);
-    return isRecord(parsed) ? parsed : { value: parsed };
-  } catch {
-    return { message: text };
-  }
 }
 
 export class BytePlusModelArkClient {

--- a/tests/byteplus-provider-architecture.test.ts
+++ b/tests/byteplus-provider-architecture.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const pollPath = 'frontend/server/byteplus-poll.ts';
+const accountingPath = 'frontend/server/byteplus-accounting.ts';
+const storageCopyPath = 'frontend/server/byteplus-storage-copy.ts';
+const pollTypesPath = 'frontend/server/byteplus-poll-types.ts';
+const providerPath = 'frontend/src/server/video-providers/byteplus-modelark.ts';
+const providerConstantsPath = 'frontend/src/server/video-providers/byteplus-modelark-constants.ts';
+const providerErrorPath = 'frontend/src/server/video-providers/byteplus-modelark-error.ts';
+const providerPayloadPath = 'frontend/src/server/video-providers/byteplus-modelark-payload.ts';
+const providerResponsePath = 'frontend/src/server/video-providers/byteplus-modelark-response.ts';
+
+test('BytePlus poll delegates accounting, storage-copy retry, and shared types', () => {
+  for (const path of [pollPath, accountingPath, storageCopyPath, pollTypesPath]) {
+    assert.equal(existsSync(path), true, `${path} should exist`);
+  }
+
+  const pollSource = readFileSync(pollPath, 'utf8');
+  const accountingSource = readFileSync(accountingPath, 'utf8');
+  const storageCopySource = readFileSync(storageCopyPath, 'utf8');
+  const pollTypesSource = readFileSync(pollTypesPath, 'utf8');
+
+  assert.ok(pollSource.split('\n').length < 430, 'byteplus-poll.ts should stay under 430 lines');
+  assert.match(pollSource, /from '\.\/byteplus-accounting'/);
+  assert.match(pollSource, /from '\.\/byteplus-storage-copy'/);
+  assert.match(pollSource, /from '\.\/byteplus-poll-types'/);
+  assert.doesNotMatch(pollSource, /const BYTEPLUS_TOKEN_DIMENSIONS/);
+  assert.doesNotMatch(pollSource, /const BYTEPLUS_STORAGE_COPY_RETRY_DELAYS_MS/);
+
+  assert.match(accountingSource, /export function expectedBytePlusTokens/);
+  assert.match(accountingSource, /export function getBytePlusAccounting/);
+  assert.match(accountingSource, /export function getBytePlusUnitPriceUsdPer1kTokens/);
+  assert.match(storageCopySource, /export function getBytePlusStorageCopyState/);
+  assert.match(storageCopySource, /export function shouldRetryBytePlusStorageCopy/);
+  assert.match(pollTypesSource, /export type BytePlusPendingJob/);
+});
+
+test('BytePlus ModelArk provider delegates payload and response normalization', () => {
+  for (const path of [providerPath, providerConstantsPath, providerErrorPath, providerPayloadPath, providerResponsePath]) {
+    assert.equal(existsSync(path), true, `${path} should exist`);
+  }
+
+  const providerSource = readFileSync(providerPath, 'utf8');
+  const payloadSource = readFileSync(providerPayloadPath, 'utf8');
+  const responseSource = readFileSync(providerResponsePath, 'utf8');
+
+  assert.ok(providerSource.split('\n').length < 430, 'byteplus-modelark.ts should stay under 430 lines');
+  assert.match(providerSource, /from '\.\/byteplus-modelark-constants'/);
+  assert.match(providerSource, /from '\.\/byteplus-modelark-payload'/);
+  assert.match(providerSource, /from '\.\/byteplus-modelark-response'/);
+  assert.doesNotMatch(providerSource, /function extractVideoUrl/);
+  assert.doesNotMatch(providerSource, /function uniqueNonEmptyUrls/);
+  assert.doesNotMatch(providerSource, /export function buildBytePlusSeedancePayload/);
+
+  assert.match(payloadSource, /export function buildBytePlusSeedancePayload/);
+  assert.match(payloadSource, /export function buildBytePlusSeedanceFastPayload/);
+  assert.match(responseSource, /export function normalizeBytePlusTask/);
+  assert.match(responseSource, /export function scrubBytePlusError/);
+  assert.match(responseSource, /export async function parseJsonResponse/);
+});


### PR DESCRIPTION
## Summary
- split BytePlus polling accounting, storage-copy retry state, shared record/type helpers from `byteplus-poll.ts`
- split BytePlus ModelArk constants, errors, payload construction, and response normalization from `byteplus-modelark.ts`
- keep existing public imports compatible through facade re-exports
- add architecture contracts for the BytePlus module boundaries

## Impact
- removes `frontend/server/byteplus-poll.ts` from the >=500-line audit
- removes `frontend/src/server/video-providers/byteplus-modelark.ts` from the >=500-line audit
- updates the BytePlus QA script expectation to match the existing provider-hidden user message

## Validation
- pnpm --prefix frontend exec tsx --tsconfig tsconfig.scripts.json scripts/qa/byteplus-provider-test.ts
- pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/byteplus-provider-architecture.test.ts tests/provider-message-copy.test.ts tests/workspace-gallery-rail-contract.test.ts tests/generate-byteplus-submission.test.ts
- pnpm --dir frontend exec tsc --noEmit --pretty false
- npm run architecture:audit -- --min-lines 500
- npm --prefix frontend run lint
- npm run lint:exposure
- npm run test:validate
- git diff --check
- sub-agent review: no actionable findings