### PR TITLE
Harden SEO indexing and comparison coverage

### DIFF
--- a/ACTION-PLAN.md
+++ b/ACTION-PLAN.md
@@ -1,0 +1,258 @@
+# MaxVideoAI — SEO Action Plan
+
+**North-star objective:** Grow qualified US organic acquisition while increasing the percentage of organic visitors who reach wallet top-up and first render.
+
+## Measurement framework
+
+Track weekly:
+
+| KPI | Current baseline | 90-day direction |
+|---|---:|---:|
+| US GSC CTR | 0.3% | At least 0.6% without losing position |
+| Desktop GSC CTR | 0.6% | At least 1.0% |
+| Global GSC CTR | 1.0% | 1.3–1.5% |
+| Actionable HTML crawled, not indexed | 329 URLs | Down after qualified pruning; report CSS separately |
+| Indexed comparison details | 641/876 | Preserve winners, shrink weak inventory in controlled batches |
+| CSS in “crawled, not indexed” | 531 URLs / 85 file paths | Monitor as deployment noise; do not block Next assets |
+| Mobile P75 LCP | 2.67s Vercel / >2.5s GSC cluster | <2.5s |
+| Mobile P75 CLS | 0.18 | <0.10 |
+| Signup → wallet | 9.4% | Improve through pricing/activation experiments |
+| Wallet → first render | 92.1% | Maintain above 90% |
+| Returning render users, weekly | 4 | Establish cohort target after tracking repair |
+| Attributable organic key events | 2, currently unreliable | Reliable event and revenue attribution |
+
+## Days 0–7 — stop data loss and index dilution
+
+### P0.1 Repair analytics ownership and attribution
+
+**Impact:** Critical
+
+**Primary files:** analytics bootstrap, GTM loader, GA4 server sender, Stripe webhook
+
+- Choose one client-side owner: GTM or direct `gtag.js`.
+- On the same page as consent acceptance, issue and verify the granted consent update.
+- Persist GA4 `client_id`, `session_id`, consent state and timestamp into checkout metadata.
+- Send these identifiers with Measurement Protocol purchase events.
+- Emit recommended `sign_up`, `login` and `purchase` events, while retaining custom diagnostic events if useful.
+- Add funnel events: `view_model`, `view_example`, `select_model`, `generate_intent`, `begin_checkout`, `wallet_top_up`, `first_render_completed`.
+- Validate in GA4 DebugView and compare the event ledger against admin transactions.
+
+**Done when:** first-session consent produces the correct granted state without reload; one page view is sent; purchases retain their source/session/landing page.
+
+### P0.2 Stop URL discovery and IndexNow leaks
+
+**Impact:** Critical
+
+**Implementation status — 11 July 2026:** the comparison/hub submission leak is fixed locally. IndexNow now derives comparison URLs from the same `publishedPairs` publication set as the sitemap, emits the canonical FR/ES hubs, and no longer silently truncates the sorted list at 200 URLs. A contract test enforces exact parity between the IndexNow comparison set and the sitemap source of truth. Deployment and post-deployment observation remain required.
+
+- Make `scripts/indexnow-submit-changed.mjs` consume the official `publishedPairs`/sitemap URL builder instead of generating every model combination.
+- Submit only canonical, indexable, 200-status URLs.
+- Replace redirecting `/fr/ai-video-engines` and `/es/ai-video-engines` submissions with the canonical localized hubs.
+- Add a contract test enforcing `IndexNow URLs ⊆ sitemap canonical URLs`.
+- Remove the arbitrary alphabetical 200-URL truncation so prioritization is explicit and deterministic.
+- Stop exposing public links to `/video/job_*`, application state URLs and sort/filter variants.
+
+**Done when:** a dry run contains no redirect, `noindex`, private job, parameter variant or non-sitemap URL.
+
+Current verified dry run: 1,072 URLs, including 876 localized published comparison URLs, with zero query-string, `/app`, `/video/job_*`, redirecting localized hub or non-sitemap model URL. The broader cleanup of private-job discovery and already indexed application URLs remains under P0.4.
+
+### P0.3 Contain the programmatic comparison surface
+
+**Impact:** Critical
+
+- Use the complete GSC inventory: 641 comparison details are already indexed and 183 additional clean comparisons are crawled but not indexed.
+- Score every pair on impressions, clicks, rank, backlinks, conversions, paired media, unique verdict and source quality.
+- Preserve every proven winner regardless of whether it belongs to the code-defined strategic set.
+- Use 56 strategic English pairs and 17 genuinely enriched FR/ES pairs as a conservative floor, then add proven GSC/backlink/conversion winners.
+- Remove weak pairs from sitemaps and apply `noindex,follow` until they qualify.
+- Deploy changes in batches of 50–100 URLs and measure for 28 days; do not bulk-deindex all candidates at once.
+- Only localize a comparison after English proof or local query evidence.
+
+**Index eligibility gate:** unique verdict + real paired outputs + documented test setup + demand/strategic justification + accurate visible prices.
+
+### P0.4 Remove private and parameter URLs from the index
+
+**Implementation status — 11 July 2026:** `/app` is now crawlable for general search crawlers in the local robots policy so Google can read the existing page-level `noindex` metadata and middleware `X-Robots-Tag` on every query variant. Named AI crawlers remain blocked from the workspace, as do API, admin and other sensitive routes. Approved related-video links now point directly to their editorial canonical slug instead of creating a crawlable `job_*` redirect URL.
+
+- Audit the 53 indexed `/video/` URLs against the 44 intended editorial video pages.
+- Keep public editorial videos stable; protect user render jobs with auth/signed URLs and stop linking them publicly.
+- Remove the two indexed `/app?...` URLs. Use `401/403`, `404/410`, or a crawlable `noindex` response according to the route; do not rely on `robots.txt` alone.
+- Consolidate `/es/galeria?engine=hailuo` toward the canonical gallery unless it has distinct search demand.
+- Remove internal links to `?order=`, filters and tracking variants; redirect purely promotional parameters when safe.
+
+Still pending: deploy the robots change, request temporary removal of the two already indexed `/app?...` URLs in GSC, audit public gallery/share links before changing their product behavior, and reconcile the 53 indexed video URLs with the 44 editorial sitemap entries.
+
+### P0.5 Correct trust-breaking facts and schema
+
+- Make every schema price equal to a visible purchasable offer or remove the offer.
+- Replace physical-product properties with `SoftwareApplication`/`WebApplication` semantics where appropriate.
+- Unify the homepage organization identity and logo.
+- Remove commercial FAQ/retired HowTo JSON-LD while keeping visible content.
+- Update or redirect the obsolete Sora article.
+- Audit unsupported claims in Docs, especially shared wallets, review workflows and trust controls.
+- Correct the ranking inconsistency on “Best AI Video Engines for Ads”.
+
+### P0.6 Launch the first snippet experiments
+
+Test intentional, non-truncated titles and descriptions on:
+
+1. `/examples/kling`
+2. `/examples/ltx`
+3. Seedance 2.0 vs Fast
+4. `/pricing`
+5. `/models/ltx-2-3-fast`
+6. `/models/veo-3-1`
+7. Veo Fast vs Lite
+8. `/models/pika-text-to-video`
+
+Suggested title directions:
+
+- `Kling AI Examples: Prompts, Settings, Costs & Videos`
+- `LTX 2.3 Prompt Examples: Videos, Settings & Real Costs`
+- `Seedance 2.0 vs Fast: Quality, Speed & Price Test`
+- `AI Video Pricing: Compare Veo, Kling, LTX & More`
+- `Veo 3.1 Pricing, Examples & Settings — Tested`
+
+Descriptions should lead with the US differentiator: same-prompt output, exact price, test date and no subscription. Measure each change for at least 14–28 days and annotate GSC.
+
+### P0.7 Begin the mobile/CWV fix
+
+- Separate public marketing rendering from server-side auth/cookie reads.
+- Make public pages CDN-cacheable.
+- Identify the LCP element on homepage, models, pricing and blog templates.
+- Preload only the real hero asset; provide correct responsive media dimensions.
+- Reduce serialized catalog/comparison payloads and non-critical hydration.
+- Audit font loading and remove render-blocking/unneeded CSS.
+- Set explicit layout dimensions to bring CLS below 0.10.
+- Set a suitable Next Image cache TTL, provide accurate `sizes`, and reduce offscreen SSR galleries. Do not block `/_next/static` or `/_next/image` in robots.
+
+### P0.8 Clean obvious index errors
+
+**Implementation status — 11 July 2026:** the legacy `/models/google-veo-3` redirect now points directly to `/models/veo-3-1`, the `startupfa.me` tracking-source exception no longer escapes noindex treatment, and Next Image has a conservative seven-day minimum optimized-image cache TTL while mutable marketing assets still use stable filenames.
+
+- Resolve the 72 reported 404s or return intentional 410s where appropriate.
+- Replace long-term localized 307 redirects with 301/308.
+- Add `/return-policy` to the sitemap if it is intentionally indexable.
+- Synchronize sitemap-index and child `lastmod` values.
+- Fix the `/models/google-veo-3` → `/models/veo-3` → `/models/veo-3-1` redirect chain. **Implemented locally.**
+- Remove the special indexable `utm_source=startupfa.me` behavior. **Implemented locally.**
+- Decide whether `/v/{id}` should redirect to a stable public video or disappear from all discovery paths.
+
+## Days 8–30 — turn evidence into an SEO moat
+
+### P1.1 Publish the MaxVideoAI Benchmark Lab
+
+Create a methodology hub with:
+
+- tested date and model version;
+- sample size and prompts;
+- resolution, aspect ratio, duration and settings;
+- number of retries/failures;
+- median/P90 render time;
+- success and automatic-refund rate;
+- evaluator and weighting method;
+- limitations and update changelog.
+
+Expose aggregated admin data, never user-level data. Link the methodology from every model and comparison scorecard.
+
+### P1.2 Strengthen human trust
+
+- Expand About with the legal operating entity, location, named team/testers and mission.
+- Add author and reviewer profiles to the blog and benchmark pages.
+- Publish editorial, corrections and benchmark-update policies.
+- Make commercial-use/licensing and input/output data treatment easy to find.
+- Add two to four real case studies with cost, iteration count and accepted output.
+
+### P1.3 Build page-to-wallet conversion paths
+
+On high-traffic examples/comparisons:
+
+- add “Run this exact prompt” with model/settings prefilled;
+- display the exact expected wallet charge before signup;
+- explain failed-render refund behavior next to the CTA;
+- offer a guided first-render flow rather than a generic workspace landing;
+- measure `generate_intent → sign_up → top_up → first_render`.
+
+The objective is to improve the 9.4% signup-to-wallet stage while preserving the 92.1% wallet-to-render stage.
+
+### P1.4 Consolidate overlapping LTX/Seedance/Veo intent
+
+- Map each significant query cluster to one primary page.
+- Merge or reposition pages that compete for “prompt guide”, “examples”, “pricing” or “vs” intent.
+- Add canonical/redirect logic only after verifying query-level page ownership in GSC.
+- Link strong examples pages to the relevant model, pricing and comparison pages using descriptive anchors.
+
+### P1.5 Publish only four competitor pages
+
+Start with:
+
+- MaxVideoAI vs Higgsfield
+- MaxVideoAI vs Pollo AI
+- MaxVideoAI vs Artlist
+- MaxVideoAI vs Runway or Dreamlux, selected by demand
+
+Each must use current US prices, supported models, licensing, same-prompt output tests and use-case verdicts. Avoid another programmatic matrix.
+
+### P1.6 Repair internal SEO operations
+
+The admin SEO cockpit currently reports no cached GSC snapshot and therefore generates zero actions.
+
+- Repair or schedule the GSC cache refresh.
+- Store the selected time window and previous-period snapshot.
+- Add index-eligibility and CTR-opportunity scoring.
+- Keep automated recommendations draft-only until a human approves changes.
+
+## Days 31–90 — compound authority and qualified demand
+
+### P2.1 Ship a US content program from proven demand
+
+Prioritize clusters already appearing in GSC:
+
+- Veo 3.1 pricing, quality modes, Lite/Fast differences and examples;
+- Kling prompt examples, model versions and image-to-video workflows;
+- LTX 2.3 pricing, video length and image-to-video prompting;
+- Seedance 2.0 vs Fast and 1.5/2.0 comparisons;
+- Pika maximum video length and plan limitations;
+- use cases: ecommerce ads, UGC ads, product launches, storyboards and short films.
+
+Every page should contain a direct answer, primary source, real output, test date, exact cost and next action.
+
+### P2.2 Earn deep links with original data
+
+- Publish a monthly AI Video Model Benchmark report.
+- Offer a downloadable/embeddable table with source attribution.
+- Pitch findings to creator-economy, video-production and AI publications.
+- Target links to Benchmark Lab, model studies and comparison research—not only the homepage.
+- Reduce dependence on directories and sitewide low-authority links.
+
+### P2.3 Introduce an index-quality operating rule
+
+Review monthly:
+
+- pages with no impressions after 60–90 days;
+- pages with impressions but zero clicks;
+- pages with no unique media/evidence;
+- comparison pages whose model versions are obsolete;
+- pages cannibalizing the same query cluster.
+
+Refresh, merge or `noindex` them. Do not let the sitemap grow automatically with every possible model pair.
+
+### P2.4 Expand internationally only after English proof
+
+- Keep English as `x-default`; localized pages remain self-canonical.
+- Prioritize Spanish and French clusters where CTR and engagement already outperform the US.
+- Localize examples, query framing and pricing context—not just interface copy.
+- Add new languages only when search demand and support capacity justify them.
+
+## Recommended first implementation batch
+
+The safest high-impact batch is:
+
+1. analytics consent/tag deduplication and session-aware purchases;
+2. comparison index-eligibility rules and sitemap filtering;
+3. accurate software-offer schema;
+4. five top-page snippet rewrites;
+5. cacheable marketing layout and homepage/model/pricing mobile LCP work;
+6. Benchmark Lab methodology page and per-page test metadata.
+
+This sequence fixes measurement first, then controls crawl quality, then improves the pages with the greatest demonstrated demand.

--- a/DEEP-INDEXATION-AUDIT.md
+++ b/DEEP-INDEXATION-AUDIT.md
@@ -1,0 +1,289 @@
+# MaxVideoAI — Audit approfondi de l’indexation
+
+**Date de l’audit :** 11 juillet 2026
+
+**Source principale :** exports complets des rapports d’indexation Google Search Console
+
+**Périmètre :** propriété `https://maxvideoai.com/`, sitemaps live, routes Next.js et mécanismes de soumission
+
+## Conclusion opérationnelle
+
+L’intuition sur les CSS était juste, avec une nuance importante : Google ne les a pas indexés. Il les a explorés puis rangés dans « Explorée, actuellement non indexée ».
+
+Sur les **866 URL** de ce rapport :
+
+| Type | URL | Part |
+|---|---:|---:|
+| CSS Next.js versionnés | 531 | 61,3 % |
+| Images `/_next/image` | 6 | 0,7 % |
+| Pages HTML | 329 | 38,0 % |
+| JavaScript | 0 | 0 % |
+
+Les 531 CSS sont surtout du bruit de crawl lié aux déploiements Vercel. Ils ne doivent pas masquer le problème central : le site donne à Google beaucoup trop d’URL HTML générées ou faiblement différenciées, notamment des comparatifs, des pages de rendu privées et des variantes avec paramètres.
+
+La priorité n’est donc pas de bloquer les CSS. Elle est de contrôler strictement quelles pages HTML peuvent être découvertes, soumises, liées et indexées.
+
+## 1. Ce qui est réellement indexé
+
+Google Search Console recense exactement **905 pages indexées**. L’extraction complète ne contient :
+
+- aucun fichier `.css` ;
+- aucun fichier `.js` ;
+- aucune ressource `/_next/` ;
+- seulement trois URL avec paramètres.
+
+### Répartition principale des 905 pages
+
+| Famille | URL indexées |
+|---|---:|
+| Comparatifs détaillés | 641 |
+| Pages `/video/` | 53 |
+| Modèles | 99 |
+| Exemples | 25 |
+| Blog | 23 |
+| Outils | 10 |
+| Autres pages marketing, légales, docs et application | 54 |
+
+Les comparatifs détaillés représentent **70,8 % de tout l’index Google du domaine**.
+
+### Comparatifs indexés par langue
+
+| Langue | Comparatifs déclarés | Comparatifs indexés | Taux d’indexation |
+|---|---:|---:|---:|
+| Anglais | 292 | 261 | 89,4 % |
+| Français | 292 | 174 | 59,6 % |
+| Espagnol | 292 | 206 | 70,5 % |
+| **Total** | **876** | **641** | **73,2 %** |
+
+Ce résultat change le diagnostic : Google n’ignore pas massivement la matrice de comparatifs. Il en a déjà indexé près des trois quarts, alors que seule une minorité dispose d’un contenu éditorial ou de tests réellement spécifiques.
+
+Les trois URL paramétrées indexées sont :
+
+- `/es/galeria?engine=hailuo` ;
+- `/app?from=job_…` ;
+- `/app?engine=seedance-2-0-fast&ar=9:16&mode=t2v`.
+
+Les deux URL `/app` correspondent vraisemblablement aux deux cas « Indexée malgré le blocage par robots.txt ». Un blocage robots n’est pas une méthode fiable de désindexation : il empêche Google de lire une directive `noindex`.
+
+## 2. Les 866 URL explorées mais non indexées
+
+L’extraction a couvert les quatre pages du rapport GSC : 250 + 250 + 250 + 116 URL, sans doublon.
+
+### Les 531 URL CSS
+
+Elles correspondent à :
+
+- 85 chemins de fichiers CSS uniques ;
+- 254 identifiants de déploiement Vercel `dpl_*` ;
+- 531 variantes possédant toutes un paramètre `?dpl=`.
+
+Principaux fichiers concernés :
+
+| Fichier CSS | Variantes explorées |
+|---|---:|
+| `9395511f6d488668.css` | 107 |
+| `59b57aafdfb7f36c.css` | 66 |
+| `ed10512024e2b318.css` | 47 |
+| `82f024a52000045c.css` | 31 |
+| `5016c9854110d15b.css` | 30 |
+
+Ce phénomène provient de ressources hachées et de paramètres de déploiement découverts au fil des versions. Les réponses actuelles ont le bon type MIME et un cache long `immutable`. Les anciens bundles finissent naturellement en 404 lorsqu’ils ne sont plus déployés.
+
+### Ce qu’il ne faut pas faire avec ces CSS
+
+- Ne pas bloquer `/_next/static` dans `robots.txt` : Google a besoin du CSS et du JavaScript pour rendre les pages.
+- Ne pas rediriger les anciens bundles vers les nouveaux : leur contenu n’est pas interchangeable.
+- Ne pas essayer de leur ajouter une canonical HTML.
+- Ne pas considérer la baisse de ces 531 URL comme un KPI SEO prioritaire.
+
+Le bon indicateur est le nombre de **pages HTML utiles** indexées ou exclues, pas le nombre brut de ressources explorées.
+
+### Les 329 pages HTML réellement actionnables
+
+| Famille | URL |
+|---|---:|
+| Comparatifs propres | 183 |
+| Pages `/video/job_*` | 36 |
+| Pages modèles | 28 |
+| Exemples avec paramètres | 17 |
+| Autres URL avec paramètres | 14 |
+| Application, connexion ou workspace | 9 |
+| Pages légales | 7 |
+| Exemples propres | 5 |
+| Comparatifs `?order=` | 5 |
+| Docs | 2 |
+| Outils | 2 |
+| Blog | 1 |
+| Autres pages propres | 20 |
+
+La majorité des comparatifs propres non indexés est en français ou en espagnol. Cela confirme une combinaison de faible différenciation, dilution du maillage et demande locale insuffisante — pas une incapacité technique générale de Google à explorer le site.
+
+## 3. Les autres catégories d’exclusion
+
+### Exclues par `noindex` : 733 URL
+
+| Famille principale | URL |
+|---|---:|
+| Vidéos de rendu EN `/video/job_*` | 470 |
+| Vidéos de rendu localisées | 9 |
+| Variantes de comparatifs `?order=` | 158 |
+| Comparatifs propres non publiés/inversés | 74 |
+| Autres paramètres, application, login et tracking | 22 |
+
+La directive `noindex` fonctionne, mais elle révèle une surface de découverte inutilement grande. Une URL privée ou sans valeur éditoriale ne devrait idéalement pas être liée publiquement ni soumise aux moteurs avant de devoir être désindexée.
+
+### Bloquées par `robots.txt` : 383 URL
+
+Le rapport est presque entièrement constitué d’URL `/app...`, avec au moins une URL `/generate`. Ce ne sont pas des CSS/JS.
+
+Pour les routes privées, choisir une stratégie explicite :
+
+- réponse `401/403` si la ressource est réellement privée ;
+- réponse `404/410` si elle ne doit plus exister publiquement ;
+- ou page accessible au crawler avec `noindex` si une page de connexion publique doit rester disponible.
+
+Éviter de combiner `Disallow` et `noindex` pour tenter une désindexation.
+
+**État au 11 juillet 2026 :** les règles locales `Disallow: /app`, `/fr/app` et `/es/app` ont été retirées uniquement de la section générale afin que Google puisse lire le `noindex`. Elles restent présentes pour les crawlers IA nommés. Les routes `/app` conservent leur metadata `noindex` et leur en-tête middleware `X-Robots-Tag`, y compris avec paramètres. Les API, l’admin et les autres zones sensibles restent bloqués. Après déploiement, les deux URL déjà indexées devront également être demandées en suppression temporaire dans GSC pour accélérer leur disparition.
+
+### Autres motifs GSC
+
+| Motif | URL |
+|---|---:|
+| Redirections | 156 |
+| 404 | 72 |
+| Page alternative avec canonical correcte | 25 |
+| Détectée, actuellement non indexée | 116 |
+| Doublon, Google a choisi une autre canonical | 1 |
+| Indexée malgré blocage robots | 2 |
+
+## 4. Causes racines dans l’application
+
+### 4.1 IndexNow soumet des comparatifs non publiés
+
+Le script `scripts/indexnow-submit-changed.mjs` génère toutes les combinaisons entre un modèle modifié et les modèles live/early-access, au lieu d’utiliser la liste officielle `publishedPairs`.
+
+- 36 modèles peuvent créer 630 paires théoriques.
+- Seulement 292 paires sont officiellement publiées.
+- Jusqu’à 338 paires anglaises non publiées, soit 1 014 URL EN/FR/ES, peuvent être soumises au fil du temps.
+- Les URL non publiées répondent souvent `200` avec `noindex, follow` et une canonical propre : elles sont donc explorables et consomment inutilement du crawl.
+- Le script soumet aussi les mauvais hubs localisés `/fr/ai-video-engines` et `/es/ai-video-engines`, qui redirigent vers `/fr/comparatif` et `/es/comparativa`.
+
+**Correctif impératif :** toute URL envoyée à IndexNow doit être un sous-ensemble des URL canoniques, indexables et `200` du sitemap actif. Ajouter un test automatisé `IndexNow URLs ⊆ sitemap canonical URLs`.
+
+**État au 11 juillet 2026 :** le sélecteur de comparatifs IndexNow a été aligné localement sur la même liste `publishedPairs` que le sitemap. Les mauvais hubs localisés, six pages modèle hors sitemap et la troncature silencieuse à 200 URL ont été retirés. Un test d’intégration exécute désormais le dry-run complet et contrôle les URL privées, paramétrées, redirigées ou `noindex`. Le déploiement et le contrôle post-déploiement restent à effectuer.
+
+### 4.2 La matrice de comparatifs domine le sitemap
+
+Le sitemap live contient 1 226 URL de pages :
+
+| Famille | URL |
+|---|---:|
+| Comparatifs | 879 |
+| Modèles | 129 |
+| Vidéos éditoriales | 44 |
+| Best-for | 39 |
+| Exemples | 33 |
+| Blog | 27 |
+| Outils | 15 |
+| Docs | 9 |
+| Pages fixes | 51 |
+
+Les comparatifs constituent **71,7 % du sitemap** et **82,5 % de chaque sitemap linguistique**.
+
+Seulement 17 paires par langue disposent d’overrides éditoriaux dédiés. Le code ne révèle que 56 paires anglaises soutenues par au moins un signal stratégique fort (showdown, score, popularité, use case ou enrichissement). Le volume publié excède donc largement le volume réellement différencié.
+
+### 4.3 Les rendus privés deviennent des URL crawlables
+
+GSC expose environ 479 URL `/video/job_*` en `noindex`, auxquelles s’ajoutent 36 pages de job dans « explorée, non indexée » et 53 URL `/video/` déjà indexées. Le sitemap vidéo ne contient pourtant que 44 pages éditoriales.
+
+Il faut séparer sans ambiguïté :
+
+- les 44 vidéos publiques, éditoriales et indexables ;
+- les rendus utilisateurs privés ou temporaires, non liés publiquement et servis via contrôle d’accès ou URL signée ;
+- les anciens jobs publics devenus inutiles, à retirer des liens et à faire expirer proprement.
+
+Les liens entre vidéos éditoriales approuvées utilisent désormais localement leur slug canonique au lieu de l’identifiant `job_*`. Les liens de galerie et les pages de partage utilisateur restent inchangés dans ce lot afin de ne pas casser une fonctionnalité produit sans validation préalable.
+
+### 4.4 Trop de variantes d’images sont rendues dans le HTML
+
+Sur huit pages représentatives, le HTML référençait 1 064 ressources distinctes, dont 989 variantes `/_next/image`. La page d’accueil seule exposait 478 variantes optimisées issues de 43 images.
+
+Ce n’est pas un problème d’indexation directe, mais cela augmente le travail de rendu et le coût de crawl. Les réponses `/_next/image` observées ont aussi un cache faible (`max-age=0, must-revalidate`).
+
+Actions : renseigner des `sizes` précis, réduire les galeries hors écran rendues côté serveur, configurer un TTL d’image de 30–60 jours et versionner les médias publics durables.
+
+**État au 11 juillet 2026 :** `images.minimumCacheTTL` est configuré localement à 604 800 secondes, soit 7 jours. Ce compromis améliore le cache sans risquer de figer pendant un mois les médias marketing encore servis sous des noms stables. Le travail restant porte sur le versionnement des images mutables, les attributs `sizes` et la réduction des variantes rendues au SSR ; un TTL de 30–60 jours pourra ensuite être appliqué aux URL versionnées.
+
+## 5. Politique d’indexation recommandée
+
+| Famille | Décision | Conditions |
+|---|---|---|
+| Accueil, pricing, modèles, exemples, outils | Garder et enrichir | Contenu exact, schema fiable, intention unique |
+| Hubs comparatifs | Garder | Maillage vers une sélection éditoriale limitée |
+| Comparatifs avec demande ou preuve unique | Garder | GSC/backlinks/conversions ou test réel documenté |
+| Comparatifs générés sans preuve | Retirer du sitemap + `noindex,follow` | Réindexer uniquement après passage du gate qualité |
+| Variantes `?order=`, filtres et tracking | Canonicaliser et ne plus lier | Rediriger les paramètres purement marketing quand sûr |
+| Jobs/rendus privés | Ne jamais indexer | Auth, URL signée, `401/403`, expiration ou `404/410` |
+| Vidéos publiques éditoriales | Garder | Page stable, titre, description, miniature, date et contexte |
+| `/app`, login, workspace | Non indexable | Ne pas compter sur `robots.txt` seul |
+| Docs obsolètes et status statique | Mettre à jour ou `noindex` | Ne pas afficher de `lastmod` artificiellement récent |
+| CSS/JS Next.js | Autoriser le crawl | Aucun blocage robots ni redirection de bundles |
+
+### Taille cible de la surface
+
+Une première coupe conservatrice peut conserver :
+
+- 56 comparatifs anglais stratégiques ;
+- 17 comparatifs français réellement enrichis ;
+- 17 comparatifs espagnols réellement enrichis ;
+- tous les gagnants GSC/backlinks/conversions supplémentaires, même hors de ce socle.
+
+Sans les gagnants additionnels, cela ramènerait le sitemap d’environ **1 226 à 440 URL** et retirerait temporairement **786 comparatifs faibles**. Une variante moins agressive consiste à conserver les 56 paires stratégiques dans les trois langues, soit 168 détails et 708 retraits.
+
+La décision finale ne doit jamais être prise uniquement à partir du code : avant chaque `noindex`, joindre les données GSC par URL, les backlinks et les conversions. Les pages qui génèrent déjà une valeur mesurable restent indexables et sont enrichies en priorité.
+
+## 6. Ordre d’exécution
+
+### P0 — arrêter les nouvelles fuites
+
+1. Aligner IndexNow sur `publishedPairs` et le sitemap canonical.
+2. Corriger les hubs localisés soumis.
+3. Empêcher tout lien public vers les jobs privés, les paramètres de tri et les URL d’application générées.
+4. Ajouter des tests de contrat sur les URL soumises, sitemapées et indexables.
+
+### P0 — retirer les erreurs déjà indexées
+
+1. Traiter immédiatement les deux URL `/app?...` indexées malgré robots.
+2. Retirer la variante `/es/galeria?engine=hailuo` de tout maillage interne et consolider vers la galerie canonique si elle n’a pas d’intention propre.
+3. Auditer les 53 pages `/video/` indexées contre les 44 pages éditoriales prévues.
+4. Résoudre les 72 404 et convertir les redirections historiques 307 en 301/308.
+
+### P1 — réduire la matrice sans perdre de trafic
+
+1. Croiser les 876 comparatifs avec clics, impressions, position, liens et conversions.
+2. Classer chaque URL en `keep`, `enrich`, `noindex` ou `redirect`.
+3. Déployer par lots de 50–100 URL et surveiller les requêtes ainsi que les pages de destination pendant 28 jours.
+4. Ne pas lancer une suppression globale en une seule fois.
+
+### P1 — améliorer rendu et cache
+
+1. Réduire les variantes d’images présentes au SSR.
+2. Définir `images.minimumCacheTTL` et des `sizes` réalistes.
+3. Rendre le shell marketing cacheable.
+4. Corriger LCP/CLS mobile sur l’accueil, pricing, modèles et outils.
+
+## 7. Tableau de bord mensuel à conserver
+
+Suivre séparément :
+
+- pages indexées présentes dans le sitemap ;
+- pages indexées absentes du sitemap ;
+- pages HTML explorées mais non indexées ;
+- ressources CSS/image explorées mais non indexées ;
+- comparatifs indexés par langue ;
+- URL `/app`, `/login`, `/video/job_*` et paramètres découvertes ;
+- URL IndexNow rejetées par le test de parité sitemap ;
+- clics et conversions perdus/gagnés après chaque lot de consolidation.
+
+Le KPI principal n’est pas « moins d’URL dans GSC ». C’est une proportion croissante de pages indexées qui possèdent une intention, une preuve unique et une contribution mesurable au trafic ou au revenu.

--- a/FULL-AUDIT-REPORT.md
+++ b/FULL-AUDIT-REPORT.md
@@ -1,0 +1,340 @@
+# MaxVideoAI — Full SEO Audit
+
+**Audit date:** 10 July 2026
+
+**Primary market:** United States
+
+**Secondary scope:** Worldwide, with English as `x-default` and French/Spanish localization
+
+**Mode:** Read-only audit; no production setting or application behavior was changed
+
+## Executive summary
+
+MaxVideoAI already has genuine search traction and a commercially distinctive proposition: an independent, pay-as-you-go layer for comparing AI video models using real outputs and visible prices. Search visibility is growing, the homepage and model/example architecture are strong, and the product converts very well **after** a user funds a wallet.
+
+The current constraint is not a lack of pages. It is the combination of:
+
+1. a very low US and desktop click-through rate;
+2. excessive indexable comparison-page inventory relative to domain authority;
+3. broken/incomplete analytics attribution;
+4. weak human trust and benchmark methodology signals;
+5. mobile LCP/CLS and an uncacheable marketing shell;
+6. a large signup-to-wallet activation leak.
+
+The recommended strategy is therefore **fewer indexable pages, stronger evidence, better snippets, reliable attribution, and tighter page-to-purchase journeys**.
+
+## Directional SEO health score: 60/100
+
+This is a prioritization score, not a Google metric.
+
+| Category | Score | Weight | Main reason |
+|---|---:|---:|---|
+| Technical SEO | 14/25 | 25% | Valid crawl paths and hreflang, but index bloat, no-cache marketing pages and stale sitemap dates |
+| Content quality | 15/25 | 25% | Strong model/example pages, but templated comparisons, stale claims and weak authorship |
+| On-page SEO | 14/20 | 20% | Titles, metas and H1s are broadly complete; CTR and title truncation remain material |
+| Structured data | 5/10 | 10% | Broad implementation, but inaccurate offers, duplicate organizations and unsuitable types |
+| Performance/CWV | 5/10 | 10% | Desktop is good; mobile LCP/CLS and the application routes need work |
+| Images/video | 3/5 | 5% | Real output media is a major asset, but delivery and evidence framing can improve |
+| AI-search readiness | 4/5 | 5% | SSR, `llms.txt` and crawler access are strong; citability and named expertise are weak |
+
+## Data reviewed
+
+- Google Search Console, including performance, indexation, links, security and manual actions.
+- Google Analytics 4, including the Search Console landing-page report.
+- Vercel Web Analytics and Speed Insights.
+- MaxVideoAI admin insights and SEO cockpit.
+- Semrush project data.
+- Live crawl and source-code review.
+- Public review of Higgsfield, Artlist, Pollo AI and Dreamlux.
+
+## 1. Search performance
+
+### Three-month Search Console baseline
+
+Period: 9 April–8 July 2026.
+
+| Metric | Result |
+|---|---:|
+| Clicks | 5,526 |
+| Impressions | 570,717 |
+| CTR | 1.0% |
+| Average position | 8.5 |
+
+The average position is already competitive. The larger short-term opportunity is converting existing visibility into clicks.
+
+### US market gap
+
+| Market | Clicks | Impressions | CTR | Position |
+|---|---:|---:|---:|---:|
+| United States | 704 | 257,482 | 0.3% | 9.7 |
+| India | 513 | 20,541 | 2.5% | 7.4 |
+| France | 283 | 15,005 | 1.9% | 7.4 |
+| Germany | 236 | 16,034 | 1.5% | 7.4 |
+| Spain | 234 | 11,617 | 2.0% | 7.6 |
+
+The United States produces about 45% of impressions but only about 13% of clicks. Its CTR is roughly one sixth of France/Spain and one eighth of India. This supports a US-first snippet, intent and trust program.
+
+### Device gap
+
+| Device | Clicks | Impressions | CTR | Position |
+|---|---:|---:|---:|---:|
+| Desktop | 3,189 | 511,703 | 0.6% | 8.5 |
+| Mobile | 2,254 | 57,502 | 3.9% | 8.4 |
+| Tablet | 83 | 1,512 | 5.5% | 11.2 |
+
+Desktop owns 90% of impressions but has a 0.6% CTR. The page titles/descriptions and SERP fit should be tested primarily on US desktop queries.
+
+### Highest-leverage pages
+
+| Page | Clicks | Impressions | CTR | Position | Observation |
+|---|---:|---:|---:|---:|---|
+| `/examples/ltx` | 1,206 | 96,328 | 1.3% | 7.1 | Largest proven non-brand asset; strong engagement |
+| `/examples/kling` | 199 | 60,013 | 0.3% | 7.2 | Severe snippet/intent mismatch despite page-one visibility |
+| Seedance 2.0 vs Fast | 218 | 33,636 | 0.6% | 6.2 | Strong comparison demand, weak CTR |
+| `/models/ltx-2-3-fast` | 39 | 19,244 | 0.2% | 7.8 | Very high upside from clearer title/intent |
+| `/pricing` | 37 | 14,037 | 0.3% | 10.0 | Commercial page is barely converting impressions into clicks |
+| Veo 3.1 Fast vs Lite | 28 | 13,396 | 0.2% | 7.6 | Strong BOFU opportunity |
+| `/models/pika-text-to-video` | 3 | 12,135 | ~0% | 8.0 | Page-one visibility with virtually no clicks |
+| `/ai-video-engines` | 16 | 11,099 | 0.1% | 9.0 | Hub needs a much more explicit promise |
+
+A rough opportunity model using conservative position-based CTR targets suggests that `/examples/ltx` and `/examples/kling` alone could produce the largest incremental click gains. These are directional estimates, not forecasts.
+
+### Query clusters
+
+Strong assets:
+
+- `ltx 2.3 prompt examples`: 126 clicks, 682 impressions, 18.5% CTR, position 2.4.
+- `pay as you go ai video generator`: 13 clicks, 138 impressions, 9.4% CTR, position 2.0.
+- Seedance comparisons frequently rank positions 2–4.
+
+Underperforming demand:
+
+- `veo 3.1`: 32 clicks, 5,694 impressions, 0.6% CTR, position 8.3.
+- `ltx 2.3 prompt guide`: 34 clicks, 1,923 impressions, 1.8% CTR, position 7.4.
+- `ltx 2.3 prompting guide`: 11 clicks, 1,341 impressions, 0.8% CTR, position 7.6.
+- Numerous zero-click queries already have 80–160 impressions: Google Veo 3.1, Kling prompts/examples, LTX pricing/video length and Pika maximum video length.
+
+## 2. Analytics and commercial attribution
+
+### GA4 is not reliable enough for SEO revenue attribution
+
+Over 90 days, the linked GA4 Search Console report shows:
+
+- 5,434 organic Google clicks;
+- 580,552 impressions;
+- only 705 active users;
+- 905 engaged sessions;
+- 71.09% engagement rate;
+- 4m34s average engagement per active user;
+- only 2 key events, both attached to an empty landing-page value.
+
+The 705 active users represent only about 13% of Search Console clicks. Consent refusals and blockers explain part of this, but the implementation has additional defects:
+
+1. On first consent acceptance, GA initially sends `analytics_storage: denied`; the granted state is correctly applied only after reload.
+2. Direct `gtag.js` and GTM both emit identical GA4 and Google Ads requests.
+3. Server-side `purchase` events omit `session_id`; when no `_ga` cookie exists, an invented client ID disconnects the purchase from its acquisition session.
+4. Auth events use `sign_up_completed` and `login_completed` instead of the recommended `sign_up` and `login` events.
+
+Relevant code:
+
+- `frontend/components/analytics/ConsentModeBootstrap.tsx`
+- `frontend/components/legal/cookie-banner-client.ts`
+- `frontend/components/analytics/GtmLazyLoader.tsx`
+- `frontend/components/analytics/GoogleAds.tsx`
+- `frontend/src/server/ga4.ts`
+- `frontend/app/api/stripe/webhook/route.ts`
+
+Until this is corrected, SEO-to-signup, SEO-to-wallet and SEO-to-revenue reporting should be treated as incomplete.
+
+### Internal business funnel
+
+The admin data provides the clearest commercial signal:
+
+| Funnel stage | Users | Rate |
+|---|---:|---:|
+| Synced accounts | 2,432 | 100% |
+| Loaded wallet | 228 | 9.4% |
+| First render within 30 days of top-up | 210 | 8.6% overall / 92.1% of wallet users |
+
+The main commercial leak is **signup → wallet top-up**, not wallet → first render.
+
+Current 90-day momentum:
+
+- 1,024 signups, +71.2% vs the previous period;
+- $2,921 in wallet top-ups across 196 loads, +215.8%;
+- $3,187 in render charges across 1,646 charges, +247.9%;
+- average wallet load: $14.90;
+- average render charge: $1.94;
+- average renders per paying user: 9.6, median 5;
+- only 4 returning users generated in both the latest 7-day windows.
+
+SEO pages should therefore make the first financial commitment feel concrete: show the exact cost of reproducing the example, prefill the model/settings/prompt, explain refund protection, and minimize the gap between “I learned something” and “I can run this now.”
+
+## 3. Indexation and crawl architecture
+
+### What is healthy
+
+- XML sitemaps are valid.
+- 205 sampled sitemap URLs returned 200.
+- No sampled sitemap URL was blocked by `robots.txt`.
+- 45 canonical/hreflang checks passed.
+- HTTPS, `www`, trailing-slash behavior and EN/FR/ES self-canonicals are broadly correct.
+- `llms.txt` exists and all 49 referenced URLs returned 200.
+- No manual action or security issue is reported in Search Console.
+- The submitted sitemap succeeds and reports 1,264 pages plus 44 videos discovered.
+
+### Deep indexation inventory
+
+Search Console reports:
+
+| Status/reason | URLs |
+|---|---:|
+| Indexed | 905 |
+| Not indexed | 2,352 |
+| Crawled, currently not indexed | 866 |
+| Excluded by `noindex` | 733 |
+| Blocked by `robots.txt` | 383 |
+| Redirect | 156 |
+| Discovered, currently not indexed | 116 |
+| 404 | 72 |
+
+The full affected-URL exports materially refine the diagnosis:
+
+- none of the 905 indexed URLs is a CSS, JavaScript or `/_next/` resource;
+- 641 indexed URLs are comparison details, or 70.8% of the entire Google index;
+- 261/292 English, 174/292 French and 206/292 Spanish comparisons are indexed;
+- 531/866 “crawled, currently not indexed” URLs are deployment-versioned CSS resources;
+- only 329/866 are actionable HTML pages, including 183 clean comparisons and 36 `/video/job_*` pages;
+- the 733 `noindex` URLs include about 479 render-job pages, 158 `?order=` variants and 74 unpublished/reversed comparisons;
+- the 383 robots-blocked URLs are overwhelmingly `/app` routes, not static assets;
+- two `/app?...` URLs are already indexed despite the robots block.
+
+The CSS count is crawl-report noise, not evidence that CSS files are in Google's public index. Blocking `/_next/static` would be counterproductive because Google needs those assets to render pages.
+
+The deeper root cause is uncontrolled HTML discovery. `scripts/indexnow-submit-changed.mjs` can submit non-published comparison combinations rather than the canonical `publishedPairs`, exposing up to 1,014 EN/FR/ES URLs over time. It also submits redirecting localized hub paths. IndexNow submissions must be constrained to canonical, indexable, 200-status sitemap URLs and protected by an automated subset test.
+
+The 1,226-URL live sitemap contains 879 comparison URLs. Only 56 English pairs have a meaningful strategic signal in code and only 17 pairs per language have dedicated editorial overrides. The safe policy is to preserve every GSC/backlink/conversion winner, then keep a strategic editorial floor and remove low-evidence pairs from sitemaps with `noindex,follow` until they qualify.
+
+The complete URL-family analysis, CSS explanation and keep/noindex/redirect policy are documented in `DEEP-INDEXATION-AUDIT.md`.
+
+Other technical issues:
+
+- approximately 479 private render-job URLs are already represented in the `noindex` report;
+- 53 `/video/` URLs are indexed versus 44 intended editorial video pages;
+- app URLs rely on robots blocking even though robots cannot reliably remove an already indexed URL;
+- comparison URLs lack meaningful `lastmod` values;
+- sitemap-index dates are older than child sitemap dates;
+- `/return-policy` is indexable and linked but missing from the sitemap;
+- several old localized routes use temporary 307 redirects instead of permanent 301/308 redirects.
+
+## 4. On-page and content quality
+
+### Strong foundations
+
+The live English crawl found:
+
+- no missing title, meta description or H1 among 354 pages;
+- no exact title/meta duplication;
+- no multiple-H1 issue;
+- model pages averaging roughly 1,542 words;
+- strong examples pages with real prompts, settings, media and internal links;
+- `/models/veo-3-1` at roughly 2,024 words with pricing, prompts, limits, specifications and an official source.
+
+### Main quality risks
+
+- 292 comparison pages are indexable; most use repeated “same prompts”, “Specs & Pricing” and scorecard formulas.
+- 66 comparison titles and at least 11/40 model titles are visibly clamped with an ellipsis.
+- `/pricing` is also automatically truncated rather than intentionally written to fit.
+- About is only about 183 words and lacks a named team, operating entity, testing credentials, methodology and customer evidence.
+- Blog posts show dates but no human author/reviewer profiles.
+- Benchmark scores expose neither sample size, weights, evaluator, uncertainty nor “last tested” date.
+- Several docs claim features that appear unavailable or marked “coming soon”.
+- The Sora 2 article contains obsolete lifecycle/access claims and should be updated or redirected.
+
+This is an E-E-A-T and citability issue more than a word-count issue.
+
+## 5. Structured data
+
+Positive: JSON-LD parses correctly on representative pages, and Breadcrumb/WebSite/Organization coverage is broad.
+
+Priority corrections:
+
+1. Model pages emit `Product` offers that can disagree with visible prices. `/models/veo-3-1`, for example, exposes a schema price of $4.40 while visible offers are $2.08, $3.12, $4.16 and $6.24.
+2. Use `SoftwareApplication`/`WebApplication + Offer` where the offer exactly matches visible content.
+3. Unify two homepage `Organization` entities and reference one stable `@id`.
+4. The blog publisher logo points to an OG image rather than the official square logo.
+5. Remove or deprioritize `FAQPage` JSON-LD on commercial SaaS pages; FAQ rich results are largely restricted to government/health sites.
+6. Remove `HowTo` JSON-LD from tools; HowTo rich results were retired. Keep the visible instructions.
+
+## 6. Performance and Core Web Vitals
+
+Search Console reports 156 mobile URLs needing improvement because LCP exceeds 2.5 seconds.
+
+Vercel field data, P75 over seven days:
+
+| Metric | Desktop | Mobile |
+|---|---:|---:|
+| Real Experience Score | 96 | 86 |
+| FCP | 2.02s | 2.47s |
+| LCP | 2.40s | 2.67s |
+| INP | 72ms | 152ms |
+| CLS | 0.06 | 0.18 |
+| TTFB | 0.56s | 0.65s |
+
+Mobile route scores are especially weak for `/app` (46), `/tools/angle` (37), pricing (66), localized/blog routes and the homepage/models (roughly 77–88). Example and comparison routes are generally much stronger.
+
+Additional technical findings:
+
+- marketing pages return `Cache-Control: private, no-cache, no-store`;
+- root marketing rendering reads cookies and calls `auth.getUser()`, neutralizing expected CDN/ISR behavior;
+- Lighthouse mobile homepage: performance 88 and LCP 3.84s;
+- approximate HTML weight: homepage 0.8 MiB, pricing 1.06 MiB, model 0.7 MiB;
+- homepage DOM contains about 1,428 elements.
+
+The first performance project should make the public marketing shell cacheable by moving personalized navigation/auth state to a small client-side island, then reduce serialized data and simplify hero media.
+
+## 7. Authority, backlinks and AI visibility
+
+Search Console reports 687 external links, concentrated on:
+
+- webcatalog.io: 247;
+- reddit.com: 121;
+- toolify.ai: 75;
+- mossai.org: 38;
+- beyond-the-ai.com: 37.
+
+The homepage receives 617 external links; deep pages receive very few. Semrush reports:
+
+- Authority Score: 14;
+- 157 referring domains;
+- 24.9k backlinks, but 87.9% of referring domains have Authority Score 0–20;
+- estimated organic traffic: 2.1k, +86%;
+- 863 ranking keywords, +13.9%;
+- AI visibility: 14, four mentions and seven cited pages.
+
+The backlink quantity is inflated by a small number of low-authority/directory sources. The next authority gains should come from original benchmark data, transparent methodology, expert bylines and digital PR rather than more directory links.
+
+## 8. Competitive position
+
+| Competitor | What it does better | MaxVideoAI opening |
+|---|---|---|
+| Higgsfield | Editorial velocity, proprietary creative features, social proof | Neutral cross-model tests, exact cost and no subscription |
+| Artlist | Licensing clarity, authors, professional workflow trust | Independent pricing and model-choice transparency |
+| Pollo AI | Huge transactional page coverage and embedded generators | Less cluttered, more credible evidence and unbiased verdicts |
+| Dreamlux | Captures free/no-watermark/social trends | Much deeper model evidence and commercial transparency |
+
+Recommended US positioning:
+
+> **Compare AI video models before you spend. Real outputs, live pricing, no subscription.**
+
+The defensible moat is not page volume. It is proprietary benchmark evidence: same-prompt outputs, price before render, success/refund rates, render-time distributions and transparent test methodology.
+
+## Top five critical actions
+
+1. Repair GA4 consent, deduplicate tagging and preserve `client_id` + `session_id` through checkout.
+2. Reduce indexable comparison inventory and define a measurable publish/index threshold.
+3. Fix inaccurate structured-data offers and stale/unsupported content claims.
+4. Rewrite/test the snippets and first-screen promise of the top US opportunity pages.
+5. Make the marketing shell cacheable and resolve mobile LCP/CLS.
+
+The detailed execution sequence and KPIs are in `ACTION-PLAN.md`.

--- a/docs/seo/comparison-indexation-matrix-2026-07-08.json
+++ b/docs/seo/comparison-indexation-matrix-2026-07-08.json
@@ -1,0 +1,17519 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-07-11",
+  "source": {
+    "property": "sc-domain:maxvideoai.com",
+    "searchType": "Web",
+    "range": {
+      "start": "2026-04-09",
+      "end": "2026-07-08"
+    },
+    "exportedAt": "2026-07-11",
+    "rawPageRows": 996,
+    "comparisonRows": 661,
+    "gscRows": 661
+  },
+  "policy": {
+    "keep": [
+      "clicks > 0",
+      "impressions >= 500",
+      "localized editorial override",
+      "English URL on a strategic comparison surface"
+    ],
+    "enrich": [
+      "100 <= impressions < 500 without a keep signal"
+    ],
+    "review": [
+      "30 <= impressions < 100 without a keep signal",
+      "0 < impressions < 30 with average position <= 10",
+      "FR/ES strategic URL without local proof"
+    ],
+    "noindexCandidate": [
+      "impressions < 30",
+      "average position > 10 or no GSC row",
+      "clicks = 0",
+      "no localized editorial override",
+      "no strategic comparison signal"
+    ],
+    "safety": "Recommendation only; no sitemap, robots, canonical, or noindex change is applied."
+  },
+  "summary": {
+    "publishedSlugs": 292,
+    "totalUrls": 876,
+    "withGscRows": 639,
+    "withoutGscRows": 237,
+    "withClicks": 144,
+    "gscRowsOutsidePublishedSet": 21,
+    "gscRowsOutsidePublishedSetWithClicks": 2,
+    "byLocale": {
+      "en": 292,
+      "fr": 292,
+      "es": 292
+    },
+    "byClassification": {
+      "keep": 220,
+      "enrich": 49,
+      "review": 380,
+      "noindex_candidate": 227
+    }
+  },
+  "rows": [
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/dreamina-seedance-2-0-mini-vs-happy-horse-1-1",
+      "locale": "en",
+      "slug": "dreamina-seedance-2-0-mini-vs-happy-horse-1-1",
+      "clicks": 0,
+      "impressions": 52,
+      "ctr": 0,
+      "position": 6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/dreamina-seedance-2-0-mini-vs-happy-horse-1-1"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "scoreboard",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/dreamina-seedance-2-0-mini-vs-ltx-2-3-fast",
+      "locale": "en",
+      "slug": "dreamina-seedance-2-0-mini-vs-ltx-2-3-fast",
+      "clicks": 2,
+      "impressions": 76,
+      "ctr": 2.6,
+      "position": 8.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/dreamina-seedance-2-0-mini-vs-ltx-2-3-fast"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "scoreboard",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "localized_editorial_override",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/dreamina-seedance-2-0-mini-vs-luma-ray-3-2",
+      "locale": "en",
+      "slug": "dreamina-seedance-2-0-mini-vs-luma-ray-3-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "scoreboard",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/dreamina-seedance-2-0-mini-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "dreamina-seedance-2-0-mini-vs-seedance-2-0",
+      "clicks": 4,
+      "impressions": 720,
+      "ctr": 0.6,
+      "position": 7.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/dreamina-seedance-2-0-mini-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "showdown",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions",
+        "localized_editorial_override",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/dreamina-seedance-2-0-mini-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "dreamina-seedance-2-0-mini-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "showdown",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/dreamina-seedance-2-0-mini-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "dreamina-seedance-2-0-mini-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 209,
+      "ctr": 0,
+      "position": 8.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/dreamina-seedance-2-0-mini-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "scoreboard",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/gemini-omni-flash-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "gemini-omni-flash-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "related_graph",
+        "scoreboard"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/gemini-omni-flash-vs-sora-2",
+      "locale": "en",
+      "slug": "gemini-omni-flash-vs-sora-2",
+      "clicks": 0,
+      "impressions": 21,
+      "ctr": 0,
+      "position": 7.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/gemini-omni-flash-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "related_graph",
+        "scoreboard"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/gemini-omni-flash-vs-veo-3-1",
+      "locale": "en",
+      "slug": "gemini-omni-flash-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 380,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/gemini-omni-flash-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "scoreboard",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/gemini-omni-flash-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "gemini-omni-flash-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 39,
+      "ctr": 0,
+      "position": 9.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/gemini-omni-flash-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "related_graph",
+        "scoreboard"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-0-vs-happy-horse-1-1",
+      "locale": "en",
+      "slug": "happy-horse-1-0-vs-happy-horse-1-1",
+      "clicks": 0,
+      "impressions": 66,
+      "ctr": 0,
+      "position": 13.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/happy-horse-1-0-vs-happy-horse-1-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "popular"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-0-vs-kling-3-pro",
+      "locale": "en",
+      "slug": "happy-horse-1-0-vs-kling-3-pro",
+      "clicks": 1,
+      "impressions": 287,
+      "ctr": 0.3,
+      "position": 9.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/happy-horse-1-0-vs-kling-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-0-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "happy-horse-1-0-vs-seedance-2-0",
+      "clicks": 2,
+      "impressions": 540,
+      "ctr": 0.4,
+      "position": 14.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/happy-horse-1-0-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-0-vs-veo-3-1",
+      "locale": "en",
+      "slug": "happy-horse-1-0-vs-veo-3-1",
+      "clicks": 1,
+      "impressions": 192,
+      "ctr": 0.5,
+      "position": 14,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/happy-horse-1-0-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-1-vs-kling-3-pro",
+      "locale": "en",
+      "slug": "happy-horse-1-1-vs-kling-3-pro",
+      "clicks": 2,
+      "impressions": 52,
+      "ctr": 3.8,
+      "position": 8.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/happy-horse-1-1-vs-kling-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-1-vs-kling-o3-pro",
+      "locale": "en",
+      "slug": "happy-horse-1-1-vs-kling-o3-pro",
+      "clicks": 0,
+      "impressions": 89,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/happy-horse-1-1-vs-kling-o3-pro"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-1-vs-ltx-2-3-pro",
+      "locale": "en",
+      "slug": "happy-horse-1-1-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-1-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "happy-horse-1-1-vs-seedance-2-0",
+      "clicks": 9,
+      "impressions": 281,
+      "ctr": 3.2,
+      "position": 10.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/happy-horse-1-1-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-1-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "happy-horse-1-1-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 35,
+      "ctr": 0,
+      "position": 7.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/happy-horse-1-1-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-1-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "happy-horse-1-1-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 7.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/happy-horse-1-1-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-1-vs-veo-3-1",
+      "locale": "en",
+      "slug": "happy-horse-1-1-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 3.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/happy-horse-1-1-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-1-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "happy-horse-1-1-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-kling-2-6-pro",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-kling-2-6-pro",
+      "clicks": 3,
+      "impressions": 2422,
+      "ctr": 0.1,
+      "position": 10.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-kling-2-6-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-kling-3-4k",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-kling-3-4k",
+      "clicks": 0,
+      "impressions": 145,
+      "ctr": 0,
+      "position": 7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-kling-3-4k"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-kling-3-pro",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-kling-3-pro",
+      "clicks": 4,
+      "impressions": 1445,
+      "ctr": 0.3,
+      "position": 11.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-kling-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-kling-3-standard",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-kling-3-standard",
+      "clicks": 9,
+      "impressions": 2195,
+      "ctr": 0.4,
+      "position": 7.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-kling-3-standard"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-ltx-2",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-ltx-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-ltx-2-3-fast",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-ltx-2-3-pro",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 135,
+      "ctr": 0,
+      "position": 8.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-ltx-2-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-ltx-2-fast",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-luma-ray-2",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-luma-ray-2",
+      "clicks": 1,
+      "impressions": 32,
+      "ctr": 3.1,
+      "position": 5.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-luma-ray-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-luma-ray-2-flash",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 13,
+      "ctr": 0,
+      "position": 7.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-luma-ray-2-flash"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-minimax-hailuo-02-text",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-minimax-hailuo-02-text",
+      "clicks": 2,
+      "impressions": 2061,
+      "ctr": 0.1,
+      "position": 8.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-pika-text-to-video",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-pika-text-to-video"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-seedance-1-5-pro",
+      "clicks": 1,
+      "impressions": 303,
+      "ctr": 0.3,
+      "position": 6.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-seedance-2-0",
+      "clicks": 2,
+      "impressions": 230,
+      "ctr": 0.9,
+      "position": 5.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-seedance-2-0-fast",
+      "clicks": 1,
+      "impressions": 307,
+      "ctr": 0.3,
+      "position": 7.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-sora-2",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-sora-2",
+      "clicks": 0,
+      "impressions": 278,
+      "ctr": 0,
+      "position": 6.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "showdown"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 39,
+      "ctr": 0,
+      "position": 9.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-veo-3-1",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 175,
+      "ctr": 0,
+      "position": 7.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 139,
+      "ctr": 0,
+      "position": 8.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-veo-3-1-lite",
+      "clicks": 1,
+      "impressions": 114,
+      "ctr": 0.9,
+      "position": 10.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-wan-2-5",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 69,
+      "ctr": 0,
+      "position": 8.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-wan-2-6",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 155,
+      "ctr": 0,
+      "position": 12.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-kling-3-4k",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-kling-3-4k",
+      "clicks": 0,
+      "impressions": 144,
+      "ctr": 0,
+      "position": 11.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-kling-3-4k"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-kling-3-pro",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 376,
+      "ctr": 0,
+      "position": 11.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-kling-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-kling-3-standard",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-kling-3-standard",
+      "clicks": 0,
+      "impressions": 16,
+      "ctr": 0,
+      "position": 14.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-kling-3-standard"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-ltx-2",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-ltx-2",
+      "clicks": 1,
+      "impressions": 448,
+      "ctr": 0.2,
+      "position": 7.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-ltx-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-ltx-2-3-fast",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 34,
+      "ctr": 0,
+      "position": 5.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-ltx-2-3-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-ltx-2-3-pro",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-ltx-2-fast",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-luma-ray-2",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 72,
+      "ctr": 0,
+      "position": 10.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-luma-ray-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-luma-ray-2-flash",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 133,
+      "ctr": 0,
+      "position": 8.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-luma-ray-2-flash"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-minimax-hailuo-02-text",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 270,
+      "ctr": 0,
+      "position": 14.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-pika-text-to-video",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 159,
+      "ctr": 0,
+      "position": 9.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-pika-text-to-video"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph",
+        "showdown",
+        "trophy"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-seedance-1-5-pro",
+      "clicks": 1,
+      "impressions": 708,
+      "ctr": 0.1,
+      "position": 9.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-seedance-2-0",
+      "clicks": 2,
+      "impressions": 240,
+      "ctr": 0.8,
+      "position": 7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 64,
+      "ctr": 0,
+      "position": 9.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-sora-2",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-sora-2",
+      "clicks": 0,
+      "impressions": 50,
+      "ctr": 0,
+      "position": 11.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph",
+        "showdown",
+        "trophy"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 35,
+      "ctr": 0,
+      "position": 14.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-veo-3-1",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 93,
+      "ctr": 0,
+      "position": 12.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "popular",
+        "related_graph",
+        "showdown",
+        "trophy",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 41,
+      "ctr": 0,
+      "position": 8.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-wan-2-5",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 187,
+      "ctr": 0,
+      "position": 9.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-wan-2-6",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 284,
+      "ctr": 0,
+      "position": 8.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph",
+        "showdown",
+        "trophy",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-kling-3-pro",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 41,
+      "ctr": 0,
+      "position": 10.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-kling-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "popular",
+        "related_graph"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-kling-3-standard",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-kling-3-standard",
+      "clicks": 0,
+      "impressions": 178,
+      "ctr": 0,
+      "position": 11.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-kling-3-standard"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-ltx-2",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-ltx-2",
+      "clicks": 0,
+      "impressions": 23,
+      "ctr": 0,
+      "position": 24.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-ltx-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-ltx-2-3-fast",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-ltx-2-3-fast",
+      "clicks": 1,
+      "impressions": 80,
+      "ctr": 1.3,
+      "position": 9.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-ltx-2-3-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-ltx-2-3-pro",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 7.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-ltx-2-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-ltx-2-fast",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 35,
+      "ctr": 0,
+      "position": 7.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-ltx-2-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-luma-ray-2",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 56,
+      "ctr": 0,
+      "position": 7.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-luma-ray-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-luma-ray-2-flash",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 42,
+      "ctr": 0,
+      "position": 10.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-luma-ray-2-flash"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-minimax-hailuo-02-text",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 122,
+      "ctr": 0,
+      "position": 9.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-pika-text-to-video",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 53,
+      "ctr": 0,
+      "position": 7.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-pika-text-to-video"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 44,
+      "ctr": 0,
+      "position": 11.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 203,
+      "ctr": 0,
+      "position": 7.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 132,
+      "ctr": 0,
+      "position": 11.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-sora-2",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-sora-2",
+      "clicks": 0,
+      "impressions": 26,
+      "ctr": 0,
+      "position": 8.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 9.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-veo-3-1",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 42,
+      "ctr": 0,
+      "position": 13.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "related_graph"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 18,
+      "ctr": 0,
+      "position": 9.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 30,
+      "ctr": 0,
+      "position": 9.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-wan-2-5",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 29,
+      "ctr": 0,
+      "position": 7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-wan-2-6",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 27,
+      "ctr": 0,
+      "position": 5.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-kling-3-standard",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-kling-3-standard",
+      "clicks": 27,
+      "impressions": 3851,
+      "ctr": 0.7,
+      "position": 7.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-kling-3-standard"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "related_graph"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions",
+        "localized_editorial_override",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-kling-o3-4k",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-kling-o3-4k",
+      "clicks": 2,
+      "impressions": 179,
+      "ctr": 1.1,
+      "position": 7.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-kling-o3-4k"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-kling-o3-pro",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-kling-o3-pro",
+      "clicks": 0,
+      "impressions": 64,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-kling-o3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-kling-o3-standard",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-kling-o3-standard",
+      "clicks": 0,
+      "impressions": 78,
+      "ctr": 0,
+      "position": 16.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-kling-o3-standard"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-ltx-2",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-ltx-2",
+      "clicks": 0,
+      "impressions": 29,
+      "ctr": 0,
+      "position": 22.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-ltx-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-ltx-2-3-fast",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-ltx-2-3-pro",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-ltx-2-3-pro",
+      "clicks": 4,
+      "impressions": 913,
+      "ctr": 0.4,
+      "position": 8.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-ltx-2-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-ltx-2-fast",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 33,
+      "ctr": 0,
+      "position": 18.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-ltx-2-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-luma-ray-2",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 42,
+      "ctr": 0,
+      "position": 10.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-luma-ray-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-luma-ray-2-flash",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 56,
+      "ctr": 0,
+      "position": 10.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-luma-ray-2-flash"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-luma-ray-3-2",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-luma-ray-3-2",
+      "clicks": 0,
+      "impressions": 86,
+      "ctr": 0,
+      "position": 13.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-luma-ray-3-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-minimax-hailuo-02-text",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 35,
+      "ctr": 0,
+      "position": 7.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-pika-text-to-video",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 66,
+      "ctr": 0,
+      "position": 12.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-pika-text-to-video"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-seedance-1-5-pro",
+      "clicks": 1,
+      "impressions": 56,
+      "ctr": 1.8,
+      "position": 9.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "popular",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-seedance-2-0",
+      "clicks": 2,
+      "impressions": 140,
+      "ctr": 1.4,
+      "position": 8.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 58,
+      "ctr": 0,
+      "position": 8.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-sora-2",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-sora-2",
+      "clicks": 0,
+      "impressions": 42,
+      "ctr": 0,
+      "position": 22,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 24.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-veo-3-1",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 175,
+      "ctr": 0,
+      "position": 15.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 22,
+      "ctr": 0,
+      "position": 7.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 27,
+      "ctr": 0,
+      "position": 10.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-wan-2-5",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 20,
+      "ctr": 0,
+      "position": 9.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-wan-2-6",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-wan-2-6",
+      "clicks": 5,
+      "impressions": 1361,
+      "ctr": 0.4,
+      "position": 10.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-kling-o3-4k",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-kling-o3-4k",
+      "clicks": 0,
+      "impressions": 84,
+      "ctr": 0,
+      "position": 9.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-kling-o3-4k"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-kling-o3-pro",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-kling-o3-pro",
+      "clicks": 0,
+      "impressions": 39,
+      "ctr": 0,
+      "position": 6.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-kling-o3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-kling-o3-standard",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-kling-o3-standard",
+      "clicks": 0,
+      "impressions": 250,
+      "ctr": 0,
+      "position": 13.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-kling-o3-standard"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-ltx-2",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-ltx-2",
+      "clicks": 2,
+      "impressions": 1280,
+      "ctr": 0.2,
+      "position": 8.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-ltx-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-ltx-2-3-fast",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-ltx-2-3-fast",
+      "clicks": 1,
+      "impressions": 644,
+      "ctr": 0.2,
+      "position": 5.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-ltx-2-3-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-ltx-2-3-pro",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-ltx-2-fast",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 57,
+      "ctr": 0,
+      "position": 13.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-ltx-2-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-luma-ray-2",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-luma-ray-2",
+      "clicks": 1,
+      "impressions": 280,
+      "ctr": 0.4,
+      "position": 8.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-luma-ray-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-luma-ray-2-flash",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 42,
+      "ctr": 0,
+      "position": 8.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-luma-ray-2-flash"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-minimax-hailuo-02-text",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 120,
+      "ctr": 0,
+      "position": 9.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-pika-text-to-video",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-seedance-1-5-pro",
+      "clicks": 4,
+      "impressions": 1265,
+      "ctr": 0.3,
+      "position": 6.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-seedance-2-0",
+      "clicks": 1,
+      "impressions": 237,
+      "ctr": 0.4,
+      "position": 8.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-seedance-2-0-fast",
+      "clicks": 2,
+      "impressions": 488,
+      "ctr": 0.4,
+      "position": 10,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-sora-2",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-sora-2",
+      "clicks": 0,
+      "impressions": 54,
+      "ctr": 0,
+      "position": 14.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 26,
+      "ctr": 0,
+      "position": 11.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-veo-3-1",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 84,
+      "ctr": 0,
+      "position": 16.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 128,
+      "ctr": 0,
+      "position": 12,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-veo-3-1-lite",
+      "clicks": 1,
+      "impressions": 159,
+      "ctr": 0.6,
+      "position": 9.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-wan-2-5",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-wan-2-5",
+      "clicks": 1,
+      "impressions": 737,
+      "ctr": 0.1,
+      "position": 8.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-wan-2-6",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 108,
+      "ctr": 0,
+      "position": 10.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-o3-4k-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "kling-o3-4k-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 104,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-o3-4k-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-o3-4k-vs-veo-3-1",
+      "locale": "en",
+      "slug": "kling-o3-4k-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 84,
+      "ctr": 0,
+      "position": 9.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-o3-4k-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-o3-pro-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "kling-o3-pro-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 67,
+      "ctr": 0,
+      "position": 9.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-o3-pro-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-o3-pro-vs-veo-3-1",
+      "locale": "en",
+      "slug": "kling-o3-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 48,
+      "ctr": 0,
+      "position": 8.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-o3-pro-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-o3-standard-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "kling-o3-standard-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 115,
+      "ctr": 0,
+      "position": 8.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-o3-standard-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-o3-standard-vs-veo-3-1",
+      "locale": "en",
+      "slug": "kling-o3-standard-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 81,
+      "ctr": 0,
+      "position": 10.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/kling-o3-standard-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-ltx-2-3-pro",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-ltx-2-3-pro",
+      "clicks": 11,
+      "impressions": 2766,
+      "ctr": 0.4,
+      "position": 12.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-ltx-2-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "showdown",
+        "trophy",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-ltx-2-fast",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-ltx-2-fast",
+      "clicks": 30,
+      "impressions": 12049,
+      "ctr": 0.2,
+      "position": 9.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-ltx-2-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-luma-ray-2",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 290,
+      "ctr": 0,
+      "position": 8.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-luma-ray-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-luma-ray-2-flash",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-luma-ray-2-flash",
+      "clicks": 1,
+      "impressions": 342,
+      "ctr": 0.3,
+      "position": 8.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-luma-ray-2-flash"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-minimax-hailuo-02-text",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-pika-text-to-video",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-seedance-2-0",
+      "clicks": 47,
+      "impressions": 5218,
+      "ctr": 0.9,
+      "position": 5.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-seedance-2-0-fast",
+      "clicks": 9,
+      "impressions": 1369,
+      "ctr": 0.7,
+      "position": 8.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-sora-2",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-sora-2",
+      "clicks": 1,
+      "impressions": 525,
+      "ctr": 0.2,
+      "position": 5.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 193,
+      "ctr": 0,
+      "position": 8.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-veo-3-1",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-veo-3-1",
+      "clicks": 19,
+      "impressions": 1472,
+      "ctr": 1.3,
+      "position": 10.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-veo-3-1-fast",
+      "clicks": 1,
+      "impressions": 39,
+      "ctr": 2.6,
+      "position": 8.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-veo-3-1-lite",
+      "clicks": 2,
+      "impressions": 304,
+      "ctr": 0.7,
+      "position": 8.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-wan-2-5",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-wan-2-5",
+      "clicks": 6,
+      "impressions": 2814,
+      "ctr": 0.2,
+      "position": 10.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-wan-2-6",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-ltx-2-fast",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-ltx-2-fast",
+      "clicks": 7,
+      "impressions": 5044,
+      "ctr": 0.1,
+      "position": 11.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-ltx-2-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-luma-ray-2",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 636,
+      "ctr": 0,
+      "position": 6.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-luma-ray-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-luma-ray-2-flash",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 114,
+      "ctr": 0,
+      "position": 8.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-luma-ray-2-flash"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-minimax-hailuo-02-text",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-pika-text-to-video",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-seedance-2-0-fast",
+      "clicks": 3,
+      "impressions": 741,
+      "ctr": 0.4,
+      "position": 8.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-sora-2",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-sora-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 73,
+      "ctr": 0,
+      "position": 10.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-veo-3-1",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 220,
+      "ctr": 0,
+      "position": 10.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "showdown",
+        "trophy",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 91,
+      "ctr": 0,
+      "position": 6.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-wan-2-5",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-wan-2-6",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-luma-ray-2",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 153,
+      "ctr": 0,
+      "position": 8.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-luma-ray-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-luma-ray-2-flash",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 30,
+      "ctr": 0,
+      "position": 11,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-luma-ray-2-flash"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-minimax-hailuo-02-text",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 219,
+      "ctr": 0,
+      "position": 12.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-pika-text-to-video",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 55,
+      "ctr": 0,
+      "position": 9.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-pika-text-to-video"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 105,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-seedance-2-0",
+      "clicks": 7,
+      "impressions": 2357,
+      "ctr": 0.3,
+      "position": 6.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 243,
+      "ctr": 0,
+      "position": 9.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-sora-2",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-sora-2",
+      "clicks": 0,
+      "impressions": 119,
+      "ctr": 0,
+      "position": 7.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-sora-2-pro",
+      "clicks": 2,
+      "impressions": 60,
+      "ctr": 3.3,
+      "position": 14.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-veo-3-1",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 32,
+      "ctr": 0,
+      "position": 11.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 13,
+      "ctr": 0,
+      "position": 5.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 74,
+      "ctr": 0,
+      "position": 7.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-wan-2-5",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-wan-2-5",
+      "clicks": 1,
+      "impressions": 1872,
+      "ctr": 0.1,
+      "position": 10.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-wan-2-6",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-wan-2-6",
+      "clicks": 1,
+      "impressions": 2126,
+      "ctr": 0,
+      "position": 11.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-ltx-2-3-fast",
+      "locale": "en",
+      "slug": "ltx-2-vs-ltx-2-3-fast",
+      "clicks": 19,
+      "impressions": 6588,
+      "ctr": 0.3,
+      "position": 10.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-vs-ltx-2-3-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-ltx-2-3-pro",
+      "locale": "en",
+      "slug": "ltx-2-vs-ltx-2-3-pro",
+      "clicks": 5,
+      "impressions": 3319,
+      "ctr": 0.2,
+      "position": 10.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-vs-ltx-2-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-ltx-2-fast",
+      "locale": "en",
+      "slug": "ltx-2-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 41,
+      "ctr": 0,
+      "position": 41.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-vs-ltx-2-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-luma-ray-2",
+      "locale": "en",
+      "slug": "ltx-2-vs-luma-ray-2",
+      "clicks": 1,
+      "impressions": 110,
+      "ctr": 0.9,
+      "position": 6.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-vs-luma-ray-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-luma-ray-2-flash",
+      "locale": "en",
+      "slug": "ltx-2-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 37,
+      "ctr": 0,
+      "position": 10.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-vs-luma-ray-2-flash"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-minimax-hailuo-02-text",
+      "locale": "en",
+      "slug": "ltx-2-vs-minimax-hailuo-02-text",
+      "clicks": 1,
+      "impressions": 169,
+      "ctr": 0.6,
+      "position": 10.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-pika-text-to-video",
+      "locale": "en",
+      "slug": "ltx-2-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 61,
+      "ctr": 0,
+      "position": 7.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-vs-pika-text-to-video"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "ltx-2-vs-seedance-1-5-pro",
+      "clicks": 1,
+      "impressions": 200,
+      "ctr": 0.5,
+      "position": 6.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "ltx-2-vs-seedance-2-0",
+      "clicks": 14,
+      "impressions": 1861,
+      "ctr": 0.8,
+      "position": 7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "ltx-2-vs-seedance-2-0-fast",
+      "clicks": 1,
+      "impressions": 175,
+      "ctr": 0.6,
+      "position": 6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-sora-2",
+      "locale": "en",
+      "slug": "ltx-2-vs-sora-2",
+      "clicks": 2,
+      "impressions": 491,
+      "ctr": 0.4,
+      "position": 7.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph",
+        "showdown",
+        "trophy"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "ltx-2-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 27,
+      "ctr": 0,
+      "position": 7.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-veo-3-1",
+      "locale": "en",
+      "slug": "ltx-2-vs-veo-3-1",
+      "clicks": 4,
+      "impressions": 1285,
+      "ctr": 0.3,
+      "position": 7.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph",
+        "showdown",
+        "trophy"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "ltx-2-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 39,
+      "ctr": 0,
+      "position": 14,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "ltx-2-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 42,
+      "ctr": 0,
+      "position": 7.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-wan-2-5",
+      "locale": "en",
+      "slug": "ltx-2-vs-wan-2-5",
+      "clicks": 2,
+      "impressions": 276,
+      "ctr": 0.7,
+      "position": 14.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-wan-2-6",
+      "locale": "en",
+      "slug": "ltx-2-vs-wan-2-6",
+      "clicks": 9,
+      "impressions": 5846,
+      "ctr": 0.2,
+      "position": 10.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/ltx-2-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-minimax-hailuo-02-text",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 26.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-pika-text-to-video",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 23,
+      "ctr": 0,
+      "position": 16,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-pika-text-to-video"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 28,
+      "ctr": 0,
+      "position": 9.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-seedance-2-0",
+      "clicks": 1,
+      "impressions": 526,
+      "ctr": 0.2,
+      "position": 8.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-seedance-2-0-fast",
+      "clicks": 1,
+      "impressions": 66,
+      "ctr": 1.5,
+      "position": 5.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-sora-2",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-sora-2",
+      "clicks": 0,
+      "impressions": 21,
+      "ctr": 0,
+      "position": 7.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 15,
+      "ctr": 0,
+      "position": 12.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-veo-3-1",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 45,
+      "ctr": 0,
+      "position": 10.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 39,
+      "ctr": 0,
+      "position": 11.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 41,
+      "ctr": 0,
+      "position": 7.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-wan-2-5",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 31,
+      "ctr": 0,
+      "position": 8.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-wan-2-6",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 60,
+      "ctr": 0,
+      "position": 12.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-luma-ray-2-flash",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 183,
+      "ctr": 0,
+      "position": 9.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-luma-ray-2-flash"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-luma-ray-3-2",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-luma-ray-3-2",
+      "clicks": 0,
+      "impressions": 222,
+      "ctr": 0,
+      "position": 16.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-luma-ray-3-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-minimax-hailuo-02-text",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 86,
+      "ctr": 0,
+      "position": 11.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-pika-text-to-video",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 114,
+      "ctr": 0,
+      "position": 5.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-pika-text-to-video"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 46,
+      "ctr": 0,
+      "position": 5.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-seedance-2-0",
+      "clicks": 9,
+      "impressions": 723,
+      "ctr": 1.2,
+      "position": 6.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 159,
+      "ctr": 0,
+      "position": 6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-sora-2",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-sora-2",
+      "clicks": 0,
+      "impressions": 71,
+      "ctr": 0,
+      "position": 6.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 8.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-veo-3-1",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-veo-3-1",
+      "clicks": 1,
+      "impressions": 222,
+      "ctr": 0.5,
+      "position": 6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 111,
+      "ctr": 0,
+      "position": 6.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 55,
+      "ctr": 0,
+      "position": 8.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-wan-2-5",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 28,
+      "ctr": 0,
+      "position": 7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-wan-2-6",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-wan-2-6",
+      "clicks": 1,
+      "impressions": 165,
+      "ctr": 0.6,
+      "position": 7.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-3-2-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "luma-ray-3-2-vs-seedance-2-0",
+      "clicks": 1,
+      "impressions": 121,
+      "ctr": 0.8,
+      "position": 6.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-3-2-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "related_graph"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-3-2-vs-veo-3-1",
+      "locale": "en",
+      "slug": "luma-ray-3-2-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 68,
+      "ctr": 0,
+      "position": 6.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-3-2-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "related_graph"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-3-2-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "luma-ray-3-2-vs-veo-3-1-fast",
+      "clicks": 3,
+      "impressions": 60,
+      "ctr": 5,
+      "position": 5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/luma-ray-3-2-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "localized_editorial_override",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-pika-text-to-video",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-pika-text-to-video",
+      "clicks": 4,
+      "impressions": 710,
+      "ctr": 0.6,
+      "position": 11.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-pika-text-to-video"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "showdown",
+        "trophy",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-seedance-2-0",
+      "clicks": 4,
+      "impressions": 3713,
+      "ctr": 0.1,
+      "position": 7.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-seedance-2-0-fast",
+      "clicks": 1,
+      "impressions": 1012,
+      "ctr": 0.1,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-sora-2",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-sora-2",
+      "clicks": 1,
+      "impressions": 267,
+      "ctr": 0.4,
+      "position": 8.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 73,
+      "ctr": 0,
+      "position": 6.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-veo-3-1",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 103,
+      "ctr": 0,
+      "position": 8.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 209,
+      "ctr": 0,
+      "position": 9.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-veo-3-1-lite",
+      "clicks": 1,
+      "impressions": 78,
+      "ctr": 1.3,
+      "position": 6.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-wan-2-5",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-wan-2-5",
+      "clicks": 3,
+      "impressions": 457,
+      "ctr": 0.7,
+      "position": 9.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-wan-2-6",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 196,
+      "ctr": 0,
+      "position": 11,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 145,
+      "ctr": 0,
+      "position": 10.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-seedance-2-0",
+      "clicks": 1,
+      "impressions": 362,
+      "ctr": 0.3,
+      "position": 7.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-seedance-2-0-fast",
+      "clicks": 1,
+      "impressions": 577,
+      "ctr": 0.2,
+      "position": 8.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-sora-2",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-sora-2",
+      "clicks": 0,
+      "impressions": 116,
+      "ctr": 0,
+      "position": 8.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 65,
+      "ctr": 0,
+      "position": 7.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-veo-3-1",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-veo-3-1",
+      "clicks": 1,
+      "impressions": 144,
+      "ctr": 0.7,
+      "position": 6.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-veo-3-1-fast",
+      "clicks": 2,
+      "impressions": 469,
+      "ctr": 0.4,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-veo-3-1-lite",
+      "clicks": 1,
+      "impressions": 69,
+      "ctr": 1.4,
+      "position": 7.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-wan-2-5",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-wan-2-5",
+      "clicks": 2,
+      "impressions": 1309,
+      "ctr": 0.2,
+      "position": 8.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-wan-2-6",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 476,
+      "ctr": 0,
+      "position": 10.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "seedance-1-5-pro-vs-seedance-2-0",
+      "clicks": 74,
+      "impressions": 13976,
+      "ctr": 0.5,
+      "position": 5.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions",
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "seedance-1-5-pro-vs-seedance-2-0-fast",
+      "clicks": 8,
+      "impressions": 2385,
+      "ctr": 0.3,
+      "position": 8.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-sora-2",
+      "locale": "en",
+      "slug": "seedance-1-5-pro-vs-sora-2",
+      "clicks": 0,
+      "impressions": 58,
+      "ctr": 0,
+      "position": 11,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "seedance-1-5-pro-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 8.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-veo-3-1",
+      "locale": "en",
+      "slug": "seedance-1-5-pro-vs-veo-3-1",
+      "clicks": 1,
+      "impressions": 1190,
+      "ctr": 0.1,
+      "position": 8.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "seedance-1-5-pro-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "seedance-1-5-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 115,
+      "ctr": 0,
+      "position": 6.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-wan-2-5",
+      "locale": "en",
+      "slug": "seedance-1-5-pro-vs-wan-2-5",
+      "clicks": 1,
+      "impressions": 464,
+      "ctr": 0.2,
+      "position": 6.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-wan-2-6",
+      "locale": "en",
+      "slug": "seedance-1-5-pro-vs-wan-2-6",
+      "clicks": 3,
+      "impressions": 1532,
+      "ctr": 0.2,
+      "position": 7.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-sora-2",
+      "locale": "en",
+      "slug": "seedance-2-0-fast-vs-sora-2",
+      "clicks": 0,
+      "impressions": 128,
+      "ctr": 0,
+      "position": 10.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "seedance-2-0-fast-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 49,
+      "ctr": 0,
+      "position": 8.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-veo-3-1",
+      "locale": "en",
+      "slug": "seedance-2-0-fast-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 242,
+      "ctr": 0,
+      "position": 10.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "seedance-2-0-fast-vs-veo-3-1-fast",
+      "clicks": 1,
+      "impressions": 426,
+      "ctr": 0.2,
+      "position": 12.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "seedance-2-0-fast-vs-veo-3-1-lite",
+      "clicks": 2,
+      "impressions": 262,
+      "ctr": 0.8,
+      "position": 10.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-wan-2-5",
+      "locale": "en",
+      "slug": "seedance-2-0-fast-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 876,
+      "ctr": 0,
+      "position": 8.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-wan-2-6",
+      "locale": "en",
+      "slug": "seedance-2-0-fast-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 1272,
+      "ctr": 0,
+      "position": 8.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "seedance-2-0-vs-seedance-2-0-fast",
+      "clicks": 218,
+      "impressions": 33636,
+      "ctr": 0.6,
+      "position": 6.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "related_graph",
+        "showdown"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions",
+        "localized_editorial_override",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-sora-2",
+      "locale": "en",
+      "slug": "seedance-2-0-vs-sora-2",
+      "clicks": 1,
+      "impressions": 261,
+      "ctr": 0.4,
+      "position": 15.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "seedance-2-0-vs-sora-2-pro",
+      "clicks": 1,
+      "impressions": 114,
+      "ctr": 0.9,
+      "position": 10.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-veo-3-1",
+      "locale": "en",
+      "slug": "seedance-2-0-vs-veo-3-1",
+      "clicks": 1,
+      "impressions": 699,
+      "ctr": 0.1,
+      "position": 8.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "seedance-2-0-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 174,
+      "ctr": 0,
+      "position": 10.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "seedance-2-0-vs-veo-3-1-lite",
+      "clicks": 3,
+      "impressions": 321,
+      "ctr": 0.9,
+      "position": 8.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-wan-2-5",
+      "locale": "en",
+      "slug": "seedance-2-0-vs-wan-2-5",
+      "clicks": 15,
+      "impressions": 4140,
+      "ctr": 0.4,
+      "position": 8.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-wan-2-6",
+      "locale": "en",
+      "slug": "seedance-2-0-vs-wan-2-6",
+      "clicks": 3,
+      "impressions": 1509,
+      "ctr": 0.2,
+      "position": 7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-pro-vs-veo-3-1",
+      "locale": "en",
+      "slug": "sora-2-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 44,
+      "ctr": 0,
+      "position": 8.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/sora-2-pro-vs-veo-3-1",
+        "https://maxvideoai.com/ai-video-engines/sora-2-pro-vs-veo-3-1?order=sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-pro-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "sora-2-pro-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 7.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/sora-2-pro-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-pro-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "sora-2-pro-vs-veo-3-1-lite",
+      "clicks": 1,
+      "impressions": 32,
+      "ctr": 3.1,
+      "position": 23,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/sora-2-pro-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-pro-vs-wan-2-5",
+      "locale": "en",
+      "slug": "sora-2-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 55,
+      "ctr": 0,
+      "position": 9.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/sora-2-pro-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-pro-vs-wan-2-6",
+      "locale": "en",
+      "slug": "sora-2-pro-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 96,
+      "ctr": 0,
+      "position": 11.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/sora-2-pro-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "sora-2-vs-sora-2-pro",
+      "clicks": 4,
+      "impressions": 2462,
+      "ctr": 0.2,
+      "position": 14.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/sora-2-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-vs-veo-3-1",
+      "locale": "en",
+      "slug": "sora-2-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 209,
+      "ctr": 0,
+      "position": 12.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/sora-2-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "related_graph",
+        "showdown",
+        "trophy"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "sora-2-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 99,
+      "ctr": 0,
+      "position": 17.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/sora-2-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "sora-2-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 104,
+      "ctr": 0,
+      "position": 10.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/sora-2-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-vs-wan-2-5",
+      "locale": "en",
+      "slug": "sora-2-vs-wan-2-5",
+      "clicks": 1,
+      "impressions": 137,
+      "ctr": 0.7,
+      "position": 8.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/sora-2-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-vs-wan-2-6",
+      "locale": "en",
+      "slug": "sora-2-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 188,
+      "ctr": 0,
+      "position": 9.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/sora-2-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph",
+        "showdown",
+        "trophy"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-fast-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "veo-3-1-fast-vs-veo-3-1-lite",
+      "clicks": 28,
+      "impressions": 13396,
+      "ctr": 0.2,
+      "position": 7.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/veo-3-1-fast-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "related_graph",
+        "showdown"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions",
+        "localized_editorial_override",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-fast-vs-wan-2-5",
+      "locale": "en",
+      "slug": "veo-3-1-fast-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 185,
+      "ctr": 0,
+      "position": 13.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/veo-3-1-fast-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-fast-vs-wan-2-6",
+      "locale": "en",
+      "slug": "veo-3-1-fast-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 52,
+      "ctr": 0,
+      "position": 11.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/veo-3-1-fast-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-lite-vs-wan-2-5",
+      "locale": "en",
+      "slug": "veo-3-1-lite-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 116,
+      "ctr": 0,
+      "position": 8.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/veo-3-1-lite-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-lite-vs-wan-2-6",
+      "locale": "en",
+      "slug": "veo-3-1-lite-vs-wan-2-6",
+      "clicks": 1,
+      "impressions": 236,
+      "ctr": 0.4,
+      "position": 10.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/veo-3-1-lite-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "veo-3-1-vs-veo-3-1-fast",
+      "clicks": 3,
+      "impressions": 1639,
+      "ctr": 0.2,
+      "position": 12,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/veo-3-1-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions",
+        "localized_editorial_override",
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "veo-3-1-vs-veo-3-1-lite",
+      "clicks": 6,
+      "impressions": 3014,
+      "ctr": 0.2,
+      "position": 9.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/veo-3-1-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-vs-wan-2-5",
+      "locale": "en",
+      "slug": "veo-3-1-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 192,
+      "ctr": 0,
+      "position": 7.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/veo-3-1-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-vs-wan-2-6",
+      "locale": "en",
+      "slug": "veo-3-1-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 325,
+      "ctr": 0,
+      "position": 11.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/veo-3-1-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "related_graph",
+        "showdown",
+        "trophy",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "english_strategic_surface"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/wan-2-5-vs-wan-2-6",
+      "locale": "en",
+      "slug": "wan-2-5-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 870,
+      "ctr": 0,
+      "position": 10.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/ai-video-engines/wan-2-5-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_high_impressions"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/dreamina-seedance-2-0-mini-vs-happy-horse-1-1",
+      "locale": "fr",
+      "slug": "dreamina-seedance-2-0-mini-vs-happy-horse-1-1",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 6.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/dreamina-seedance-2-0-mini-vs-happy-horse-1-1"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "scoreboard",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/dreamina-seedance-2-0-mini-vs-ltx-2-3-fast",
+      "locale": "fr",
+      "slug": "dreamina-seedance-2-0-mini-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/dreamina-seedance-2-0-mini-vs-ltx-2-3-fast"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "scoreboard",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/dreamina-seedance-2-0-mini-vs-luma-ray-3-2",
+      "locale": "fr",
+      "slug": "dreamina-seedance-2-0-mini-vs-luma-ray-3-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "scoreboard",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/dreamina-seedance-2-0-mini-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "dreamina-seedance-2-0-mini-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 25,
+      "ctr": 0,
+      "position": 11,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/dreamina-seedance-2-0-mini-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "showdown",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/dreamina-seedance-2-0-mini-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "dreamina-seedance-2-0-mini-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 31,
+      "ctr": 0,
+      "position": 4.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/dreamina-seedance-2-0-mini-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "showdown",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/dreamina-seedance-2-0-mini-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "dreamina-seedance-2-0-mini-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 14.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/dreamina-seedance-2-0-mini-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "scoreboard",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/gemini-omni-flash-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "gemini-omni-flash-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "related_graph",
+        "scoreboard"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/gemini-omni-flash-vs-sora-2",
+      "locale": "fr",
+      "slug": "gemini-omni-flash-vs-sora-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "related_graph",
+        "scoreboard"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/gemini-omni-flash-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "gemini-omni-flash-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 10,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/gemini-omni-flash-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "scoreboard",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/gemini-omni-flash-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "gemini-omni-flash-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 6.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/gemini-omni-flash-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "related_graph",
+        "scoreboard"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/happy-horse-1-0-vs-happy-horse-1-1",
+      "locale": "fr",
+      "slug": "happy-horse-1-0-vs-happy-horse-1-1",
+      "clicks": 1,
+      "impressions": 15,
+      "ctr": 6.7,
+      "position": 9.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/happy-horse-1-0-vs-happy-horse-1-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "popular"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/happy-horse-1-0-vs-kling-3-pro",
+      "locale": "fr",
+      "slug": "happy-horse-1-0-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/happy-horse-1-0-vs-kling-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/happy-horse-1-0-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "happy-horse-1-0-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/happy-horse-1-0-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "happy-horse-1-0-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 19.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/happy-horse-1-0-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/happy-horse-1-1-vs-kling-3-pro",
+      "locale": "fr",
+      "slug": "happy-horse-1-1-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/happy-horse-1-1-vs-kling-o3-pro",
+      "locale": "fr",
+      "slug": "happy-horse-1-1-vs-kling-o3-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/happy-horse-1-1-vs-ltx-2-3-pro",
+      "locale": "fr",
+      "slug": "happy-horse-1-1-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/happy-horse-1-1-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "happy-horse-1-1-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 5.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/happy-horse-1-1-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/happy-horse-1-1-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "happy-horse-1-1-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/happy-horse-1-1-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/happy-horse-1-1-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "happy-horse-1-1-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 6.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/happy-horse-1-1-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/happy-horse-1-1-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "happy-horse-1-1-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/happy-horse-1-1-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "happy-horse-1-1-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-kling-2-6-pro",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-kling-2-6-pro",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 5.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-kling-2-6-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-kling-3-4k",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-kling-3-4k",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-kling-3-4k"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-kling-3-pro",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 2.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-kling-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-kling-3-standard",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-kling-3-standard",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 7.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-kling-3-standard"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-ltx-2",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-ltx-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-ltx-2-3-fast",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-ltx-2-3-pro",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-ltx-2-fast",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-luma-ray-2",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-luma-ray-2-flash",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-minimax-hailuo-02-text",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-pika-text-to-video",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-seedance-1-5-pro",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-sora-2",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-sora-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "showdown"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-kling-3-4k",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-kling-3-4k",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 15.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-kling-3-4k"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-kling-3-pro",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 5.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-kling-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-kling-3-standard",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-kling-3-standard",
+      "clicks": 0,
+      "impressions": 45,
+      "ctr": 0,
+      "position": 4.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-kling-3-standard"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-ltx-2",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-ltx-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-ltx-2-3-fast",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-ltx-2-3-pro",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-ltx-2-fast",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-luma-ray-2",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-luma-ray-2-flash",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-minimax-hailuo-02-text",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-pika-text-to-video",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-pika-text-to-video"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph",
+        "showdown",
+        "trophy"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-seedance-1-5-pro",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 27,
+      "ctr": 0,
+      "position": 7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 10,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-sora-2",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-sora-2",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph",
+        "showdown",
+        "trophy"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "popular",
+        "related_graph",
+        "showdown",
+        "trophy",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 6.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 6.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph",
+        "showdown",
+        "trophy",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-kling-3-pro",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "popular",
+        "related_graph"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-kling-3-standard",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-kling-3-standard",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 8.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-kling-3-standard"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-ltx-2",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-ltx-2",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 23.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-ltx-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-ltx-2-3-fast",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-ltx-2-3-pro",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 8.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-ltx-2-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-ltx-2-fast",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-luma-ray-2",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 26.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-luma-ray-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-luma-ray-2-flash",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-minimax-hailuo-02-text",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-pika-text-to-video",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 7.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-pika-text-to-video"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-seedance-1-5-pro",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 24,
+      "ctr": 0,
+      "position": 6.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 20,
+      "ctr": 0,
+      "position": 8.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-sora-2",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-sora-2",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 8.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 21.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "related_graph"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 16,
+      "ctr": 0,
+      "position": 20.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-kling-3-standard",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-kling-3-standard",
+      "clicks": 2,
+      "impressions": 27,
+      "ctr": 7.4,
+      "position": 6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-kling-3-standard"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "related_graph"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-kling-o3-4k",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-kling-o3-4k",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-kling-o3-4k"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-kling-o3-pro",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-kling-o3-pro",
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 17.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-kling-o3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-kling-o3-standard",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-kling-o3-standard",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 5.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-kling-o3-standard"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-ltx-2",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-ltx-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-ltx-2-3-fast",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-ltx-2-3-pro",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-ltx-2-fast",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-luma-ray-2",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-luma-ray-2-flash",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-luma-ray-3-2",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-luma-ray-3-2",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-luma-ray-3-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-minimax-hailuo-02-text",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-pika-text-to-video",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-pika-text-to-video"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-seedance-1-5-pro",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "popular",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 22,
+      "ctr": 0,
+      "position": 6.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-sora-2",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-sora-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 10.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-kling-o3-4k",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-kling-o3-4k",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-kling-o3-pro",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-kling-o3-pro",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 36.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-kling-o3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-kling-o3-standard",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-kling-o3-standard",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 6.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-kling-o3-standard"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-ltx-2",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-ltx-2",
+      "clicks": 1,
+      "impressions": 5,
+      "ctr": 20,
+      "position": 3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-ltx-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-ltx-2-3-fast",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-ltx-2-3-pro",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-ltx-2-fast",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-luma-ray-2",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-luma-ray-2-flash",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-minimax-hailuo-02-text",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-pika-text-to-video",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-seedance-1-5-pro",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 35,
+      "ctr": 0,
+      "position": 4.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 109,
+      "ctr": 0,
+      "position": 7.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-sora-2",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-sora-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-veo-3-1-fast",
+      "clicks": 1,
+      "impressions": 18,
+      "ctr": 5.6,
+      "position": 7.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 15,
+      "ctr": 0,
+      "position": 5.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 1.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-o3-4k-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "kling-o3-4k-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 6.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-o3-4k-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-o3-4k-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "kling-o3-4k-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 6.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-o3-4k-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-o3-pro-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "kling-o3-pro-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-o3-pro-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-o3-pro-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "kling-o3-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-o3-standard-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "kling-o3-standard-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 18,
+      "ctr": 0,
+      "position": 7.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-o3-standard-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-o3-standard-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "kling-o3-standard-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 7.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/kling-o3-standard-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-ltx-2-3-pro",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "showdown",
+        "trophy",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-ltx-2-fast",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-luma-ray-2",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-luma-ray-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-luma-ray-2-flash",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-minimax-hailuo-02-text",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 6.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-pika-text-to-video",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-seedance-1-5-pro",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-seedance-2-0-fast",
+      "clicks": 2,
+      "impressions": 34,
+      "ctr": 5.9,
+      "position": 7.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-sora-2",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-sora-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-sora-2-pro",
+      "clicks": 1,
+      "impressions": 5,
+      "ctr": 20,
+      "position": 3.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 8.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 4.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-ltx-2-fast",
+      "locale": "fr",
+      "slug": "ltx-2-3-pro-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-ltx-2-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-luma-ray-2",
+      "locale": "fr",
+      "slug": "ltx-2-3-pro-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-luma-ray-2-flash",
+      "locale": "fr",
+      "slug": "ltx-2-3-pro-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-luma-ray-2-flash"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-minimax-hailuo-02-text",
+      "locale": "fr",
+      "slug": "ltx-2-3-pro-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-pika-text-to-video",
+      "locale": "fr",
+      "slug": "ltx-2-3-pro-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 10,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-pika-text-to-video"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-seedance-1-5-pro",
+      "locale": "fr",
+      "slug": "ltx-2-3-pro-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "ltx-2-3-pro-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "ltx-2-3-pro-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 4.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-sora-2",
+      "locale": "fr",
+      "slug": "ltx-2-3-pro-vs-sora-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "ltx-2-3-pro-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "ltx-2-3-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "showdown",
+        "trophy",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "ltx-2-3-pro-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "ltx-2-3-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 8.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "ltx-2-3-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 4.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "ltx-2-3-pro-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-luma-ray-2",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-luma-ray-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-luma-ray-2-flash",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-minimax-hailuo-02-text",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-pika-text-to-video",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-seedance-1-5-pro",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-seedance-1-5-pro",
+      "clicks": 1,
+      "impressions": 2,
+      "ctr": 50,
+      "position": 2.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-sora-2",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-sora-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 5.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-wan-2-6",
+      "clicks": 1,
+      "impressions": 22,
+      "ctr": 4.5,
+      "position": 8.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-ltx-2-3-fast",
+      "locale": "fr",
+      "slug": "ltx-2-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-vs-ltx-2-3-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-ltx-2-3-pro",
+      "locale": "fr",
+      "slug": "ltx-2-vs-ltx-2-3-pro",
+      "clicks": 1,
+      "impressions": 70,
+      "ctr": 1.4,
+      "position": 13.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-vs-ltx-2-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-ltx-2-fast",
+      "locale": "fr",
+      "slug": "ltx-2-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-luma-ray-2",
+      "locale": "fr",
+      "slug": "ltx-2-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 80.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-vs-luma-ray-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-luma-ray-2-flash",
+      "locale": "fr",
+      "slug": "ltx-2-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-minimax-hailuo-02-text",
+      "locale": "fr",
+      "slug": "ltx-2-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-pika-text-to-video",
+      "locale": "fr",
+      "slug": "ltx-2-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-vs-pika-text-to-video"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-seedance-1-5-pro",
+      "locale": "fr",
+      "slug": "ltx-2-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "ltx-2-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 2.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "ltx-2-vs-seedance-2-0-fast",
+      "clicks": 1,
+      "impressions": 4,
+      "ctr": 25,
+      "position": 3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-sora-2",
+      "locale": "fr",
+      "slug": "ltx-2-vs-sora-2",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 6.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph",
+        "showdown",
+        "trophy"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "ltx-2-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "ltx-2-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph",
+        "showdown",
+        "trophy"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "ltx-2-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "ltx-2-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 15,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "ltx-2-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 12.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "ltx-2-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 90,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/ltx-2-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-flash-vs-minimax-hailuo-02-text",
+      "locale": "fr",
+      "slug": "luma-ray-2-flash-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-flash-vs-pika-text-to-video",
+      "locale": "fr",
+      "slug": "luma-ray-2-flash-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-flash-vs-seedance-1-5-pro",
+      "locale": "fr",
+      "slug": "luma-ray-2-flash-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-flash-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "luma-ray-2-flash-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 12,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/luma-ray-2-flash-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-flash-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "luma-ray-2-flash-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/luma-ray-2-flash-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-flash-vs-sora-2",
+      "locale": "fr",
+      "slug": "luma-ray-2-flash-vs-sora-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-flash-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "luma-ray-2-flash-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-flash-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "luma-ray-2-flash-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-flash-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "luma-ray-2-flash-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-flash-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "luma-ray-2-flash-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/luma-ray-2-flash-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-flash-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "luma-ray-2-flash-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-flash-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "luma-ray-2-flash-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-luma-ray-2-flash",
+      "locale": "fr",
+      "slug": "luma-ray-2-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-luma-ray-3-2",
+      "locale": "fr",
+      "slug": "luma-ray-2-vs-luma-ray-3-2",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 7.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-luma-ray-3-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-minimax-hailuo-02-text",
+      "locale": "fr",
+      "slug": "luma-ray-2-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 27,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-pika-text-to-video",
+      "locale": "fr",
+      "slug": "luma-ray-2-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-pika-text-to-video"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-seedance-1-5-pro",
+      "locale": "fr",
+      "slug": "luma-ray-2-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "luma-ray-2-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "luma-ray-2-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-sora-2",
+      "locale": "fr",
+      "slug": "luma-ray-2-vs-sora-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "luma-ray-2-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "luma-ray-2-vs-veo-3-1",
+      "clicks": 1,
+      "impressions": 1,
+      "ctr": 100,
+      "position": 3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "luma-ray-2-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "luma-ray-2-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "luma-ray-2-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "luma-ray-2-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-3-2-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "luma-ray-3-2-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/luma-ray-3-2-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "related_graph"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-3-2-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "luma-ray-3-2-vs-veo-3-1",
+      "clicks": 1,
+      "impressions": 1,
+      "ctr": 100,
+      "position": 2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/luma-ray-3-2-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "related_graph"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-3-2-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "luma-ray-3-2-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/minimax-hailuo-02-text-vs-pika-text-to-video",
+      "locale": "fr",
+      "slug": "minimax-hailuo-02-text-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "showdown",
+        "trophy",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/minimax-hailuo-02-text-vs-seedance-1-5-pro",
+      "locale": "fr",
+      "slug": "minimax-hailuo-02-text-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/minimax-hailuo-02-text-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/minimax-hailuo-02-text-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "minimax-hailuo-02-text-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/minimax-hailuo-02-text-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/minimax-hailuo-02-text-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "minimax-hailuo-02-text-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 7.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/minimax-hailuo-02-text-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/minimax-hailuo-02-text-vs-sora-2",
+      "locale": "fr",
+      "slug": "minimax-hailuo-02-text-vs-sora-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/minimax-hailuo-02-text-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "minimax-hailuo-02-text-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 7.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/minimax-hailuo-02-text-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/minimax-hailuo-02-text-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "minimax-hailuo-02-text-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/minimax-hailuo-02-text-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "minimax-hailuo-02-text-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/minimax-hailuo-02-text-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "minimax-hailuo-02-text-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/minimax-hailuo-02-text-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "minimax-hailuo-02-text-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 12.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/minimax-hailuo-02-text-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/minimax-hailuo-02-text-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "minimax-hailuo-02-text-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/pika-text-to-video-vs-seedance-1-5-pro",
+      "locale": "fr",
+      "slug": "pika-text-to-video-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/pika-text-to-video-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/pika-text-to-video-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "pika-text-to-video-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 3.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/pika-text-to-video-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/pika-text-to-video-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "pika-text-to-video-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 6.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/pika-text-to-video-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/pika-text-to-video-vs-sora-2",
+      "locale": "fr",
+      "slug": "pika-text-to-video-vs-sora-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/pika-text-to-video-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "pika-text-to-video-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/pika-text-to-video-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "pika-text-to-video-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/pika-text-to-video-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "pika-text-to-video-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/pika-text-to-video-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "pika-text-to-video-vs-veo-3-1-lite",
+      "clicks": 1,
+      "impressions": 1,
+      "ctr": 100,
+      "position": 7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/pika-text-to-video-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/pika-text-to-video-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "pika-text-to-video-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 4.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/pika-text-to-video-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/pika-text-to-video-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "pika-text-to-video-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-1-5-pro-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "seedance-1-5-pro-vs-seedance-2-0",
+      "clicks": 1,
+      "impressions": 81,
+      "ctr": 1.2,
+      "position": 4.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/seedance-1-5-pro-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-1-5-pro-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "seedance-1-5-pro-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/seedance-1-5-pro-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-1-5-pro-vs-sora-2",
+      "locale": "fr",
+      "slug": "seedance-1-5-pro-vs-sora-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-1-5-pro-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "seedance-1-5-pro-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-1-5-pro-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "seedance-1-5-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-1-5-pro-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "seedance-1-5-pro-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-1-5-pro-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "seedance-1-5-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-1-5-pro-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "seedance-1-5-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-1-5-pro-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "seedance-1-5-pro-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 6.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/seedance-1-5-pro-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-fast-vs-sora-2",
+      "locale": "fr",
+      "slug": "seedance-2-0-fast-vs-sora-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-fast-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "seedance-2-0-fast-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 4.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/seedance-2-0-fast-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-fast-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "seedance-2-0-fast-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 5.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/seedance-2-0-fast-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-fast-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "seedance-2-0-fast-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 14.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/seedance-2-0-fast-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-fast-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "seedance-2-0-fast-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 4.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/seedance-2-0-fast-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-fast-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "seedance-2-0-fast-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 3.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/seedance-2-0-fast-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-fast-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "seedance-2-0-fast-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 8.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/seedance-2-0-fast-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "seedance-2-0-vs-seedance-2-0-fast",
+      "clicks": 6,
+      "impressions": 243,
+      "ctr": 2.5,
+      "position": 5.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/seedance-2-0-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "related_graph",
+        "showdown"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-vs-sora-2",
+      "locale": "fr",
+      "slug": "seedance-2-0-vs-sora-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "seedance-2-0-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "seedance-2-0-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 7.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/seedance-2-0-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "seedance-2-0-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "seedance-2-0-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/seedance-2-0-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "seedance-2-0-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "seedance-2-0-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 18,
+      "ctr": 0,
+      "position": 4.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/seedance-2-0-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/sora-2-pro-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "sora-2-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/sora-2-pro-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "sora-2-pro-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/sora-2-pro-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "sora-2-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/sora-2-pro-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "sora-2-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/sora-2-pro-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/sora-2-pro-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "sora-2-pro-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 11,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/sora-2-pro-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/sora-2-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "sora-2-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 21,
+      "ctr": 0,
+      "position": 8.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/sora-2-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/sora-2-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "sora-2-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 3.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/sora-2-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "related_graph",
+        "showdown",
+        "trophy"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/sora-2-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "sora-2-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/sora-2-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/sora-2-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "sora-2-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 1.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/sora-2-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/sora-2-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "sora-2-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/sora-2-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/sora-2-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "sora-2-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph",
+        "showdown",
+        "trophy"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/veo-3-1-fast-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "veo-3-1-fast-vs-veo-3-1-lite",
+      "clicks": 13,
+      "impressions": 155,
+      "ctr": 8.4,
+      "position": 4.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/veo-3-1-fast-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "related_graph",
+        "showdown"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/veo-3-1-fast-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "veo-3-1-fast-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/veo-3-1-fast-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/veo-3-1-fast-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "veo-3-1-fast-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/veo-3-1-fast-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/veo-3-1-lite-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "veo-3-1-lite-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/veo-3-1-lite-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "veo-3-1-lite-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/veo-3-1-lite-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/veo-3-1-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "veo-3-1-vs-veo-3-1-fast",
+      "clicks": 1,
+      "impressions": 21,
+      "ctr": 4.8,
+      "position": 5.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/veo-3-1-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/veo-3-1-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "veo-3-1-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 9.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/veo-3-1-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/veo-3-1-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "veo-3-1-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/veo-3-1-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "veo-3-1-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 3.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/veo-3-1-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "related_graph",
+        "showdown",
+        "trophy",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/wan-2-5-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "wan-2-5-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 21,
+      "ctr": 0,
+      "position": 8.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/fr/comparatif/wan-2-5-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/dreamina-seedance-2-0-mini-vs-happy-horse-1-1",
+      "locale": "es",
+      "slug": "dreamina-seedance-2-0-mini-vs-happy-horse-1-1",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "scoreboard",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/dreamina-seedance-2-0-mini-vs-ltx-2-3-fast",
+      "locale": "es",
+      "slug": "dreamina-seedance-2-0-mini-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "scoreboard",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/dreamina-seedance-2-0-mini-vs-luma-ray-3-2",
+      "locale": "es",
+      "slug": "dreamina-seedance-2-0-mini-vs-luma-ray-3-2",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 8.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/dreamina-seedance-2-0-mini-vs-luma-ray-3-2"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "scoreboard",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/dreamina-seedance-2-0-mini-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "dreamina-seedance-2-0-mini-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/dreamina-seedance-2-0-mini-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "showdown",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/dreamina-seedance-2-0-mini-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "dreamina-seedance-2-0-mini-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 15,
+      "ctr": 0,
+      "position": 7.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/dreamina-seedance-2-0-mini-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "showdown",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/dreamina-seedance-2-0-mini-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "dreamina-seedance-2-0-mini-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "scoreboard",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/gemini-omni-flash-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "gemini-omni-flash-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 6.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/gemini-omni-flash-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "related_graph",
+        "scoreboard"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/gemini-omni-flash-vs-sora-2",
+      "locale": "es",
+      "slug": "gemini-omni-flash-vs-sora-2",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/gemini-omni-flash-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "related_graph",
+        "scoreboard"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/gemini-omni-flash-vs-veo-3-1",
+      "locale": "es",
+      "slug": "gemini-omni-flash-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 5.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/gemini-omni-flash-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "scoreboard",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/gemini-omni-flash-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "gemini-omni-flash-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 26,
+      "ctr": 0,
+      "position": 7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/gemini-omni-flash-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "related_graph",
+        "scoreboard"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-0-vs-happy-horse-1-1",
+      "locale": "es",
+      "slug": "happy-horse-1-0-vs-happy-horse-1-1",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 35,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/happy-horse-1-0-vs-happy-horse-1-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "popular"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-0-vs-kling-3-pro",
+      "locale": "es",
+      "slug": "happy-horse-1-0-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 15,
+      "ctr": 0,
+      "position": 5.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/happy-horse-1-0-vs-kling-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-0-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "happy-horse-1-0-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-0-vs-veo-3-1",
+      "locale": "es",
+      "slug": "happy-horse-1-0-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 2.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/happy-horse-1-0-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-1-vs-kling-3-pro",
+      "locale": "es",
+      "slug": "happy-horse-1-1-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/happy-horse-1-1-vs-kling-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-1-vs-kling-o3-pro",
+      "locale": "es",
+      "slug": "happy-horse-1-1-vs-kling-o3-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-1-vs-ltx-2-3-pro",
+      "locale": "es",
+      "slug": "happy-horse-1-1-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/happy-horse-1-1-vs-ltx-2-3-pro"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-1-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "happy-horse-1-1-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 10.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/happy-horse-1-1-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-1-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "happy-horse-1-1-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/happy-horse-1-1-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-1-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "happy-horse-1-1-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-1-vs-veo-3-1",
+      "locale": "es",
+      "slug": "happy-horse-1-1-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-1-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "happy-horse-1-1-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 5.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/happy-horse-1-1-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-kling-2-6-pro",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-kling-2-6-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-kling-3-4k",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-kling-3-4k",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 6.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-kling-3-4k"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-kling-3-pro",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-kling-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-kling-3-standard",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-kling-3-standard",
+      "clicks": 2,
+      "impressions": 64,
+      "ctr": 3.1,
+      "position": 8.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-kling-3-standard"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-ltx-2",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-ltx-2",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-ltx-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-ltx-2-3-fast",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-ltx-2-3-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-ltx-2-3-pro",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-ltx-2-fast",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-luma-ray-2",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-luma-ray-2",
+      "clicks": 1,
+      "impressions": 3,
+      "ctr": 33.3,
+      "position": 9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-luma-ray-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-luma-ray-2-flash",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-luma-ray-2-flash"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-minimax-hailuo-02-text",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 4.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-pika-text-to-video",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 5.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-sora-2",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-sora-2",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "showdown"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-veo-3-1",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 19,
+      "ctr": 0,
+      "position": 5.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-wan-2-5",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-wan-2-6",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 5.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-kling-3-4k",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-kling-3-4k",
+      "clicks": 0,
+      "impressions": 26,
+      "ctr": 0,
+      "position": 8.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-kling-3-4k"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-kling-3-pro",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 8.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-kling-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-kling-3-standard",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-kling-3-standard",
+      "clicks": 1,
+      "impressions": 70,
+      "ctr": 1.4,
+      "position": 7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-kling-3-standard"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-ltx-2",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-ltx-2",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-ltx-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-ltx-2-3-fast",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-ltx-2-3-pro",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-ltx-2-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-ltx-2-fast",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-luma-ray-2",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-luma-ray-2-flash",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-minimax-hailuo-02-text",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-pika-text-to-video",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-pika-text-to-video"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph",
+        "showdown",
+        "trophy"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 6.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 9.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 22,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-sora-2",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-sora-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph",
+        "showdown",
+        "trophy"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-veo-3-1",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "popular",
+        "related_graph",
+        "showdown",
+        "trophy",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-wan-2-5",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 5.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-wan-2-6",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 11,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph",
+        "showdown",
+        "trophy",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-kling-3-pro",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 16,
+      "ctr": 0,
+      "position": 25.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-kling-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "popular",
+        "related_graph"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-kling-3-standard",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-kling-3-standard",
+      "clicks": 0,
+      "impressions": 16,
+      "ctr": 0,
+      "position": 31,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-kling-3-standard"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-ltx-2",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-ltx-2",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 40.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-ltx-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-ltx-2-3-fast",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-ltx-2-3-pro",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-ltx-2-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-ltx-2-fast",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-ltx-2-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-luma-ray-2",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 67.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-luma-ray-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-luma-ray-2-flash",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-minimax-hailuo-02-text",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 21,
+      "ctr": 0,
+      "position": 8.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-pika-text-to-video",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 24,
+      "ctr": 0,
+      "position": 6.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-pika-text-to-video"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 23,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 18,
+      "ctr": 0,
+      "position": 7.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-seedance-2-0-fast",
+      "clicks": 1,
+      "impressions": 10,
+      "ctr": 10,
+      "position": 20.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-sora-2",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-sora-2",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 26.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 9.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-veo-3-1",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 22,
+      "ctr": 0,
+      "position": 10.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "related_graph"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 7.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 17.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-wan-2-5",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 5.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-wan-2-6",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 57,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-kling-3-standard",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-kling-3-standard",
+      "clicks": 0,
+      "impressions": 53,
+      "ctr": 0,
+      "position": 8.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-kling-3-standard"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "related_graph"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-kling-o3-4k",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-kling-o3-4k",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 9.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-kling-o3-4k"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-kling-o3-pro",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-kling-o3-pro",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 14.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-kling-o3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-kling-o3-standard",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-kling-o3-standard",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 16.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-kling-o3-standard"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-ltx-2",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-ltx-2",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 35.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-ltx-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-ltx-2-3-fast",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-ltx-2-3-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-ltx-2-3-pro",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-ltx-2-fast",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 4.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-ltx-2-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-luma-ray-2",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-luma-ray-2-flash",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 24.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-luma-ray-2-flash"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-luma-ray-3-2",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-luma-ray-3-2",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-luma-ray-3-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-minimax-hailuo-02-text",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 28,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-pika-text-to-video",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 6.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "popular",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-seedance-2-0",
+      "clicks": 1,
+      "impressions": 11,
+      "ctr": 9.1,
+      "position": 7.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 14,
+      "ctr": 0,
+      "position": 9.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-sora-2",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-sora-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-veo-3-1",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-wan-2-5",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 44.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-wan-2-6",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-wan-2-6",
+      "clicks": 1,
+      "impressions": 16,
+      "ctr": 6.3,
+      "position": 7.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-kling-o3-4k",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-kling-o3-4k",
+      "clicks": 0,
+      "impressions": 13,
+      "ctr": 0,
+      "position": 7.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-kling-o3-4k"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-kling-o3-pro",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-kling-o3-pro",
+      "clicks": 0,
+      "impressions": 22,
+      "ctr": 0,
+      "position": 10.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-kling-o3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-kling-o3-standard",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-kling-o3-standard",
+      "clicks": 1,
+      "impressions": 67,
+      "ctr": 1.5,
+      "position": 6.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-kling-o3-standard"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-ltx-2",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-ltx-2",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-ltx-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-ltx-2-3-fast",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 13,
+      "ctr": 0,
+      "position": 4.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-ltx-2-3-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-ltx-2-3-pro",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 3.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-ltx-2-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-ltx-2-fast",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-ltx-2-fast",
+      "clicks": 1,
+      "impressions": 3,
+      "ctr": 33.3,
+      "position": 6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-ltx-2-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-luma-ray-2",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 7.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-luma-ray-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-luma-ray-2-flash",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 11,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-luma-ray-2-flash"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-minimax-hailuo-02-text",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-pika-text-to-video",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 35,
+      "ctr": 0,
+      "position": 5.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-pika-text-to-video"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 192,
+      "ctr": 0,
+      "position": 8.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-seedance-2-0",
+      "clicks": 1,
+      "impressions": 61,
+      "ctr": 1.6,
+      "position": 8.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-seedance-2-0-fast",
+      "clicks": 1,
+      "impressions": 78,
+      "ctr": 1.3,
+      "position": 7.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-sora-2",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-sora-2",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 9.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 9.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-veo-3-1",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 101,
+      "ctr": 0,
+      "position": 11.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 35,
+      "ctr": 0,
+      "position": 8.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 21,
+      "ctr": 0,
+      "position": 9.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-wan-2-5",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 7.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-wan-2-6",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 6.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-o3-4k-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "kling-o3-4k-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 17.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-o3-4k-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-o3-4k-vs-veo-3-1",
+      "locale": "es",
+      "slug": "kling-o3-4k-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-o3-4k-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-o3-pro-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "kling-o3-pro-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 5.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-o3-pro-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-o3-pro-vs-veo-3-1",
+      "locale": "es",
+      "slug": "kling-o3-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 10.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-o3-pro-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-o3-standard-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "kling-o3-standard-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 41,
+      "ctr": 0,
+      "position": 11.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-o3-standard-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-o3-standard-vs-veo-3-1",
+      "locale": "es",
+      "slug": "kling-o3-standard-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 13,
+      "ctr": 0,
+      "position": 15.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/kling-o3-standard-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-ltx-2-3-pro",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-ltx-2-3-pro",
+      "clicks": 3,
+      "impressions": 147,
+      "ctr": 2,
+      "position": 8.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-ltx-2-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "showdown",
+        "trophy",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-ltx-2-fast",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-ltx-2-fast",
+      "clicks": 1,
+      "impressions": 37,
+      "ctr": 2.7,
+      "position": 13.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-ltx-2-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-luma-ray-2",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-luma-ray-2",
+      "clicks": 1,
+      "impressions": 7,
+      "ctr": 14.3,
+      "position": 5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-luma-ray-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-luma-ray-2-flash",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 35,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-luma-ray-2-flash"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-minimax-hailuo-02-text",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 6.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-pika-text-to-video",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 6.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 9.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-sora-2",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-sora-2",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 5.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-veo-3-1",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 5.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 23,
+      "ctr": 0,
+      "position": 9.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-wan-2-5",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 45,
+      "ctr": 0,
+      "position": 9.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-wan-2-6",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 140,
+      "ctr": 0,
+      "position": 7.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "use_case_bucket"
+      ],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-ltx-2-fast",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 10.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-ltx-2-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-luma-ray-2",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-luma-ray-2-flash",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 12,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-luma-ray-2-flash"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-minimax-hailuo-02-text",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 6.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-pika-text-to-video",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-seedance-2-0",
+      "clicks": 3,
+      "impressions": 66,
+      "ctr": 4.5,
+      "position": 5.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 40,
+      "ctr": 0,
+      "position": 6.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-sora-2",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-sora-2",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 2.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-veo-3-1",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 2.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "showdown",
+        "trophy",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-wan-2-5",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-wan-2-5",
+      "clicks": 1,
+      "impressions": 67,
+      "ctr": 1.5,
+      "position": 11.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-wan-2-6",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 38,
+      "ctr": 0,
+      "position": 8.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-luma-ray-2",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-luma-ray-2-flash",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-minimax-hailuo-02-text",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-pika-text-to-video",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 15,
+      "ctr": 0,
+      "position": 7.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 14,
+      "ctr": 0,
+      "position": 5.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-sora-2",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-sora-2",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 44.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-veo-3-1",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 58,
+      "ctr": 0,
+      "position": 6.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-wan-2-5",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 9.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-wan-2-6",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 35,
+      "ctr": 0,
+      "position": 8.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-ltx-2-3-fast",
+      "locale": "es",
+      "slug": "ltx-2-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 126,
+      "ctr": 0,
+      "position": 12.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-vs-ltx-2-3-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "enrich",
+      "rationale": [
+        "gsc_enrichment_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-ltx-2-3-pro",
+      "locale": "es",
+      "slug": "ltx-2-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 71,
+      "ctr": 0,
+      "position": 14.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-vs-ltx-2-3-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-ltx-2-fast",
+      "locale": "es",
+      "slug": "ltx-2-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 86,
+      "ctr": 0,
+      "position": 10,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-vs-ltx-2-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-luma-ray-2",
+      "locale": "es",
+      "slug": "ltx-2-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 22.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-vs-luma-ray-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-luma-ray-2-flash",
+      "locale": "es",
+      "slug": "ltx-2-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-vs-luma-ray-2-flash"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-minimax-hailuo-02-text",
+      "locale": "es",
+      "slug": "ltx-2-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 4.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-pika-text-to-video",
+      "locale": "es",
+      "slug": "ltx-2-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "ltx-2-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 6.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "ltx-2-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 14,
+      "ctr": 0,
+      "position": 5.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "ltx-2-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 15,
+      "ctr": 0,
+      "position": 5.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-sora-2",
+      "locale": "es",
+      "slug": "ltx-2-vs-sora-2",
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 20.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph",
+        "showdown",
+        "trophy"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "ltx-2-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-veo-3-1",
+      "locale": "es",
+      "slug": "ltx-2-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph",
+        "showdown",
+        "trophy"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "ltx-2-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "ltx-2-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-wan-2-5",
+      "locale": "es",
+      "slug": "ltx-2-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 23,
+      "ctr": 0,
+      "position": 13.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-wan-2-6",
+      "locale": "es",
+      "slug": "ltx-2-vs-wan-2-6",
+      "clicks": 2,
+      "impressions": 103,
+      "ctr": 1.9,
+      "position": 11.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/ltx-2-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-minimax-hailuo-02-text",
+      "locale": "es",
+      "slug": "luma-ray-2-flash-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-pika-text-to-video",
+      "locale": "es",
+      "slug": "luma-ray-2-flash-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "luma-ray-2-flash-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "luma-ray-2-flash-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "luma-ray-2-flash-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 8.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-sora-2",
+      "locale": "es",
+      "slug": "luma-ray-2-flash-vs-sora-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "luma-ray-2-flash-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-veo-3-1",
+      "locale": "es",
+      "slug": "luma-ray-2-flash-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "luma-ray-2-flash-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "luma-ray-2-flash-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 8.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-wan-2-5",
+      "locale": "es",
+      "slug": "luma-ray-2-flash-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-wan-2-6",
+      "locale": "es",
+      "slug": "luma-ray-2-flash-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-luma-ray-2-flash",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-luma-ray-3-2",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-luma-ray-3-2",
+      "clicks": 0,
+      "impressions": 13,
+      "ctr": 0,
+      "position": 24.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-luma-ray-3-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-minimax-hailuo-02-text",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 9.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-minimax-hailuo-02-text"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-pika-text-to-video",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-pika-text-to-video"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 7.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-seedance-2-0-fast",
+      "clicks": 1,
+      "impressions": 13,
+      "ctr": 7.7,
+      "position": 5.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-sora-2",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-sora-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-veo-3-1",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 5.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 10.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-wan-2-5",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 20,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-wan-2-6",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-3-2-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "luma-ray-3-2-vs-seedance-2-0",
+      "clicks": 1,
+      "impressions": 22,
+      "ctr": 4.5,
+      "position": 8.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/luma-ray-3-2-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "related_graph"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-3-2-vs-veo-3-1",
+      "locale": "es",
+      "slug": "luma-ray-3-2-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 32,
+      "ctr": 0,
+      "position": 6.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/luma-ray-3-2-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "related_graph"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-3-2-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "luma-ray-3-2-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 8.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/luma-ray-3-2-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-pika-text-to-video",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 8.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-pika-text-to-video"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "showdown",
+        "trophy",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 18,
+      "ctr": 0,
+      "position": 20.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-seedance-1-5-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 13,
+      "ctr": 0,
+      "position": 6.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 16,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-sora-2",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-sora-2",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 7.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-veo-3-1",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 9.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-wan-2-5",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-wan-2-5",
+      "clicks": 2,
+      "impressions": 15,
+      "ctr": 13.3,
+      "position": 16.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-wan-2-6",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 1.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "pika-text-to-video-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "pika-text-to-video-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 29,
+      "ctr": 0,
+      "position": 7.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "pika-text-to-video-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 24,
+      "ctr": 0,
+      "position": 16.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-sora-2",
+      "locale": "es",
+      "slug": "pika-text-to-video-vs-sora-2",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 7.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "pika-text-to-video-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-veo-3-1",
+      "locale": "es",
+      "slug": "pika-text-to-video-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "pika-text-to-video-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 5.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "pika-text-to-video-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 8.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-wan-2-5",
+      "locale": "es",
+      "slug": "pika-text-to-video-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 6.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-wan-2-6",
+      "locale": "es",
+      "slug": "pika-text-to-video-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-1-5-pro-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "seedance-1-5-pro-vs-seedance-2-0",
+      "clicks": 3,
+      "impressions": 200,
+      "ctr": 1.5,
+      "position": 4.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/seedance-1-5-pro-vs-seedance-2-0"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-1-5-pro-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "seedance-1-5-pro-vs-seedance-2-0-fast",
+      "clicks": 3,
+      "impressions": 209,
+      "ctr": 1.4,
+      "position": 7.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/seedance-1-5-pro-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-1-5-pro-vs-sora-2",
+      "locale": "es",
+      "slug": "seedance-1-5-pro-vs-sora-2",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-1-5-pro-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "seedance-1-5-pro-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-1-5-pro-vs-veo-3-1",
+      "locale": "es",
+      "slug": "seedance-1-5-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/seedance-1-5-pro-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-1-5-pro-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "seedance-1-5-pro-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-1-5-pro-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "seedance-1-5-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 21,
+      "ctr": 0,
+      "position": 4.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/seedance-1-5-pro-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-1-5-pro-vs-wan-2-5",
+      "locale": "es",
+      "slug": "seedance-1-5-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 6.1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/seedance-1-5-pro-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-1-5-pro-vs-wan-2-6",
+      "locale": "es",
+      "slug": "seedance-1-5-pro-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-fast-vs-sora-2",
+      "locale": "es",
+      "slug": "seedance-2-0-fast-vs-sora-2",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/seedance-2-0-fast-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-fast-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "seedance-2-0-fast-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 33,
+      "ctr": 0,
+      "position": 9.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/seedance-2-0-fast-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-fast-vs-veo-3-1",
+      "locale": "es",
+      "slug": "seedance-2-0-fast-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 53,
+      "ctr": 0,
+      "position": 7.6,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/seedance-2-0-fast-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-fast-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "seedance-2-0-fast-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 7.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/seedance-2-0-fast-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-fast-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "seedance-2-0-fast-vs-veo-3-1-lite",
+      "clicks": 2,
+      "impressions": 85,
+      "ctr": 2.4,
+      "position": 8.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/seedance-2-0-fast-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-fast-vs-wan-2-5",
+      "locale": "es",
+      "slug": "seedance-2-0-fast-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 7.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/seedance-2-0-fast-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-fast-vs-wan-2-6",
+      "locale": "es",
+      "slug": "seedance-2-0-fast-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 5.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/seedance-2-0-fast-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "seedance-2-0-vs-seedance-2-0-fast",
+      "clicks": 34,
+      "impressions": 973,
+      "ctr": 3.5,
+      "position": 5.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-seedance-2-0-fast"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "related_graph",
+        "showdown"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions",
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-sora-2",
+      "locale": "es",
+      "slug": "seedance-2-0-vs-sora-2",
+      "clicks": 0,
+      "impressions": 24,
+      "ctr": 0,
+      "position": 8.5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-sora-2"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "seedance-2-0-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 32,
+      "ctr": 0,
+      "position": 8.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-veo-3-1",
+      "locale": "es",
+      "slug": "seedance-2-0-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 28,
+      "ctr": 0,
+      "position": 6.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override",
+        "popular",
+        "related_graph",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "seedance-2-0-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 60,
+      "ctr": 0,
+      "position": 7.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "seedance-2-0-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 5.8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-wan-2-5",
+      "locale": "es",
+      "slug": "seedance-2-0-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 6.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-wan-2-6",
+      "locale": "es",
+      "slug": "seedance-2-0-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 14,
+      "ctr": 0,
+      "position": 5.4,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/sora-2-pro-vs-veo-3-1",
+      "locale": "es",
+      "slug": "sora-2-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/sora-2-pro-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "sora-2-pro-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/sora-2-pro-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "sora-2-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 10,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/sora-2-pro-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/sora-2-pro-vs-wan-2-5",
+      "locale": "es",
+      "slug": "sora-2-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/sora-2-pro-vs-wan-2-6",
+      "locale": "es",
+      "slug": "sora-2-pro-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/sora-2-pro-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/sora-2-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "sora-2-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 79,
+      "ctr": 0,
+      "position": 9.2,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/sora-2-vs-sora-2-pro"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/sora-2-vs-veo-3-1",
+      "locale": "es",
+      "slug": "sora-2-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 10,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/sora-2-vs-veo-3-1"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "related_graph",
+        "showdown",
+        "trophy"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/sora-2-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "sora-2-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/sora-2-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/sora-2-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "sora-2-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 11,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/sora-2-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "low_demand_outside_top_10"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/sora-2-vs-wan-2-5",
+      "locale": "es",
+      "slug": "sora-2-vs-wan-2-5",
+      "clicks": 1,
+      "impressions": 7,
+      "ctr": 14.3,
+      "position": 18.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/sora-2-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/sora-2-vs-wan-2-6",
+      "locale": "es",
+      "slug": "sora-2-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 6.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/sora-2-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "related_graph",
+        "showdown",
+        "trophy"
+      ],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review",
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/veo-3-1-fast-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "veo-3-1-fast-vs-veo-3-1-lite",
+      "clicks": 25,
+      "impressions": 1251,
+      "ctr": 2,
+      "position": 5,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/veo-3-1-fast-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "related_graph",
+        "showdown"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks",
+        "gsc_high_impressions",
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/veo-3-1-fast-vs-wan-2-5",
+      "locale": "es",
+      "slug": "veo-3-1-fast-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 8.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/veo-3-1-fast-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/veo-3-1-fast-vs-wan-2-6",
+      "locale": "es",
+      "slug": "veo-3-1-fast-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 3.7,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/veo-3-1-fast-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/veo-3-1-lite-vs-wan-2-5",
+      "locale": "es",
+      "slug": "veo-3-1-lite-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 6.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/veo-3-1-lite-vs-wan-2-5"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/veo-3-1-lite-vs-wan-2-6",
+      "locale": "es",
+      "slug": "veo-3-1-lite-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/veo-3-1-lite-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_top_10_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/veo-3-1-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "veo-3-1-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/veo-3-1-vs-veo-3-1-fast"
+      ],
+      "hasLocalizedOverride": true,
+      "strategicSignals": [
+        "best_for_related",
+        "opponent_override"
+      ],
+      "classification": "keep",
+      "rationale": [
+        "localized_editorial_override"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/veo-3-1-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "veo-3-1-vs-veo-3-1-lite",
+      "clicks": 2,
+      "impressions": 206,
+      "ctr": 1,
+      "position": 6.9,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/veo-3-1-vs-veo-3-1-lite"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "keep",
+      "rationale": [
+        "gsc_clicks"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/veo-3-1-vs-wan-2-5",
+      "locale": "es",
+      "slug": "veo-3-1-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "noindex_candidate",
+      "rationale": [
+        "no_gsc_row_or_editorial_signal"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/veo-3-1-vs-wan-2-6",
+      "locale": "es",
+      "slug": "veo-3-1-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0,
+      "position": 0,
+      "hasGscRow": false,
+      "gscSourceUrls": [],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [
+        "opponent_override",
+        "related_graph",
+        "showdown",
+        "trophy",
+        "use_case_bucket"
+      ],
+      "classification": "review",
+      "rationale": [
+        "strategic_localization_review"
+      ]
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/wan-2-5-vs-wan-2-6",
+      "locale": "es",
+      "slug": "wan-2-5-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 42,
+      "ctr": 0,
+      "position": 8.3,
+      "hasGscRow": true,
+      "gscSourceUrls": [
+        "https://maxvideoai.com/es/comparativa/wan-2-5-vs-wan-2-6"
+      ],
+      "hasLocalizedOverride": false,
+      "strategicSignals": [],
+      "classification": "review",
+      "rationale": [
+        "gsc_review_opportunity"
+      ]
+    }
+  ],
+  "legacyGscRows": [
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-first-last-vs-wan-2-5",
+      "locale": "en",
+      "slug": "veo-3-1-first-last-vs-wan-2-5",
+      "clicks": 1,
+      "impressions": 39,
+      "ctr": 2.6,
+      "position": 10.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "sora-2-vs-veo-3-1-first-last",
+      "clicks": 1,
+      "impressions": 10,
+      "ctr": 10,
+      "position": 5.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 150,
+      "ctr": 0,
+      "position": 6.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-0-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "happy-horse-1-0-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 147,
+      "ctr": 0,
+      "position": 7.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "seedance-2-0-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 68,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 51,
+      "ctr": 0,
+      "position": 8.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 45,
+      "ctr": 0,
+      "position": 7.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 37,
+      "ctr": 0,
+      "position": 7.1
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "seedance-1-5-pro-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 19,
+      "ctr": 0,
+      "position": 12.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "veo-3-1-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 6.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 15,
+      "ctr": 0,
+      "position": 7.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 14,
+      "ctr": 0,
+      "position": 15.1
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-fast-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "veo-3-1-fast-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 15.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "ltx-2-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 7.9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-0-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "happy-horse-1-0-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 3.9
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/veo-3-1-first-last-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "veo-3-1-first-last-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 9.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/veo-3-1-vs-veo-3-1-first-last",
+      "locale": "es",
+      "slug": "veo-3-1-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-veo-3-1-first-last",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-veo-3-1-first-last",
+      "locale": "es",
+      "slug": "ltx-2-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-veo-3-1-first-last",
+      "locale": "es",
+      "slug": "seedance-2-0-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/veo-3-1-fast-vs-veo-3-1-first-last",
+      "locale": "es",
+      "slug": "veo-3-1-fast-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 11
+    }
+  ]
+}

--- a/docs/seo/comparison-indexation-matrix-2026-07-08.md
+++ b/docs/seo/comparison-indexation-matrix-2026-07-08.md
@@ -1,0 +1,223 @@
+# Matrice d'indexation des comparatifs — GSC au 2026-07-08
+
+Source : Google Search Console, propriété `sc-domain:maxvideoai.com`, recherche Web, période du 2026-04-09 au 2026-07-08.
+
+> Aucun noindex n'est applique automatiquement par cette matrice. `noindex_candidate` signifie uniquement qu'une URL doit être validée manuellement avant consolidation, retrait du sitemap ou ajout éventuel d'une directive.
+
+## Résumé
+
+| Mesure | Total |
+| --- | ---: |
+| Slugs publiés | 292 |
+| URLs localisées auditées | 876 |
+| URLs présentes dans l'export GSC | 639 |
+| URLs sans ligne GSC dans les 996 premières pages | 237 |
+| URLs avec au moins un clic | 144 |
+| Lignes GSC hors du périmètre publié | 21 |
+| Lignes hors périmètre avec clics | 2 |
+| Keep | 220 |
+| Enrich | 49 |
+| Review | 380 |
+| Noindex candidate | 227 |
+
+## Règles conservatrices
+
+- **Keep** : au moins 1 clic, au moins 500 impressions, override éditorial localisé, ou page anglaise présente sur une surface stratégique.
+- **Enrich** : 100 à 499 impressions sans signal prioritaire ; améliorer le contenu et le CTR avant toute consolidation.
+- **Review** : 30 à 99 impressions, position moyenne dans le top 10 avec une demande observée, ou version FR/ES d'un comparatif stratégique sans preuve locale suffisante.
+- **Noindex candidate** : moins de 30 impressions, hors top 10 ou absente de l'export GSC, aucun clic, aucun override localisé et aucun signal stratégique. Validation manuelle obligatoire.
+
+## Pages à conserver en priorité
+
+| Locale | Comparatif | Clics | Impressions | Position | Signaux |
+| --- | --- | ---: | ---: | ---: | --- |
+| en | [seedance-2-0-vs-seedance-2-0-fast](https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-seedance-2-0-fast) | 218 | 33636 | 6.2 | override localise, related_graph, showdown, gsc_clicks, gsc_high_impressions, localized_editorial_override, english_strategic_surface |
+| en | [seedance-1-5-pro-vs-seedance-2-0](https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-seedance-2-0) | 74 | 13976 | 5.8 | override localise, gsc_clicks, gsc_high_impressions, localized_editorial_override |
+| en | [ltx-2-3-fast-vs-seedance-2-0](https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-seedance-2-0) | 47 | 5218 | 5.9 | gsc_clicks, gsc_high_impressions |
+| es | [seedance-2-0-vs-seedance-2-0-fast](https://maxvideoai.com/es/comparativa/seedance-2-0-vs-seedance-2-0-fast) | 34 | 973 | 5.4 | override localise, related_graph, showdown, gsc_clicks, gsc_high_impressions, localized_editorial_override |
+| en | [ltx-2-3-fast-vs-ltx-2-fast](https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-ltx-2-fast) | 30 | 12049 | 9.9 | opponent_override, gsc_clicks, gsc_high_impressions, english_strategic_surface |
+| en | [veo-3-1-fast-vs-veo-3-1-lite](https://maxvideoai.com/ai-video-engines/veo-3-1-fast-vs-veo-3-1-lite) | 28 | 13396 | 7.6 | override localise, related_graph, showdown, gsc_clicks, gsc_high_impressions, localized_editorial_override, english_strategic_surface |
+| en | [kling-3-pro-vs-kling-3-standard](https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-kling-3-standard) | 27 | 3851 | 7.2 | override localise, best_for_related, related_graph, gsc_clicks, gsc_high_impressions, localized_editorial_override, english_strategic_surface |
+| es | [veo-3-1-fast-vs-veo-3-1-lite](https://maxvideoai.com/es/comparativa/veo-3-1-fast-vs-veo-3-1-lite) | 25 | 1251 | 5 | override localise, related_graph, showdown, gsc_clicks, gsc_high_impressions, localized_editorial_override |
+| en | [ltx-2-vs-ltx-2-3-fast](https://maxvideoai.com/ai-video-engines/ltx-2-vs-ltx-2-3-fast) | 19 | 6588 | 10.5 | gsc_clicks, gsc_high_impressions |
+| en | [ltx-2-3-fast-vs-veo-3-1](https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-veo-3-1) | 19 | 1472 | 10.8 | gsc_clicks, gsc_high_impressions |
+| en | [seedance-2-0-vs-wan-2-5](https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-wan-2-5) | 15 | 4140 | 8.4 | gsc_clicks, gsc_high_impressions |
+| en | [ltx-2-vs-seedance-2-0](https://maxvideoai.com/ai-video-engines/ltx-2-vs-seedance-2-0) | 14 | 1861 | 7 | gsc_clicks, gsc_high_impressions |
+| fr | [veo-3-1-fast-vs-veo-3-1-lite](https://maxvideoai.com/fr/comparatif/veo-3-1-fast-vs-veo-3-1-lite) | 13 | 155 | 4.7 | override localise, related_graph, showdown, gsc_clicks, localized_editorial_override |
+| en | [ltx-2-3-fast-vs-ltx-2-3-pro](https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-ltx-2-3-pro) | 11 | 2766 | 12.4 | opponent_override, popular, related_graph, showdown, trophy, use_case_bucket, gsc_clicks, gsc_high_impressions, english_strategic_surface |
+| en | [ltx-2-vs-wan-2-6](https://maxvideoai.com/ai-video-engines/ltx-2-vs-wan-2-6) | 9 | 5846 | 10.7 | use_case_bucket, gsc_clicks, gsc_high_impressions, english_strategic_surface |
+| en | [kling-2-5-turbo-vs-kling-3-standard](https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-kling-3-standard) | 9 | 2195 | 7.6 | gsc_clicks, gsc_high_impressions |
+| en | [ltx-2-3-fast-vs-seedance-2-0-fast](https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-seedance-2-0-fast) | 9 | 1369 | 8.7 | best_for_related, opponent_override, use_case_bucket, gsc_clicks, gsc_high_impressions, english_strategic_surface |
+| en | [luma-ray-2-vs-seedance-2-0](https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-seedance-2-0) | 9 | 723 | 6.3 | gsc_clicks, gsc_high_impressions |
+| en | [happy-horse-1-1-vs-seedance-2-0](https://maxvideoai.com/ai-video-engines/happy-horse-1-1-vs-seedance-2-0) | 9 | 281 | 10.3 | best_for_related, opponent_override, popular, related_graph, use_case_bucket, gsc_clicks, english_strategic_surface |
+| en | [seedance-1-5-pro-vs-seedance-2-0-fast](https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-seedance-2-0-fast) | 8 | 2385 | 8.8 | gsc_clicks, gsc_high_impressions |
+| en | [ltx-2-3-pro-vs-ltx-2-fast](https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-ltx-2-fast) | 7 | 5044 | 11.3 | gsc_clicks, gsc_high_impressions |
+| en | [ltx-2-fast-vs-seedance-2-0](https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-seedance-2-0) | 7 | 2357 | 6.5 | gsc_clicks, gsc_high_impressions |
+| en | [veo-3-1-vs-veo-3-1-lite](https://maxvideoai.com/ai-video-engines/veo-3-1-vs-veo-3-1-lite) | 6 | 3014 | 9.7 | gsc_clicks, gsc_high_impressions |
+| en | [ltx-2-3-fast-vs-wan-2-5](https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-wan-2-5) | 6 | 2814 | 10.6 | gsc_clicks, gsc_high_impressions |
+| fr | [seedance-2-0-vs-seedance-2-0-fast](https://maxvideoai.com/fr/comparatif/seedance-2-0-vs-seedance-2-0-fast) | 6 | 243 | 5.9 | override localise, related_graph, showdown, gsc_clicks, localized_editorial_override |
+| en | [ltx-2-vs-ltx-2-3-pro](https://maxvideoai.com/ai-video-engines/ltx-2-vs-ltx-2-3-pro) | 5 | 3319 | 10.7 | gsc_clicks, gsc_high_impressions |
+| en | [kling-3-pro-vs-wan-2-6](https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-wan-2-6) | 5 | 1361 | 10.4 | gsc_clicks, gsc_high_impressions |
+| en | [minimax-hailuo-02-text-vs-seedance-2-0](https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-seedance-2-0) | 4 | 3713 | 7.9 | gsc_clicks, gsc_high_impressions |
+| en | [sora-2-vs-sora-2-pro](https://maxvideoai.com/ai-video-engines/sora-2-vs-sora-2-pro) | 4 | 2462 | 14.8 | opponent_override, gsc_clicks, gsc_high_impressions, english_strategic_surface |
+| en | [kling-2-5-turbo-vs-kling-3-pro](https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-kling-3-pro) | 4 | 1445 | 11.1 | gsc_clicks, gsc_high_impressions |
+
+## Pages à enrichir
+
+| Locale | Comparatif | Clics | Impressions | Position | Signaux |
+| --- | --- | ---: | ---: | ---: | --- |
+| en | [pika-text-to-video-vs-wan-2-6](https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-wan-2-6) | 0 | 476 | 10.8 | gsc_enrichment_opportunity |
+| en | [kling-2-6-pro-vs-kling-3-pro](https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-kling-3-pro) | 0 | 376 | 11.7 | gsc_enrichment_opportunity |
+| en | [ltx-2-3-fast-vs-luma-ray-2](https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-luma-ray-2) | 0 | 290 | 8.2 | gsc_enrichment_opportunity |
+| en | [kling-2-6-pro-vs-minimax-hailuo-02-text](https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-minimax-hailuo-02-text) | 0 | 270 | 14.5 | gsc_enrichment_opportunity |
+| en | [kling-3-standard-vs-kling-o3-standard](https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-kling-o3-standard) | 0 | 250 | 13.9 | gsc_enrichment_opportunity |
+| en | [seedance-2-0-fast-vs-veo-3-1](https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-veo-3-1) | 0 | 242 | 10.1 | gsc_enrichment_opportunity |
+| en | [ltx-2-fast-vs-minimax-hailuo-02-text](https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-minimax-hailuo-02-text) | 0 | 219 | 12.9 | gsc_enrichment_opportunity |
+| en | [minimax-hailuo-02-text-vs-veo-3-1-fast](https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-veo-3-1-fast) | 0 | 209 | 9.8 | gsc_enrichment_opportunity |
+| en | [kling-3-4k-vs-seedance-2-0](https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-seedance-2-0) | 0 | 203 | 7.9 | gsc_enrichment_opportunity |
+| en | [minimax-hailuo-02-text-vs-wan-2-6](https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-wan-2-6) | 0 | 196 | 11 | gsc_enrichment_opportunity |
+| en | [ltx-2-3-fast-vs-sora-2-pro](https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-sora-2-pro) | 0 | 193 | 8.5 | gsc_enrichment_opportunity |
+| en | [veo-3-1-vs-wan-2-5](https://maxvideoai.com/ai-video-engines/veo-3-1-vs-wan-2-5) | 0 | 192 | 7.9 | gsc_enrichment_opportunity |
+| es | [kling-3-standard-vs-seedance-1-5-pro](https://maxvideoai.com/es/comparativa/kling-3-standard-vs-seedance-1-5-pro) | 0 | 192 | 8.8 | gsc_enrichment_opportunity |
+| en | [kling-2-6-pro-vs-wan-2-5](https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-wan-2-5) | 0 | 187 | 9.9 | gsc_enrichment_opportunity |
+| en | [veo-3-1-fast-vs-wan-2-5](https://maxvideoai.com/ai-video-engines/veo-3-1-fast-vs-wan-2-5) | 0 | 185 | 13.5 | gsc_enrichment_opportunity |
+| en | [luma-ray-2-vs-luma-ray-2-flash](https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-luma-ray-2-flash) | 0 | 183 | 9.4 | gsc_enrichment_opportunity |
+| en | [kling-3-4k-vs-kling-3-standard](https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-kling-3-standard) | 0 | 178 | 11.2 | gsc_enrichment_opportunity |
+| en | [kling-2-5-turbo-vs-veo-3-1](https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-veo-3-1) | 0 | 175 | 7.5 | gsc_enrichment_opportunity |
+| en | [seedance-2-0-vs-veo-3-1-fast](https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-veo-3-1-fast) | 0 | 174 | 10.1 | gsc_enrichment_opportunity |
+| en | [luma-ray-2-vs-seedance-2-0-fast](https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-seedance-2-0-fast) | 0 | 159 | 6 | gsc_enrichment_opportunity |
+| en | [kling-2-5-turbo-vs-wan-2-6](https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-wan-2-6) | 0 | 155 | 12.3 | gsc_enrichment_opportunity |
+| en | [ltx-2-fast-vs-luma-ray-2](https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-luma-ray-2) | 0 | 153 | 8.9 | gsc_enrichment_opportunity |
+| en | [kling-2-5-turbo-vs-kling-3-4k](https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-kling-3-4k) | 0 | 145 | 7 | gsc_enrichment_opportunity |
+| en | [pika-text-to-video-vs-seedance-1-5-pro](https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-seedance-1-5-pro) | 0 | 145 | 10.3 | gsc_enrichment_opportunity |
+| en | [kling-2-6-pro-vs-kling-3-4k](https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-kling-3-4k) | 0 | 144 | 11.3 | gsc_enrichment_opportunity |
+| es | [ltx-2-3-fast-vs-wan-2-6](https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-wan-2-6) | 0 | 140 | 7.3 | opponent_override, use_case_bucket, gsc_enrichment_opportunity |
+| en | [kling-2-5-turbo-vs-veo-3-1-fast](https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-veo-3-1-fast) | 0 | 139 | 8.2 | gsc_enrichment_opportunity |
+| en | [kling-2-5-turbo-vs-ltx-2-3-pro](https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-ltx-2-3-pro) | 0 | 135 | 8.4 | gsc_enrichment_opportunity |
+| en | [kling-2-6-pro-vs-luma-ray-2-flash](https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-luma-ray-2-flash) | 0 | 133 | 8.8 | gsc_enrichment_opportunity |
+| en | [kling-3-4k-vs-seedance-2-0-fast](https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-seedance-2-0-fast) | 0 | 132 | 11.2 | gsc_enrichment_opportunity |
+
+## Pages à revoir
+
+| Locale | Comparatif | Clics | Impressions | Position | Signaux |
+| --- | --- | ---: | ---: | ---: | --- |
+| en | [ltx-2-3-pro-vs-veo-3-1-lite](https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-veo-3-1-lite) | 0 | 91 | 6.6 | gsc_review_opportunity |
+| fr | [ltx-2-vs-wan-2-6](https://maxvideoai.com/fr/comparatif/ltx-2-vs-wan-2-6) | 0 | 90 | 8 | use_case_bucket, gsc_review_opportunity, strategic_localization_review |
+| en | [luma-ray-2-vs-minimax-hailuo-02-text](https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-minimax-hailuo-02-text) | 0 | 86 | 11.5 | gsc_review_opportunity |
+| es | [ltx-2-vs-ltx-2-fast](https://maxvideoai.com/es/comparativa/ltx-2-vs-ltx-2-fast) | 0 | 86 | 10 | gsc_review_opportunity |
+| en | [kling-3-standard-vs-kling-o3-4k](https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-kling-o3-4k) | 0 | 84 | 9.1 | gsc_review_opportunity |
+| en | [kling-3-standard-vs-veo-3-1](https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-veo-3-1) | 0 | 84 | 16.7 | gsc_review_opportunity |
+| en | [kling-o3-4k-vs-veo-3-1](https://maxvideoai.com/ai-video-engines/kling-o3-4k-vs-veo-3-1) | 0 | 84 | 9.1 | gsc_review_opportunity |
+| en | [kling-o3-standard-vs-veo-3-1](https://maxvideoai.com/ai-video-engines/kling-o3-standard-vs-veo-3-1) | 0 | 81 | 10.7 | gsc_review_opportunity |
+| es | [sora-2-vs-sora-2-pro](https://maxvideoai.com/es/comparativa/sora-2-vs-sora-2-pro) | 0 | 79 | 9.2 | opponent_override, gsc_review_opportunity, strategic_localization_review |
+| en | [kling-3-pro-vs-kling-o3-standard](https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-kling-o3-standard) | 0 | 78 | 16.3 | gsc_review_opportunity |
+| en | [ltx-2-fast-vs-veo-3-1-lite](https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-veo-3-1-lite) | 0 | 74 | 7.6 | gsc_review_opportunity |
+| en | [ltx-2-3-pro-vs-sora-2-pro](https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-sora-2-pro) | 0 | 73 | 10.6 | gsc_review_opportunity |
+| en | [minimax-hailuo-02-text-vs-sora-2-pro](https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-sora-2-pro) | 0 | 73 | 6.8 | gsc_review_opportunity |
+| en | [kling-2-6-pro-vs-luma-ray-2](https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-luma-ray-2) | 0 | 72 | 10.4 | gsc_review_opportunity |
+| en | [luma-ray-2-vs-sora-2](https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-sora-2) | 0 | 71 | 6.6 | gsc_review_opportunity |
+| es | [ltx-2-vs-ltx-2-3-pro](https://maxvideoai.com/es/comparativa/ltx-2-vs-ltx-2-3-pro) | 0 | 71 | 14.4 | gsc_review_opportunity |
+| en | [kling-2-5-turbo-vs-wan-2-5](https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-wan-2-5) | 0 | 69 | 8.1 | gsc_review_opportunity |
+| en | [kling-o3-pro-vs-seedance-2-0](https://maxvideoai.com/ai-video-engines/kling-o3-pro-vs-seedance-2-0) | 0 | 67 | 9.2 | gsc_review_opportunity |
+| en | [pika-text-to-video-vs-sora-2-pro](https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-sora-2-pro) | 0 | 65 | 7.2 | gsc_review_opportunity |
+| en | [kling-2-6-pro-vs-seedance-2-0-fast](https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-seedance-2-0-fast) | 0 | 64 | 9.5 | gsc_review_opportunity |
+| en | [kling-3-pro-vs-kling-o3-pro](https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-kling-o3-pro) | 0 | 64 | 8 | gsc_review_opportunity |
+| en | [ltx-2-vs-pika-text-to-video](https://maxvideoai.com/ai-video-engines/ltx-2-vs-pika-text-to-video) | 0 | 61 | 7.6 | gsc_review_opportunity |
+| en | [luma-ray-2-flash-vs-wan-2-6](https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-wan-2-6) | 0 | 60 | 12.1 | gsc_review_opportunity |
+| es | [seedance-2-0-vs-veo-3-1-fast](https://maxvideoai.com/es/comparativa/seedance-2-0-vs-veo-3-1-fast) | 0 | 60 | 7.2 | gsc_review_opportunity |
+| en | [kling-3-pro-vs-seedance-2-0-fast](https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-seedance-2-0-fast) | 0 | 58 | 8.3 | gsc_review_opportunity |
+| en | [seedance-1-5-pro-vs-sora-2](https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-sora-2) | 0 | 58 | 11 | gsc_review_opportunity |
+| es | [ltx-2-fast-vs-veo-3-1-lite](https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-veo-3-1-lite) | 0 | 58 | 6.6 | gsc_review_opportunity |
+| en | [kling-3-standard-vs-ltx-2-fast](https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-ltx-2-fast) | 0 | 57 | 13.6 | gsc_review_opportunity |
+| en | [kling-3-4k-vs-luma-ray-2](https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-luma-ray-2) | 0 | 56 | 7.5 | gsc_review_opportunity |
+| en | [kling-3-pro-vs-luma-ray-2-flash](https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-luma-ray-2-flash) | 0 | 56 | 10.7 | gsc_review_opportunity |
+
+## Premier lot de candidates à valider manuellement
+
+Ce lot commence par les URLs absentes de l'export GSC, puis par celles avec le moins d'impressions. Il ne constitue pas une instruction de mise en noindex.
+
+| Locale | Comparatif | Clics | Impressions | Position | Signaux |
+| --- | --- | ---: | ---: | ---: | --- |
+| en | [kling-2-5-turbo-vs-ltx-2](https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-ltx-2) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| en | [kling-2-5-turbo-vs-ltx-2-3-fast](https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-ltx-2-3-fast) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| en | [kling-2-5-turbo-vs-ltx-2-fast](https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-ltx-2-fast) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| en | [kling-2-6-pro-vs-ltx-2-3-pro](https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-ltx-2-3-pro) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| en | [kling-2-6-pro-vs-ltx-2-fast](https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-ltx-2-fast) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| en | [kling-2-6-pro-vs-veo-3-1-fast](https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-veo-3-1-fast) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| en | [kling-3-pro-vs-ltx-2-3-fast](https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-ltx-2-3-fast) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| en | [ltx-2-3-fast-vs-minimax-hailuo-02-text](https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-minimax-hailuo-02-text) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| en | [ltx-2-3-fast-vs-seedance-1-5-pro](https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-seedance-1-5-pro) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| en | [ltx-2-3-pro-vs-minimax-hailuo-02-text](https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-minimax-hailuo-02-text) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| en | [ltx-2-3-pro-vs-pika-text-to-video](https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-pika-text-to-video) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| en | [ltx-2-3-pro-vs-seedance-1-5-pro](https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-seedance-1-5-pro) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| en | [ltx-2-3-pro-vs-sora-2](https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-sora-2) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| en | [ltx-2-3-pro-vs-veo-3-1-fast](https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-veo-3-1-fast) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| en | [ltx-2-3-pro-vs-wan-2-5](https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-wan-2-5) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| en | [ltx-2-3-pro-vs-wan-2-6](https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-wan-2-6) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| en | [minimax-hailuo-02-text-vs-seedance-1-5-pro](https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-seedance-1-5-pro) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| en | [seedance-1-5-pro-vs-veo-3-1-fast](https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-veo-3-1-fast) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [kling-2-5-turbo-vs-kling-2-6-pro](https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-kling-2-6-pro) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [kling-2-5-turbo-vs-ltx-2-3-pro](https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-ltx-2-3-pro) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [kling-2-5-turbo-vs-ltx-2-fast](https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-ltx-2-fast) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [kling-2-5-turbo-vs-pika-text-to-video](https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-pika-text-to-video) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [kling-2-5-turbo-vs-seedance-2-0](https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-seedance-2-0) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [kling-2-5-turbo-vs-sora-2-pro](https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-sora-2-pro) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [kling-2-5-turbo-vs-veo-3-1](https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-veo-3-1) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [kling-2-5-turbo-vs-wan-2-5](https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-wan-2-5) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [kling-2-6-pro-vs-ltx-2-3-fast](https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-ltx-2-3-fast) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [kling-2-6-pro-vs-ltx-2-fast](https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-ltx-2-fast) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [kling-2-6-pro-vs-luma-ray-2](https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-luma-ray-2) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [kling-2-6-pro-vs-luma-ray-2-flash](https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-luma-ray-2-flash) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [kling-2-6-pro-vs-minimax-hailuo-02-text](https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-minimax-hailuo-02-text) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [kling-2-6-pro-vs-sora-2-pro](https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-sora-2-pro) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [kling-3-4k-vs-ltx-2-3-fast](https://maxvideoai.com/es/comparativa/kling-3-4k-vs-ltx-2-3-fast) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [kling-3-4k-vs-luma-ray-2-flash](https://maxvideoai.com/es/comparativa/kling-3-4k-vs-luma-ray-2-flash) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [kling-3-pro-vs-ltx-2-3-pro](https://maxvideoai.com/es/comparativa/kling-3-pro-vs-ltx-2-3-pro) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [kling-3-pro-vs-luma-ray-2](https://maxvideoai.com/es/comparativa/kling-3-pro-vs-luma-ray-2) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [ltx-2-3-pro-vs-luma-ray-2](https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-luma-ray-2) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [ltx-2-3-pro-vs-pika-text-to-video](https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-pika-text-to-video) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [ltx-2-3-pro-vs-sora-2-pro](https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-sora-2-pro) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [ltx-2-3-pro-vs-veo-3-1-fast](https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-veo-3-1-fast) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [ltx-2-3-pro-vs-veo-3-1-lite](https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-veo-3-1-lite) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [ltx-2-fast-vs-luma-ray-2](https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-luma-ray-2) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [ltx-2-fast-vs-luma-ray-2-flash](https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-luma-ray-2-flash) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [ltx-2-fast-vs-pika-text-to-video](https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-pika-text-to-video) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [ltx-2-fast-vs-seedance-1-5-pro](https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-seedance-1-5-pro) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [ltx-2-fast-vs-sora-2-pro](https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-sora-2-pro) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [ltx-2-vs-pika-text-to-video](https://maxvideoai.com/es/comparativa/ltx-2-vs-pika-text-to-video) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [luma-ray-2-flash-vs-minimax-hailuo-02-text](https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-minimax-hailuo-02-text) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [luma-ray-2-flash-vs-pika-text-to-video](https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-pika-text-to-video) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+| es | [luma-ray-2-flash-vs-seedance-1-5-pro](https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-seedance-1-5-pro) | 0 | 0 | — | no_gsc_row_or_editorial_signal |
+
+## URLs GSC hors du périmètre publié
+
+Ces anciennes URLs ou variantes ne font pas partie des 292 slugs actuellement publiés. Celles qui ont des clics doivent être vérifiées en priorité pour décider entre republication, redirection 301 pertinente ou maintien temporaire.
+
+- 19 anciennes variantes Veo `first-last` sont déjà normalisées par une redirection permanente vers les comparatifs Veo 3.1 canoniques.
+- Les 2 URLs localisées Happy Horse 1.0 vs Sora 2 Pro passent désormais par une redirection permanente vers le comparatif publié Happy Horse 1.1 vs Sora 2 Pro dans cette branche.
+
+| Locale | URL GSC | Clics | Impressions | Position |
+| --- | --- | ---: | ---: | ---: |
+| en | [veo-3-1-first-last-vs-wan-2-5](https://maxvideoai.com/ai-video-engines/veo-3-1-first-last-vs-wan-2-5) | 1 | 39 | 10.8 |
+| en | [sora-2-vs-veo-3-1-first-last](https://maxvideoai.com/ai-video-engines/sora-2-vs-veo-3-1-first-last) | 1 | 10 | 5.7 |
+| en | [ltx-2-3-fast-vs-veo-3-1-first-last](https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-veo-3-1-first-last) | 0 | 150 | 6.8 |
+| en | [happy-horse-1-0-vs-sora-2-pro](https://maxvideoai.com/ai-video-engines/happy-horse-1-0-vs-sora-2-pro) | 0 | 147 | 7.3 |
+| en | [seedance-2-0-vs-veo-3-1-first-last](https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-veo-3-1-first-last) | 0 | 68 | 8 |
+| en | [ltx-2-fast-vs-veo-3-1-first-last](https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-veo-3-1-first-last) | 0 | 51 | 8.6 |
+| en | [minimax-hailuo-02-text-vs-veo-3-1-first-last](https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-veo-3-1-first-last) | 0 | 45 | 7.3 |
+| en | [pika-text-to-video-vs-veo-3-1-first-last](https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-veo-3-1-first-last) | 0 | 37 | 7.1 |
+| en | [seedance-1-5-pro-vs-veo-3-1-first-last](https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-veo-3-1-first-last) | 0 | 19 | 12.2 |
+| en | [veo-3-1-vs-veo-3-1-first-last](https://maxvideoai.com/ai-video-engines/veo-3-1-vs-veo-3-1-first-last) | 0 | 17 | 6.5 |
+| en | [kling-2-6-pro-vs-veo-3-1-first-last](https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-veo-3-1-first-last) | 0 | 15 | 7.8 |
+| en | [kling-2-5-turbo-vs-veo-3-1-first-last](https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-veo-3-1-first-last) | 0 | 14 | 15.1 |
+| en | [veo-3-1-fast-vs-veo-3-1-first-last](https://maxvideoai.com/ai-video-engines/veo-3-1-fast-vs-veo-3-1-first-last) | 0 | 12 | 15.4 |
+| en | [ltx-2-vs-veo-3-1-first-last](https://maxvideoai.com/ai-video-engines/ltx-2-vs-veo-3-1-first-last) | 0 | 10 | 7.9 |
+| es | [happy-horse-1-0-vs-sora-2-pro](https://maxvideoai.com/es/comparativa/happy-horse-1-0-vs-sora-2-pro) | 0 | 9 | 3.9 |
+| fr | [veo-3-1-first-last-vs-wan-2-5](https://maxvideoai.com/fr/comparatif/veo-3-1-first-last-vs-wan-2-5) | 0 | 3 | 9.3 |
+| es | [veo-3-1-vs-veo-3-1-first-last](https://maxvideoai.com/es/comparativa/veo-3-1-vs-veo-3-1-first-last) | 0 | 2 | 9 |
+| fr | [ltx-2-fast-vs-veo-3-1-first-last](https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-veo-3-1-first-last) | 0 | 2 | 8 |
+| es | [ltx-2-vs-veo-3-1-first-last](https://maxvideoai.com/es/comparativa/ltx-2-vs-veo-3-1-first-last) | 0 | 1 | 8 |
+| es | [seedance-2-0-vs-veo-3-1-first-last](https://maxvideoai.com/es/comparativa/seedance-2-0-vs-veo-3-1-first-last) | 0 | 1 | 9 |
+| es | [veo-3-1-fast-vs-veo-3-1-first-last](https://maxvideoai.com/es/comparativa/veo-3-1-fast-vs-veo-3-1-first-last) | 0 | 1 | 11 |
+
+L'inventaire exhaustif des 876 URLs se trouve dans `docs/seo/comparison-indexation-matrix-2026-07-08.json`.

--- a/docs/seo/gsc-comparison-performance-2026-07-08.json
+++ b/docs/seo/gsc-comparison-performance-2026-07-08.json
@@ -1,0 +1,5963 @@
+{
+  "source": "Google Search Console Performance / Pages",
+  "property": "sc-domain:maxvideoai.com",
+  "searchType": "Web",
+  "range": {
+    "start": "2026-04-09",
+    "end": "2026-07-08"
+  },
+  "exportedAt": "2026-07-11",
+  "rawPageRows": 996,
+  "comparisonRows": 661,
+  "rows": [
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "seedance-2-0-vs-seedance-2-0-fast",
+      "clicks": 218,
+      "impressions": 33636,
+      "ctr": 0.6,
+      "position": 6.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "seedance-1-5-pro-vs-seedance-2-0",
+      "clicks": 74,
+      "impressions": 13976,
+      "ctr": 0.5,
+      "position": 5.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-seedance-2-0",
+      "clicks": 47,
+      "impressions": 5218,
+      "ctr": 0.9,
+      "position": 5.9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "seedance-2-0-vs-seedance-2-0-fast",
+      "clicks": 34,
+      "impressions": 973,
+      "ctr": 3.5,
+      "position": 5.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-ltx-2-fast",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-ltx-2-fast",
+      "clicks": 30,
+      "impressions": 12049,
+      "ctr": 0.2,
+      "position": 9.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-fast-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "veo-3-1-fast-vs-veo-3-1-lite",
+      "clicks": 28,
+      "impressions": 13396,
+      "ctr": 0.2,
+      "position": 7.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-kling-3-standard",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-kling-3-standard",
+      "clicks": 27,
+      "impressions": 3851,
+      "ctr": 0.7,
+      "position": 7.2
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/veo-3-1-fast-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "veo-3-1-fast-vs-veo-3-1-lite",
+      "clicks": 25,
+      "impressions": 1251,
+      "ctr": 2,
+      "position": 5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-ltx-2-3-fast",
+      "locale": "en",
+      "slug": "ltx-2-vs-ltx-2-3-fast",
+      "clicks": 19,
+      "impressions": 6588,
+      "ctr": 0.3,
+      "position": 10.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-veo-3-1",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-veo-3-1",
+      "clicks": 19,
+      "impressions": 1472,
+      "ctr": 1.3,
+      "position": 10.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-wan-2-5",
+      "locale": "en",
+      "slug": "seedance-2-0-vs-wan-2-5",
+      "clicks": 15,
+      "impressions": 4140,
+      "ctr": 0.4,
+      "position": 8.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "ltx-2-vs-seedance-2-0",
+      "clicks": 14,
+      "impressions": 1861,
+      "ctr": 0.8,
+      "position": 7
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/veo-3-1-fast-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "veo-3-1-fast-vs-veo-3-1-lite",
+      "clicks": 13,
+      "impressions": 155,
+      "ctr": 8.4,
+      "position": 4.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-ltx-2-3-pro",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-ltx-2-3-pro",
+      "clicks": 11,
+      "impressions": 2766,
+      "ctr": 0.4,
+      "position": 12.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-wan-2-6",
+      "locale": "en",
+      "slug": "ltx-2-vs-wan-2-6",
+      "clicks": 9,
+      "impressions": 5846,
+      "ctr": 0.2,
+      "position": 10.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-kling-3-standard",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-kling-3-standard",
+      "clicks": 9,
+      "impressions": 2195,
+      "ctr": 0.4,
+      "position": 7.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-seedance-2-0-fast",
+      "clicks": 9,
+      "impressions": 1369,
+      "ctr": 0.7,
+      "position": 8.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-seedance-2-0",
+      "clicks": 9,
+      "impressions": 723,
+      "ctr": 1.2,
+      "position": 6.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-1-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "happy-horse-1-1-vs-seedance-2-0",
+      "clicks": 9,
+      "impressions": 281,
+      "ctr": 3.2,
+      "position": 10.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "seedance-1-5-pro-vs-seedance-2-0-fast",
+      "clicks": 8,
+      "impressions": 2385,
+      "ctr": 0.3,
+      "position": 8.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-ltx-2-fast",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-ltx-2-fast",
+      "clicks": 7,
+      "impressions": 5044,
+      "ctr": 0.1,
+      "position": 11.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-seedance-2-0",
+      "clicks": 7,
+      "impressions": 2357,
+      "ctr": 0.3,
+      "position": 6.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "veo-3-1-vs-veo-3-1-lite",
+      "clicks": 6,
+      "impressions": 3014,
+      "ctr": 0.2,
+      "position": 9.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-wan-2-5",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-wan-2-5",
+      "clicks": 6,
+      "impressions": 2814,
+      "ctr": 0.2,
+      "position": 10.6
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "seedance-2-0-vs-seedance-2-0-fast",
+      "clicks": 6,
+      "impressions": 243,
+      "ctr": 2.5,
+      "position": 5.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-ltx-2-3-pro",
+      "locale": "en",
+      "slug": "ltx-2-vs-ltx-2-3-pro",
+      "clicks": 5,
+      "impressions": 3319,
+      "ctr": 0.2,
+      "position": 10.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-wan-2-6",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-wan-2-6",
+      "clicks": 5,
+      "impressions": 1361,
+      "ctr": 0.4,
+      "position": 10.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-seedance-2-0",
+      "clicks": 4,
+      "impressions": 3713,
+      "ctr": 0.1,
+      "position": 7.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "sora-2-vs-sora-2-pro",
+      "clicks": 4,
+      "impressions": 2462,
+      "ctr": 0.2,
+      "position": 14.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-kling-3-pro",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-kling-3-pro",
+      "clicks": 4,
+      "impressions": 1445,
+      "ctr": 0.3,
+      "position": 11.1
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-veo-3-1",
+      "locale": "en",
+      "slug": "ltx-2-vs-veo-3-1",
+      "clicks": 4,
+      "impressions": 1285,
+      "ctr": 0.3,
+      "position": 7.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-seedance-1-5-pro",
+      "clicks": 4,
+      "impressions": 1265,
+      "ctr": 0.3,
+      "position": 6.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-ltx-2-3-pro",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-ltx-2-3-pro",
+      "clicks": 4,
+      "impressions": 913,
+      "ctr": 0.4,
+      "position": 8.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/dreamina-seedance-2-0-mini-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "dreamina-seedance-2-0-mini-vs-seedance-2-0",
+      "clicks": 4,
+      "impressions": 720,
+      "ctr": 0.6,
+      "position": 7.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-pika-text-to-video",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-pika-text-to-video",
+      "clicks": 4,
+      "impressions": 710,
+      "ctr": 0.6,
+      "position": 11.1
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-kling-2-6-pro",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-kling-2-6-pro",
+      "clicks": 3,
+      "impressions": 2422,
+      "ctr": 0.1,
+      "position": 10.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "veo-3-1-vs-veo-3-1-fast",
+      "clicks": 3,
+      "impressions": 1639,
+      "ctr": 0.2,
+      "position": 12
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-wan-2-6",
+      "locale": "en",
+      "slug": "seedance-1-5-pro-vs-wan-2-6",
+      "clicks": 3,
+      "impressions": 1532,
+      "ctr": 0.2,
+      "position": 7.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-wan-2-6",
+      "locale": "en",
+      "slug": "seedance-2-0-vs-wan-2-6",
+      "clicks": 3,
+      "impressions": 1509,
+      "ctr": 0.2,
+      "position": 7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-seedance-2-0-fast",
+      "clicks": 3,
+      "impressions": 741,
+      "ctr": 0.4,
+      "position": 8.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-wan-2-5",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-wan-2-5",
+      "clicks": 3,
+      "impressions": 457,
+      "ctr": 0.7,
+      "position": 9.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "seedance-2-0-vs-veo-3-1-lite",
+      "clicks": 3,
+      "impressions": 321,
+      "ctr": 0.9,
+      "position": 8.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-1-5-pro-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "seedance-1-5-pro-vs-seedance-2-0-fast",
+      "clicks": 3,
+      "impressions": 209,
+      "ctr": 1.4,
+      "position": 7.9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-1-5-pro-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "seedance-1-5-pro-vs-seedance-2-0",
+      "clicks": 3,
+      "impressions": 200,
+      "ctr": 1.5,
+      "position": 4.9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-ltx-2-3-pro",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-ltx-2-3-pro",
+      "clicks": 3,
+      "impressions": 147,
+      "ctr": 2,
+      "position": 8.8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-seedance-2-0",
+      "clicks": 3,
+      "impressions": 66,
+      "ctr": 4.5,
+      "position": 5.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-3-2-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "luma-ray-3-2-vs-veo-3-1-fast",
+      "clicks": 3,
+      "impressions": 60,
+      "ctr": 5,
+      "position": 5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-minimax-hailuo-02-text",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-minimax-hailuo-02-text",
+      "clicks": 2,
+      "impressions": 2061,
+      "ctr": 0.1,
+      "position": 8.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-wan-2-5",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-wan-2-5",
+      "clicks": 2,
+      "impressions": 1309,
+      "ctr": 0.2,
+      "position": 8.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-ltx-2",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-ltx-2",
+      "clicks": 2,
+      "impressions": 1280,
+      "ctr": 0.2,
+      "position": 8.1
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-0-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "happy-horse-1-0-vs-seedance-2-0",
+      "clicks": 2,
+      "impressions": 540,
+      "ctr": 0.4,
+      "position": 14.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-sora-2",
+      "locale": "en",
+      "slug": "ltx-2-vs-sora-2",
+      "clicks": 2,
+      "impressions": 491,
+      "ctr": 0.4,
+      "position": 7.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-seedance-2-0-fast",
+      "clicks": 2,
+      "impressions": 488,
+      "ctr": 0.4,
+      "position": 10
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-veo-3-1-fast",
+      "clicks": 2,
+      "impressions": 469,
+      "ctr": 0.4,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-veo-3-1-lite",
+      "clicks": 2,
+      "impressions": 304,
+      "ctr": 0.7,
+      "position": 8.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-wan-2-5",
+      "locale": "en",
+      "slug": "ltx-2-vs-wan-2-5",
+      "clicks": 2,
+      "impressions": 276,
+      "ctr": 0.7,
+      "position": 14.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "seedance-2-0-fast-vs-veo-3-1-lite",
+      "clicks": 2,
+      "impressions": 262,
+      "ctr": 0.8,
+      "position": 10.1
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-seedance-2-0",
+      "clicks": 2,
+      "impressions": 240,
+      "ctr": 0.8,
+      "position": 7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-seedance-2-0",
+      "clicks": 2,
+      "impressions": 230,
+      "ctr": 0.9,
+      "position": 5.8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/veo-3-1-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "veo-3-1-vs-veo-3-1-lite",
+      "clicks": 2,
+      "impressions": 206,
+      "ctr": 1,
+      "position": 6.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-kling-o3-4k",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-kling-o3-4k",
+      "clicks": 2,
+      "impressions": 179,
+      "ctr": 1.1,
+      "position": 7.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-seedance-2-0",
+      "clicks": 2,
+      "impressions": 140,
+      "ctr": 1.4,
+      "position": 8.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-wan-2-6",
+      "locale": "es",
+      "slug": "ltx-2-vs-wan-2-6",
+      "clicks": 2,
+      "impressions": 103,
+      "ctr": 1.9,
+      "position": 11.1
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-fast-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "seedance-2-0-fast-vs-veo-3-1-lite",
+      "clicks": 2,
+      "impressions": 85,
+      "ctr": 2.4,
+      "position": 8.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/dreamina-seedance-2-0-mini-vs-ltx-2-3-fast",
+      "locale": "en",
+      "slug": "dreamina-seedance-2-0-mini-vs-ltx-2-3-fast",
+      "clicks": 2,
+      "impressions": 76,
+      "ctr": 2.6,
+      "position": 8.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-kling-3-standard",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-kling-3-standard",
+      "clicks": 2,
+      "impressions": 64,
+      "ctr": 3.1,
+      "position": 8.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-sora-2-pro",
+      "clicks": 2,
+      "impressions": 60,
+      "ctr": 3.3,
+      "position": 14.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-1-vs-kling-3-pro",
+      "locale": "en",
+      "slug": "happy-horse-1-1-vs-kling-3-pro",
+      "clicks": 2,
+      "impressions": 52,
+      "ctr": 3.8,
+      "position": 8.9
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-seedance-2-0-fast",
+      "clicks": 2,
+      "impressions": 34,
+      "ctr": 5.9,
+      "position": 7.4
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-kling-3-standard",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-kling-3-standard",
+      "clicks": 2,
+      "impressions": 27,
+      "ctr": 7.4,
+      "position": 6
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-wan-2-5",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-wan-2-5",
+      "clicks": 2,
+      "impressions": 15,
+      "ctr": 13.3,
+      "position": 16.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-wan-2-6",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-wan-2-6",
+      "clicks": 1,
+      "impressions": 2126,
+      "ctr": 0,
+      "position": 11.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-wan-2-5",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-wan-2-5",
+      "clicks": 1,
+      "impressions": 1872,
+      "ctr": 0.1,
+      "position": 10.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-veo-3-1",
+      "locale": "en",
+      "slug": "seedance-1-5-pro-vs-veo-3-1",
+      "clicks": 1,
+      "impressions": 1190,
+      "ctr": 0.1,
+      "position": 8.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-seedance-2-0-fast",
+      "clicks": 1,
+      "impressions": 1012,
+      "ctr": 0.1,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-wan-2-5",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-wan-2-5",
+      "clicks": 1,
+      "impressions": 737,
+      "ctr": 0.1,
+      "position": 8.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-seedance-1-5-pro",
+      "clicks": 1,
+      "impressions": 708,
+      "ctr": 0.1,
+      "position": 9.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-veo-3-1",
+      "locale": "en",
+      "slug": "seedance-2-0-vs-veo-3-1",
+      "clicks": 1,
+      "impressions": 699,
+      "ctr": 0.1,
+      "position": 8.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-ltx-2-3-fast",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-ltx-2-3-fast",
+      "clicks": 1,
+      "impressions": 644,
+      "ctr": 0.2,
+      "position": 5.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-seedance-2-0-fast",
+      "clicks": 1,
+      "impressions": 577,
+      "ctr": 0.2,
+      "position": 8.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-seedance-2-0",
+      "clicks": 1,
+      "impressions": 526,
+      "ctr": 0.2,
+      "position": 8.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-sora-2",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-sora-2",
+      "clicks": 1,
+      "impressions": 525,
+      "ctr": 0.2,
+      "position": 5.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-wan-2-5",
+      "locale": "en",
+      "slug": "seedance-1-5-pro-vs-wan-2-5",
+      "clicks": 1,
+      "impressions": 464,
+      "ctr": 0.2,
+      "position": 6.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-ltx-2",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-ltx-2",
+      "clicks": 1,
+      "impressions": 448,
+      "ctr": 0.2,
+      "position": 7.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "seedance-2-0-fast-vs-veo-3-1-fast",
+      "clicks": 1,
+      "impressions": 426,
+      "ctr": 0.2,
+      "position": 12.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-seedance-2-0",
+      "clicks": 1,
+      "impressions": 362,
+      "ctr": 0.3,
+      "position": 7.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-luma-ray-2-flash",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-luma-ray-2-flash",
+      "clicks": 1,
+      "impressions": 342,
+      "ctr": 0.3,
+      "position": 8.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-seedance-2-0-fast",
+      "clicks": 1,
+      "impressions": 307,
+      "ctr": 0.3,
+      "position": 7.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-seedance-1-5-pro",
+      "clicks": 1,
+      "impressions": 303,
+      "ctr": 0.3,
+      "position": 6.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-0-vs-kling-3-pro",
+      "locale": "en",
+      "slug": "happy-horse-1-0-vs-kling-3-pro",
+      "clicks": 1,
+      "impressions": 287,
+      "ctr": 0.3,
+      "position": 9.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-luma-ray-2",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-luma-ray-2",
+      "clicks": 1,
+      "impressions": 280,
+      "ctr": 0.4,
+      "position": 8.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-sora-2",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-sora-2",
+      "clicks": 1,
+      "impressions": 267,
+      "ctr": 0.4,
+      "position": 8.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-sora-2",
+      "locale": "en",
+      "slug": "seedance-2-0-vs-sora-2",
+      "clicks": 1,
+      "impressions": 261,
+      "ctr": 0.4,
+      "position": 15.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-seedance-2-0",
+      "clicks": 1,
+      "impressions": 237,
+      "ctr": 0.4,
+      "position": 8.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-lite-vs-wan-2-6",
+      "locale": "en",
+      "slug": "veo-3-1-lite-vs-wan-2-6",
+      "clicks": 1,
+      "impressions": 236,
+      "ctr": 0.4,
+      "position": 10.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-veo-3-1",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-veo-3-1",
+      "clicks": 1,
+      "impressions": 222,
+      "ctr": 0.5,
+      "position": 6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "ltx-2-vs-seedance-1-5-pro",
+      "clicks": 1,
+      "impressions": 200,
+      "ctr": 0.5,
+      "position": 6.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-0-vs-veo-3-1",
+      "locale": "en",
+      "slug": "happy-horse-1-0-vs-veo-3-1",
+      "clicks": 1,
+      "impressions": 192,
+      "ctr": 0.5,
+      "position": 14
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "ltx-2-vs-seedance-2-0-fast",
+      "clicks": 1,
+      "impressions": 175,
+      "ctr": 0.6,
+      "position": 6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-minimax-hailuo-02-text",
+      "locale": "en",
+      "slug": "ltx-2-vs-minimax-hailuo-02-text",
+      "clicks": 1,
+      "impressions": 169,
+      "ctr": 0.6,
+      "position": 10.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-wan-2-6",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-wan-2-6",
+      "clicks": 1,
+      "impressions": 165,
+      "ctr": 0.6,
+      "position": 7.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-veo-3-1-lite",
+      "clicks": 1,
+      "impressions": 159,
+      "ctr": 0.6,
+      "position": 9.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-veo-3-1",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-veo-3-1",
+      "clicks": 1,
+      "impressions": 144,
+      "ctr": 0.7,
+      "position": 6.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-vs-wan-2-5",
+      "locale": "en",
+      "slug": "sora-2-vs-wan-2-5",
+      "clicks": 1,
+      "impressions": 137,
+      "ctr": 0.7,
+      "position": 8.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-3-2-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "luma-ray-3-2-vs-seedance-2-0",
+      "clicks": 1,
+      "impressions": 121,
+      "ctr": 0.8,
+      "position": 6.1
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-veo-3-1-lite",
+      "clicks": 1,
+      "impressions": 114,
+      "ctr": 0.9,
+      "position": 10.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "seedance-2-0-vs-sora-2-pro",
+      "clicks": 1,
+      "impressions": 114,
+      "ctr": 0.9,
+      "position": 10.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-luma-ray-2",
+      "locale": "en",
+      "slug": "ltx-2-vs-luma-ray-2",
+      "clicks": 1,
+      "impressions": 110,
+      "ctr": 0.9,
+      "position": 6.9
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-1-5-pro-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "seedance-1-5-pro-vs-seedance-2-0",
+      "clicks": 1,
+      "impressions": 81,
+      "ctr": 1.2,
+      "position": 4.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-ltx-2-3-fast",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-ltx-2-3-fast",
+      "clicks": 1,
+      "impressions": 80,
+      "ctr": 1.3,
+      "position": 9.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-veo-3-1-lite",
+      "clicks": 1,
+      "impressions": 78,
+      "ctr": 1.3,
+      "position": 6.2
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-seedance-2-0-fast",
+      "clicks": 1,
+      "impressions": 78,
+      "ctr": 1.3,
+      "position": 7.8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-kling-3-standard",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-kling-3-standard",
+      "clicks": 1,
+      "impressions": 70,
+      "ctr": 1.4,
+      "position": 7
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-ltx-2-3-pro",
+      "locale": "fr",
+      "slug": "ltx-2-vs-ltx-2-3-pro",
+      "clicks": 1,
+      "impressions": 70,
+      "ctr": 1.4,
+      "position": 13.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-veo-3-1-lite",
+      "clicks": 1,
+      "impressions": 69,
+      "ctr": 1.4,
+      "position": 7.1
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-kling-o3-standard",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-kling-o3-standard",
+      "clicks": 1,
+      "impressions": 67,
+      "ctr": 1.5,
+      "position": 6.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-wan-2-5",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-wan-2-5",
+      "clicks": 1,
+      "impressions": 67,
+      "ctr": 1.5,
+      "position": 11.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-seedance-2-0-fast",
+      "clicks": 1,
+      "impressions": 66,
+      "ctr": 1.5,
+      "position": 5.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-seedance-2-0",
+      "clicks": 1,
+      "impressions": 61,
+      "ctr": 1.6,
+      "position": 8.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-seedance-1-5-pro",
+      "clicks": 1,
+      "impressions": 56,
+      "ctr": 1.8,
+      "position": 9.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-veo-3-1-fast",
+      "clicks": 1,
+      "impressions": 39,
+      "ctr": 2.6,
+      "position": 8.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-first-last-vs-wan-2-5",
+      "locale": "en",
+      "slug": "veo-3-1-first-last-vs-wan-2-5",
+      "clicks": 1,
+      "impressions": 39,
+      "ctr": 2.6,
+      "position": 10.8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-ltx-2-fast",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-ltx-2-fast",
+      "clicks": 1,
+      "impressions": 37,
+      "ctr": 2.7,
+      "position": 13.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-luma-ray-2",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-luma-ray-2",
+      "clicks": 1,
+      "impressions": 32,
+      "ctr": 3.1,
+      "position": 5.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-pro-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "sora-2-pro-vs-veo-3-1-lite",
+      "clicks": 1,
+      "impressions": 32,
+      "ctr": 3.1,
+      "position": 23
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-wan-2-6",
+      "clicks": 1,
+      "impressions": 22,
+      "ctr": 4.5,
+      "position": 8.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-3-2-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "luma-ray-3-2-vs-seedance-2-0",
+      "clicks": 1,
+      "impressions": 22,
+      "ctr": 4.5,
+      "position": 8.6
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/veo-3-1-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "veo-3-1-vs-veo-3-1-fast",
+      "clicks": 1,
+      "impressions": 21,
+      "ctr": 4.8,
+      "position": 5.8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-veo-3-1-fast",
+      "clicks": 1,
+      "impressions": 18,
+      "ctr": 5.6,
+      "position": 7.4
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-wan-2-6",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-wan-2-6",
+      "clicks": 1,
+      "impressions": 16,
+      "ctr": 6.3,
+      "position": 7.3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/happy-horse-1-0-vs-happy-horse-1-1",
+      "locale": "fr",
+      "slug": "happy-horse-1-0-vs-happy-horse-1-1",
+      "clicks": 1,
+      "impressions": 15,
+      "ctr": 6.7,
+      "position": 9.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-seedance-2-0-fast",
+      "clicks": 1,
+      "impressions": 13,
+      "ctr": 7.7,
+      "position": 5.6
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-seedance-2-0",
+      "clicks": 1,
+      "impressions": 11,
+      "ctr": 9.1,
+      "position": 7.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "sora-2-vs-veo-3-1-first-last",
+      "clicks": 1,
+      "impressions": 10,
+      "ctr": 10,
+      "position": 5.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-seedance-2-0-fast",
+      "clicks": 1,
+      "impressions": 10,
+      "ctr": 10,
+      "position": 20.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-luma-ray-2",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-luma-ray-2",
+      "clicks": 1,
+      "impressions": 7,
+      "ctr": 14.3,
+      "position": 5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/sora-2-vs-wan-2-5",
+      "locale": "es",
+      "slug": "sora-2-vs-wan-2-5",
+      "clicks": 1,
+      "impressions": 7,
+      "ctr": 14.3,
+      "position": 18.3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-ltx-2",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-ltx-2",
+      "clicks": 1,
+      "impressions": 5,
+      "ctr": 20,
+      "position": 3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-sora-2-pro",
+      "clicks": 1,
+      "impressions": 5,
+      "ctr": 20,
+      "position": 3.8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "ltx-2-vs-seedance-2-0-fast",
+      "clicks": 1,
+      "impressions": 4,
+      "ctr": 25,
+      "position": 3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-ltx-2-fast",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-ltx-2-fast",
+      "clicks": 1,
+      "impressions": 3,
+      "ctr": 33.3,
+      "position": 6
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-luma-ray-2",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-luma-ray-2",
+      "clicks": 1,
+      "impressions": 3,
+      "ctr": 33.3,
+      "position": 9
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-seedance-1-5-pro",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-seedance-1-5-pro",
+      "clicks": 1,
+      "impressions": 2,
+      "ctr": 50,
+      "position": 2.5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-3-2-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "luma-ray-3-2-vs-veo-3-1",
+      "clicks": 1,
+      "impressions": 1,
+      "ctr": 100,
+      "position": 2
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "luma-ray-2-vs-veo-3-1",
+      "clicks": 1,
+      "impressions": 1,
+      "ctr": 100,
+      "position": 3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/pika-text-to-video-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "pika-text-to-video-vs-veo-3-1-lite",
+      "clicks": 1,
+      "impressions": 1,
+      "ctr": 100,
+      "position": 7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-wan-2-6",
+      "locale": "en",
+      "slug": "seedance-2-0-fast-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 1272,
+      "ctr": 0,
+      "position": 8.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-wan-2-5",
+      "locale": "en",
+      "slug": "seedance-2-0-fast-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 876,
+      "ctr": 0,
+      "position": 8.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/wan-2-5-vs-wan-2-6",
+      "locale": "en",
+      "slug": "wan-2-5-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 870,
+      "ctr": 0,
+      "position": 10.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-luma-ray-2",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 636,
+      "ctr": 0,
+      "position": 6.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-wan-2-6",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 476,
+      "ctr": 0,
+      "position": 10.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/gemini-omni-flash-vs-veo-3-1",
+      "locale": "en",
+      "slug": "gemini-omni-flash-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 380,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-kling-3-pro",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 376,
+      "ctr": 0,
+      "position": 11.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-vs-wan-2-6",
+      "locale": "en",
+      "slug": "veo-3-1-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 325,
+      "ctr": 0,
+      "position": 11.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-luma-ray-2",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 290,
+      "ctr": 0,
+      "position": 8.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-wan-2-6",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 284,
+      "ctr": 0,
+      "position": 8.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-sora-2",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-sora-2",
+      "clicks": 0,
+      "impressions": 278,
+      "ctr": 0,
+      "position": 6.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-minimax-hailuo-02-text",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 270,
+      "ctr": 0,
+      "position": 14.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-kling-o3-standard",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-kling-o3-standard",
+      "clicks": 0,
+      "impressions": 250,
+      "ctr": 0,
+      "position": 13.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 243,
+      "ctr": 0,
+      "position": 9.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-veo-3-1",
+      "locale": "en",
+      "slug": "seedance-2-0-fast-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 242,
+      "ctr": 0,
+      "position": 10.1
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-luma-ray-3-2",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-luma-ray-3-2",
+      "clicks": 0,
+      "impressions": 222,
+      "ctr": 0,
+      "position": 16.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-veo-3-1",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 220,
+      "ctr": 0,
+      "position": 10.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-minimax-hailuo-02-text",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 219,
+      "ctr": 0,
+      "position": 12.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/dreamina-seedance-2-0-mini-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "dreamina-seedance-2-0-mini-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 209,
+      "ctr": 0,
+      "position": 8.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 209,
+      "ctr": 0,
+      "position": 9.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-vs-veo-3-1",
+      "locale": "en",
+      "slug": "sora-2-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 209,
+      "ctr": 0,
+      "position": 12.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 203,
+      "ctr": 0,
+      "position": 7.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-wan-2-6",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 196,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 193,
+      "ctr": 0,
+      "position": 8.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-vs-wan-2-5",
+      "locale": "en",
+      "slug": "veo-3-1-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 192,
+      "ctr": 0,
+      "position": 7.9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 192,
+      "ctr": 0,
+      "position": 8.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-vs-wan-2-6",
+      "locale": "en",
+      "slug": "sora-2-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 188,
+      "ctr": 0,
+      "position": 9.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-wan-2-5",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 187,
+      "ctr": 0,
+      "position": 9.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-fast-vs-wan-2-5",
+      "locale": "en",
+      "slug": "veo-3-1-fast-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 185,
+      "ctr": 0,
+      "position": 13.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-luma-ray-2-flash",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 183,
+      "ctr": 0,
+      "position": 9.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-kling-3-standard",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-kling-3-standard",
+      "clicks": 0,
+      "impressions": 178,
+      "ctr": 0,
+      "position": 11.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-veo-3-1",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 175,
+      "ctr": 0,
+      "position": 7.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-veo-3-1",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 175,
+      "ctr": 0,
+      "position": 15.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "seedance-2-0-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 174,
+      "ctr": 0,
+      "position": 10.1
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 159,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-pika-text-to-video",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 159,
+      "ctr": 0,
+      "position": 9.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-wan-2-6",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 155,
+      "ctr": 0,
+      "position": 12.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-luma-ray-2",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 153,
+      "ctr": 0,
+      "position": 8.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-fast-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "ltx-2-3-fast-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 150,
+      "ctr": 0,
+      "position": 6.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-0-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "happy-horse-1-0-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 147,
+      "ctr": 0,
+      "position": 7.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-kling-3-4k",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-kling-3-4k",
+      "clicks": 0,
+      "impressions": 145,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 145,
+      "ctr": 0,
+      "position": 10.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-kling-3-4k",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-kling-3-4k",
+      "clicks": 0,
+      "impressions": 144,
+      "ctr": 0,
+      "position": 11.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-wan-2-6",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 140,
+      "ctr": 0,
+      "position": 7.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 139,
+      "ctr": 0,
+      "position": 8.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-ltx-2-3-pro",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 135,
+      "ctr": 0,
+      "position": 8.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-luma-ray-2-flash",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 133,
+      "ctr": 0,
+      "position": 8.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 132,
+      "ctr": 0,
+      "position": 11.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-sora-2",
+      "locale": "en",
+      "slug": "seedance-2-0-fast-vs-sora-2",
+      "clicks": 0,
+      "impressions": 128,
+      "ctr": 0,
+      "position": 10.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 128,
+      "ctr": 0,
+      "position": 12
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-ltx-2-3-fast",
+      "locale": "es",
+      "slug": "ltx-2-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 126,
+      "ctr": 0,
+      "position": 12.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-minimax-hailuo-02-text",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 122,
+      "ctr": 0,
+      "position": 9.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-minimax-hailuo-02-text",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 120,
+      "ctr": 0,
+      "position": 9.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-sora-2",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-sora-2",
+      "clicks": 0,
+      "impressions": 119,
+      "ctr": 0,
+      "position": 7.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-lite-vs-wan-2-5",
+      "locale": "en",
+      "slug": "veo-3-1-lite-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 116,
+      "ctr": 0,
+      "position": 8.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-sora-2",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-sora-2",
+      "clicks": 0,
+      "impressions": 116,
+      "ctr": 0,
+      "position": 8.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "seedance-1-5-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 115,
+      "ctr": 0,
+      "position": 6.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-o3-standard-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "kling-o3-standard-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 115,
+      "ctr": 0,
+      "position": 8.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-pika-text-to-video",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 114,
+      "ctr": 0,
+      "position": 5.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-luma-ray-2-flash",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 114,
+      "ctr": 0,
+      "position": 8.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 111,
+      "ctr": 0,
+      "position": 6.7
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 109,
+      "ctr": 0,
+      "position": 7.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-wan-2-6",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 108,
+      "ctr": 0,
+      "position": 10.1
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 105,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-o3-4k-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "kling-o3-4k-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 104,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "sora-2-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 104,
+      "ctr": 0,
+      "position": 10.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-veo-3-1",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 103,
+      "ctr": 0,
+      "position": 8.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-veo-3-1",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 101,
+      "ctr": 0,
+      "position": 11.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "sora-2-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 99,
+      "ctr": 0,
+      "position": 17.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-pro-vs-wan-2-6",
+      "locale": "en",
+      "slug": "sora-2-pro-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 96,
+      "ctr": 0,
+      "position": 11.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-veo-3-1",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 93,
+      "ctr": 0,
+      "position": 12.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 91,
+      "ctr": 0,
+      "position": 6.6
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "ltx-2-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 90,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-1-vs-kling-o3-pro",
+      "locale": "en",
+      "slug": "happy-horse-1-1-vs-kling-o3-pro",
+      "clicks": 0,
+      "impressions": 89,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-ltx-2-fast",
+      "locale": "es",
+      "slug": "ltx-2-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 86,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-minimax-hailuo-02-text",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 86,
+      "ctr": 0,
+      "position": 11.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-luma-ray-3-2",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-luma-ray-3-2",
+      "clicks": 0,
+      "impressions": 86,
+      "ctr": 0,
+      "position": 13.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-kling-o3-4k",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-kling-o3-4k",
+      "clicks": 0,
+      "impressions": 84,
+      "ctr": 0,
+      "position": 9.1
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-o3-4k-vs-veo-3-1",
+      "locale": "en",
+      "slug": "kling-o3-4k-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 84,
+      "ctr": 0,
+      "position": 9.1
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-veo-3-1",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 84,
+      "ctr": 0,
+      "position": 16.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-o3-standard-vs-veo-3-1",
+      "locale": "en",
+      "slug": "kling-o3-standard-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 81,
+      "ctr": 0,
+      "position": 10.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/sora-2-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "sora-2-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 79,
+      "ctr": 0,
+      "position": 9.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-kling-o3-standard",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-kling-o3-standard",
+      "clicks": 0,
+      "impressions": 78,
+      "ctr": 0,
+      "position": 16.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 74,
+      "ctr": 0,
+      "position": 7.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 73,
+      "ctr": 0,
+      "position": 6.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-3-pro-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "ltx-2-3-pro-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 73,
+      "ctr": 0,
+      "position": 10.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-luma-ray-2",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 72,
+      "ctr": 0,
+      "position": 10.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-sora-2",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-sora-2",
+      "clicks": 0,
+      "impressions": 71,
+      "ctr": 0,
+      "position": 6.6
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-ltx-2-3-pro",
+      "locale": "es",
+      "slug": "ltx-2-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 71,
+      "ctr": 0,
+      "position": 14.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-wan-2-5",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 69,
+      "ctr": 0,
+      "position": 8.1
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-3-2-vs-veo-3-1",
+      "locale": "en",
+      "slug": "luma-ray-3-2-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 68,
+      "ctr": 0,
+      "position": 6.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "seedance-2-0-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 68,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-o3-pro-vs-seedance-2-0",
+      "locale": "en",
+      "slug": "kling-o3-pro-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 67,
+      "ctr": 0,
+      "position": 9.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-pika-text-to-video",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 66,
+      "ctr": 0,
+      "position": 12.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-0-vs-happy-horse-1-1",
+      "locale": "en",
+      "slug": "happy-horse-1-0-vs-happy-horse-1-1",
+      "clicks": 0,
+      "impressions": 66,
+      "ctr": 0,
+      "position": 13.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 65,
+      "ctr": 0,
+      "position": 7.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-kling-o3-pro",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-kling-o3-pro",
+      "clicks": 0,
+      "impressions": 64,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 64,
+      "ctr": 0,
+      "position": 9.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-pika-text-to-video",
+      "locale": "en",
+      "slug": "ltx-2-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 61,
+      "ctr": 0,
+      "position": 7.6
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "seedance-2-0-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 60,
+      "ctr": 0,
+      "position": 7.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-wan-2-6",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 60,
+      "ctr": 0,
+      "position": 12.1
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 58,
+      "ctr": 0,
+      "position": 6.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 58,
+      "ctr": 0,
+      "position": 8.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-sora-2",
+      "locale": "en",
+      "slug": "seedance-1-5-pro-vs-sora-2",
+      "clicks": 0,
+      "impressions": 58,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-ltx-2-fast",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 57,
+      "ctr": 0,
+      "position": 13.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-luma-ray-2",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 56,
+      "ctr": 0,
+      "position": 7.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-luma-ray-2-flash",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 56,
+      "ctr": 0,
+      "position": 10.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 55,
+      "ctr": 0,
+      "position": 8.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-pro-vs-wan-2-5",
+      "locale": "en",
+      "slug": "sora-2-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 55,
+      "ctr": 0,
+      "position": 9.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-pika-text-to-video",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 55,
+      "ctr": 0,
+      "position": 9.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-sora-2",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-sora-2",
+      "clicks": 0,
+      "impressions": 54,
+      "ctr": 0,
+      "position": 14.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-pika-text-to-video",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 53,
+      "ctr": 0,
+      "position": 7.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-fast-vs-veo-3-1",
+      "locale": "es",
+      "slug": "seedance-2-0-fast-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 53,
+      "ctr": 0,
+      "position": 7.6
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-kling-3-standard",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-kling-3-standard",
+      "clicks": 0,
+      "impressions": 53,
+      "ctr": 0,
+      "position": 8.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/dreamina-seedance-2-0-mini-vs-happy-horse-1-1",
+      "locale": "en",
+      "slug": "dreamina-seedance-2-0-mini-vs-happy-horse-1-1",
+      "clicks": 0,
+      "impressions": 52,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-fast-vs-wan-2-6",
+      "locale": "en",
+      "slug": "veo-3-1-fast-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 52,
+      "ctr": 0,
+      "position": 11.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 51,
+      "ctr": 0,
+      "position": 8.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-sora-2",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-sora-2",
+      "clicks": 0,
+      "impressions": 50,
+      "ctr": 0,
+      "position": 11.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-2-0-fast-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "seedance-2-0-fast-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 49,
+      "ctr": 0,
+      "position": 8.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-o3-pro-vs-veo-3-1",
+      "locale": "en",
+      "slug": "kling-o3-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 48,
+      "ctr": 0,
+      "position": 8.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 46,
+      "ctr": 0,
+      "position": 5.9
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-kling-3-standard",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-kling-3-standard",
+      "clicks": 0,
+      "impressions": 45,
+      "ctr": 0,
+      "position": 4.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/minimax-hailuo-02-text-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "minimax-hailuo-02-text-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 45,
+      "ctr": 0,
+      "position": 7.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-wan-2-5",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 45,
+      "ctr": 0,
+      "position": 9.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-veo-3-1",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 45,
+      "ctr": 0,
+      "position": 10.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 44,
+      "ctr": 0,
+      "position": 11.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "ltx-2-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 42,
+      "ctr": 0,
+      "position": 7.2
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/wan-2-5-vs-wan-2-6",
+      "locale": "es",
+      "slug": "wan-2-5-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 42,
+      "ctr": 0,
+      "position": 8.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-luma-ray-2-flash",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 42,
+      "ctr": 0,
+      "position": 8.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-luma-ray-2-flash",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 42,
+      "ctr": 0,
+      "position": 10.1
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-luma-ray-2",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 42,
+      "ctr": 0,
+      "position": 10.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-veo-3-1",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 42,
+      "ctr": 0,
+      "position": 13.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-sora-2",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-sora-2",
+      "clicks": 0,
+      "impressions": 42,
+      "ctr": 0,
+      "position": 22
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 41,
+      "ctr": 0,
+      "position": 7.1
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 41,
+      "ctr": 0,
+      "position": 8.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-kling-3-pro",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 41,
+      "ctr": 0,
+      "position": 10.6
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-o3-standard-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "kling-o3-standard-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 41,
+      "ctr": 0,
+      "position": 11.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-ltx-2-fast",
+      "locale": "en",
+      "slug": "ltx-2-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 41,
+      "ctr": 0,
+      "position": 41.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 40,
+      "ctr": 0,
+      "position": 6.1
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-kling-o3-pro",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-kling-o3-pro",
+      "clicks": 0,
+      "impressions": 39,
+      "ctr": 0,
+      "position": 6.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/gemini-omni-flash-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "gemini-omni-flash-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 39,
+      "ctr": 0,
+      "position": 9.1
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 39,
+      "ctr": 0,
+      "position": 9.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 39,
+      "ctr": 0,
+      "position": 11.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "ltx-2-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 39,
+      "ctr": 0,
+      "position": 14
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-wan-2-6",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 38,
+      "ctr": 0,
+      "position": 8.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/pika-text-to-video-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "pika-text-to-video-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 37,
+      "ctr": 0,
+      "position": 7.1
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-luma-ray-2-flash",
+      "locale": "en",
+      "slug": "ltx-2-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 37,
+      "ctr": 0,
+      "position": 10.5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 35,
+      "ctr": 0,
+      "position": 4.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-pika-text-to-video",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 35,
+      "ctr": 0,
+      "position": 5.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-1-vs-seedance-2-0-fast",
+      "locale": "en",
+      "slug": "happy-horse-1-1-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 35,
+      "ctr": 0,
+      "position": 7.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-minimax-hailuo-02-text",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 35,
+      "ctr": 0,
+      "position": 7.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-ltx-2-fast",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 35,
+      "ctr": 0,
+      "position": 7.9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 35,
+      "ctr": 0,
+      "position": 8.6
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-wan-2-6",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 35,
+      "ctr": 0,
+      "position": 8.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 35,
+      "ctr": 0,
+      "position": 14.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-ltx-2-3-fast",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 34,
+      "ctr": 0,
+      "position": 5.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-fast-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "seedance-2-0-fast-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 33,
+      "ctr": 0,
+      "position": 9.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-ltx-2-fast",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 33,
+      "ctr": 0,
+      "position": 18.2
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-3-2-vs-veo-3-1",
+      "locale": "es",
+      "slug": "luma-ray-3-2-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 32,
+      "ctr": 0,
+      "position": 6.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "seedance-2-0-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 32,
+      "ctr": 0,
+      "position": 8.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-veo-3-1",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 32,
+      "ctr": 0,
+      "position": 11.7
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/dreamina-seedance-2-0-mini-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "dreamina-seedance-2-0-mini-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 31,
+      "ctr": 0,
+      "position": 4.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-wan-2-5",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 31,
+      "ctr": 0,
+      "position": 8.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 30,
+      "ctr": 0,
+      "position": 9.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-luma-ray-2-flash",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 30,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-wan-2-5",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 29,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "pika-text-to-video-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 29,
+      "ctr": 0,
+      "position": 7.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-ltx-2",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-ltx-2",
+      "clicks": 0,
+      "impressions": 29,
+      "ctr": 0,
+      "position": 22.4
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-veo-3-1",
+      "locale": "es",
+      "slug": "seedance-2-0-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 28,
+      "ctr": 0,
+      "position": 6.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-wan-2-5",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 28,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-pro-vs-veo-3-1",
+      "locale": "en",
+      "slug": "sora-2-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 28,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-seedance-1-5-pro",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 28,
+      "ctr": 0,
+      "position": 9.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-wan-2-6",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 27,
+      "ctr": 0,
+      "position": 5.9
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 27,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "ltx-2-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 27,
+      "ctr": 0,
+      "position": 7.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-veo-3-1-lite",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 27,
+      "ctr": 0,
+      "position": 10.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/gemini-omni-flash-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "gemini-omni-flash-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 26,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-sora-2",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-sora-2",
+      "clicks": 0,
+      "impressions": 26,
+      "ctr": 0,
+      "position": 8.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-kling-3-4k",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-kling-3-4k",
+      "clicks": 0,
+      "impressions": 26,
+      "ctr": 0,
+      "position": 8.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-standard-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "kling-3-standard-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 26,
+      "ctr": 0,
+      "position": 11.9
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/dreamina-seedance-2-0-mini-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "dreamina-seedance-2-0-mini-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 25,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-pika-text-to-video",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 24,
+      "ctr": 0,
+      "position": 6.4
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 24,
+      "ctr": 0,
+      "position": 6.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-sora-2",
+      "locale": "es",
+      "slug": "seedance-2-0-vs-sora-2",
+      "clicks": 0,
+      "impressions": 24,
+      "ctr": 0,
+      "position": 8.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "pika-text-to-video-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 24,
+      "ctr": 0,
+      "position": 16.2
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 23,
+      "ctr": 0,
+      "position": 9.2
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-wan-2-5",
+      "locale": "es",
+      "slug": "ltx-2-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 23,
+      "ctr": 0,
+      "position": 13.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-pika-text-to-video",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 23,
+      "ctr": 0,
+      "position": 16
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-ltx-2",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-ltx-2",
+      "clicks": 0,
+      "impressions": 23,
+      "ctr": 0,
+      "position": 24.3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 22,
+      "ctr": 0,
+      "position": 6.5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 22,
+      "ctr": 0,
+      "position": 7.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-veo-3-1",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 22,
+      "ctr": 0,
+      "position": 10.6
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-kling-o3-pro",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-kling-o3-pro",
+      "clicks": 0,
+      "impressions": 22,
+      "ctr": 0,
+      "position": 10.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-1-5-pro-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "seedance-1-5-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 21,
+      "ctr": 0,
+      "position": 4.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-sora-2",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-sora-2",
+      "clicks": 0,
+      "impressions": 21,
+      "ctr": 0,
+      "position": 7.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/gemini-omni-flash-vs-sora-2",
+      "locale": "en",
+      "slug": "gemini-omni-flash-vs-sora-2",
+      "clicks": 0,
+      "impressions": 21,
+      "ctr": 0,
+      "position": 7.9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-minimax-hailuo-02-text",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 21,
+      "ctr": 0,
+      "position": 8.6
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/wan-2-5-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "wan-2-5-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 21,
+      "ctr": 0,
+      "position": 8.6
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/sora-2-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "sora-2-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 21,
+      "ctr": 0,
+      "position": 8.6
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 21,
+      "ctr": 0,
+      "position": 9.9
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 20,
+      "ctr": 0,
+      "position": 8.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-wan-2-5",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 20,
+      "ctr": 0,
+      "position": 9.1
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 19,
+      "ctr": 0,
+      "position": 5.1
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "seedance-1-5-pro-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 19,
+      "ctr": 0,
+      "position": 12.2
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "seedance-2-0-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 18,
+      "ctr": 0,
+      "position": 4.8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-o3-standard-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "kling-o3-standard-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 18,
+      "ctr": 0,
+      "position": 7.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 18,
+      "ctr": 0,
+      "position": 7.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 18,
+      "ctr": 0,
+      "position": 9.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 18,
+      "ctr": 0,
+      "position": 20.2
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/happy-horse-1-0-vs-kling-3-pro",
+      "locale": "fr",
+      "slug": "happy-horse-1-0-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "veo-3-1-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 6.5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/minimax-hailuo-02-text-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "minimax-hailuo-02-text-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 7.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "luma-ray-2-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 8.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/seedance-1-5-pro-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "seedance-1-5-pro-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 8.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-wan-2-5",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 9.4
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-sora-2",
+      "locale": "es",
+      "slug": "ltx-2-vs-sora-2",
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 20.5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 21.4
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-pro-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "kling-3-pro-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 17,
+      "ctr": 0,
+      "position": 24.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-pro-vs-veo-3-1?order=sora-2-pro",
+      "locale": "en",
+      "slug": "sora-2-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 16,
+      "ctr": 0,
+      "position": 8.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-kling-3-standard",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-kling-3-standard",
+      "clicks": 0,
+      "impressions": 16,
+      "ctr": 0,
+      "position": 14.6
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 16,
+      "ctr": 0,
+      "position": 20.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-kling-3-pro",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 16,
+      "ctr": 0,
+      "position": 25.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-kling-3-standard",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-kling-3-standard",
+      "clicks": 0,
+      "impressions": 16,
+      "ctr": 0,
+      "position": 31
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "ltx-2-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 15,
+      "ctr": 0,
+      "position": 5.1
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-0-vs-kling-3-pro",
+      "locale": "es",
+      "slug": "happy-horse-1-0-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 15,
+      "ctr": 0,
+      "position": 5.3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 15,
+      "ctr": 0,
+      "position": 5.8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 15,
+      "ctr": 0,
+      "position": 7.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-6-pro-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "kling-2-6-pro-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 15,
+      "ctr": 0,
+      "position": 7.8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/dreamina-seedance-2-0-mini-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "dreamina-seedance-2-0-mini-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 15,
+      "ctr": 0,
+      "position": 7.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 15,
+      "ctr": 0,
+      "position": 12.2
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-wan-2-6",
+      "locale": "es",
+      "slug": "seedance-2-0-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 14,
+      "ctr": 0,
+      "position": 5.4
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 14,
+      "ctr": 0,
+      "position": 5.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "ltx-2-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 14,
+      "ctr": 0,
+      "position": 5.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 14,
+      "ctr": 0,
+      "position": 9.7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 14,
+      "ctr": 0,
+      "position": 15.1
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-ltx-2-3-fast",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 13,
+      "ctr": 0,
+      "position": 4.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-fast-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "ltx-2-fast-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 13,
+      "ctr": 0,
+      "position": 5.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 13,
+      "ctr": 0,
+      "position": 6.4
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-kling-o3-4k",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-kling-o3-4k",
+      "clicks": 0,
+      "impressions": 13,
+      "ctr": 0,
+      "position": 7.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-luma-ray-2-flash",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 13,
+      "ctr": 0,
+      "position": 7.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-o3-standard-vs-veo-3-1",
+      "locale": "es",
+      "slug": "kling-o3-standard-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 13,
+      "ctr": 0,
+      "position": 15.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-luma-ray-3-2",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-luma-ray-3-2",
+      "clicks": 0,
+      "impressions": 13,
+      "ctr": 0,
+      "position": 24.1
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-1-vs-veo-3-1",
+      "locale": "en",
+      "slug": "happy-horse-1-1-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 3.8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 5.6
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/gemini-omni-flash-vs-veo-3-1",
+      "locale": "es",
+      "slug": "gemini-omni-flash-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 5.8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-kling-o3-standard",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-kling-o3-standard",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 6.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-wan-2-5",
+      "locale": "es",
+      "slug": "pika-text-to-video-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 6.8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-kling-3-pro",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 8.8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/veo-3-1-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "veo-3-1-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 9.1
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-kling-o3-pro",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-kling-o3-pro",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 14.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/veo-3-1-fast-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "veo-3-1-fast-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 15.4
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-kling-3-4k",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-kling-3-4k",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 15.9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 22
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-ltx-2",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-ltx-2",
+      "clicks": 0,
+      "impressions": 12,
+      "ctr": 0,
+      "position": 23.3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "ltx-2-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 2.4
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-ltx-2-3-pro",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 3.6
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 4.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-minimax-hailuo-02-text",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 4.9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-veo-3-1",
+      "locale": "es",
+      "slug": "pika-text-to-video-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 6.1
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-pika-text-to-video",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-fast-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "seedance-2-0-fast-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 7.7
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 8.8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-kling-3-standard",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-kling-3-standard",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 8.9
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/happy-horse-1-0-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "happy-horse-1-0-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 19.9
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/luma-ray-2-flash-vs-minimax-hailuo-02-text",
+      "locale": "en",
+      "slug": "luma-ray-2-flash-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 26.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-sora-2",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-sora-2",
+      "clicks": 0,
+      "impressions": 11,
+      "ctr": 0,
+      "position": 26.8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/pika-text-to-video-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "pika-text-to-video-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 3.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 5.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 5.6
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-wan-2-6",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 5.7
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-o3-4k-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "kling-o3-4k-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 6.2
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-kling-3-standard",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-kling-3-standard",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 7.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 7.8
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/ltx-2-vs-veo-3-1-first-last",
+      "locale": "en",
+      "slug": "ltx-2-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 7.9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "luma-ray-2-flash-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 8.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-1-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "happy-horse-1-1-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 10.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 16
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-o3-4k-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "kling-o3-4k-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 17.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-wan-2-5",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 10,
+      "ctr": 0,
+      "position": 44.6
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-0-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "happy-horse-1-0-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 3.9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-fast-vs-wan-2-6",
+      "locale": "es",
+      "slug": "seedance-2-0-fast-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 5.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-minimax-hailuo-02-text",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 6.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 7.1
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-pika-text-to-video",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 7.6
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 9.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-o3-pro-vs-veo-3-1",
+      "locale": "es",
+      "slug": "kling-o3-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 10.1
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "ltx-2-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 12.1
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-kling-o3-pro",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-kling-o3-pro",
+      "clicks": 0,
+      "impressions": 9,
+      "ctr": 0,
+      "position": 17.2
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 5.4
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-wan-2-5",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 5.9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-1-5-pro-vs-wan-2-5",
+      "locale": "es",
+      "slug": "seedance-1-5-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 6.1
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-wan-2-5",
+      "locale": "es",
+      "slug": "seedance-2-0-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 6.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-kling-3-4k",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-kling-3-4k",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 6.6
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 6.8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-fast-vs-wan-2-5",
+      "locale": "es",
+      "slug": "seedance-2-0-fast-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 7.4
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 9.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-sora-2",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-sora-2",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 9.4
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-kling-o3-standard",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-kling-o3-standard",
+      "clicks": 0,
+      "impressions": 8,
+      "ctr": 0,
+      "position": 16.9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-veo-3-1",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 2.9
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-fast-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "seedance-2-0-fast-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 3.3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/sora-2-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "sora-2-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 3.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "pika-text-to-video-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 5.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-1-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "happy-horse-1-1-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 5.9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/veo-3-1-lite-vs-wan-2-5",
+      "locale": "es",
+      "slug": "veo-3-1-lite-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 6.3
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/sora-2-pro-vs-veo-3-1-fast",
+      "locale": "en",
+      "slug": "sora-2-pro-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 7.7
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/minimax-hailuo-02-text-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "minimax-hailuo-02-text-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 7.9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-pika-text-to-video",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 8.1
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "pika-text-to-video-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 8.1
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-3-2-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "luma-ray-3-2-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 8.6
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-ltx-2",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-ltx-2",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 35.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-wan-2-6",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 7,
+      "ctr": 0,
+      "position": 57
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 1.8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-0-vs-veo-3-1",
+      "locale": "es",
+      "slug": "happy-horse-1-0-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 2.2
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-sora-2",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-sora-2",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 2.8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-fast-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "seedance-2-0-fast-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 5.2
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-minimax-hailuo-02-text",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 6.2
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/dreamina-seedance-2-0-mini-vs-happy-horse-1-1",
+      "locale": "fr",
+      "slug": "dreamina-seedance-2-0-mini-vs-happy-horse-1-1",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 6.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/gemini-omni-flash-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "gemini-omni-flash-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 6.8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 6.8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-luma-ray-2",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 7.8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-luma-ray-3-2",
+      "locale": "fr",
+      "slug": "luma-ray-2-vs-luma-ray-3-2",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 7.8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-ltx-2-3-fast",
+      "locale": "fr",
+      "slug": "ltx-2-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 9.2
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-wan-2-6",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-0-vs-happy-horse-1-1",
+      "locale": "es",
+      "slug": "happy-horse-1-0-vs-happy-horse-1-1",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 35
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-ltx-2",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-ltx-2",
+      "clicks": 0,
+      "impressions": 6,
+      "ctr": 0,
+      "position": 40.3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-kling-2-6-pro",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-kling-2-6-pro",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 5.2
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-kling-3-pro",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 5.2
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-wan-2-5",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 5.8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "seedance-2-0-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 5.8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "ltx-2-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 6.2
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-wan-2-6",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 6.6
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-o3-4k-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "kling-o3-4k-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 6.8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-1-5-pro-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "seedance-1-5-pro-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 6.8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-pika-text-to-video",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/happy-horse-1-1-vs-sora-2-pro",
+      "locale": "en",
+      "slug": "happy-horse-1-1-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 7.2
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-o3-standard-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "kling-o3-standard-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 7.2
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-3-4k-vs-ltx-2-3-pro",
+      "locale": "en",
+      "slug": "kling-3-4k-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 7.8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-wan-2-5",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 7.8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "luma-ray-2-flash-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 8.2
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-sora-2",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-sora-2",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 8.8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "ltx-2-3-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 8.8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 9.2
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 9.4
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-luma-ray-2",
+      "locale": "fr",
+      "slug": "ltx-2-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 5,
+      "ctr": 0,
+      "position": 80.6
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-kling-3-pro",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 2.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-ltx-2-3-fast",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/veo-3-1-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "veo-3-1-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 3.3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/sora-2-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "sora-2-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 5.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/sora-2-vs-wan-2-6",
+      "locale": "es",
+      "slug": "sora-2-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 6.3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/gemini-omni-flash-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "gemini-omni-flash-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 6.3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-minimax-hailuo-02-text",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 6.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 6.5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-sora-2",
+      "locale": "fr",
+      "slug": "ltx-2-vs-sora-2",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 6.8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 7.5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "seedance-2-0-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 7.8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-ltx-2-3-fast",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/dreamina-seedance-2-0-mini-vs-luma-ray-3-2",
+      "locale": "es",
+      "slug": "dreamina-seedance-2-0-mini-vs-luma-ray-3-2",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 8.8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/dreamina-seedance-2-0-mini-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "dreamina-seedance-2-0-mini-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-kling-o3-4k",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-kling-o3-4k",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 9.5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-pika-text-to-video",
+      "locale": "fr",
+      "slug": "ltx-2-3-pro-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 10.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-ltx-2-fast",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 10.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/sora-2-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "sora-2-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-luma-ray-2",
+      "locale": "es",
+      "slug": "ltx-2-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 22.5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-luma-ray-2",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 26.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-luma-ray-2",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 4,
+      "ctr": 0,
+      "position": 67.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-wan-2-6",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 1.7
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/sora-2-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "sora-2-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 1.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-wan-2-6",
+      "locale": "es",
+      "slug": "pika-text-to-video-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-pika-text-to-video",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-luma-ray-2",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/veo-3-1-fast-vs-wan-2-6",
+      "locale": "es",
+      "slug": "veo-3-1-fast-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 3.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-ltx-2-fast",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-veo-3-1",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "ltx-2-3-pro-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 4.7
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "ltx-2-3-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 4.7
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/pika-text-to-video-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "pika-text-to-video-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 4.7
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-fast-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "seedance-2-0-fast-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 4.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-o3-pro-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "kling-o3-pro-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 5.3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/happy-horse-1-1-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "happy-horse-1-1-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 5.7
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-kling-o3-standard",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-kling-o3-standard",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 5.7
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "luma-ray-2-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 6.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-sora-2",
+      "locale": "es",
+      "slug": "pika-text-to-video-vs-sora-2",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 7.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-kling-3-pro",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-ltx-2",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-ltx-2",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/dreamina-seedance-2-0-mini-vs-ltx-2-3-fast",
+      "locale": "fr",
+      "slug": "dreamina-seedance-2-0-mini-vs-ltx-2-3-fast",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/veo-3-1-fast-vs-wan-2-5",
+      "locale": "es",
+      "slug": "veo-3-1-fast-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 8.3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-fast-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "seedance-2-0-fast-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 8.3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-ltx-2-3-pro",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 8.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-minimax-hailuo-02-text",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 9.3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/veo-3-1-first-last-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "veo-3-1-first-last-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 9.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 9.7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/sora-2-vs-veo-3-1",
+      "locale": "es",
+      "slug": "sora-2-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/minimax-hailuo-02-text-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "minimax-hailuo-02-text-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 12.7
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-fast-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "seedance-2-0-fast-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 14.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 23
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-kling-o3-pro",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-kling-o3-pro",
+      "clicks": 0,
+      "impressions": 3,
+      "ctr": 0,
+      "position": 36.3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-sora-2",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-sora-2",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-1-vs-seedance-2-0-fast",
+      "locale": "es",
+      "slug": "happy-horse-1-1-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-ltx-2-fast",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 4.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-minimax-hailuo-02-text",
+      "locale": "es",
+      "slug": "ltx-2-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 4.5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-fast-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "seedance-2-0-fast-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 4.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-seedance-1-5-pro",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-ltx-2",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-ltx-2",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-veo-3-1",
+      "locale": "es",
+      "slug": "ltx-2-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-kling-3-4k",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-kling-3-4k",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/veo-3-1-fast-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "veo-3-1-fast-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "url": "https://maxvideoai.com/ai-video-engines/kling-2-5-turbo-vs-pika-text-to-video",
+      "locale": "en",
+      "slug": "kling-2-5-turbo-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5.5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-luma-ray-3-2",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-luma-ray-3-2",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5.5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 5.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-1-vs-kling-3-pro",
+      "locale": "es",
+      "slug": "happy-horse-1-1-vs-kling-3-pro",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-pika-text-to-video",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-o3-pro-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "kling-o3-pro-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/happy-horse-1-1-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "happy-horse-1-1-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 6.5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/pika-text-to-video-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "pika-text-to-video-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 6.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-ltx-2",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-ltx-2",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/gemini-omni-flash-vs-sora-2",
+      "locale": "es",
+      "slug": "gemini-omni-flash-vs-sora-2",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/pika-text-to-video-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "pika-text-to-video-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-minimax-hailuo-02-text",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-veo-3-1-first-last",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8.5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8.5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8.5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/minimax-hailuo-02-text-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "minimax-hailuo-02-text-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 8.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-wan-2-5",
+      "locale": "es",
+      "slug": "luma-ray-2-flash-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/veo-3-1-vs-veo-3-1-first-last",
+      "locale": "es",
+      "slug": "veo-3-1-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-pro-vs-kling-o3-4k",
+      "locale": "fr",
+      "slug": "kling-3-pro-vs-kling-o3-4k",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-ltx-2-3-pro",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-o3-4k-vs-veo-3-1",
+      "locale": "es",
+      "slug": "kling-o3-4k-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9.5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-seedance-1-5-pro",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 9.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/sora-2-pro-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "sora-2-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/gemini-omni-flash-vs-veo-3-1",
+      "locale": "fr",
+      "slug": "gemini-omni-flash-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 10.5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/dreamina-seedance-2-0-mini-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "dreamina-seedance-2-0-mini-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 14.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 17.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-wan-2-5",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 20
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-luma-ray-2-flash",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 24.5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-minimax-hailuo-02-text",
+      "locale": "fr",
+      "slug": "luma-ray-2-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 27
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-sora-2",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-sora-2",
+      "clicks": 0,
+      "impressions": 2,
+      "ctr": 0,
+      "position": 44.5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-fast-vs-sora-2",
+      "locale": "es",
+      "slug": "seedance-2-0-fast-vs-sora-2",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/veo-3-1-fast-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "veo-3-1-fast-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 1
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-2-0-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "seedance-2-0-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 2
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "ltx-2-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-flash-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "luma-ray-2-flash-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/pika-text-to-video-vs-seedance-1-5-pro",
+      "locale": "fr",
+      "slug": "pika-text-to-video-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 3
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-veo-3-1",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-fast-vs-luma-ray-2",
+      "locale": "fr",
+      "slug": "ltx-2-3-fast-vs-luma-ray-2",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-3-2-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "luma-ray-3-2-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 4
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-veo-3-1",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-luma-ray-2-flash",
+      "locale": "es",
+      "slug": "ltx-2-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-sora-2-pro",
+      "locale": "es",
+      "slug": "ltx-2-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-vs-veo-3-1",
+      "locale": "es",
+      "slug": "luma-ray-2-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/sora-2-pro-vs-wan-2-6",
+      "locale": "es",
+      "slug": "sora-2-pro-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-veo-3-1-fast",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-seedance-1-5-pro",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-fast-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "ltx-2-fast-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/minimax-hailuo-02-text-vs-seedance-1-5-pro",
+      "locale": "fr",
+      "slug": "minimax-hailuo-02-text-vs-seedance-1-5-pro",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 5
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-minimax-hailuo-02-text",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/happy-horse-1-1-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "happy-horse-1-1-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-pika-text-to-video",
+      "locale": "fr",
+      "slug": "ltx-2-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-pika-text-to-video",
+      "locale": "fr",
+      "slug": "luma-ray-2-vs-pika-text-to-video",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "luma-ray-2-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 6
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/happy-horse-1-1-vs-ltx-2-3-pro",
+      "locale": "es",
+      "slug": "happy-horse-1-1-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-sora-2",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-sora-2",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-6-pro-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "kling-2-6-pro-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-ltx-2-fast",
+      "locale": "fr",
+      "slug": "ltx-2-3-pro-vs-ltx-2-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/sora-2-pro-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "sora-2-pro-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 7
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-luma-ray-3-2",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-luma-ray-3-2",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-fast-vs-minimax-hailuo-02-text",
+      "locale": "es",
+      "slug": "ltx-2-fast-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "ltx-2-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-veo-3-1-first-last",
+      "locale": "es",
+      "slug": "ltx-2-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/minimax-hailuo-02-text-vs-sora-2",
+      "locale": "es",
+      "slug": "minimax-hailuo-02-text-vs-sora-2",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/sora-2-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "sora-2-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-5-turbo-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "kling-2-5-turbo-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-2-6-pro-vs-sora-2",
+      "locale": "fr",
+      "slug": "kling-2-6-pro-vs-sora-2",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-standard-vs-minimax-hailuo-02-text",
+      "locale": "fr",
+      "slug": "kling-3-standard-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/seedance-1-5-pro-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "seedance-1-5-pro-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/sora-2-vs-wan-2-5",
+      "locale": "fr",
+      "slug": "sora-2-vs-wan-2-5",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 8
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-1-5-pro-vs-veo-3-1",
+      "locale": "es",
+      "slug": "seedance-1-5-pro-vs-veo-3-1",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/seedance-2-0-vs-veo-3-1-first-last",
+      "locale": "es",
+      "slug": "seedance-2-0-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/veo-3-1-vs-veo-3-1-fast",
+      "locale": "es",
+      "slug": "veo-3-1-vs-veo-3-1-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-3-pro-vs-luma-ray-2-flash",
+      "locale": "fr",
+      "slug": "ltx-2-3-pro-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-flash-vs-seedance-2-0-fast",
+      "locale": "fr",
+      "slug": "luma-ray-2-flash-vs-seedance-2-0-fast",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 9
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-2-5-turbo-vs-luma-ray-2-flash",
+      "locale": "es",
+      "slug": "kling-2-5-turbo-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-4k-vs-ltx-2-3-pro",
+      "locale": "es",
+      "slug": "kling-3-4k-vs-ltx-2-3-pro",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-vs-veo-3-1-lite",
+      "locale": "es",
+      "slug": "ltx-2-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/luma-ray-2-flash-vs-seedance-2-0",
+      "locale": "es",
+      "slug": "luma-ray-2-flash-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/veo-3-1-lite-vs-wan-2-6",
+      "locale": "es",
+      "slug": "veo-3-1-lite-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/kling-3-4k-vs-sora-2-pro",
+      "locale": "fr",
+      "slug": "kling-3-4k-vs-sora-2-pro",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/veo-3-1-lite-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "veo-3-1-lite-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 10
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-standard-vs-luma-ray-2-flash",
+      "locale": "es",
+      "slug": "kling-3-standard-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/veo-3-1-fast-vs-veo-3-1-first-last",
+      "locale": "es",
+      "slug": "veo-3-1-fast-vs-veo-3-1-first-last",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/sora-2-pro-vs-wan-2-6",
+      "locale": "fr",
+      "slug": "sora-2-pro-vs-wan-2-6",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 11
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-pro-vs-luma-ray-2-flash",
+      "locale": "es",
+      "slug": "ltx-2-3-pro-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 12
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/luma-ray-2-flash-vs-seedance-2-0",
+      "locale": "fr",
+      "slug": "luma-ray-2-flash-vs-seedance-2-0",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 12
+    },
+    {
+      "url": "https://maxvideoai.com/fr/comparatif/ltx-2-vs-veo-3-1-lite",
+      "locale": "fr",
+      "slug": "ltx-2-vs-veo-3-1-lite",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 15
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/kling-3-pro-vs-minimax-hailuo-02-text",
+      "locale": "es",
+      "slug": "kling-3-pro-vs-minimax-hailuo-02-text",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 28
+    },
+    {
+      "url": "https://maxvideoai.com/es/comparativa/ltx-2-3-fast-vs-luma-ray-2-flash",
+      "locale": "es",
+      "slug": "ltx-2-3-fast-vs-luma-ray-2-flash",
+      "clicks": 0,
+      "impressions": 1,
+      "ctr": 0,
+      "position": 35
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-07-11-indexnow-indexation-guardrails.md
+++ b/docs/superpowers/plans/2026-07-11-indexnow-indexation-guardrails.md
@@ -1,0 +1,173 @@
+# IndexNow Indexation Guardrails Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure IndexNow submits only published, canonical comparison URLs and correct localized hubs, without silently dropping URLs through alphabetical truncation.
+
+**Architecture:** Extract pure comparison-publication selection into a Node-compatible module under `scripts/`. Keep Git change detection and HTTP submission in the existing command. Test the pure module against the sitemap’s TypeScript source of truth so future catalog changes cannot make IndexNow broader than the sitemap.
+
+**Tech Stack:** Node.js ESM, TypeScript Node test runner through `tsx`, Next.js sitemap helpers, JSON model catalog.
+
+## Global Constraints
+
+- Preserve all existing public URLs and current sitemap behavior.
+- Do not modify the authenticated workspace or the user’s existing editor changes.
+- Do not submit private render jobs, parameter variants, redirects, or `noindex` comparison URLs.
+- Use test-first development and observe the new tests failing before changing production code.
+- Do not mass-deindex comparison pages in this batch.
+
+---
+
+### Task 1: Published comparison URL selector
+
+**Files:**
+- Create: `scripts/indexnow-url-selection.mjs`
+- Create: `tests/indexnow-url-selection.test.ts`
+
+**Interfaces:**
+- Consumes: engine catalog entries containing `modelSlug` and `surfaces.compare.publishedPairs`.
+- Produces: `getPublishedComparisonSlugs(catalog)`, `getPublishedComparisonSlugsForModels(catalog, changedModelSlugs)`, `addComparisonUrls(urls, site, slug)`, and `addComparisonHubUrls(urls, site)`.
+
+- [x] **Step 1: Write the failing behavioral tests**
+
+```ts
+test('IndexNow comparison slugs are exactly the sitemap publication set', async () => {
+  const actual = getPublishedComparisonSlugs(engineCatalog);
+  const expected = getHubComparisonSlugsForSitemap();
+  assert.deepEqual(actual, expected);
+});
+
+test('changed models only select published comparisons involving that model', () => {
+  const slugs = getPublishedComparisonSlugsForModels(fixtureCatalog, new Set(['alpha']));
+  assert.deepEqual(slugs, ['alpha-vs-beta']);
+});
+
+test('localized comparison and hub URLs use canonical public paths', () => {
+  const urls = new Set<string>();
+  addComparisonHubUrls(urls, 'https://maxvideoai.com');
+  addComparisonUrls(urls, 'https://maxvideoai.com', 'alpha-vs-beta');
+  assert.ok(urls.has('https://maxvideoai.com/fr/comparatif'));
+  assert.ok(urls.has('https://maxvideoai.com/es/comparativa'));
+  assert.ok(!urls.has('https://maxvideoai.com/fr/ai-video-engines'));
+});
+```
+
+- [x] **Step 2: Run the focused test and confirm RED**
+
+Run:
+
+```bash
+./frontend/node_modules/.bin/tsx --tsconfig frontend/tsconfig.json --test tests/indexnow-url-selection.test.ts
+```
+
+Expected: failure because `scripts/indexnow-url-selection.mjs` does not exist.
+
+- [x] **Step 3: Implement the minimal selector**
+
+```js
+export function getPublishedComparisonSlugs(catalog) {
+  const validSlugs = new Set(catalog.map((entry) => entry?.modelSlug).filter(Boolean));
+  const published = new Set();
+  for (const entry of catalog) {
+    const left = entry?.modelSlug;
+    if (!left || EXCLUDED_ENGINE_SLUGS.has(left)) continue;
+    for (const right of entry?.surfaces?.compare?.publishedPairs ?? []) {
+      if (!validSlugs.has(right) || right === left || EXCLUDED_ENGINE_SLUGS.has(right)) continue;
+      published.add(canonicalCompareSlug(left, right));
+    }
+  }
+  return [...published].sort((a, b) => a.localeCompare(b));
+}
+```
+
+- [x] **Step 4: Run the focused test and confirm GREEN**
+
+Run the command from Step 2. Expected: all tests pass with zero failures.
+
+### Task 2: Integrate the selector into the IndexNow command
+
+**Files:**
+- Modify: `scripts/indexnow-submit-changed.mjs`
+- Modify: `tests/indexnow-url-selection.test.ts`
+
+**Interfaces:**
+- Consumes: selector functions from Task 1.
+- Produces: a dry-run URL list limited to published comparisons and canonical localized hubs.
+
+- [x] **Step 1: Add failing integration-contract assertions**
+
+```ts
+test('IndexNow delegates publication selection and does not synthesize combinations', () => {
+  const source = readFileSync('scripts/indexnow-submit-changed.mjs', 'utf8');
+  assert.match(source, /getPublishedComparisonSlugsForModels/);
+  assert.doesNotMatch(source, /collectCatalogComparisonSlugsForModels/);
+  assert.doesNotMatch(source, /\.slice\(0,.*MAX_URLS/);
+});
+```
+
+- [x] **Step 2: Run the focused test and confirm RED**
+
+Expected: failure because the command still generates all live/early-access combinations and truncates the sorted list.
+
+- [x] **Step 3: Replace generated combinations with published comparisons**
+
+```js
+import {
+  addComparisonHubUrls,
+  addComparisonUrls,
+  getPublishedComparisonSlugs,
+  getPublishedComparisonSlugsForModels,
+} from './indexnow-url-selection.mjs';
+```
+
+Use the full published set when comparison configuration changes and the changed-model subset when model content changes. Route hub additions through `addComparisonHubUrls`.
+
+- [x] **Step 4: Remove silent alphabetical truncation**
+
+Pass the complete deterministic URL list to dry-run/submission. The receiving API already handles one URL per request, so no new batching abstraction is required.
+
+- [x] **Step 5: Run the focused test and confirm GREEN**
+
+Run the focused command from Task 1. Expected: all selector and integration-contract tests pass.
+
+### Task 3: Verification and documentation alignment
+
+**Files:**
+- Modify: `ACTION-PLAN.md`
+- Verify: `scripts/indexnow-submit-changed.mjs`
+- Verify: `scripts/indexnow-url-selection.mjs`
+- Verify: `tests/indexnow-url-selection.test.ts`
+
+**Interfaces:**
+- Consumes: completed implementation from Tasks 1–2.
+- Produces: a checked-off P0 IndexNow action and fresh validation evidence.
+
+- [x] **Step 1: Run focused SEO contracts**
+
+```bash
+./frontend/node_modules/.bin/tsx --tsconfig frontend/tsconfig.json --test tests/indexnow-url-selection.test.ts tests/schema-sitemap-architecture.test.ts
+```
+
+Expected: zero failures.
+
+- [x] **Step 2: Run repository checks proportionate to the change**
+
+```bash
+npm run lint:exposure
+npm --prefix frontend run lint
+git diff --check
+```
+
+Expected: every command exits successfully.
+
+- [x] **Step 3: Run a safe dry-run and inspect its invariants**
+
+```bash
+node scripts/indexnow-submit-changed.mjs --dry-run
+```
+
+Expected: no `/app`, `/video/job_`, query-string comparison, `/fr/ai-video-engines`, `/es/ai-video-engines`, or unpublished comparison URL.
+
+- [x] **Step 4: Mark only the completed IndexNow action in the action plan**
+
+Update the report to distinguish implemented safeguards from later work on private jobs, application routes and controlled comparison consolidation.

--- a/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-helpers.ts
+++ b/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-helpers.ts
@@ -32,6 +32,7 @@ export {
   getCanonicalCompareSlug,
   resolveEngines,
   resolveExcludedCompareRedirect,
+  resolveLegacyCompareRedirect,
   reverseCompareSlug,
 } from './compare-page-routing';
 export {

--- a/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-routing.ts
+++ b/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-routing.ts
@@ -1,7 +1,19 @@
 import type { AppLocale } from '@/i18n/locales';
 import { localePathnames } from '@/i18n/locales';
 import { canonicalizeFalModelSlug } from '@/config/falEngines';
-import { CATALOG_BY_SLUG, EXCLUDED_ENGINE_SLUGS, MODELS_SLUG_MAP } from './compare-page-config';
+import {
+  CATALOG_BY_SLUG,
+  COMPARE_SLUG_MAP,
+  EXCLUDED_ENGINE_SLUGS,
+  MODELS_SLUG_MAP,
+} from './compare-page-config';
+
+const LEGACY_COMPARE_REPLACEMENTS: Record<string, { slug: string; orderAliases: Record<string, string> }> = {
+  'happy-horse-1-0-vs-sora-2-pro': {
+    slug: 'happy-horse-1-1-vs-sora-2-pro',
+    orderAliases: { 'happy-horse-1-0': 'happy-horse-1-1' },
+  },
+};
 
 export function reverseCompareSlug(slug: string) {
   const parts = slug.split('-vs-');
@@ -53,6 +65,20 @@ export function resolveExcludedCompareRedirect({
   const localePrefix = localePathnames[locale] ? `/${localePathnames[locale]}` : '';
   const modelsBase = MODELS_SLUG_MAP[locale] ?? MODELS_SLUG_MAP.en ?? 'models';
   return `${localePrefix}/${modelsBase}/${preferred}`.replace(/\/{2,}/g, '/');
+}
+
+export function resolveLegacyCompareRedirect({ slug, order, locale }: {
+  slug: string;
+  order?: string | null;
+  locale: AppLocale;
+}) {
+  const replacement = LEGACY_COMPARE_REPLACEMENTS[slug];
+  if (!replacement) return null;
+  const localePrefix = localePathnames[locale] ? `/${localePathnames[locale]}` : '';
+  const compareBase = COMPARE_SLUG_MAP[locale] ?? COMPARE_SLUG_MAP.en ?? 'ai-video-engines';
+  const targetOrder = order ? replacement.orderAliases[order] ?? order : null;
+  const query = targetOrder ? `?order=${encodeURIComponent(targetOrder)}` : '';
+  return `${localePrefix}/${compareBase}/${replacement.slug}${query}`.replace(/\/{2,}/g, '/');
 }
 
 export function buildGenerateHref(engineSlug: string, prompt?: string | null, aspectRatio?: string | null, mode?: string | null) {

--- a/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/page.tsx
+++ b/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/page.tsx
@@ -32,6 +32,7 @@ import {
   isEngineGeneratable,
   resolveEngines,
   resolveExcludedCompareRedirect,
+  resolveLegacyCompareRedirect,
 } from './_lib/compare-page-helpers';
 
 export const dynamicParams = true;
@@ -74,14 +75,10 @@ export default async function CompareDetailPage(
     notFound();
   }
   const requestedOrder = typeof searchParams?.order === 'string' ? searchParams.order : null;
-  const excludedRedirect = resolveExcludedCompareRedirect({
-    slug: canonicalInfo.canonicalSlug,
-    order: requestedOrder,
-    locale: activeLocale,
-  });
-  if (excludedRedirect) {
-    redirect(excludedRedirect);
-  }
+  const excludedRedirect = resolveExcludedCompareRedirect({ slug: canonicalInfo.canonicalSlug, order: requestedOrder, locale: activeLocale });
+  if (excludedRedirect) redirect(excludedRedirect);
+  const legacyRedirect = resolveLegacyCompareRedirect({ slug: canonicalInfo.canonicalSlug, order: requestedOrder, locale: activeLocale });
+  if (legacyRedirect) permanentRedirect(legacyRedirect);
   const resolved = resolveEngines(canonicalInfo.canonicalSlug);
   if (!resolved) {
     notFound();

--- a/frontend/lib/middleware/routing-query.ts
+++ b/frontend/lib/middleware/routing-query.ts
@@ -60,10 +60,6 @@ export function shouldMarkTrackingNoindex(req: NextRequest, pathname: string, is
   if (isAdminRoute) {
     return false;
   }
-  const trackingSource = req.nextUrl.searchParams.get('utm_source')?.toLowerCase();
-  if (trackingSource === 'startupfa.me') {
-    return false;
-  }
   if (!hasTrackingParams(req.nextUrl.searchParams)) {
     return false;
   }

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -72,6 +72,7 @@ const nextConfig = {
   transpilePackages: ['@maxvideoai/pricing'],
   images: {
     qualities: [52, 70, 72, 75, 80],
+    minimumCacheTTL: 604800,
     localPatterns: [
       { pathname: '/assets/**' },
       { pathname: '/brand/**' },
@@ -178,7 +179,7 @@ const nextConfig = {
       },
       {
         source: '/models/google-veo-3',
-        destination: '/models/veo-3',
+        destination: '/models/veo-3-1',
         permanent: true,
       },
       {

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -2,7 +2,7 @@
 
 # AI search and answer crawlers are allowed on public marketing, docs,
 # examples, model, pricing, and blog pages. Private app/admin/API surfaces
-# remain blocked for these crawlers just as they are for general crawlers.
+# remain blocked for named AI crawlers.
 User-agent: OAI-SearchBot
 User-agent: OAI-AdsBot
 User-agent: ChatGPT-User
@@ -19,7 +19,7 @@ Allow: /hero/
 Allow: /favicon.ico
 Allow: /api/legal/cookies/version
 Disallow: /api/
-Disallow: /admin/
+Disallow: /admin
 Disallow: /app
 Disallow: /generate
 Disallow: /dashboard
@@ -54,24 +54,22 @@ Allow: /hero/
 Allow: /favicon.ico
 Allow: /api/legal/cookies/version
 
-# Sensitive areas
+# Sensitive and authenticated areas. /app is intentionally crawlable because
+# it returns noindex metadata and an X-Robots-Tag for every query variant.
 Disallow: /api/
-Disallow: /admin/
-Disallow: /app
+Disallow: /admin
 Disallow: /generate
 Disallow: /dashboard
 Disallow: /jobs
 Disallow: /billing
 Disallow: /settings
 Disallow: /connect
-Disallow: /fr/app
 Disallow: /fr/generate
 Disallow: /fr/dashboard
 Disallow: /fr/jobs
 Disallow: /fr/billing
 Disallow: /fr/settings
 Disallow: /fr/connect
-Disallow: /es/app
 Disallow: /es/generate
 Disallow: /es/dashboard
 Disallow: /es/jobs

--- a/frontend/server/video-seo.ts
+++ b/frontend/server/video-seo.ts
@@ -239,7 +239,7 @@ export async function getVideoWatchPageDataById(id: string): Promise<VideoWatchP
     video,
     signals,
     related: pickRelatedWatchPages({
-      currentId: id,
+      currentId: resolvedId,
       currentSignals: signals,
       candidates: candidateRows,
       limit: 4,

--- a/frontend/server/watch-page-signals/related.ts
+++ b/frontend/server/watch-page-signals/related.ts
@@ -1,4 +1,5 @@
 import type { SeoWatchVideoConfig } from '@/config/video-seo-watchlist';
+import { buildVideoWatchPath } from '@/lib/video-seo-canonical';
 import type { GalleryVideo } from '@/server/videos';
 import type { CandidateRow, WatchPageDerivedSignals, WatchPageRelatedLink } from './types';
 
@@ -10,6 +11,7 @@ export function toWatchPageRelatedCandidate(params: {
   const { entry, video, signals } = params;
   return {
     id: entry.id,
+    canonicalSlug: signals.canonicalSlug,
     title: signals.title,
     subtitle: signals.intro,
     engineLabel: signals.engineLabel,
@@ -68,7 +70,7 @@ export function pickRelatedWatchPages(params: {
 
       return {
         id: candidate.id,
-        href: `/video/${encodeURIComponent(candidate.id)}`,
+        href: buildVideoWatchPath(candidate.id, candidate.canonicalSlug),
         title: candidate.title,
         subtitle: candidate.subtitle,
         engineLabel: candidate.engineLabel,

--- a/frontend/server/watch-page-signals/types.ts
+++ b/frontend/server/watch-page-signals/types.ts
@@ -129,6 +129,7 @@ export type WatchPageDerivedSignals = {
 
 export type CandidateRow = {
   id: string;
+  canonicalSlug: string | null;
   title: string;
   subtitle: string;
   engineLabel: string;

--- a/scripts/comparison-indexation-policy.ts
+++ b/scripts/comparison-indexation-policy.ts
@@ -1,0 +1,162 @@
+export type ComparisonLocale = 'en' | 'fr' | 'es';
+
+export type ComparisonIndexationClass =
+  | 'keep'
+  | 'enrich'
+  | 'review'
+  | 'noindex_candidate';
+
+export type ComparisonPolicyInput = {
+  locale: ComparisonLocale;
+  clicks: number;
+  impressions: number;
+  position: number;
+  hasLocalizedOverride: boolean;
+  isStrategic: boolean;
+};
+
+export type ComparisonGscRow = {
+  url: string;
+  locale: ComparisonLocale;
+  slug: string;
+  clicks: number;
+  impressions: number;
+  ctr: number;
+  position: number;
+};
+
+export type ComparisonMatrixRow = ComparisonGscRow & {
+  hasGscRow: boolean;
+  gscSourceUrls: string[];
+  hasLocalizedOverride: boolean;
+  strategicSignals: string[];
+  classification: ComparisonIndexationClass;
+  rationale: string[];
+};
+
+export type ComparisonMatrixInput = {
+  publishedSlugs: string[];
+  gscRows: ComparisonGscRow[];
+  localizedOverrideSlugs: Record<ComparisonLocale, ReadonlySet<string>>;
+  strategicSignalsBySlug: ReadonlyMap<string, readonly string[]>;
+  baseUrl?: string;
+};
+
+export function classifyComparison(
+  input: ComparisonPolicyInput,
+): ComparisonIndexationClass {
+  if (
+    input.clicks > 0 ||
+    input.impressions >= 500 ||
+    input.hasLocalizedOverride ||
+    (input.locale === 'en' && input.isStrategic)
+  ) {
+    return 'keep';
+  }
+
+  if (input.impressions >= 100) return 'enrich';
+  if (
+    input.impressions >= 30 ||
+    (input.impressions > 0 && input.position > 0 && input.position <= 10) ||
+    input.isStrategic
+  ) {
+    return 'review';
+  }
+
+  return 'noindex_candidate';
+}
+
+export function buildComparisonIndexationMatrix(
+  input: ComparisonMatrixInput,
+): ComparisonMatrixRow[] {
+  const baseUrl = (input.baseUrl ?? 'https://maxvideoai.com').replace(/\/$/, '');
+  const locales: ComparisonLocale[] = ['en', 'fr', 'es'];
+  const localePaths: Record<ComparisonLocale, string> = {
+    en: '/ai-video-engines',
+    fr: '/fr/comparatif',
+    es: '/es/comparativa',
+  };
+  const metricsRowsByKey = new Map<string, ComparisonGscRow[]>();
+  input.gscRows.forEach((row) => {
+    const key = `${row.locale}:${row.slug}`;
+    const current = metricsRowsByKey.get(key) ?? [];
+    current.push(row);
+    metricsRowsByKey.set(key, current);
+  });
+
+  return locales.flatMap((locale) =>
+    Array.from(new Set(input.publishedSlugs))
+      .sort((a, b) => a.localeCompare(b, 'en'))
+      .map((slug) => {
+        const metricsRows = metricsRowsByKey.get(`${locale}:${slug}`) ?? [];
+        const clicks = metricsRows.reduce((sum, row) => sum + row.clicks, 0);
+        const impressions = metricsRows.reduce((sum, row) => sum + row.impressions, 0);
+        const ctr = impressions > 0 ? Math.round((clicks / impressions) * 1_000) / 10 : 0;
+        const weightedPosition = metricsRows.reduce(
+          (sum, row) => sum + row.position * row.impressions,
+          0,
+        );
+        const position =
+          impressions > 0
+            ? Math.round((weightedPosition / impressions) * 10) / 10
+            : metricsRows[0]?.position ?? 0;
+        const strategicSignals = Array.from(
+          new Set(input.strategicSignalsBySlug.get(slug) ?? []),
+        ).sort((a, b) => a.localeCompare(b, 'en'));
+        const hasLocalizedOverride = input.localizedOverrideSlugs[locale].has(slug);
+        const isStrategic = strategicSignals.length > 0;
+        const classification = classifyComparison({
+          locale,
+          clicks,
+          impressions,
+          position,
+          hasLocalizedOverride,
+          isStrategic,
+        });
+        const rationale: string[] = [];
+
+        if (clicks > 0) rationale.push('gsc_clicks');
+        if (impressions >= 500) rationale.push('gsc_high_impressions');
+        if (hasLocalizedOverride) rationale.push('localized_editorial_override');
+        if (locale === 'en' && isStrategic) rationale.push('english_strategic_surface');
+        if (classification === 'enrich') rationale.push('gsc_enrichment_opportunity');
+        if (classification === 'review' && impressions >= 30) {
+          rationale.push('gsc_review_opportunity');
+        }
+        if (
+          classification === 'review' &&
+          impressions < 30 &&
+          position > 0 &&
+          position <= 10
+        ) {
+          rationale.push('gsc_top_10_review');
+        }
+        if (classification === 'review' && locale !== 'en' && isStrategic) {
+          rationale.push('strategic_localization_review');
+        }
+        if (classification === 'noindex_candidate') {
+          rationale.push(
+            metricsRows.length > 0
+              ? 'low_demand_outside_top_10'
+              : 'no_gsc_row_or_editorial_signal',
+          );
+        }
+
+        return {
+          url: `${baseUrl}${localePaths[locale]}/${slug}`,
+          locale,
+          slug,
+          clicks,
+          impressions,
+          ctr,
+          position,
+          hasGscRow: metricsRows.length > 0,
+          gscSourceUrls: metricsRows.map((row) => row.url).sort((a, b) => a.localeCompare(b)),
+          hasLocalizedOverride,
+          strategicSignals,
+          classification,
+          rationale,
+        };
+      }),
+  );
+}

--- a/scripts/generate-comparison-indexation-matrix.ts
+++ b/scripts/generate-comparison-indexation-matrix.ts
@@ -1,0 +1,383 @@
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import compareConfig from '../frontend/config/compare-config.json';
+import compareHubConfig from '../frontend/config/compare-hub.json';
+import {
+  buildCanonicalCompareSlug,
+  canonicalizePublishedCompareSlug,
+  getHubComparisonSlugsForSitemap,
+} from '../frontend/lib/compare-hub/data.ts';
+import { EN_COMPARE_PAGE_OVERRIDES } from '../frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-en.ts';
+import { ES_COMPARE_PAGE_OVERRIDES } from '../frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-es.ts';
+import { FR_COMPARE_PAGE_OVERRIDES } from '../frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-fr.ts';
+import gscSnapshot from '../docs/seo/gsc-comparison-performance-2026-07-08.json';
+import {
+  buildComparisonIndexationMatrix,
+  type ComparisonGscRow,
+  type ComparisonIndexationClass,
+  type ComparisonLocale,
+  type ComparisonMatrixRow,
+} from './comparison-indexation-policy.ts';
+
+const JSON_OUTPUT = 'docs/seo/comparison-indexation-matrix-2026-07-08.json';
+const MARKDOWN_OUTPUT = 'docs/seo/comparison-indexation-matrix-2026-07-08.md';
+const CLASSIFICATIONS: ComparisonIndexationClass[] = [
+  'keep',
+  'enrich',
+  'review',
+  'noindex_candidate',
+];
+const LOCALES: ComparisonLocale[] = ['en', 'fr', 'es'];
+
+type PairSeed = { left: string; right: string };
+type StrategicCompareConfig = {
+  trophyComparisons?: string[];
+  scoreboardOnlyComparisons?: string[];
+  bestForPages?: Array<{ relatedComparisons?: string[] }>;
+  relatedComparisons?: Record<string, string[]>;
+  showdowns?: Record<string, unknown>;
+};
+type StrategicHubConfig = {
+  popularComparisons?: PairSeed[];
+  useCaseBuckets?: Array<{ pairs?: PairSeed[] }>;
+  opponentOverrides?: Record<string, string[]>;
+};
+
+export type ComparisonIndexationDocument = {
+  schemaVersion: 1;
+  generatedAt: string;
+  source: {
+    property: string;
+    searchType: string;
+    range: { start: string; end: string };
+    exportedAt: string;
+    rawPageRows: number;
+    comparisonRows: number;
+    gscRows: number;
+  };
+  policy: {
+    keep: string[];
+    enrich: string[];
+    review: string[];
+    noindexCandidate: string[];
+    safety: string;
+  };
+  summary: {
+    publishedSlugs: number;
+    totalUrls: number;
+    withGscRows: number;
+    withoutGscRows: number;
+    withClicks: number;
+    gscRowsOutsidePublishedSet: number;
+    gscRowsOutsidePublishedSetWithClicks: number;
+    byLocale: Record<ComparisonLocale, number>;
+    byClassification: Record<ComparisonIndexationClass, number>;
+  };
+  rows: ComparisonMatrixRow[];
+  legacyGscRows: ComparisonGscRow[];
+};
+
+type ComparisonIndexationArtifacts = {
+  document: ComparisonIndexationDocument;
+  markdown: string;
+};
+
+function addStrategicSignal(
+  signals: Map<string, Set<string>>,
+  published: ReadonlySet<string>,
+  slug: string,
+  signal: string,
+) {
+  const canonical = canonicalizePublishedCompareSlug(slug);
+  if (!published.has(canonical)) return;
+  const current = signals.get(canonical) ?? new Set<string>();
+  current.add(signal);
+  signals.set(canonical, current);
+}
+
+function addPairSeedSignal(
+  signals: Map<string, Set<string>>,
+  published: ReadonlySet<string>,
+  pair: PairSeed,
+  signal: string,
+) {
+  addStrategicSignal(
+    signals,
+    published,
+    buildCanonicalCompareSlug(pair.left, pair.right),
+    signal,
+  );
+}
+
+export function collectStrategicComparisonSignals(
+  publishedSlugs: string[],
+): Map<string, readonly string[]> {
+  const published = new Set(publishedSlugs);
+  const signals = new Map<string, Set<string>>();
+  const editorial = compareConfig as StrategicCompareConfig;
+  const hub = compareHubConfig as StrategicHubConfig;
+
+  editorial.trophyComparisons?.forEach((slug) =>
+    addStrategicSignal(signals, published, slug, 'trophy'),
+  );
+  editorial.scoreboardOnlyComparisons?.forEach((slug) =>
+    addStrategicSignal(signals, published, slug, 'scoreboard'),
+  );
+  editorial.bestForPages?.forEach((page) =>
+    page.relatedComparisons?.forEach((slug) =>
+      addStrategicSignal(signals, published, slug, 'best_for_related'),
+    ),
+  );
+  Object.entries(editorial.relatedComparisons ?? {}).forEach(([slug, related]) => {
+    addStrategicSignal(signals, published, slug, 'related_graph');
+    related.forEach((relatedSlug) =>
+      addStrategicSignal(signals, published, relatedSlug, 'related_graph'),
+    );
+  });
+  Object.keys(editorial.showdowns ?? {}).forEach((slug) =>
+    addStrategicSignal(signals, published, slug, 'showdown'),
+  );
+  hub.popularComparisons?.forEach((pair) =>
+    addPairSeedSignal(signals, published, pair, 'popular'),
+  );
+  hub.useCaseBuckets?.forEach((bucket) =>
+    bucket.pairs?.forEach((pair) =>
+      addPairSeedSignal(signals, published, pair, 'use_case_bucket'),
+    ),
+  );
+  Object.entries(hub.opponentOverrides ?? {}).forEach(([left, opponents]) =>
+    opponents.forEach((right) =>
+      addPairSeedSignal(signals, published, { left, right }, 'opponent_override'),
+    ),
+  );
+
+  return new Map(
+    Array.from(signals, ([slug, values]) => [
+      slug,
+      Array.from(values).sort((a, b) => a.localeCompare(b, 'en')),
+    ]),
+  );
+}
+
+function countByClassification(rows: ComparisonMatrixRow[]) {
+  return Object.fromEntries(
+    CLASSIFICATIONS.map((classification) => [
+      classification,
+      rows.filter((row) => row.classification === classification).length,
+    ]),
+  ) as Record<ComparisonIndexationClass, number>;
+}
+
+function escapeTableCell(value: string) {
+  return value.replaceAll('|', '\\|').replaceAll('\n', ' ');
+}
+
+function rowTable(rows: ComparisonMatrixRow[], limit: number) {
+  const selected = rows.slice(0, limit);
+  if (!selected.length) return '_Aucune URL._';
+  return [
+    '| Locale | Comparatif | Clics | Impressions | Position | Signaux |',
+    '| --- | --- | ---: | ---: | ---: | --- |',
+    ...selected.map((row) => {
+      const cells = [
+        row.locale,
+        `[${escapeTableCell(row.slug)}](${row.url})`,
+        String(row.clicks),
+        String(row.impressions),
+        String(row.position || '—'),
+        escapeTableCell(
+          [
+            row.hasLocalizedOverride ? 'override localise' : '',
+            ...row.strategicSignals,
+            ...row.rationale,
+          ]
+            .filter(Boolean)
+            .join(', '),
+        ) || '—',
+      ];
+      return `| ${cells.join(' | ')} |`;
+    }),
+  ].join('\n');
+}
+
+function legacyRowTable(rows: ComparisonGscRow[]) {
+  if (!rows.length) return '_Aucune URL._';
+  return [
+    '| Locale | URL GSC | Clics | Impressions | Position |',
+    '| --- | --- | ---: | ---: | ---: |',
+    ...rows.map(
+      (row) =>
+        `| ${row.locale} | [${escapeTableCell(row.slug)}](${row.url}) | ${row.clicks} | ${row.impressions} | ${row.position || '—'} |`,
+    ),
+  ].join('\n');
+}
+
+function buildMarkdown(document: ComparisonIndexationDocument) {
+  const rowsByDemand = [...document.rows].sort(
+    (a, b) => b.clicks - a.clicks || b.impressions - a.impressions || a.url.localeCompare(b.url),
+  );
+  const noindexCandidates = document.rows
+    .filter((row) => row.classification === 'noindex_candidate')
+    .sort(
+      (a, b) =>
+        Number(a.hasGscRow) - Number(b.hasGscRow) ||
+        a.impressions - b.impressions ||
+        a.url.localeCompare(b.url),
+    );
+  const classes = document.summary.byClassification;
+  const veoAliasRows = document.legacyGscRows.filter((row) =>
+    row.slug.includes('veo-3-1-first-last'),
+  ).length;
+  const happyHorseLegacyRows = document.legacyGscRows.filter(
+    (row) => row.slug === 'happy-horse-1-0-vs-sora-2-pro',
+  ).length;
+
+  return `# Matrice d'indexation des comparatifs — GSC au ${document.source.range.end}
+
+Source : Google Search Console, propriété \`${document.source.property}\`, recherche ${document.source.searchType}, période du ${document.source.range.start} au ${document.source.range.end}.
+
+> Aucun noindex n'est applique automatiquement par cette matrice. \`noindex_candidate\` signifie uniquement qu'une URL doit être validée manuellement avant consolidation, retrait du sitemap ou ajout éventuel d'une directive.
+
+## Résumé
+
+| Mesure | Total |
+| --- | ---: |
+| Slugs publiés | ${document.summary.publishedSlugs} |
+| URLs localisées auditées | ${document.summary.totalUrls} |
+| URLs présentes dans l'export GSC | ${document.summary.withGscRows} |
+| URLs sans ligne GSC dans les ${document.source.rawPageRows} premières pages | ${document.summary.withoutGscRows} |
+| URLs avec au moins un clic | ${document.summary.withClicks} |
+| Lignes GSC hors du périmètre publié | ${document.summary.gscRowsOutsidePublishedSet} |
+| Lignes hors périmètre avec clics | ${document.summary.gscRowsOutsidePublishedSetWithClicks} |
+| Keep | ${classes.keep} |
+| Enrich | ${classes.enrich} |
+| Review | ${classes.review} |
+| Noindex candidate | ${classes.noindex_candidate} |
+
+## Règles conservatrices
+
+- **Keep** : au moins 1 clic, au moins 500 impressions, override éditorial localisé, ou page anglaise présente sur une surface stratégique.
+- **Enrich** : 100 à 499 impressions sans signal prioritaire ; améliorer le contenu et le CTR avant toute consolidation.
+- **Review** : 30 à 99 impressions, position moyenne dans le top 10 avec une demande observée, ou version FR/ES d'un comparatif stratégique sans preuve locale suffisante.
+- **Noindex candidate** : moins de 30 impressions, hors top 10 ou absente de l'export GSC, aucun clic, aucun override localisé et aucun signal stratégique. Validation manuelle obligatoire.
+
+## Pages à conserver en priorité
+
+${rowTable(rowsByDemand.filter((row) => row.classification === 'keep'), 30)}
+
+## Pages à enrichir
+
+${rowTable(rowsByDemand.filter((row) => row.classification === 'enrich'), 30)}
+
+## Pages à revoir
+
+${rowTable(rowsByDemand.filter((row) => row.classification === 'review'), 30)}
+
+## Premier lot de candidates à valider manuellement
+
+Ce lot commence par les URLs absentes de l'export GSC, puis par celles avec le moins d'impressions. Il ne constitue pas une instruction de mise en noindex.
+
+${rowTable(noindexCandidates, 50)}
+
+## URLs GSC hors du périmètre publié
+
+Ces anciennes URLs ou variantes ne font pas partie des 292 slugs actuellement publiés. Celles qui ont des clics doivent être vérifiées en priorité pour décider entre republication, redirection 301 pertinente ou maintien temporaire.
+
+- ${veoAliasRows} anciennes variantes Veo \`first-last\` sont déjà normalisées par une redirection permanente vers les comparatifs Veo 3.1 canoniques.
+- Les ${happyHorseLegacyRows} URLs localisées Happy Horse 1.0 vs Sora 2 Pro passent désormais par une redirection permanente vers le comparatif publié Happy Horse 1.1 vs Sora 2 Pro dans cette branche.
+
+${legacyRowTable(document.legacyGscRows)}
+
+L'inventaire exhaustif des ${document.summary.totalUrls} URLs se trouve dans \`${JSON_OUTPUT}\`.
+`;
+}
+
+export function generateComparisonIndexationArtifacts(): ComparisonIndexationArtifacts {
+  const publishedSlugs = getHubComparisonSlugsForSitemap();
+  const strategicSignalsBySlug = collectStrategicComparisonSignals(publishedSlugs);
+  const localizedOverrideSlugs: Record<ComparisonLocale, ReadonlySet<string>> = {
+    en: new Set(Object.keys(EN_COMPARE_PAGE_OVERRIDES)),
+    fr: new Set(Object.keys(FR_COMPARE_PAGE_OVERRIDES)),
+    es: new Set(Object.keys(ES_COMPARE_PAGE_OVERRIDES)),
+  };
+  const gscRows = gscSnapshot.rows as ComparisonGscRow[];
+  const publishedSlugSet = new Set(publishedSlugs);
+  const legacyGscRows = gscRows
+    .filter((row) => !publishedSlugSet.has(row.slug))
+    .sort(
+      (a, b) => b.clicks - a.clicks || b.impressions - a.impressions || a.url.localeCompare(b.url),
+    );
+  const rows = buildComparisonIndexationMatrix({
+    publishedSlugs,
+    gscRows,
+    localizedOverrideSlugs,
+    strategicSignalsBySlug,
+  });
+  const byLocale = Object.fromEntries(
+    LOCALES.map((locale) => [locale, rows.filter((row) => row.locale === locale).length]),
+  ) as Record<ComparisonLocale, number>;
+  const document: ComparisonIndexationDocument = {
+    schemaVersion: 1,
+    generatedAt: gscSnapshot.exportedAt,
+    source: {
+      property: gscSnapshot.property,
+      searchType: gscSnapshot.searchType,
+      range: gscSnapshot.range,
+      exportedAt: gscSnapshot.exportedAt,
+      rawPageRows: gscSnapshot.rawPageRows,
+      comparisonRows: gscSnapshot.comparisonRows,
+      gscRows: gscRows.length,
+    },
+    policy: {
+      keep: [
+        'clicks > 0',
+        'impressions >= 500',
+        'localized editorial override',
+        'English URL on a strategic comparison surface',
+      ],
+      enrich: ['100 <= impressions < 500 without a keep signal'],
+      review: [
+        '30 <= impressions < 100 without a keep signal',
+        '0 < impressions < 30 with average position <= 10',
+        'FR/ES strategic URL without local proof',
+      ],
+      noindexCandidate: [
+        'impressions < 30',
+        'average position > 10 or no GSC row',
+        'clicks = 0',
+        'no localized editorial override',
+        'no strategic comparison signal',
+      ],
+      safety: 'Recommendation only; no sitemap, robots, canonical, or noindex change is applied.',
+    },
+    summary: {
+      publishedSlugs: publishedSlugs.length,
+      totalUrls: rows.length,
+      withGscRows: rows.filter((row) => row.hasGscRow).length,
+      withoutGscRows: rows.filter((row) => !row.hasGscRow).length,
+      withClicks: rows.filter((row) => row.clicks > 0).length,
+      gscRowsOutsidePublishedSet: legacyGscRows.length,
+      gscRowsOutsidePublishedSetWithClicks: legacyGscRows.filter((row) => row.clicks > 0).length,
+      byLocale,
+      byClassification: countByClassification(rows),
+    },
+    rows,
+    legacyGscRows,
+  };
+
+  return { document, markdown: buildMarkdown(document) };
+}
+
+export function writeComparisonIndexationArtifacts() {
+  const artifacts = generateComparisonIndexationArtifacts();
+  writeFileSync(JSON_OUTPUT, `${JSON.stringify(artifacts.document, null, 2)}\n`, 'utf8');
+  writeFileSync(MARKDOWN_OUTPUT, artifacts.markdown, 'utf8');
+  return artifacts.document.summary;
+}
+
+const invokedPath = process.argv[1] ? fileURLToPath(import.meta.url) === process.argv[1] : false;
+if (invokedPath) {
+  const summary = writeComparisonIndexationArtifacts();
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+}

--- a/scripts/indexnow-submit-changed.mjs
+++ b/scripts/indexnow-submit-changed.mjs
@@ -3,35 +3,26 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
+import {
+  addComparisonHubUrls,
+  addComparisonUrls,
+  getPublishedComparisonSlugs,
+  getPublishedComparisonSlugsForModels,
+} from './indexnow-url-selection.mjs';
 
 const SITE = (process.env.SITE || 'https://maxvideoai.com').replace(/\/+$/, '');
 const INDEXNOW_PROXY = process.env.INDEXNOW_PROXY || `${SITE}/api/indexnow`;
 const BEFORE = process.env.GITHUB_EVENT_BEFORE || '';
 const AFTER = process.env.GITHUB_SHA || 'HEAD';
 const DRY_RUN = process.argv.includes('--dry-run');
-const MAX_URLS = Number.parseInt(process.env.INDEXNOW_MAX_URLS || '200', 10);
 
 const REPO_ROOT = process.cwd();
-const COMPARE_CONFIG_PATH = path.join(REPO_ROOT, 'frontend/config/compare-config.json');
-const COMPARE_HUB_PATH = path.join(REPO_ROOT, 'frontend/config/compare-hub.json');
 const ENGINE_CATALOG_PATH = path.join(REPO_ROOT, 'frontend/config/engine-catalog.json');
+const MODEL_ROSTER_PATH = path.join(REPO_ROOT, 'frontend/config/model-roster.json');
 
 function toAbsoluteUrl(pathname) {
   if (!pathname || pathname === '/') return SITE;
   return `${SITE}${pathname.startsWith('/') ? pathname : `/${pathname}`}`;
-}
-
-function canonicalCompareSlug(slug) {
-  if (typeof slug !== 'string' || !slug.includes('-vs-')) return null;
-  const [left, right] = slug.split('-vs-');
-  if (!left || !right) return null;
-  const canonical = [left.trim(), right.trim()].sort((a, b) => a.localeCompare(b));
-  return `${canonical[0]}-vs-${canonical[1]}`;
-}
-
-function canonicalCompareSlugFromPair(left, right) {
-  if (!left || !right) return null;
-  return canonicalCompareSlug(`${left}-vs-${right}`);
 }
 
 function readJson(filePath, fallback = {}) {
@@ -60,68 +51,6 @@ function safeGitChangedFiles(before, after) {
       .map((line) => line.trim())
       .filter(Boolean);
   }
-}
-
-function collectAllComparisonSlugs() {
-  const slugs = new Set();
-  const compareConfig = readJson(COMPARE_CONFIG_PATH, {});
-  const compareHub = readJson(COMPARE_HUB_PATH, {});
-
-  const addSlug = (slug) => {
-    const normalized = canonicalCompareSlug(slug);
-    if (normalized) slugs.add(normalized);
-  };
-
-  const addPair = (left, right) => {
-    const normalized = canonicalCompareSlugFromPair(left, right);
-    if (normalized) slugs.add(normalized);
-  };
-
-  (compareConfig.trophyComparisons || []).forEach(addSlug);
-  Object.keys(compareConfig.relatedComparisons || {}).forEach(addSlug);
-  Object.values(compareConfig.relatedComparisons || {}).forEach((list) => (list || []).forEach(addSlug));
-  Object.keys(compareConfig.showdowns || {}).forEach(addSlug);
-
-  (compareHub.popularComparisons || []).forEach((entry) => addPair(entry?.left, entry?.right));
-  (compareHub.useCaseBuckets || []).forEach((bucket) =>
-    (bucket?.pairs || []).forEach((entry) => addPair(entry?.left, entry?.right))
-  );
-
-  return slugs;
-}
-
-function collectCatalogComparisonSlugsForModels(changedModelSlugs) {
-  const slugs = new Set();
-  const catalog = readJson(ENGINE_CATALOG_PATH, []);
-  const excluded = new Set(['nano-banana', 'nano-banana-pro', 'nano-banana-2']);
-  const eligibleStatuses = new Set(['live', 'early_access']);
-
-  const eligibleModels = (Array.isArray(catalog) ? catalog : [])
-    .filter((entry) => {
-      const slug = entry?.modelSlug;
-      const status = String(entry?.engine?.status || '').toLowerCase();
-      return Boolean(slug) && !excluded.has(slug) && eligibleStatuses.has(status);
-    })
-    .map((entry) => entry.modelSlug);
-
-  const eligibleSet = new Set(eligibleModels);
-  const changedEligible = Array.from(changedModelSlugs).filter((slug) => eligibleSet.has(slug));
-
-  changedEligible.forEach((changedSlug) => {
-    eligibleModels.forEach((otherSlug) => {
-      if (otherSlug === changedSlug) return;
-      const canonical = canonicalCompareSlugFromPair(changedSlug, otherSlug);
-      if (canonical) slugs.add(canonical);
-    });
-  });
-
-  return slugs;
-}
-
-function addCompareUrlsForSlug(urls, comparisonSlug) {
-  urls.add(toAbsoluteUrl(`/ai-video-engines/${comparisonSlug}`));
-  urls.add(toAbsoluteUrl(`/fr/comparatif/${comparisonSlug}`));
-  urls.add(toAbsoluteUrl(`/es/comparativa/${comparisonSlug}`));
 }
 
 function addModelUrl(urls, locale, slug) {
@@ -166,14 +95,21 @@ function collectUrlsFromChangedFiles(changedFiles) {
   ]);
 
   const changedModelSlugs = new Set();
-  let compareConfigTouched = false;
+  const indexableModelSlugs = new Set(
+    readJson(MODEL_ROSTER_PATH, [])
+      .filter((entry) => entry?.modelSlug && entry?.surfaces?.modelPage?.includeInSitemap !== false)
+      .map((entry) => entry.modelSlug)
+  );
+  let comparisonPublicationTouched = false;
 
   changedFiles.forEach((filePath) => {
     const modelMatch = filePath.match(/^content\/models\/(en|fr|es)\/([a-z0-9-]+)\.json$/);
     if (modelMatch) {
       const [, locale, slug] = modelMatch;
       changedModelSlugs.add(slug);
-      addModelUrl(urls, locale, slug);
+      if (indexableModelSlugs.has(slug)) {
+        addModelUrl(urls, locale, slug);
+      }
       return;
     }
 
@@ -206,14 +142,16 @@ function collectUrlsFromChangedFiles(changedFiles) {
       return;
     }
 
-    if (filePath === 'frontend/config/compare-config.json' || filePath === 'frontend/config/compare-hub.json') {
-      compareConfigTouched = true;
+    if (
+      filePath === 'frontend/config/engine-catalog.json' ||
+      filePath === 'frontend/config/compare-config.json' ||
+      filePath === 'frontend/config/compare-hub.json'
+    ) {
+      comparisonPublicationTouched = true;
     }
 
     if (filePath.startsWith('frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/')) {
-      urls.add(toAbsoluteUrl('/ai-video-engines'));
-      urls.add(toAbsoluteUrl('/fr/ai-video-engines'));
-      urls.add(toAbsoluteUrl('/es/ai-video-engines'));
+      addComparisonHubUrls(urls, SITE);
     }
 
     if (
@@ -230,20 +168,14 @@ function collectUrlsFromChangedFiles(changedFiles) {
     }
   });
 
-  const comparisonSlugs = collectAllComparisonSlugs();
-  const catalogDerivedComparisonSlugs = collectCatalogComparisonSlugsForModels(changedModelSlugs);
-  if (compareConfigTouched) {
+  const engineCatalog = readJson(ENGINE_CATALOG_PATH, []);
+  if (comparisonPublicationTouched) {
     addBestForHubUrls(urls);
-    comparisonSlugs.forEach((slug) => addCompareUrlsForSlug(urls, slug));
+    getPublishedComparisonSlugs(engineCatalog).forEach((slug) => addComparisonUrls(urls, SITE, slug));
   } else if (changedModelSlugs.size > 0) {
-    const slugsToNotify =
-      catalogDerivedComparisonSlugs.size > 0 ? catalogDerivedComparisonSlugs : comparisonSlugs;
-    slugsToNotify.forEach((slug) => {
-      const [left, right] = slug.split('-vs-');
-      if (changedModelSlugs.has(left) || changedModelSlugs.has(right)) {
-        addCompareUrlsForSlug(urls, slug);
-      }
-    });
+    getPublishedComparisonSlugsForModels(engineCatalog, changedModelSlugs).forEach((slug) =>
+      addComparisonUrls(urls, SITE, slug)
+    );
   }
 
   return Array.from(urls).sort((a, b) => a.localeCompare(b));
@@ -280,18 +212,14 @@ async function main() {
   process.stdout.write(`[indexnow] changed_files=${changedFiles.length}\n`);
 
   const urls = collectUrlsFromChangedFiles(changedFiles);
-  const limitedUrls = urls.slice(0, Number.isFinite(MAX_URLS) && MAX_URLS > 0 ? MAX_URLS : 200);
-  if (urls.length > limitedUrls.length) {
-    process.stdout.write(`[indexnow] truncating url list ${urls.length} -> ${limitedUrls.length}\n`);
-  }
 
   if (DRY_RUN) {
-    process.stdout.write(`[indexnow] dry-run urls=${limitedUrls.length}\n`);
-    limitedUrls.forEach((url) => process.stdout.write(`${url}\n`));
+    process.stdout.write(`[indexnow] dry-run urls=${urls.length}\n`);
+    urls.forEach((url) => process.stdout.write(`${url}\n`));
     return;
   }
 
-  await submitUrls(limitedUrls);
+  await submitUrls(urls);
 }
 
 await main();

--- a/scripts/indexnow-url-selection.mjs
+++ b/scripts/indexnow-url-selection.mjs
@@ -1,0 +1,72 @@
+const EXCLUDED_ENGINE_SLUGS = new Set([
+  'nano-banana',
+  'nano-banana-lite',
+  'nano-banana-pro',
+  'nano-banana-2',
+  'gpt-image-2',
+  'seedream',
+  'seedream-5-0-pro',
+  'luma-uni-1',
+  'luma-uni-1-max',
+]);
+
+function canonicalCompareSlug(left, right) {
+  if (!left || !right || left === right) return null;
+  const [canonicalLeft, canonicalRight] = [left.trim(), right.trim()].sort((a, b) => a.localeCompare(b, 'en'));
+  if (!canonicalLeft || !canonicalRight) return null;
+  return `${canonicalLeft}-vs-${canonicalRight}`;
+}
+
+function canonicalizeComparisonSlug(slug) {
+  if (typeof slug !== 'string' || !slug.includes('-vs-')) return null;
+  const [left, right] = slug.split('-vs-');
+  return canonicalCompareSlug(left, right);
+}
+
+function toAbsoluteUrl(site, pathname) {
+  const normalizedSite = site.replace(/\/+$/, '');
+  return `${normalizedSite}${pathname.startsWith('/') ? pathname : `/${pathname}`}`;
+}
+
+export function getPublishedComparisonSlugs(catalog) {
+  const entries = Array.isArray(catalog) ? catalog : [];
+  const validSlugs = new Set(entries.map((entry) => entry?.modelSlug).filter(Boolean));
+  const published = new Set();
+
+  entries.forEach((entry) => {
+    const left = entry?.modelSlug;
+    if (!left || EXCLUDED_ENGINE_SLUGS.has(left)) return;
+    const opponents = entry?.surfaces?.compare?.publishedPairs;
+    if (!Array.isArray(opponents)) return;
+
+    opponents.forEach((right) => {
+      if (!validSlugs.has(right) || right === left || EXCLUDED_ENGINE_SLUGS.has(right)) return;
+      const slug = canonicalCompareSlug(left, right);
+      if (slug) published.add(slug);
+    });
+  });
+
+  return Array.from(published).sort((a, b) => a.localeCompare(b, 'en'));
+}
+
+export function getPublishedComparisonSlugsForModels(catalog, changedModelSlugs) {
+  const changed = changedModelSlugs instanceof Set ? changedModelSlugs : new Set(changedModelSlugs ?? []);
+  return getPublishedComparisonSlugs(catalog).filter((slug) => {
+    const [left, right] = slug.split('-vs-');
+    return changed.has(left) || changed.has(right);
+  });
+}
+
+export function addComparisonUrls(urls, site, comparisonSlug) {
+  const slug = canonicalizeComparisonSlug(comparisonSlug);
+  if (!slug) return;
+  urls.add(toAbsoluteUrl(site, `/ai-video-engines/${slug}`));
+  urls.add(toAbsoluteUrl(site, `/fr/comparatif/${slug}`));
+  urls.add(toAbsoluteUrl(site, `/es/comparativa/${slug}`));
+}
+
+export function addComparisonHubUrls(urls, site) {
+  urls.add(toAbsoluteUrl(site, '/ai-video-engines'));
+  urls.add(toAbsoluteUrl(site, '/fr/comparatif'));
+  urls.add(toAbsoluteUrl(site, '/es/comparativa'));
+}

--- a/tests/compare-page-architecture.test.ts
+++ b/tests/compare-page-architecture.test.ts
@@ -7,6 +7,11 @@ import {
   ENGINE_OPTIONS,
 } from '../frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-config.ts';
 import { resolvePromptInheritedShowdowns } from '../frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-showdowns.ts';
+import * as compareRouting from '../frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-routing.ts';
+import {
+  getCanonicalCompareSlug,
+  resolveLegacyCompareRedirect,
+} from '../frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-routing.ts';
 import { buildSeoMetadata } from '../frontend/lib/seo/metadata.ts';
 
 const routePath = 'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/page.tsx';
@@ -75,6 +80,52 @@ const metadataSource = readFileSync(
   'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-metadata.ts',
   'utf8'
 );
+
+test('comparison routing exposes a focused legacy replacement resolver', () => {
+  assert.equal(
+    typeof (compareRouting as Record<string, unknown>).resolveLegacyCompareRedirect,
+    'function',
+  );
+});
+
+test('legacy Happy Horse 1.0 vs Sora comparison redirects to the published 1.1 replacement', () => {
+  assert.equal(
+    resolveLegacyCompareRedirect({
+      slug: 'happy-horse-1-0-vs-sora-2-pro',
+      locale: 'en',
+    }),
+    '/ai-video-engines/happy-horse-1-1-vs-sora-2-pro',
+  );
+  assert.equal(
+    resolveLegacyCompareRedirect({
+      slug: 'happy-horse-1-0-vs-sora-2-pro',
+      order: 'happy-horse-1-0',
+      locale: 'es',
+    }),
+    '/es/comparativa/happy-horse-1-1-vs-sora-2-pro?order=happy-horse-1-1',
+  );
+  assert.equal(
+    resolveLegacyCompareRedirect({
+      slug: 'happy-horse-1-0-vs-seedance-2-0',
+      locale: 'fr',
+    }),
+    null,
+  );
+  const reversed = getCanonicalCompareSlug('sora-2-pro-vs-happy-horse-1-0');
+  assert.equal(
+    resolveLegacyCompareRedirect({
+      slug: reversed?.canonicalSlug ?? '',
+      order: 'sora-2-pro',
+      locale: 'fr',
+    }),
+    '/fr/comparatif/happy-horse-1-1-vs-sora-2-pro?order=sora-2-pro',
+  );
+});
+
+test('comparison detail page applies legacy replacements as permanent redirects', () => {
+  assert.match(pageSource, /resolveLegacyCompareRedirect/);
+  assert.match(pageSource, /legacyRedirect[\s\S]*permanentRedirect\(legacyRedirect\)/);
+});
 const scorecardSource = readFileSync(
   'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-scorecard.ts',
   'utf8'

--- a/tests/comparison-indexation-matrix.test.ts
+++ b/tests/comparison-indexation-matrix.test.ts
@@ -1,0 +1,311 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import test from 'node:test';
+
+import gscSnapshot from '../docs/seo/gsc-comparison-performance-2026-07-08.json';
+import * as comparisonPolicy from '../scripts/comparison-indexation-policy.ts';
+import {
+  buildComparisonIndexationMatrix,
+  classifyComparison,
+} from '../scripts/comparison-indexation-policy.ts';
+import * as comparisonGenerator from '../scripts/generate-comparison-indexation-matrix.ts';
+import { generateComparisonIndexationArtifacts } from '../scripts/generate-comparison-indexation-matrix.ts';
+
+test('comparison indexation policy is implemented as a reusable module', () => {
+  assert.ok(
+    existsSync('scripts/comparison-indexation-policy.ts'),
+    'missing reusable comparison indexation policy',
+  );
+});
+
+test('comparison indexation matrix has a reproducible report generator', () => {
+  assert.ok(
+    existsSync('scripts/generate-comparison-indexation-matrix.ts'),
+    'missing comparison indexation report generator',
+  );
+});
+
+test('comparison indexation generator exposes an artifact builder', () => {
+  assert.equal(
+    typeof (comparisonGenerator as Record<string, unknown>).generateComparisonIndexationArtifacts,
+    'function',
+  );
+});
+
+test('the saved GSC comparison rows contain clean canonical slugs', () => {
+  assert.equal(
+    (gscSnapshot as typeof gscSnapshot & { rawPageRows?: number }).rawPageRows,
+    996,
+  );
+  assert.equal(gscSnapshot.comparisonRows, gscSnapshot.rows.length);
+  for (const row of gscSnapshot.rows) {
+    assert.doesNotMatch(row.url, /[\n\r]|Copy URL|Inspect URL/);
+    assert.doesNotMatch(row.slug, /%20|Copy URL|Inspect URL/);
+  }
+});
+
+test('comparison indexation policy exposes a classifier', () => {
+  assert.equal(
+    typeof (comparisonPolicy as Record<string, unknown>).classifyComparison,
+    'function',
+  );
+});
+
+test('comparison indexation policy exposes a matrix builder', () => {
+  assert.equal(
+    typeof (comparisonPolicy as Record<string, unknown>).buildComparisonIndexationMatrix,
+    'function',
+  );
+});
+
+const BASE_INPUT = {
+  locale: 'fr' as const,
+  clicks: 0,
+  impressions: 0,
+  position: 0,
+  hasLocalizedOverride: false,
+  isStrategic: false,
+};
+
+test('a comparison with a GSC click is kept', () => {
+  assert.equal(classifyComparison({ ...BASE_INPUT, clicks: 1 }), 'keep');
+});
+
+test('a comparison with at least 500 impressions is kept', () => {
+  assert.equal(classifyComparison({ ...BASE_INPUT, impressions: 500 }), 'keep');
+});
+
+test('a comparison with a localized editorial override is kept', () => {
+  assert.equal(classifyComparison({ ...BASE_INPUT, hasLocalizedOverride: true }), 'keep');
+});
+
+test('an English strategic comparison is kept', () => {
+  assert.equal(
+    classifyComparison({ ...BASE_INPUT, locale: 'en', isStrategic: true }),
+    'keep',
+  );
+});
+
+test('a comparison with at least 100 impressions is queued for enrichment', () => {
+  assert.equal(classifyComparison({ ...BASE_INPUT, impressions: 100 }), 'enrich');
+});
+
+test('a comparison with at least 30 impressions is queued for review', () => {
+  assert.equal(classifyComparison({ ...BASE_INPUT, impressions: 30 }), 'review');
+});
+
+test('a low-impression comparison already ranking in the top 10 is reviewed', () => {
+  assert.equal(
+    classifyComparison({
+      ...BASE_INPUT,
+      impressions: 12,
+      position: 8,
+    }),
+    'review',
+  );
+});
+
+test('a non-English strategic comparison without local proof is reviewed', () => {
+  assert.equal(classifyComparison({ ...BASE_INPUT, isStrategic: true }), 'review');
+});
+
+test('a comparison without GSC or editorial signals is only a noindex candidate', () => {
+  assert.equal(classifyComparison(BASE_INPUT), 'noindex_candidate');
+});
+
+test('the matrix expands every published slug across the three canonical locale URLs', () => {
+  const rows = buildComparisonIndexationMatrix({
+    publishedSlugs: ['alpha-vs-beta', 'alpha-vs-gamma'],
+    gscRows: [],
+    localizedOverrideSlugs: {
+      en: new Set(),
+      fr: new Set(),
+      es: new Set(),
+    },
+    strategicSignalsBySlug: new Map(),
+  });
+
+  assert.equal(rows.length, 6);
+  assert.deepEqual(
+    rows.map((row) => row.url).sort(),
+    [
+      'https://maxvideoai.com/ai-video-engines/alpha-vs-beta',
+      'https://maxvideoai.com/ai-video-engines/alpha-vs-gamma',
+      'https://maxvideoai.com/es/comparativa/alpha-vs-beta',
+      'https://maxvideoai.com/es/comparativa/alpha-vs-gamma',
+      'https://maxvideoai.com/fr/comparatif/alpha-vs-beta',
+      'https://maxvideoai.com/fr/comparatif/alpha-vs-gamma',
+    ],
+  );
+});
+
+test('the matrix joins GSC, localized editorial, and strategic signals before classifying', () => {
+  const rows = buildComparisonIndexationMatrix({
+    publishedSlugs: ['alpha-vs-beta', 'alpha-vs-gamma'],
+    gscRows: [
+      {
+        url: 'https://maxvideoai.com/ai-video-engines/alpha-vs-beta',
+        locale: 'en',
+        slug: 'alpha-vs-beta',
+        clicks: 2,
+        impressions: 25,
+        ctr: 8,
+        position: 4,
+      },
+      {
+        url: 'https://maxvideoai.com/fr/comparatif/alpha-vs-beta',
+        locale: 'fr',
+        slug: 'alpha-vs-beta',
+        clicks: 0,
+        impressions: 120,
+        ctr: 0,
+        position: 15,
+      },
+    ],
+    localizedOverrideSlugs: {
+      en: new Set(),
+      fr: new Set(),
+      es: new Set(['alpha-vs-gamma']),
+    },
+    strategicSignalsBySlug: new Map([['alpha-vs-beta', ['popular']]]),
+  });
+
+  const byKey = new Map(rows.map((row) => [`${row.locale}:${row.slug}`, row]));
+  assert.equal(byKey.get('en:alpha-vs-beta')?.classification, 'keep');
+  assert.equal(byKey.get('fr:alpha-vs-beta')?.classification, 'enrich');
+  assert.equal(byKey.get('es:alpha-vs-beta')?.classification, 'review');
+  assert.equal(byKey.get('es:alpha-vs-gamma')?.classification, 'keep');
+  assert.equal(byKey.get('fr:alpha-vs-gamma')?.classification, 'noindex_candidate');
+  assert.deepEqual(byKey.get('en:alpha-vs-beta')?.strategicSignals, ['popular']);
+  assert.equal(byKey.get('en:alpha-vs-beta')?.hasGscRow, true);
+  assert.equal(byKey.get('es:alpha-vs-beta')?.hasGscRow, false);
+});
+
+test('the matrix aggregates canonical and parameterized GSC variants by locale and slug', () => {
+  const rows = buildComparisonIndexationMatrix({
+    publishedSlugs: ['alpha-vs-beta'],
+    gscRows: [
+      {
+        url: 'https://maxvideoai.com/ai-video-engines/alpha-vs-beta',
+        locale: 'en',
+        slug: 'alpha-vs-beta',
+        clicks: 1,
+        impressions: 20,
+        ctr: 5,
+        position: 4,
+      },
+      {
+        url: 'https://maxvideoai.com/ai-video-engines/alpha-vs-beta?order=beta',
+        locale: 'en',
+        slug: 'alpha-vs-beta',
+        clicks: 2,
+        impressions: 30,
+        ctr: 6.7,
+        position: 6,
+      },
+    ],
+    localizedOverrideSlugs: {
+      en: new Set(),
+      fr: new Set(),
+      es: new Set(),
+    },
+    strategicSignalsBySlug: new Map(),
+  });
+  const english = rows.find((row) => row.locale === 'en');
+
+  assert.equal(english?.clicks, 3);
+  assert.equal(english?.impressions, 50);
+  assert.equal(english?.ctr, 6);
+  assert.equal(english?.position, 5.2);
+});
+
+test('a noindex candidate with observed low demand gets an accurate rationale', () => {
+  const rows = buildComparisonIndexationMatrix({
+    publishedSlugs: ['alpha-vs-beta'],
+    gscRows: [{
+      url: 'https://maxvideoai.com/ai-video-engines/alpha-vs-beta',
+      locale: 'en',
+      slug: 'alpha-vs-beta',
+      clicks: 0,
+      impressions: 12,
+      ctr: 0,
+      position: 12,
+    }],
+    localizedOverrideSlugs: { en: new Set(), fr: new Set(), es: new Set() },
+    strategicSignalsBySlug: new Map(),
+  });
+  const english = rows.find((row) => row.locale === 'en');
+
+  assert.equal(english?.classification, 'noindex_candidate');
+  assert.deepEqual(english?.rationale, ['low_demand_outside_top_10']);
+});
+
+test('the generated inventory covers all 876 localized published comparison URLs', () => {
+  const artifacts = generateComparisonIndexationArtifacts() as {
+    document: {
+      summary: {
+        publishedSlugs: number;
+        totalUrls: number;
+        gscRowsOutsidePublishedSet: number;
+        gscRowsOutsidePublishedSetWithClicks: number;
+        byClassification: Record<string, number>;
+      };
+      rows: Array<{
+        locale: string;
+        slug: string;
+        clicks: number;
+        classification: string;
+      }>;
+      legacyGscRows: Array<{ clicks: number }>;
+    };
+    markdown: string;
+  };
+
+  assert.equal(artifacts.document.summary.publishedSlugs, 292);
+  assert.equal(artifacts.document.summary.totalUrls, 876);
+  assert.equal(artifacts.document.summary.gscRowsOutsidePublishedSet, 21);
+  assert.equal(artifacts.document.summary.gscRowsOutsidePublishedSetWithClicks, 2);
+  assert.equal(artifacts.document.legacyGscRows.length, 21);
+  assert.equal(artifacts.document.rows.length, 876);
+  assert.equal(
+    new Set(artifacts.document.rows.map((row) => `${row.locale}:${row.slug}`)).size,
+    876,
+  );
+  assert.equal(
+    Object.values(artifacts.document.summary.byClassification).reduce(
+      (sum, count) => sum + count,
+      0,
+    ),
+    876,
+  );
+  assert.ok(
+    artifacts.document.rows
+      .filter((row) => row.clicks > 0)
+      .every((row) => row.classification === 'keep'),
+    'every comparison with GSC clicks must remain in the keep class',
+  );
+  assert.match(artifacts.markdown, /Aucun noindex n'est applique/i);
+  assert.match(artifacts.markdown, /996 premières pages/);
+  assert.match(artifacts.markdown, /URLs GSC hors du périmètre publié/);
+  assert.match(artifacts.markdown, /19 anciennes variantes Veo/);
+  assert.match(artifacts.markdown, /Happy Horse 1\.0[\s\S]*redirection permanente/);
+  assert.match(artifacts.markdown, /^\| en \| \[/m);
+});
+
+test('the generator CLI writes the JSON and Markdown audit artifacts', () => {
+  const result = spawnSync(
+    './frontend/node_modules/.bin/tsx',
+    [
+      '--tsconfig',
+      'frontend/tsconfig.json',
+      'scripts/generate-comparison-indexation-matrix.ts',
+    ],
+    { cwd: process.cwd(), encoding: 'utf8' },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(existsSync('docs/seo/comparison-indexation-matrix-2026-07-08.json'));
+  assert.ok(existsSync('docs/seo/comparison-indexation-matrix-2026-07-08.md'));
+  assert.match(result.stdout, /"totalUrls": 876/);
+});

--- a/tests/indexnow-url-selection.test.ts
+++ b/tests/indexnow-url-selection.test.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import engineCatalog from '../frontend/config/engine-catalog.json';
+import modelRoster from '../frontend/config/model-roster.json';
+import { getHubComparisonSlugsForSitemap } from '../frontend/lib/compare-hub/data.ts';
+import {
+  addComparisonHubUrls,
+  addComparisonUrls,
+  getPublishedComparisonSlugs,
+  getPublishedComparisonSlugsForModels,
+} from '../scripts/indexnow-url-selection.mjs';
+
+test('IndexNow comparison slugs are exactly the sitemap publication set', () => {
+  assert.deepEqual(getPublishedComparisonSlugs(engineCatalog), getHubComparisonSlugsForSitemap());
+});
+
+test('changed models only select published comparisons involving that model', () => {
+  const fixtureCatalog = [
+    {
+      modelSlug: 'alpha',
+      surfaces: { compare: { publishedPairs: ['beta'] } },
+    },
+    {
+      modelSlug: 'beta',
+      surfaces: { compare: { publishedPairs: ['alpha'] } },
+    },
+    {
+      modelSlug: 'gamma',
+      surfaces: { compare: { publishedPairs: [] } },
+    },
+  ];
+
+  assert.deepEqual(
+    getPublishedComparisonSlugsForModels(fixtureCatalog, new Set(['alpha'])),
+    ['alpha-vs-beta'],
+  );
+  assert.deepEqual(getPublishedComparisonSlugsForModels(fixtureCatalog, new Set(['gamma'])), []);
+});
+
+test('localized comparison and hub URLs use canonical public paths', () => {
+  const urls = new Set<string>();
+  addComparisonHubUrls(urls, 'https://maxvideoai.com');
+  addComparisonUrls(urls, 'https://maxvideoai.com', 'beta-vs-alpha');
+
+  assert.deepEqual(Array.from(urls).sort(), [
+    'https://maxvideoai.com/ai-video-engines',
+    'https://maxvideoai.com/ai-video-engines/alpha-vs-beta',
+    'https://maxvideoai.com/es/comparativa',
+    'https://maxvideoai.com/es/comparativa/alpha-vs-beta',
+    'https://maxvideoai.com/fr/comparatif',
+    'https://maxvideoai.com/fr/comparatif/alpha-vs-beta',
+  ]);
+  assert.ok(!urls.has('https://maxvideoai.com/fr/ai-video-engines'));
+  assert.ok(!urls.has('https://maxvideoai.com/es/ai-video-engines'));
+});
+
+test('IndexNow command delegates publication selection without synthesizing or truncating combinations', () => {
+  const source = readFileSync('scripts/indexnow-submit-changed.mjs', 'utf8');
+
+  assert.match(source, /getPublishedComparisonSlugsForModels/);
+  assert.match(source, /getPublishedComparisonSlugs/);
+  assert.match(source, /addComparisonHubUrls/);
+  assert.match(source, /addComparisonUrls/);
+  assert.doesNotMatch(source, /collectCatalogComparisonSlugsForModels/);
+  assert.doesNotMatch(source, /MAX_URLS/);
+  assert.doesNotMatch(source, /\/fr\/ai-video-engines/);
+  assert.doesNotMatch(source, /\/es\/ai-video-engines/);
+});
+
+test('IndexNow dry run excludes private, parameterized, redirecting, and noindex URLs', () => {
+  const result = spawnSync(process.execPath, ['scripts/indexnow-submit-changed.mjs', '--dry-run'], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GITHUB_EVENT_BEFORE: '',
+      GITHUB_SHA: 'HEAD',
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const urls = result.stdout
+    .split('\n')
+    .filter((line) => line.startsWith('https://'))
+    .map((url) => new URL(url));
+  const comparisonUrls = urls.filter(
+    ({ pathname }) =>
+      pathname.includes('-vs-') &&
+      (pathname.startsWith('/ai-video-engines/') ||
+        pathname.startsWith('/fr/comparatif/') ||
+        pathname.startsWith('/es/comparativa/')),
+  );
+
+  assert.equal(comparisonUrls.length, getHubComparisonSlugsForSitemap().length * 3);
+  urls.forEach(({ pathname, search }) => {
+    assert.equal(search, '', `IndexNow must not submit parameterized URL ${pathname}${search}`);
+    assert.ok(pathname !== '/app' && !pathname.startsWith('/app/'), `private app URL submitted: ${pathname}`);
+    assert.ok(!pathname.startsWith('/video/job_'), `private render URL submitted: ${pathname}`);
+    assert.ok(!pathname.startsWith('/fr/ai-video-engines'), `redirecting FR hub submitted: ${pathname}`);
+    assert.ok(!pathname.startsWith('/es/ai-video-engines'), `redirecting ES hub submitted: ${pathname}`);
+  });
+
+  const sitemapModelSlugs = new Set(
+    modelRoster
+      .filter((entry) => entry.surfaces?.modelPage?.includeInSitemap !== false)
+      .map((entry) => entry.modelSlug),
+  );
+  urls.forEach(({ pathname }) => {
+    const modelMatch = pathname.match(/^\/(?:models|fr\/modeles|es\/modelos)\/([^/]+)$/);
+    if (!modelMatch) return;
+    assert.ok(sitemapModelSlugs.has(modelMatch[1]), `non-sitemap model submitted: ${pathname}`);
+  });
+});

--- a/tests/robots-app-deindex.test.ts
+++ b/tests/robots-app-deindex.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import { shouldMarkAppNoindex } from '../frontend/lib/middleware/routing-query.ts';
+
+const robotsSource = readFileSync('frontend/public/robots.txt', 'utf8');
+const [namedAiCrawlerRules, generalCrawlerRules = ''] = robotsSource.split('User-agent: *');
+const workspaceLayoutSource = readFileSync('frontend/app/(core)/(workspace)/app/layout.tsx', 'utf8');
+const routingResponseSource = readFileSync('frontend/lib/middleware/routing-response.ts', 'utf8');
+
+test('robots allows crawlers to read the noindex directive on app URLs', () => {
+  assert.doesNotMatch(generalCrawlerRules, /^Disallow:\s*\/app\s*$/m);
+  assert.doesNotMatch(generalCrawlerRules, /^Disallow:\s*\/fr\/app\s*$/m);
+  assert.doesNotMatch(generalCrawlerRules, /^Disallow:\s*\/es\/app\s*$/m);
+
+  assert.match(namedAiCrawlerRules, /^Disallow:\s*\/app\s*$/m);
+  assert.match(namedAiCrawlerRules, /^Disallow:\s*\/fr\/app\s*$/m);
+  assert.match(namedAiCrawlerRules, /^Disallow:\s*\/es\/app\s*$/m);
+
+  assert.match(namedAiCrawlerRules, /^Disallow:\s*\/admin\s*$/m);
+  assert.match(generalCrawlerRules, /^Disallow:\s*\/admin\s*$/m);
+  assert.match(robotsSource, /^Disallow:\s*\/api\/\s*$/m);
+  assert.match(robotsSource, /^Disallow:\s*\/private\/\s*$/m);
+});
+
+test('app routes remain noindex in metadata and middleware for every query variant', () => {
+  assert.equal(shouldMarkAppNoindex('/app'), true);
+  assert.equal(shouldMarkAppNoindex('/app/studio/projects'), true);
+  assert.equal(shouldMarkAppNoindex('/models/veo-3-1'), false);
+
+  assert.match(workspaceLayoutSource, /robots:\s*\{[\s\S]*index:\s*false/);
+  assert.match(routingResponseSource, /X-Robots-Tag/);
+  assert.match(routingResponseSource, /noindex, follow/);
+});

--- a/tests/seo-technical-hygiene.test.ts
+++ b/tests/seo-technical-hygiene.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { NextRequest } from 'next/server';
+
+import { shouldMarkTrackingNoindex } from '../frontend/lib/middleware/routing-query.ts';
+
+const nextConfigSource = readFileSync('frontend/next.config.js', 'utf8');
+
+test('all marketing tracking sources receive noindex treatment', () => {
+  const request = new NextRequest('https://maxvideoai.com/?utm_source=startupfa.me');
+
+  assert.equal(shouldMarkTrackingNoindex(request, '/', false), true);
+});
+
+test('legacy Google Veo URL redirects directly to the current canonical model', () => {
+  const redirectBlock = nextConfigSource.match(
+    /\{\s*source:\s*'\/models\/google-veo-3',[\s\S]*?permanent:\s*true,\s*\}/,
+  )?.[0];
+
+  assert.ok(redirectBlock, 'legacy Google Veo redirect should exist');
+  assert.match(redirectBlock, /destination:\s*'\/models\/veo-3-1'/);
+  assert.doesNotMatch(redirectBlock, /destination:\s*'\/models\/veo-3'/);
+});
+
+test('Next image optimization uses a conservative seven-day floor until mutable assets are versioned', () => {
+  const ttlMatch = nextConfigSource.match(/minimumCacheTTL:\s*(\d+)/);
+
+  assert.ok(ttlMatch, 'images.minimumCacheTTL should be configured');
+  assert.equal(Number(ttlMatch[1]), 60 * 60 * 24 * 7);
+});

--- a/tests/watch-page-related-canonical-links.test.ts
+++ b/tests/watch-page-related-canonical-links.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import {
+  pickRelatedWatchPages,
+  toWatchPageRelatedCandidate,
+} from '../frontend/server/watch-page-signals/related.ts';
+
+test('approved related watch pages link directly to their canonical slug', () => {
+  const candidate = toWatchPageRelatedCandidate({
+    entry: { id: 'job_related' } as any,
+    video: { id: 'job_related', thumbUrl: '/thumb.jpg' } as any,
+    signals: {
+      canonicalSlug: 'veo-product-ad-example-related',
+      title: 'Related Veo product ad',
+      intro: 'A related approved example.',
+      engineLabel: 'Veo 3.1',
+      engineSlug: 'veo-3-1',
+      exampleFamily: 'veo',
+      mode: 't2v',
+      primaryIntent: 'product-ad',
+      capabilityTags: ['text-to-video'],
+      styleTags: ['cinematic'],
+    } as any,
+  });
+
+  const related = pickRelatedWatchPages({
+    currentId: 'job_current',
+    currentSignals: {
+      exampleFamily: 'veo',
+      primaryIntent: 'product-ad',
+      capabilityTags: ['text-to-video'],
+      engineSlug: 'veo-3-1',
+      mode: 't2v',
+      styleTags: ['cinematic'],
+    } as any,
+    candidates: [candidate],
+  });
+
+  assert.equal(related.length, 1);
+  assert.equal(related[0]?.href, '/video/veo-product-ad-example-related');
+  assert.doesNotMatch(related[0]?.href ?? '', /job_related/);
+});
+
+test('canonical watch-page requests exclude the current video by its resolved job id', () => {
+  const videoSeoSource = readFileSync('frontend/server/video-seo.ts', 'utf8');
+
+  assert.match(videoSeoSource, /pickRelatedWatchPages\(\{[\s\S]*currentId:\s*resolvedId/);
+  assert.doesNotMatch(videoSeoSource, /pickRelatedWatchPages\(\{[\s\S]*currentId:\s*id,/);
+});


### PR DESCRIPTION
## What changed

- fixes crawler access so Google can read `noindex` directives on private app routes while named AI crawlers remain blocked from the workspace
- restricts IndexNow submissions to canonical, published, sitemap-eligible URLs
- fixes canonical related-video links, legacy Veo routing, tracking-query indexing, and image cache policy
- permanently redirects the legacy Happy Horse 1.0 comparison to the published 1.1 replacement
- adds a reproducible GSC-backed indexation matrix for 876 localized comparison URLs
- documents the audit, prioritization policy, and follow-up plan

## Why

The site exposed inconsistent crawl/indexation signals: some private pages were blocked before crawlers could read their `noindex`, IndexNow could submit non-canonical or non-indexable URLs, and the comparison inventory had no evidence-based keep/enrich/review policy.

## Impact

- protects all comparison URLs with clicks or strong editorial/strategic signals
- classifies 876 URLs as 220 keep, 49 enrich, 380 review, and 227 manual noindex candidates
- applies no mass `noindex` or sitemap removal
- consolidates two localized legacy Happy Horse URLs through permanent redirects

## Validation

- clean branch created directly from current `main`
- full suite: 1,608/1,608 tests pass
- targeted SEO and routing tests: 50/50 pass
- TypeScript check passes
- public exposure check passes
- ESLint passes with no warnings
- independent code review approved the final state