### PR TITLE
Enrich high-impression comparison pages in EN, FR, and ES

### DIFF
--- a/docs/superpowers/plans/2026-07-11-seo-comparison-enrichment-3-locales.md
+++ b/docs/superpowers/plans/2026-07-11-seo-comparison-enrichment-3-locales.md
@@ -1,0 +1,565 @@
+# Localized SEO Comparison Enrichment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add complete, fact-based SEO overrides for ten high-impression comparison pages in American English, French, and LATAM-neutral Spanish.
+
+**Architecture:** Keep the comparison route and shared SEO builders unchanged. Add 30 static entries to the three existing route-local override maps and protect the editorial contract with one focused Node test file that imports the real maps, engine catalog, and comparison publication resolver.
+
+**Tech Stack:** TypeScript, Next.js App Router, Node test runner, `tsx`, static engine catalog JSON, existing `ComparePageOverride` maps.
+
+## Global Constraints
+
+- Work only in `codex/seo-comparison-enrichment-3-locales`, based on `origin/main` at `9a72aedb4b2963d0d3b7ecdcb8ecbea8352264c3`.
+- Write English copy in American English.
+- Write Spanish copy in LATAM-neutral Spanish while retaining the generic `es` route and hreflang.
+- In Spanish copy, use `video` without the Spain-specific accent and avoid `vídeo`, `móvil`, `ordenador`, `monedero`, and `vosotros`.
+- Derive feature, duration, resolution, audio, pricing, and legacy claims from `frontend/config/engine-catalog.json`.
+- Do not change sitemap, robots, publication lists, canonicals, hreflang, JSON-LD architecture, pricing, scorecards, or engine configuration.
+- Do not touch unrelated Studio or workspace files.
+- Use test-driven development: add the failing contract before adding any override entries.
+- Keep internal hrefs canonical and unprefixed; the existing localized `Link` component adds locale routing.
+
+---
+
+## File Map
+
+**Create**
+
+- `tests/comparison-enrichment-locales.test.ts` — focused content, localization, route, and publication contract for this 30-entry wave.
+
+**Modify**
+
+- `frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-en.ts` — ten American-English overrides.
+- `frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-fr.ts` — ten French adaptations.
+- `frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-es.ts` — ten LATAM-neutral Spanish adaptations.
+
+**Read-only sources**
+
+- `frontend/config/engine-catalog.json`
+- `frontend/config/model-publication.ts`
+- `frontend/lib/compare-hub/data.ts`
+- `docs/seo/comparison-indexation-matrix-2026-07-08.json`
+- `docs/seo/localization-notes.md`
+- `tests/compare-page-architecture.test.ts`
+
+---
+
+### Task 1: Add the failing localized-enrichment contract
+
+**Files:**
+
+- Create: `tests/comparison-enrichment-locales.test.ts`
+
+**Interfaces:**
+
+- Consumes: `EN_COMPARE_PAGE_OVERRIDES`, `FR_COMPARE_PAGE_OVERRIDES`, `ES_COMPARE_PAGE_OVERRIDES`, `engine-catalog.json`, and `isPublishedComparisonSlug(slug: string): boolean`.
+- Produces: `TARGET_COMPARISONS`, locale-specific structural tests, cross-locale localization checks, and internal-link publication checks.
+
+- [ ] **Step 1: Create the focused contract test**
+
+Create `tests/comparison-enrichment-locales.test.ts` with this complete content:
+
+```ts
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import engineCatalog from '../frontend/config/engine-catalog.json' with { type: 'json' };
+import { EN_COMPARE_PAGE_OVERRIDES } from '../frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-en.ts';
+import { ES_COMPARE_PAGE_OVERRIDES } from '../frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-es.ts';
+import { FR_COMPARE_PAGE_OVERRIDES } from '../frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-fr.ts';
+import type { ComparePageOverride } from '../frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-types.ts';
+import { isPublishedComparisonSlug } from '../frontend/lib/compare-hub/data.ts';
+
+const TARGET_COMPARISONS = [
+  ['pika-text-to-video-vs-wan-2-6', 'pika-text-to-video', 'wan-2-6'],
+  ['kling-2-6-pro-vs-kling-3-pro', 'kling-2-6-pro', 'kling-3-pro'],
+  ['ltx-2-3-fast-vs-luma-ray-2', 'ltx-2-3-fast', 'luma-ray-2'],
+  ['kling-2-6-pro-vs-minimax-hailuo-02-text', 'kling-2-6-pro', 'minimax-hailuo-02-text'],
+  ['kling-3-standard-vs-kling-o3-standard', 'kling-3-standard', 'kling-o3-standard'],
+  ['seedance-2-0-fast-vs-veo-3-1', 'seedance-2-0-fast', 'veo-3-1'],
+  ['ltx-2-fast-vs-minimax-hailuo-02-text', 'ltx-2-fast', 'minimax-hailuo-02-text'],
+  ['minimax-hailuo-02-text-vs-veo-3-1-fast', 'minimax-hailuo-02-text', 'veo-3-1-fast'],
+  ['kling-3-4k-vs-seedance-2-0', 'kling-3-4k', 'seedance-2-0'],
+  ['minimax-hailuo-02-text-vs-wan-2-6', 'minimax-hailuo-02-text', 'wan-2-6'],
+] as const;
+
+type Locale = 'en' | 'fr' | 'es';
+type OverrideMap = Record<string, ComparePageOverride>;
+
+const OVERRIDES_BY_LOCALE: Record<Locale, OverrideMap> = {
+  en: EN_COMPARE_PAGE_OVERRIDES,
+  fr: FR_COMPARE_PAGE_OVERRIDES,
+  es: ES_COMPARE_PAGE_OVERRIDES,
+};
+
+const CATALOG_BY_SLUG = new Map(engineCatalog.map((entry) => [entry.modelSlug, entry]));
+
+function getEntry(locale: Locale, slug: string): ComparePageOverride {
+  const entry = OVERRIDES_BY_LOCALE[locale][slug];
+  assert.ok(entry, `missing ${locale.toUpperCase()} override for ${slug}`);
+  return entry;
+}
+
+function collectText(entry: ComparePageOverride): string {
+  return [
+    entry.meta?.title,
+    entry.meta?.description,
+    entry.heroIntro,
+    entry.quickVerdict?.title,
+    entry.quickVerdict?.body,
+    ...(entry.topCards ?? []).flatMap((card) => [card.title, card.body]),
+    ...(entry.primaryLinks ?? []).map((link) => link.label),
+    entry.faq?.title,
+    entry.faq?.subtitle,
+    ...(entry.faq?.items ?? []).flatMap((item) => [
+      item.question,
+      ...(Array.isArray(item.answer) ? item.answer : [item.answer]),
+    ]),
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+function assertCompleteOverride(locale: Locale, slug: string): void {
+  const entry = getEntry(locale, slug);
+  const title = entry.meta?.title ?? '';
+  const description = entry.meta?.description ?? '';
+
+  assert.ok(title.length >= 35 && title.length <= 80, `${locale} title length for ${slug}: ${title.length}`);
+  assert.ok(description.length >= 120 && description.length <= 180, `${locale} description length for ${slug}: ${description.length}`);
+  assert.equal(entry.meta?.titleBranding, 'none', `${locale} should disable automatic branding for ${slug}`);
+  assert.ok((entry.heroIntro?.length ?? 0) >= 140, `${locale} hero should be decision-focused for ${slug}`);
+  assert.ok((entry.quickVerdict?.body.length ?? 0) >= 120, `${locale} verdict should be substantive for ${slug}`);
+  assert.equal(entry.topCards?.length, 4, `${locale} should have four decision cards for ${slug}`);
+  assert.ok((entry.primaryLinks?.length ?? 0) >= 3, `${locale} should have at least three internal links for ${slug}`);
+  assert.ok((entry.faq?.items.length ?? 0) >= 3, `${locale} should have at least three FAQ items for ${slug}`);
+  assert.ok((entry.faq?.items.length ?? 0) <= 5, `${locale} should have at most five FAQ items for ${slug}`);
+
+  const faqQuestions = (entry.faq?.items ?? []).map((item) => item.question);
+  assert.equal(new Set(faqQuestions).size, faqQuestions.length, `${locale} FAQ questions should be unique for ${slug}`);
+  const hrefs = (entry.primaryLinks ?? []).map((link) => link.href);
+  assert.equal(new Set(hrefs).size, hrefs.length, `${locale} internal links should be unique for ${slug}`);
+  hrefs.forEach((href) => {
+    assert.match(href, /^\/(models|examples|ai-video-engines)\//, `${locale} unsupported internal href ${href}`);
+    assert.doesNotMatch(href, /^\/(fr|es)\//, `${locale} href must remain locale-neutral: ${href}`);
+  });
+}
+
+for (const locale of ['en', 'fr', 'es'] as const) {
+  test(`${locale.toUpperCase()} comparison enrichment entries satisfy the editorial contract`, () => {
+    const titles = new Set<string>();
+    const descriptions = new Set<string>();
+
+    TARGET_COMPARISONS.forEach(([slug, leftSlug, rightSlug]) => {
+      assert.ok(isPublishedComparisonSlug(slug), `${slug} should remain published`);
+      const left = CATALOG_BY_SLUG.get(leftSlug);
+      const right = CATALOG_BY_SLUG.get(rightSlug);
+      assert.ok(left, `missing catalog entry ${leftSlug}`);
+      assert.ok(right, `missing catalog entry ${rightSlug}`);
+
+      assertCompleteOverride(locale, slug);
+      const entry = getEntry(locale, slug);
+      const pageText = collectText(entry);
+      assert.match(pageText, new RegExp(left.marketingName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'));
+      assert.match(pageText, new RegExp(right.marketingName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'));
+
+      const title = entry.meta?.title ?? '';
+      const description = entry.meta?.description ?? '';
+      assert.ok(!titles.has(title), `${locale} title should be unique: ${title}`);
+      assert.ok(!descriptions.has(description), `${locale} description should be unique: ${description}`);
+      titles.add(title);
+      descriptions.add(description);
+    });
+  });
+}
+
+test('French and LATAM Spanish are localized instead of copying English', () => {
+  TARGET_COMPARISONS.forEach(([slug]) => {
+    const english = getEntry('en', slug);
+    const french = getEntry('fr', slug);
+    const spanish = getEntry('es', slug);
+    assert.notEqual(french.meta?.title, english.meta?.title, `FR title should be localized for ${slug}`);
+    assert.notEqual(spanish.meta?.title, english.meta?.title, `ES title should be localized for ${slug}`);
+    assert.notEqual(french.quickVerdict?.body, english.quickVerdict?.body, `FR verdict should be localized for ${slug}`);
+    assert.notEqual(spanish.quickVerdict?.body, english.quickVerdict?.body, `ES verdict should be localized for ${slug}`);
+  });
+});
+
+test('Spanish comparison copy stays LATAM-neutral', () => {
+  const spainSpecificTerms = /\b(vídeo|vídeos|móvil|móviles|ordenador|ordenadores|monedero|monederos|vosotros)\b/i;
+  TARGET_COMPARISONS.forEach(([slug]) => {
+    assert.doesNotMatch(collectText(getEntry('es', slug)), spainSpecificTerms, `Spain-specific term in ${slug}`);
+  });
+});
+
+test('every comparison enrichment link resolves to a public model or comparison route', () => {
+  for (const locale of ['en', 'fr', 'es'] as const) {
+    TARGET_COMPARISONS.forEach(([slug]) => {
+      for (const link of getEntry(locale, slug).primaryLinks ?? []) {
+        if (link.href.startsWith('/models/')) {
+          const modelSlug = link.href.slice('/models/'.length);
+          const model = CATALOG_BY_SLUG.get(modelSlug);
+          assert.ok(model, `missing model route ${link.href}`);
+          assert.equal(model.surfaces.modelPage.indexable, true, `model route should be public: ${link.href}`);
+        }
+        if (link.href.startsWith('/ai-video-engines/')) {
+          assert.ok(
+            isPublishedComparisonSlug(link.href.slice('/ai-video-engines/'.length)),
+            `comparison route should be published: ${link.href}`,
+          );
+        }
+      }
+    });
+  }
+});
+```
+
+- [ ] **Step 2: Run the new test and confirm RED**
+
+Run:
+
+```bash
+pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/comparison-enrichment-locales.test.ts
+```
+
+Expected: FAIL on the three locale contract tests with `missing EN override`, `missing FR override`, and `missing ES override` for the first target slug. This proves the test detects the missing 30-entry wave.
+
+- [ ] **Step 3: Commit the failing contract**
+
+```bash
+git add tests/comparison-enrichment-locales.test.ts
+git commit -m "test: define localized comparison enrichment contract"
+```
+
+---
+
+### Task 2: Add the ten American-English overrides
+
+**Files:**
+
+- Modify: `frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-en.ts`
+- Test: `tests/comparison-enrichment-locales.test.ts`
+
+**Interfaces:**
+
+- Consumes: the existing `ComparePageOverride` object shape and Task 1 contract.
+- Produces: ten complete entries in `EN_COMPARE_PAGE_OVERRIDES`, keyed by canonical slug.
+
+- [ ] **Step 1: Add all ten English entries before the closing `satisfies ComparePageOverridesBySlug`**
+
+Use this complete first entry as the field-shape reference:
+
+```ts
+'pika-text-to-video-vs-wan-2-6': {
+  meta: {
+    title: 'Pika 2.2 vs Wan 2.6: Price, Audio & Best Uses',
+    description:
+      'Compare Pika 2.2 and Wan 2.6 on price, clip length, audio, resolution, and reference workflows to choose the right AI video model.',
+    titleBranding: 'none',
+  },
+  heroIntro:
+    'Compare Pika 2.2 Text & Image to Video with Wan 2.6 Text & Image to Video when the real choice is a lower-cost short loop or a longer, audio-ready production workflow. Pika keeps simple prompt and image animation economical, while Wan adds 15-second output and reference-video control.',
+  quickVerdict: {
+    title: 'Quick verdict',
+    body:
+      'Choose Pika 2.2 for inexpensive 5- or 10-second silent loops, stylized tests, and straightforward image animation. Choose Wan 2.6 when the shot needs up to 15 seconds, native audio, or one to three reference videos, accepting the higher 720p and 1080p generation price.',
+  },
+  topCards: [
+    {
+      title: 'Choose Pika 2.2',
+      body: 'Use Pika for lower-cost 720p tests, short silent loops, and simple text-to-video or image-to-video work.',
+    },
+    {
+      title: 'Choose Wan 2.6',
+      body: 'Use Wan for clips up to 15 seconds, optional audio, 1080p delivery, or a workflow guided by reference videos.',
+    },
+    {
+      title: 'Key trade-off',
+      body: 'Pika starts at $0.04 per second at 720p; Wan starts at $0.10 per second but adds duration, audio, and reference-video control.',
+    },
+    {
+      title: 'Best workflows',
+      body: 'Pika fits stylized social loops and concept tests. Wan fits longer general-purpose shots, narrated clips, and reference-led sequences.',
+    },
+  ],
+  primaryLinksTitle: 'Recommended next steps',
+  primaryLinks: [
+    { href: '/models/pika-text-to-video', label: 'Open the Pika 2.2 model page' },
+    { href: '/models/wan-2-6', label: 'Open the Wan 2.6 model page' },
+    {
+      href: '/ai-video-engines/minimax-hailuo-02-text-vs-pika-text-to-video',
+      label: 'Compare Hailuo 02 vs Pika 2.2',
+    },
+  ],
+  faq: {
+    title: 'FAQ',
+    subtitle: 'Short answers for choosing between Pika 2.2 and Wan 2.6.',
+    items: [
+      {
+        question: 'Is Pika 2.2 or Wan 2.6 better for low-cost video tests?',
+        answer:
+          'Pika 2.2 is the lower-cost choice at 720p and works well for short silent loops. Wan 2.6 costs more but is justified when a test needs audio, longer duration, or reference videos.',
+      },
+      {
+        question: 'What can Wan 2.6 do that Pika 2.2 cannot?',
+        answer:
+          'Wan 2.6 supports clips up to 15 seconds, optional audio, and a reference-to-video workflow with one to three video references. Pika 2.2 is limited to text-to-video and image-to-video without audio.',
+      },
+      {
+        question: 'Which model should I use for a polished 1080p clip?',
+        answer:
+          'Both offer 1080p. Choose Pika for a straightforward silent shot at a lower price, or Wan when the final clip benefits from native audio, extra duration, or reference-video guidance.',
+      },
+    ],
+  },
+},
+```
+
+Use the following exact content decisions and links; do not add claims outside the listed catalog facts:
+
+| Slug | Metadata title | Decision facts | Internal links |
+| --- | --- | --- | --- |
+| `pika-text-to-video-vs-wan-2-6` | `Pika 2.2 vs Wan 2.6: Price, Audio & Best Uses` | Pika: 5–10s, 720p/1080p, silent, $0.04/s at 720p. Wan: up to 15s, 720p/1080p, audio, reference-video mode, $0.10/s at 720p. Position Pika for inexpensive loops and Wan for longer, audio/reference workflows. | Both model pages; `minimax-hailuo-02-text-vs-pika-text-to-video`. |
+| `kling-2-6-pro-vs-kling-3-pro` | `Kling 2.6 Pro vs Kling 3 Pro: Is It Worth Upgrading?` | Kling 2.6 Pro is legacy, 10s max, 1080p, audio, $0.14/s audio on. Kling 3 Pro is current, 15s max, 1080p, audio, positioned for multi-shot control, $0.168/s audio on. | Both model pages; `kling-3-pro-vs-kling-3-standard`. |
+| `ltx-2-3-fast-vs-luma-ray-2` | `LTX 2.3 Fast vs Luma Ray 2: Speed, 4K & Editing` | LTX: up to 20s, audio, 1080p/1440p/4K, fast generation. Luma Ray 2: legacy, up to 9s, silent, 540p–1080p, video-to-video and reframe. | Both model pages; `ltx-2-3-fast-vs-veo-3-1-fast`. |
+| `kling-2-6-pro-vs-minimax-hailuo-02-text` | `Kling 2.6 Pro vs Hailuo 02: Quality, Audio & Price` | Kling: 1080p and native audio for cinematic dialogue. Hailuo: 512P/768P, silent, $0.045/s and suited to stylized motion. | Both model pages; `kling-2-6-pro-vs-wan-2-6`. |
+| `kling-3-standard-vs-kling-o3-standard` | `Kling 3 Standard vs Omni Standard: Which to Choose?` | Both: 15s, 1080p, audio, same catalog base price. Kling 3 Standard: streamlined text/start-image tests. Omni Standard: adds reference-to-video and video-to-video. | Both model pages; `kling-3-pro-vs-kling-3-standard`. |
+| `seedance-2-0-fast-vs-veo-3-1` | `Seedance 2.0 Fast vs Veo 3.1: Drafts or Final 4K?` | Seedance Fast: 15s, 480p/720p, text/image/reference/video-edit/extend, audio. Veo: 8s, 720p/1080p/4K, text/image/reference/first-last/extend, audio, polished ads/B-roll positioning. | Both model pages; `seedance-2-0-fast-vs-veo-3-1-fast`. |
+| `ltx-2-fast-vs-minimax-hailuo-02-text` | `LTX 2 Fast vs Hailuo 02: Resolution, Audio & Uses` | LTX 2 Fast: legacy, landscape-only, up to 20s, audio, 1080p/1440p/4K. Hailuo: up to 10s, silent, 512P/768P, adds vertical and square formats, stylized motion. | Both model pages; `ltx-2-3-fast-vs-ltx-2-fast`. |
+| `minimax-hailuo-02-text-vs-veo-3-1-fast` | `Hailuo 02 vs Veo 3.1 Fast: Price, Audio & 4K` | Hailuo: $0.045/s, silent, 512P/768P, stylized work. Veo Fast: 720p/1080p/4K, audio, references, first/last frame and extend, starting at $0.10/s with audio. | Both model pages; `seedance-2-0-fast-vs-veo-3-1-fast`. |
+| `kling-3-4k-vs-seedance-2-0` | `Kling 3 4K vs Seedance 2.0: Final 4K or Control?` | Kling 3 4K: native-4K-only, 3–15s, text/image, audio, dedicated final renders. Seedance: 480p through 4K, 4–15s, references, video edit, extend, motion controls, audio. Do not claim which costs less because Seedance uses token pricing. | Both model pages; `kling-3-4k-vs-veo-3-1`. |
+| `minimax-hailuo-02-text-vs-wan-2-6` | `Hailuo 02 vs Wan 2.6: Price, Audio & Best Uses` | Hailuo: $0.045/s, 10s, 512P/768P, silent, stylized. Wan: $0.10/s at 720p, 15s, 720p/1080p, audio, reference-video, general purpose. | Both model pages; `veo-3-1-vs-wan-2-6`. |
+
+Write a distinct 120–180 character description and three pair-specific FAQ items for every row. The description must summarize the listed decision facts; FAQs must cover workflow choice, the main capability difference, and when the more expensive or specialized route is justified.
+
+- [ ] **Step 2: Run the English contract and confirm GREEN**
+
+Run:
+
+```bash
+pnpm exec tsx --tsconfig frontend/tsconfig.json --test --test-name-pattern="EN comparison" tests/comparison-enrichment-locales.test.ts
+```
+
+Expected: the EN contract passes. FR and ES are excluded by the name filter.
+
+- [ ] **Step 3: Check formatting and commit English content**
+
+```bash
+git diff --check
+git add 'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-en.ts'
+git commit -m "feat: enrich English high-impression comparisons"
+```
+
+---
+
+### Task 3: Add the ten natural-French overrides
+
+**Files:**
+
+- Modify: `frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-fr.ts`
+- Test: `tests/comparison-enrichment-locales.test.ts`
+
+**Interfaces:**
+
+- Consumes: the same canonical slugs, factual matrix, and canonical hrefs from Task 2.
+- Produces: ten complete entries in `FR_COMPARE_PAGE_OVERRIDES` with native French editorial phrasing.
+
+- [ ] **Step 1: Add all ten French entries using the complete override shape from Task 2**
+
+Use `Verdict rapide` for every quick-verdict title, `Prochaines étapes recommandées` for every primary-link section title, `FAQ` for the FAQ title, and a pair-specific French subtitle rather than an English fallback.
+
+Use these exact French metadata titles and the same factual distinctions and hrefs as Task 2:
+
+| Slug | French metadata title |
+| --- | --- |
+| `pika-text-to-video-vs-wan-2-6` | `Pika 2.2 vs Wan 2.6 : prix, audio et usages` |
+| `kling-2-6-pro-vs-kling-3-pro` | `Kling 2.6 Pro vs Kling 3 Pro : faut-il évoluer ?` |
+| `ltx-2-3-fast-vs-luma-ray-2` | `LTX 2.3 Fast vs Luma Ray 2 : vitesse, 4K et montage` |
+| `kling-2-6-pro-vs-minimax-hailuo-02-text` | `Kling 2.6 Pro vs Hailuo 02 : qualité, audio et prix` |
+| `kling-3-standard-vs-kling-o3-standard` | `Kling 3 Standard vs Omni Standard : lequel choisir ?` |
+| `seedance-2-0-fast-vs-veo-3-1` | `Seedance 2.0 Fast vs Veo 3.1 : brouillon ou 4K ?` |
+| `ltx-2-fast-vs-minimax-hailuo-02-text` | `LTX 2 Fast vs Hailuo 02 : résolution, audio et usages` |
+| `minimax-hailuo-02-text-vs-veo-3-1-fast` | `Hailuo 02 vs Veo 3.1 Fast : prix, audio et 4K` |
+| `kling-3-4k-vs-seedance-2-0` | `Kling 3 4K vs Seedance 2.0 : 4K finale ou contrôle ?` |
+| `minimax-hailuo-02-text-vs-wan-2-6` | `Hailuo 02 vs Wan 2.6 : prix, audio et usages` |
+
+For each row:
+
+- translate meaning rather than English sentence order;
+- keep the official catalog marketing names visible in the combined page copy;
+- use four decision-card titles such as `Choisir …`, `Choisir …`, `Différence clé`, and `Usages recommandés`;
+- localize every anchor label while preserving the canonical hrefs exactly;
+- write a unique 120–180 character meta description and three pair-specific FAQ items.
+
+- [ ] **Step 2: Run the French contract and confirm GREEN**
+
+```bash
+pnpm exec tsx --tsconfig frontend/tsconfig.json --test --test-name-pattern="FR comparison" tests/comparison-enrichment-locales.test.ts
+```
+
+Expected: the FR contract passes.
+
+- [ ] **Step 3: Check formatting and commit French content**
+
+```bash
+git diff --check
+git add 'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-fr.ts'
+git commit -m "feat: enrich French high-impression comparisons"
+```
+
+---
+
+### Task 4: Add the ten LATAM-neutral Spanish overrides
+
+**Files:**
+
+- Modify: `frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-es.ts`
+- Test: `tests/comparison-enrichment-locales.test.ts`
+
+**Interfaces:**
+
+- Consumes: the same canonical slugs, factual matrix, and canonical hrefs from Task 2 plus LATAM vocabulary rules from `docs/seo/localization-notes.md`.
+- Produces: ten complete entries in `ES_COMPARE_PAGE_OVERRIDES` without Spain-specific vocabulary.
+
+- [ ] **Step 1: Add all ten Spanish entries using the complete override shape from Task 2**
+
+Use `Veredicto rápido` for every quick-verdict title, `Siguientes pasos recomendados` for every primary-link section title, `Preguntas frecuentes` for the FAQ title, and a pair-specific LATAM Spanish subtitle rather than an English fallback.
+
+Use these exact Spanish metadata titles and the same factual distinctions and hrefs as Task 2:
+
+| Slug | LATAM Spanish metadata title |
+| --- | --- |
+| `pika-text-to-video-vs-wan-2-6` | `Pika 2.2 vs Wan 2.6: precio, audio y mejores usos` |
+| `kling-2-6-pro-vs-kling-3-pro` | `Kling 2.6 Pro vs Kling 3 Pro: ¿conviene actualizar?` |
+| `ltx-2-3-fast-vs-luma-ray-2` | `LTX 2.3 Fast vs Luma Ray 2: velocidad, 4K y edición` |
+| `kling-2-6-pro-vs-minimax-hailuo-02-text` | `Kling 2.6 Pro vs Hailuo 02: calidad, audio y precio` |
+| `kling-3-standard-vs-kling-o3-standard` | `Kling 3 Standard vs Omni Standard: ¿cuál elegir?` |
+| `seedance-2-0-fast-vs-veo-3-1` | `Seedance 2.0 Fast vs Veo 3.1: borradores o 4K final` |
+| `ltx-2-fast-vs-minimax-hailuo-02-text` | `LTX 2 Fast vs Hailuo 02: resolución, audio y usos` |
+| `minimax-hailuo-02-text-vs-veo-3-1-fast` | `Hailuo 02 vs Veo 3.1 Fast: precio, audio y 4K` |
+| `kling-3-4k-vs-seedance-2-0` | `Kling 3 4K vs Seedance 2.0: 4K final o más control` |
+| `minimax-hailuo-02-text-vs-wan-2-6` | `Hailuo 02 vs Wan 2.6: precio, audio y mejores usos` |
+
+For each row:
+
+- use `video`, `celular`, `billetera`, and `ustedes` only where those concepts are needed;
+- never use `vídeo`, `móvil`, `ordenador`, `monedero`, or `vosotros`;
+- keep the official catalog marketing names visible in the combined page copy;
+- use four card titles such as `Elige …`, `Elige …`, `Diferencia clave`, and `Mejores flujos`;
+- localize anchor labels but preserve canonical hrefs exactly;
+- write a unique 120–180 character meta description and three pair-specific FAQ items.
+
+- [ ] **Step 2: Run the Spanish and localization contracts and confirm GREEN**
+
+```bash
+pnpm exec tsx --tsconfig frontend/tsconfig.json --test --test-name-pattern="ES comparison|LATAM-neutral|localized instead" tests/comparison-enrichment-locales.test.ts
+```
+
+Expected: ES structure, cross-locale differentiation, and LATAM vocabulary tests pass.
+
+- [ ] **Step 3: Check formatting and commit Spanish content**
+
+```bash
+git diff --check
+git add 'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-es.ts'
+git commit -m "feat: enrich LATAM Spanish comparisons"
+```
+
+---
+
+### Task 5: Verify public SEO behavior and repository quality
+
+**Files:**
+
+- Test: `tests/comparison-enrichment-locales.test.ts`
+- Test: `tests/compare-page-architecture.test.ts`
+- Verify: the three override maps and existing SEO route architecture.
+
+**Interfaces:**
+
+- Consumes: all 30 localized entries from Tasks 2–4.
+- Produces: evidence that content contracts, public links, route architecture, lint, and exposure checks remain green.
+
+- [ ] **Step 1: Run the complete focused enrichment contract**
+
+```bash
+pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/comparison-enrichment-locales.test.ts
+```
+
+Expected: 6 tests pass: EN contract, FR contract, ES contract, cross-locale localization, LATAM vocabulary, and public links.
+
+- [ ] **Step 2: Run the existing comparison architecture contract**
+
+```bash
+pnpm exec tsx --tsconfig frontend/tsconfig.json --test tests/compare-page-architecture.test.ts
+```
+
+Expected: all comparison architecture tests pass with no canonical, override, schema, or route-boundary regression.
+
+- [ ] **Step 3: Run the standard repository checks**
+
+```bash
+npm --prefix frontend run lint
+npm run lint:exposure
+git diff --check
+```
+
+Expected: all commands exit 0; no lint errors, public-exposure violations, or whitespace errors.
+
+- [ ] **Step 4: Run the full validation suite**
+
+```bash
+pnpm test:validate
+```
+
+Expected: the full TypeScript test suite passes.
+
+- [ ] **Step 5: Build the frontend**
+
+```bash
+pnpm --prefix frontend run build
+```
+
+Expected: the Next.js production build exits 0 and emits all existing localized comparison routes without metadata or type errors.
+
+- [ ] **Step 6: Smoke-check one enriched comparison in every locale**
+
+Start the production server in an interactive terminal:
+
+```bash
+pnpm --prefix frontend run start -- -p 3100
+```
+
+From a second terminal, request the English, French, and Spanish versions of the same target pair:
+
+```bash
+curl -fsS http://localhost:3100/ai-video-engines/pika-text-to-video-vs-wan-2-6 -o /tmp/maxvideo-compare-en.html
+curl -fsS http://localhost:3100/fr/comparatif/pika-text-to-video-vs-wan-2-6 -o /tmp/maxvideo-compare-fr.html
+curl -fsS http://localhost:3100/es/comparativa/pika-text-to-video-vs-wan-2-6 -o /tmp/maxvideo-compare-es.html
+rg -n "Pika 2.2 vs Wan 2.6|canonical|hreflang|application/ld\\+json|Quick verdict|Verdict rapide|Veredicto rápido" /tmp/maxvideo-compare-{en,fr,es}.html
+```
+
+Expected: all three requests return 200; each HTML file contains its localized metadata and verdict, canonical and hreflang tags, and the existing JSON-LD script.
+
+- [ ] **Step 7: Review the final diff and commit any test-only correction**
+
+```bash
+git status --short
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD -- tests/comparison-enrichment-locales.test.ts \
+  'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-en.ts' \
+  'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-fr.ts' \
+  'frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-es.ts'
+```
+
+Expected: only the design, plan, focused test, and three override maps differ from `origin/main`; no sitemap, robots, engine catalog, publication, Studio, or workspace files appear.
+
+If Task 5 required a correction to the focused test, commit only that correction:
+
+```bash
+git add tests/comparison-enrichment-locales.test.ts
+git commit -m "test: finalize comparison enrichment coverage"
+```
+
+If no correction was required, do not create an empty commit.

--- a/docs/superpowers/specs/2026-07-11-seo-comparison-enrichment-3-locales-design.md
+++ b/docs/superpowers/specs/2026-07-11-seo-comparison-enrichment-3-locales-design.md
@@ -1,0 +1,205 @@
+# SEO Comparison Enrichment — 10 Pages, 3 Locales
+
+**Date:** 2026-07-11  
+**Status:** Approved for planning  
+**Branch:** `codex/seo-comparison-enrichment-3-locales`  
+**Base:** `origin/main` at `9a72aedb4b2963d0d3b7ecdcb8ecbea8352264c3`
+
+## Objective
+
+Improve organic click-through rate and decision usefulness for ten English comparison URLs that already receive Google Search Console impressions but no clicks. Enrich the same comparisons in English, French, and Spanish so each public localized page has purposeful, locale-appropriate copy rather than generic fallback content.
+
+This batch is an editorial SEO improvement. It does not change which comparisons are published or indexed.
+
+## Target Pages
+
+The pages are ordered by the GSC opportunity recorded in `docs/seo/comparison-indexation-matrix-2026-07-08.json`:
+
+| Comparison slug | Impressions | Position |
+| --- | ---: | ---: |
+| `pika-text-to-video-vs-wan-2-6` | 476 | 10.8 |
+| `kling-2-6-pro-vs-kling-3-pro` | 376 | 11.7 |
+| `ltx-2-3-fast-vs-luma-ray-2` | 290 | 8.2 |
+| `kling-2-6-pro-vs-minimax-hailuo-02-text` | 270 | 14.5 |
+| `kling-3-standard-vs-kling-o3-standard` | 250 | 13.9 |
+| `seedance-2-0-fast-vs-veo-3-1` | 242 | 10.1 |
+| `ltx-2-fast-vs-minimax-hailuo-02-text` | 219 | 12.9 |
+| `minimax-hailuo-02-text-vs-veo-3-1-fast` | 209 | 9.8 |
+| `kling-3-4k-vs-seedance-2-0` | 203 | 7.9 |
+| `minimax-hailuo-02-text-vs-wan-2-6` | 196 | 11.0 |
+
+All ten rows are classified as `enrich`, have no current localized override, and have zero recorded clicks in the matrix snapshot.
+
+## Locale Strategy
+
+### English
+
+- Write in American English.
+- Use concise commercial language aimed primarily at the US market while remaining understandable globally.
+- Prefer `quality`, `color`, and US product terminology where variants arise.
+
+### French
+
+- Write natural French copy rather than translating sentence structure literally.
+- Preserve official model names and broadly recognized AI-video terms.
+- Use clear decision language focused on workflow, quality, speed, and cost.
+
+### Spanish
+
+- Follow `docs/seo/localization-notes.md` and write LATAM-neutral Spanish.
+- Keep the route locale and hreflang as generic `es`; do not introduce a new `es-419` route.
+- Use vocabulary suitable across Mexico, Colombia, Argentina, Chile, and the US Hispanic market.
+- Use `video` without the Spain-specific accent and avoid `vídeo`, `móvil`, `ordenador`, `monedero`, and `vosotros`.
+
+Each locale must communicate the same factual comparison, but headings, phrasing, and calls to action should sound native rather than mechanically translated.
+
+## Selected Approach
+
+Add a complete override for every target slug to each existing locale map:
+
+- `compare-page-overrides-en.ts`
+- `compare-page-overrides-fr.ts`
+- `compare-page-overrides-es.ts`
+
+This produces 30 localized override entries. The existing comparison route, metadata builder, canonical logic, hreflang handling, spec table, pricing section, scorecard, and schema builders remain unchanged.
+
+This approach was selected over:
+
+1. English-only enrichment, which would leave the localized pages on generic copy.
+2. Metadata-only French and Spanish translations, which would improve snippets but not page usefulness or internal linking.
+3. A five-page pilot, which would reduce immediate scope but leave half of the already identified GSC opportunity untreated.
+
+## Content Contract Per Page
+
+Every localized override will contain:
+
+### Metadata
+
+- A unique title built around the exact model pair and a meaningful decision angle.
+- `titleBranding: 'none'` when needed to keep the final title concise and prevent automatic branding from exceeding the target length.
+- A unique description that identifies the principal trade-off and tells the searcher what the page compares.
+- Titles should normally target roughly 50–60 characters after rendering.
+- Descriptions should normally target roughly 140–160 characters after rendering, prioritizing natural copy over forced length.
+
+### Hero introduction
+
+- Explain what decision the comparison helps the reader make.
+- Name the primary distinction between the two models.
+- Avoid unsupported superiority claims and generic SEO filler.
+
+### Quick verdict
+
+- Give a direct recommendation for when to choose each model.
+- Distinguish final quality, iteration speed, price/value, resolution, controls, audio, or use case only when supported by repository data.
+- Avoid presenting subjective scorecard output as an objective fact.
+
+### Decision cards
+
+Use four short cards where the model data supports them:
+
+1. Choose model A when…
+2. Choose model B when…
+3. Key trade-off
+4. Best-fit workflows
+
+The cards must add decision value instead of repeating the hero and verdict.
+
+### Internal links
+
+- Link to both model pages where those pages exist.
+- Add an examples or closely related comparison link only when the destination is a real published route.
+- Keep links locale-aware by using the existing localized `Link` component and English canonical hrefs, which the navigation layer localizes.
+- Use descriptive anchors that name the model or comparison intent.
+
+### FAQ
+
+- Provide three to five questions unique to the pair.
+- Cover the likely search decision: which is better for a named workflow, the important capability difference, value or speed, and when to choose each model.
+- Keep answers consistent with the visible specs and pricing data.
+- Do not add a new schema type or change current FAQ schema behavior in this batch.
+
+## Fact-Sourcing Rules
+
+Comparison claims must be derived from current repository sources, in this order:
+
+1. Engine catalog and model configuration used by the comparison page.
+2. Current key specs and pricing data rendered by the route.
+3. Existing model-page copy and curated comparison showdowns.
+4. Existing repository documentation for model-specific behavior.
+
+If a capability is missing, pending, ambiguous, or inconsistent across sources, the localized copy must avoid that claim. No price, generation time, resolution, audio feature, or quality assertion may be invented to make the copy more persuasive.
+
+## Architecture
+
+No new rendering component or content system is required. The existing `ComparePageOverride` contract already supports all selected fields:
+
+- `meta`
+- `heroIntro`
+- `quickVerdict`
+- `topCards`
+- `primaryLinksTitle`
+- `primaryLinks`
+- `faq`
+
+The route remains an orchestrator. Overrides remain route-local static content. This keeps canonical, hreflang, JSON-LD, localized routing, and indexing decisions under the existing shared builders.
+
+## Test Design
+
+Use test-driven development by adding a focused contract test before the override entries.
+
+The test should verify:
+
+- all ten target slugs exist in all three locale maps;
+- every entry contains unique metadata, hero copy, a quick verdict, decision cards, internal links, and FAQ items;
+- titles and descriptions are non-empty and remain within practical snippet bounds;
+- the two compared model names are represented appropriately in metadata or page copy;
+- internal hrefs use supported public route prefixes and contain no locale prefix;
+- French and Spanish entries do not simply reuse the English text;
+- Spanish copy avoids the explicitly disallowed Spain-specific vocabulary;
+- FAQ questions are unique within each localized page;
+- existing canonical, hreflang, schema, publication, and indexing architecture tests continue to pass.
+
+Exact character limits should act as regression guardrails, not as a reason to produce awkward language. Tests should allow a small practical range around the editorial targets.
+
+## Verification
+
+Run focused checks first:
+
+```bash
+node --import tsx --test tests/<focused-comparison-enrichment-test>.test.ts
+node --import tsx --test tests/compare-page-architecture.test.ts
+git diff --check
+```
+
+Then run repository checks proportionate to the public SEO surface:
+
+```bash
+npm --prefix frontend run lint
+npm run lint:exposure
+```
+
+If feasible before merge, run the full relevant test suite and frontend build. Smoke-check at least one target comparison in each locale to confirm:
+
+- localized URL behavior;
+- canonical URL;
+- hreflang output;
+- rendered title and description;
+- visible hero, verdict, cards, links, and FAQ;
+- JSON-LD still renders without structural changes;
+- the page remains indexable under existing publication and spec-completeness rules.
+
+## Explicit Non-Goals
+
+- No sitemap additions or removals.
+- No `noindex` or robots changes.
+- No canonical or hreflang architecture changes.
+- No comparison publication-list changes.
+- No new comparison videos or generated media.
+- No scorecard, pricing, or engine-catalog changes.
+- No new locale route or `es-419` URL.
+- No redesign of the comparison template.
+- No unrelated Studio or workspace changes.
+
+## Rollout and Measurement
+
+Ship the 30 overrides as one reviewable SEO content batch. After Google recrawls the pages, compare their clicks, CTR, impressions, and average position against the GSC snapshot used for selection. Evaluate by URL and locale rather than assuming the English signal will transfer equally to French and Spanish.

--- a/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-en.ts
+++ b/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-en.ts
@@ -825,4 +825,674 @@ export const EN_COMPARE_PAGE_OVERRIDES = {
         ],
       },
     },
+    'pika-text-to-video-vs-wan-2-6': {
+      meta: {
+        title: 'Pika 2.2 vs Wan 2.6: Price, Audio & Best Uses',
+        description:
+          'Compare Pika 2.2 and Wan 2.6 on price, clip length, audio, resolution, and reference workflows to choose the right AI video model.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Compare Pika 2.2 Text & Image to Video with Wan 2.6 Text & Image to Video when the real choice is a lower-cost short loop or a longer, audio-ready production workflow. Pika keeps simple prompt and image animation economical, while Wan adds 15-second output and reference-video control.',
+      quickVerdict: {
+        title: 'Quick verdict',
+        body:
+          'Choose Pika 2.2 for inexpensive 5- or 10-second silent loops, stylized tests, and straightforward image animation. Choose Wan 2.6 when the shot needs up to 15 seconds, native audio, or one to three reference videos, accepting the higher 720p and 1080p generation price.',
+      },
+      topCards: [
+        {
+          title: 'Choose Pika 2.2',
+          body:
+            'Use Pika for lower-cost 720p tests, short silent loops, and simple text-to-video or image-to-video work.',
+        },
+        {
+          title: 'Choose Wan 2.6',
+          body:
+            'Use Wan for clips up to 15 seconds, optional audio, 1080p delivery, or a workflow guided by reference videos.',
+        },
+        {
+          title: 'Key trade-off',
+          body:
+            'Pika starts at $0.04 per second at 720p; Wan starts at $0.10 per second but adds duration, audio, and reference-video control.',
+        },
+        {
+          title: 'Best workflows',
+          body:
+            'Pika fits stylized social loops and concept tests. Wan fits longer general-purpose shots, narrated clips, and reference-led sequences.',
+        },
+      ],
+      primaryLinksTitle: 'Recommended next steps',
+      primaryLinks: [
+        { href: '/models/pika-text-to-video', label: 'Open the Pika 2.2 model page' },
+        { href: '/models/wan-2-6', label: 'Open the Wan 2.6 model page' },
+        {
+          href: '/ai-video-engines/minimax-hailuo-02-text-vs-pika-text-to-video',
+          label: 'Compare Hailuo 02 vs Pika 2.2',
+        },
+      ],
+      faq: {
+        title: 'FAQ',
+        subtitle: 'Short answers for choosing between Pika 2.2 and Wan 2.6.',
+        items: [
+          {
+            question: 'Is Pika 2.2 or Wan 2.6 better for low-cost video tests?',
+            answer:
+              'Pika 2.2 is the lower-cost choice at 720p and works well for short silent loops. Wan 2.6 costs more but is justified when a test needs audio, longer duration, or reference videos.',
+          },
+          {
+            question: 'What can Wan 2.6 do that Pika 2.2 cannot?',
+            answer:
+              'Wan 2.6 supports clips up to 15 seconds, optional audio, and a reference-to-video workflow with one to three video references. Pika 2.2 is limited to text-to-video and image-to-video without audio.',
+          },
+          {
+            question: 'Which model should I use for a polished 1080p clip?',
+            answer:
+              'Both offer 1080p. Choose Pika for a straightforward silent shot at a lower price, or Wan when the final clip benefits from native audio, extra duration, or reference-video guidance.',
+          },
+        ],
+      },
+    },
+    'kling-2-6-pro-vs-kling-3-pro': {
+      meta: {
+        title: 'Kling 2.6 Pro vs Kling 3 Pro: Is It Worth Upgrading?',
+        description:
+          'Compare Kling 2.6 Pro and Kling 3 Pro on generation length, audio, pricing, and multi-shot control to decide whether the upgrade fits your work.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Compare Kling 2.6 Pro with Kling 3 Pro to decide whether a proven legacy Kling workflow is enough or the current generation earns its higher price. Both deliver 1080p video with audio, but Kling 3 Pro extends clips to 15 seconds and targets more demanding multi-shot cinematic control.',
+      quickVerdict: {
+        title: 'Quick verdict',
+        body:
+          'Stay with Kling 2.6 Pro for familiar 5- or 10-second dialogue shots and a lower audio-on price. Upgrade to Kling 3 Pro when the project needs clips up to 15 seconds, current Kling development, and stronger positioning for structured multi-shot work where the extra cost is easier to justify.',
+      },
+      topCards: [
+        {
+          title: 'Choose Kling 2.6 Pro',
+          body:
+            'Keep the legacy route for established 1080p prompt patterns, short cinematic dialogue, and a lower $0.14-per-second audio-on rate.',
+        },
+        {
+          title: 'Choose Kling 3 Pro',
+          body:
+            'Use the current Pro model for clips up to 15 seconds and higher-priority multi-shot cinematic sequences.',
+        },
+        {
+          title: 'Key trade-off',
+          body:
+            'Both support text-to-video, image-to-video, 1080p, and audio; the decision is legacy value versus current duration and workflow ambition.',
+        },
+        {
+          title: 'Best workflows',
+          body:
+            'Kling 2.6 Pro fits repeatable short dialogue shots. Kling 3 Pro fits campaign heroes, planned sequences, and longer cinematic beats.',
+        },
+      ],
+      primaryLinksTitle: 'Recommended next steps',
+      primaryLinks: [
+        { href: '/models/kling-2-6-pro', label: 'Open the Kling 2.6 Pro model page' },
+        { href: '/models/kling-3-pro', label: 'Open the Kling 3 Pro model page' },
+        {
+          href: '/ai-video-engines/kling-3-pro-vs-kling-3-standard',
+          label: 'Compare Kling 3 Pro vs Kling 3 Standard',
+        },
+      ],
+      faq: {
+        title: 'FAQ',
+        subtitle: 'Short answers for deciding whether to move from Kling 2.6 Pro to Kling 3 Pro.',
+        items: [
+          {
+            question: 'Is Kling 3 Pro a direct upgrade from Kling 2.6 Pro?',
+            answer:
+              'Kling 3 Pro is the current Pro route and increases the maximum clip length from 10 to 15 seconds. Kling 2.6 Pro remains usable as a legacy option for established short-form workflows.',
+          },
+          {
+            question: 'Do both Kling Pro models generate audio?',
+            answer:
+              'Yes. Both catalog routes support audio with 1080p text-to-video and image-to-video. Kling 2.6 Pro costs $0.14 per second with audio on, while Kling 3 Pro lists $0.168 per second before platform margin.',
+          },
+          {
+            question: 'When is Kling 3 Pro worth the higher price?',
+            answer:
+              'Choose Kling 3 Pro when 15-second output, the current Kling generation, or multi-shot cinematic planning matters. Keep 2.6 Pro when a validated 10-second workflow already meets the brief.',
+          },
+        ],
+      },
+    },
+    'ltx-2-3-fast-vs-luma-ray-2': {
+      meta: {
+        title: 'LTX 2.3 Fast vs Luma Ray 2: Speed, 4K & Editing',
+        description:
+          'Compare LTX 2.3 Fast and Luma Ray 2 on duration, 4K, audio, video editing, and reframe controls to choose the better production route.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Compare LTX 2.3 Fast with Luma Ray 2 when choosing between fast, audio-ready generation and a legacy Luma editing toolkit. LTX 2.3 Fast reaches 20 seconds with 1080p, 1440p, or 4K output, while Luma Ray 2 stays at 9 seconds but adds video-to-video and reframe workflows.',
+      quickVerdict: {
+        title: 'Quick verdict',
+        body:
+          'Choose LTX 2.3 Fast for rapid text or image generation, native audio, longer landscape or vertical clips, and output up to 4K. Choose Luma Ray 2 when an existing clip needs video-to-video transformation or reframing across a broader set of aspect ratios and 1080p is enough.',
+      },
+      topCards: [
+        {
+          title: 'Choose LTX 2.3 Fast',
+          body:
+            'Use LTX for fast concepts, audio-ready output, clips up to 20 seconds, and 1080p through 4K delivery.',
+        },
+        {
+          title: 'Choose Luma Ray 2',
+          body:
+            'Use the legacy Luma route to modify an existing video or reframe footage for wide, square, vertical, and ultrawide formats.',
+        },
+        {
+          title: 'Key trade-off',
+          body:
+            'LTX offers more duration, resolution, and audio; Luma offers source-video transformation and more aspect-ratio choices.',
+        },
+        {
+          title: 'Best workflows',
+          body:
+            'LTX fits fast campaign drafts and high-resolution generation. Luma fits repurposing, format adaptation, and legacy edit workflows.',
+        },
+      ],
+      primaryLinksTitle: 'Recommended next steps',
+      primaryLinks: [
+        { href: '/models/ltx-2-3-fast', label: 'Open the LTX 2.3 Fast model page' },
+        { href: '/models/luma-ray-2', label: 'Open the Luma Ray 2 model page' },
+        {
+          href: '/ai-video-engines/ltx-2-3-fast-vs-veo-3-1-fast',
+          label: 'Compare LTX 2.3 Fast vs Veo 3.1 Fast',
+        },
+      ],
+      faq: {
+        title: 'FAQ',
+        subtitle: 'Short answers for choosing between LTX 2.3 Fast generation and Luma Ray 2 editing.',
+        items: [
+          {
+            question: 'Which model is better for fast 4K AI video?',
+            answer:
+              'LTX 2.3 Fast is the clear fit because it supports 4K output, native audio, and clips up to 20 seconds. Luma Ray 2 tops out at 1080p and does not generate audio.',
+          },
+          {
+            question: 'What can Luma Ray 2 do that LTX 2.3 Fast cannot?',
+            answer:
+              'Luma Ray 2 includes video-to-video and reframe modes for transforming or resizing existing footage. LTX 2.3 Fast focuses on text-to-video and image-to-video generation.',
+          },
+          {
+            question: 'Should I still choose the legacy Luma Ray 2 route?',
+            answer:
+              'Choose it when source-video modification or broad aspect-ratio reframing is the main job. For new audio-ready generation, longer clips, or high-resolution output, use LTX 2.3 Fast.',
+          },
+        ],
+      },
+    },
+    'kling-2-6-pro-vs-minimax-hailuo-02-text': {
+      meta: {
+        title: 'Kling 2.6 Pro vs Hailuo 02: Quality, Audio & Price',
+        description:
+          'Compare Kling 2.6 Pro and MiniMax Hailuo 02 on 1080p output, audio, stylized motion, and per-second price to match the model to your shot.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Compare Kling 2.6 Pro with MiniMax Hailuo 02 Standard when choosing between 1080p cinematic dialogue and lower-cost stylized exploration. Kling adds native audio and higher output resolution, while Hailuo keeps silent text or image animation economical at 512P or 768P.',
+      quickVerdict: {
+        title: 'Quick verdict',
+        body:
+          'Choose Kling 2.6 Pro for 1080p cinematic shots, dialogue, and optional native audio. Choose MiniMax Hailuo 02 Standard for inexpensive stylized tests, vertical or square social concepts, and silent motion where 512P or 768P is acceptable and cost matters more than finishing resolution.',
+      },
+      topCards: [
+        {
+          title: 'Choose Kling 2.6 Pro',
+          body:
+            'Use Kling for 1080p cinematic dialogue, optional audio, and shots where finish quality carries more weight than generation price.',
+        },
+        {
+          title: 'Choose Hailuo 02',
+          body:
+            'Use Hailuo for $0.045-per-second stylized concepts, silent social motion, and lower-resolution prompt exploration.',
+        },
+        {
+          title: 'Key trade-off',
+          body:
+            'Kling delivers 1080p and audio at $0.14 per second with audio on; Hailuo costs less but stops at 768P and stays silent.',
+        },
+        {
+          title: 'Best workflows',
+          body:
+            'Kling fits dialogue and polished cinematic shots. Hailuo fits stylized hooks, visual experiments, and budget-first batches.',
+        },
+      ],
+      primaryLinksTitle: 'Recommended next steps',
+      primaryLinks: [
+        { href: '/models/kling-2-6-pro', label: 'Open the Kling 2.6 Pro model page' },
+        { href: '/models/minimax-hailuo-02-text', label: 'Open the MiniMax Hailuo 02 model page' },
+        {
+          href: '/ai-video-engines/kling-2-6-pro-vs-wan-2-6',
+          label: 'Compare Kling 2.6 Pro vs Wan 2.6',
+        },
+      ],
+      faq: {
+        title: 'FAQ',
+        subtitle: 'Short answers for choosing cinematic Kling output or lower-cost Hailuo motion.',
+        items: [
+          {
+            question: 'Is Kling 2.6 Pro or Hailuo 02 better for dialogue?',
+            answer:
+              'Kling 2.6 Pro is the better fit because it supports native audio and 1080p output. Hailuo 02 generates silent video and is better used for visual or stylized motion tests.',
+          },
+          {
+            question: 'How much resolution do the two models provide?',
+            answer:
+              'Kling 2.6 Pro outputs 1080p. MiniMax Hailuo 02 Standard offers 512P and 768P, making it more suitable for inexpensive concepts than high-resolution finishing.',
+          },
+          {
+            question: 'When does the lower Hailuo 02 price make sense?',
+            answer:
+              'Use Hailuo when you need many silent stylized explorations at $0.045 per second and can accept lower resolution. Pay for Kling when audio and 1080p delivery are requirements.',
+          },
+        ],
+      },
+    },
+    'kling-3-standard-vs-kling-o3-standard': {
+      meta: {
+        title: 'Kling 3 Standard vs Omni Standard: Which to Choose?',
+        description:
+          'Compare Kling 3 Standard and Kling 3.0 Omni Standard on references, video editing, 1080p output, audio, and price to pick the right workflow.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Compare Kling 3 Standard with Kling 3.0 Omni Standard when both offer 15-second 1080p output and audio at the same listed base price. Standard keeps text and start-image generation focused, while Omni adds reference-to-video and video-to-video control for source-led work.',
+      quickVerdict: {
+        title: 'Quick verdict',
+        body:
+          'Choose Kling 3 Standard for streamlined text-to-video or start-frame testing when extra reference modes would only add complexity. Choose Kling 3.0 Omni Standard when characters, products, visual references, or an existing source clip need to guide the result through reference-to-video or video-to-video.',
+      },
+      topCards: [
+        {
+          title: 'Choose Kling 3 Standard',
+          body:
+            'Use Standard for direct prompt generation, start-image animation, and repeatable 1080p draft testing with optional audio.',
+        },
+        {
+          title: 'Choose Omni Standard',
+          body:
+            'Use Omni when the shot needs reference assets or an existing video source in addition to text and image generation.',
+        },
+        {
+          title: 'Key trade-off',
+          body:
+            'Resolution, duration, audio, and listed base price match; Omni expands the input workflow while Standard stays simpler.',
+        },
+        {
+          title: 'Best workflows',
+          body:
+            'Standard fits rapid start-frame drafts. Omni fits reference-guided characters, product continuity, and source-video transformations.',
+        },
+      ],
+      primaryLinksTitle: 'Recommended next steps',
+      primaryLinks: [
+        { href: '/models/kling-3-standard', label: 'Open the Kling 3 Standard model page' },
+        { href: '/models/kling-o3-standard', label: 'Open the Kling 3.0 Omni Standard model page' },
+        {
+          href: '/ai-video-engines/kling-3-pro-vs-kling-3-standard',
+          label: 'Compare Kling 3 Pro vs Kling 3 Standard',
+        },
+      ],
+      faq: {
+        title: 'FAQ',
+        subtitle: 'Short answers for choosing between the Standard and Omni Standard Kling workflows.',
+        items: [
+          {
+            question: 'What is the main difference between Kling 3 Standard and Omni Standard?',
+            answer:
+              'Both support 15-second 1080p generation with audio. Omni Standard adds reference-to-video and video-to-video, while Kling 3 Standard focuses on text-to-video and image-to-video.',
+          },
+          {
+            question: 'Do Kling 3 Standard and Omni Standard cost the same?',
+            answer:
+              'The catalog lists the same provider base rates for both: $0.084 per second with audio off and $0.126 per second with audio on, before MaxVideoAI platform margin.',
+          },
+          {
+            question: 'Which Kling Standard model should I use for reference assets?',
+            answer:
+              'Use Kling 3.0 Omni Standard when reference images or a source video must guide the output. Use Kling 3 Standard when a prompt or start image is enough.',
+          },
+        ],
+      },
+    },
+    'seedance-2-0-fast-vs-veo-3-1': {
+      meta: {
+        title: 'Seedance 2.0 Fast vs Veo 3.1: Drafts or Final 4K?',
+        description:
+          'Compare Seedance 2.0 Fast and Google Veo 3.1 on draft speed, references, editing, duration, audio, and 4K output for your next video.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Compare Seedance 2.0 Fast with Google Veo 3.1 when choosing between a broad draft-and-edit workflow and higher-resolution final delivery. Seedance Fast reaches 15 seconds with references, video editing, and extend at 480p or 720p; Veo 3.1 reaches 4K for polished 8-second ads and B-roll.',
+      quickVerdict: {
+        title: 'Quick verdict',
+        body:
+          'Choose Seedance 2.0 Fast for rapid planning, longer drafts, reference-heavy iteration, video edits, or extensions where 720p is enough. Choose Google Veo 3.1 for polished short ads, B-roll, first-and-last-frame control, and final delivery at 1080p or 4K when output resolution matters more than clip length.',
+      },
+      topCards: [
+        {
+          title: 'Choose Seedance 2.0 Fast',
+          body:
+            'Use Seedance Fast for 4- to 15-second drafts, visual references, video editing, extensions, and flexible aspect ratios.',
+        },
+        {
+          title: 'Choose Veo 3.1',
+          body:
+            'Use Veo for polished 8-second ads or B-roll, first-and-last-frame control, audio, and 1080p or 4K delivery.',
+        },
+        {
+          title: 'Key trade-off',
+          body:
+            'Seedance offers more duration and editing breadth at 480p/720p; Veo offers shorter clips with substantially higher final resolution.',
+        },
+        {
+          title: 'Best workflows',
+          body:
+            'Seedance fits shot planning and iterative edits. Veo fits approved campaign shots, polished product visuals, and high-resolution masters.',
+        },
+      ],
+      primaryLinksTitle: 'Recommended next steps',
+      primaryLinks: [
+        { href: '/models/seedance-2-0-fast', label: 'Open the Seedance 2.0 Fast model page' },
+        { href: '/models/veo-3-1', label: 'Open the Google Veo 3.1 model page' },
+        {
+          href: '/ai-video-engines/seedance-2-0-fast-vs-veo-3-1-fast',
+          label: 'Compare Seedance 2.0 Fast vs Veo 3.1 Fast',
+        },
+      ],
+      faq: {
+        title: 'FAQ',
+        subtitle: 'Short answers for choosing a fast Seedance workflow or final-quality Veo output.',
+        items: [
+          {
+            question: 'Is Seedance 2.0 Fast or Veo 3.1 better for drafts?',
+            answer:
+              'Seedance 2.0 Fast is designed for rapid drafts, reference tests, and shot planning. It also supports clips up to 15 seconds, video editing, and extension at 480p or 720p.',
+          },
+          {
+            question: 'Which model is better for final 4K delivery?',
+            answer:
+              'Google Veo 3.1 is the better fit for a polished 4K master. Seedance 2.0 Fast tops out at 720p and is better treated as an iteration and editing route.',
+          },
+          {
+            question: 'Do both models support audio and reference workflows?',
+            answer:
+              'Yes. Both support audio and reference-led generation. Seedance adds video-to-video editing and a wider aspect-ratio set, while Veo adds first-and-last-frame control and higher-resolution output.',
+          },
+        ],
+      },
+    },
+    'ltx-2-fast-vs-minimax-hailuo-02-text': {
+      meta: {
+        title: 'LTX 2 Fast vs Hailuo 02: Resolution, Audio & Uses',
+        description:
+          'Compare LTX Video 2.0 Fast and MiniMax Hailuo 02 on duration, resolution, audio, aspect ratios, and price for social and stylized clips.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Compare LTX Video 2.0 Fast with MiniMax Hailuo 02 Standard when choosing between long, high-resolution landscape clips and lower-resolution stylized formats. LTX reaches 20 seconds with audio and output up to 4K, while Hailuo adds vertical and square options for silent 512P or 768P motion.',
+      quickVerdict: {
+        title: 'Quick verdict',
+        body:
+          'Choose LTX Video 2.0 Fast for rapid landscape clips, native audio, durations up to 20 seconds, and 1080p, 1440p, or 4K output. Choose MiniMax Hailuo 02 Standard when a silent stylized concept needs vertical, square, or landscape delivery and lower resolution is acceptable.',
+      },
+      topCards: [
+        {
+          title: 'Choose LTX 2 Fast',
+          body:
+            'Use LTX for longer 16:9 social clips, audio-ready generation, and output from 1080p through 4K.',
+        },
+        {
+          title: 'Choose Hailuo 02',
+          body:
+            'Use Hailuo for silent stylized motion in 16:9, 9:16, or 1:1 when 512P or 768P meets the channel requirement.',
+        },
+        {
+          title: 'Key trade-off',
+          body:
+            'LTX offers duration, audio, and high resolution but only 16:9; Hailuo offers more social formats at lower resolution.',
+        },
+        {
+          title: 'Best workflows',
+          body:
+            'LTX fits longer landscape promos and music-backed clips. Hailuo fits stylized vertical hooks, square posts, and visual tests.',
+        },
+      ],
+      primaryLinksTitle: 'Recommended next steps',
+      primaryLinks: [
+        { href: '/models/ltx-2-fast', label: 'Open the LTX Video 2.0 Fast model page' },
+        { href: '/models/minimax-hailuo-02-text', label: 'Open the MiniMax Hailuo 02 model page' },
+        {
+          href: '/ai-video-engines/ltx-2-3-fast-vs-ltx-2-fast',
+          label: 'Compare LTX 2.3 Fast vs LTX 2 Fast',
+        },
+      ],
+      faq: {
+        title: 'FAQ',
+        subtitle: 'Short answers for choosing between high-resolution LTX and flexible-format Hailuo.',
+        items: [
+          {
+            question: 'Which model is better for long, high-resolution clips?',
+            answer:
+              'LTX Video 2.0 Fast supports clips up to 20 seconds with 1080p, 1440p, or 4K output and native audio. Hailuo 02 stops at 10 seconds and 768P.',
+          },
+          {
+            question: 'Which model works better for vertical or square social video?',
+            answer:
+              'MiniMax Hailuo 02 Standard supports 9:16 and 1:1 as well as 16:9. LTX Video 2.0 Fast is limited to 16:9, so it is best for landscape output.',
+          },
+          {
+            question: 'Do LTX 2 Fast and Hailuo 02 both generate audio?',
+            answer:
+              'No. LTX Video 2.0 Fast supports native audio, while Hailuo 02 produces silent video. Choose Hailuo only when sound can be added separately or is not needed.',
+          },
+        ],
+      },
+    },
+    'minimax-hailuo-02-text-vs-veo-3-1-fast': {
+      meta: {
+        title: 'Hailuo 02 vs Veo 3.1 Fast: Price, Audio & 4K',
+        description:
+          'Compare MiniMax Hailuo 02 and Google Veo 3.1 Fast on price, audio, references, resolution, and duration for stylized tests or polished output.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Compare MiniMax Hailuo 02 Standard with Google Veo 3.1 Fast when the choice is low-cost stylized exploration or a broader polished production workflow. Hailuo offers silent 512P or 768P motion at $0.045 per second; Veo Fast adds audio, references, extension, and output up to 4K.',
+      quickVerdict: {
+        title: 'Quick verdict',
+        body:
+          'Choose MiniMax Hailuo 02 Standard for inexpensive silent stylized concepts, especially when 768P is enough and you want up to 10 seconds. Choose Google Veo 3.1 Fast for audio-ready ads, reference-guided shots, first-and-last-frame control, extensions, or final output at 1080p or 4K.',
+      },
+      topCards: [
+        {
+          title: 'Choose Hailuo 02',
+          body:
+            'Use Hailuo for $0.045-per-second stylized tests, silent social concepts, and clips up to 10 seconds at 512P or 768P.',
+        },
+        {
+          title: 'Choose Veo 3.1 Fast',
+          body:
+            'Use Veo Fast for audio, references, first-and-last-frame control, extensions, and delivery from 720p through 4K.',
+        },
+        {
+          title: 'Key trade-off',
+          body:
+            'Hailuo costs less and offers two extra seconds; Veo Fast costs more but expands resolution, sound, and production control.',
+        },
+        {
+          title: 'Best workflows',
+          body:
+            'Hailuo fits stylized exploration and cheap hooks. Veo Fast fits ad variants, product shots, dialogue, and polished masters.',
+        },
+      ],
+      primaryLinksTitle: 'Recommended next steps',
+      primaryLinks: [
+        { href: '/models/minimax-hailuo-02-text', label: 'Open the MiniMax Hailuo 02 model page' },
+        { href: '/models/veo-3-1-fast', label: 'Open the Google Veo 3.1 Fast model page' },
+        {
+          href: '/ai-video-engines/seedance-2-0-fast-vs-veo-3-1-fast',
+          label: 'Compare Seedance 2.0 Fast vs Veo 3.1 Fast',
+        },
+      ],
+      faq: {
+        title: 'FAQ',
+        subtitle: 'Short answers for choosing lower-cost Hailuo or production-ready Veo Fast.',
+        items: [
+          {
+            question: 'Is Hailuo 02 or Veo 3.1 Fast cheaper?',
+            answer:
+              'Hailuo 02 lists $0.045 per second. Veo 3.1 Fast starts at $0.10 per second at 720p with audio, rising with resolution, so Hailuo is the lower-cost silent test route.',
+          },
+          {
+            question: 'Which model supports audio and 4K output?',
+            answer:
+              'Google Veo 3.1 Fast supports native audio and output up to 4K. MiniMax Hailuo 02 Standard is silent and tops out at 768P.',
+          },
+          {
+            question: 'When should I choose Hailuo 02 instead of Veo Fast?',
+            answer:
+              'Choose Hailuo for inexpensive stylized exploration where sound and high resolution are not required. Choose Veo Fast when references, frame control, audio, or polished delivery matter.',
+          },
+        ],
+      },
+    },
+    'kling-3-4k-vs-seedance-2-0': {
+      meta: {
+        title: 'Kling 3 4K vs Seedance 2.0: Final 4K or Control?',
+        description:
+          'Compare Kling 3 4K and Seedance 2.0 on native 4K delivery, references, editing, extensions, audio, and workflow flexibility before rendering.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Compare Kling 3 4K with Seedance 2.0 when both can deliver 4K but serve different production paths. Kling is a dedicated native-4K text and start-image route for final renders; Seedance spans 480p through 4K with reference-to-video, video editing, extension, motion controls, and audio.',
+      quickVerdict: {
+        title: 'Quick verdict',
+        body:
+          'Choose Kling 3 4K when an approved prompt or start image should render directly to native 4K and a focused final-delivery route is preferable. Choose Seedance 2.0 when the workflow needs lower-resolution iteration, multiple references, video-to-video editing, clip extension, wider aspect ratios, or more production control before the 4K master.',
+      },
+      topCards: [
+        {
+          title: 'Choose Kling 3 4K',
+          body:
+            'Use Kling for direct native-4K text-to-video or image-to-video renders from an approved concept, with optional audio.',
+        },
+        {
+          title: 'Choose Seedance 2.0',
+          body:
+            'Use Seedance for references, video edits, extensions, motion controls, varied resolutions, and a wider set of aspect ratios.',
+        },
+        {
+          title: 'Key trade-off',
+          body:
+            'Kling locks every render to native 4K; Seedance lets teams iterate from 480p upward and adds substantially broader input modes.',
+        },
+        {
+          title: 'Best workflows',
+          body:
+            'Kling fits approved final hero shots. Seedance fits iterative campaigns, reference-heavy sequences, edits, and extended clips.',
+        },
+      ],
+      primaryLinksTitle: 'Recommended next steps',
+      primaryLinks: [
+        { href: '/models/kling-3-4k', label: 'Open the Kling 3 4K model page' },
+        { href: '/models/seedance-2-0', label: 'Open the Seedance 2.0 model page' },
+        {
+          href: '/ai-video-engines/kling-3-4k-vs-veo-3-1',
+          label: 'Compare Kling 3 4K vs Veo 3.1',
+        },
+      ],
+      faq: {
+        title: 'FAQ',
+        subtitle: 'Short answers for choosing dedicated native 4K or a broader Seedance workflow.',
+        items: [
+          {
+            question: 'Do Kling 3 4K and Seedance 2.0 both support 4K?',
+            answer:
+              'Yes. Kling 3 4K is locked to native 4K output, while Seedance 2.0 offers 480p, 720p, 1080p, and 4K so teams can iterate before final delivery.',
+          },
+          {
+            question: 'Which model offers more reference and editing control?',
+            answer:
+              'Seedance 2.0 offers reference-to-video, video-to-video editing, extension, motion controls, and multiple image, video, or audio references. Kling 3 4K focuses on text and start-image generation.',
+          },
+          {
+            question: 'Which model is better for a final 4K hero shot?',
+            answer:
+              'Kling 3 4K is a focused choice for direct native-4K rendering from an approved prompt or image. Seedance is better when the shot still needs references, editing, extension, or lower-resolution iteration.',
+          },
+        ],
+      },
+    },
+    'minimax-hailuo-02-text-vs-wan-2-6': {
+      meta: {
+        title: 'Hailuo 02 vs Wan 2.6: Price, Audio & Best Uses',
+        description:
+          'Compare MiniMax Hailuo 02 and Wan 2.6 on price, duration, 1080p, audio, reference video, and stylized motion to choose the right model.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Compare MiniMax Hailuo 02 Standard with Wan 2.6 Text & Image to Video when choosing between inexpensive stylized motion and a broader general-purpose workflow. Hailuo costs $0.045 per second for silent 512P or 768P clips; Wan reaches 15 seconds with 1080p, audio, and reference-video control.',
+      quickVerdict: {
+        title: 'Quick verdict',
+        body:
+          'Choose MiniMax Hailuo 02 Standard for lower-cost silent stylized concepts, vertical or square hooks, and shots up to 10 seconds where 768P is sufficient. Choose Wan 2.6 for general-purpose production that needs 1080p, clips up to 15 seconds, optional audio, or one to three reference videos.',
+      },
+      topCards: [
+        {
+          title: 'Choose Hailuo 02',
+          body:
+            'Use Hailuo for $0.045-per-second stylized motion, silent tests, and lower-resolution vertical, square, or landscape clips.',
+        },
+        {
+          title: 'Choose Wan 2.6',
+          body:
+            'Use Wan for 720p or 1080p delivery, optional audio, clips up to 15 seconds, and reference-video guidance.',
+        },
+        {
+          title: 'Key trade-off',
+          body:
+            'Hailuo minimizes cost for stylized silent output; Wan costs more but adds resolution, duration, sound, and reference control.',
+        },
+        {
+          title: 'Best workflows',
+          body:
+            'Hailuo fits budget social concepts and visual experiments. Wan fits narrated clips, general B-roll, and reference-led sequences.',
+        },
+      ],
+      primaryLinksTitle: 'Recommended next steps',
+      primaryLinks: [
+        { href: '/models/minimax-hailuo-02-text', label: 'Open the MiniMax Hailuo 02 model page' },
+        { href: '/models/wan-2-6', label: 'Open the Wan 2.6 model page' },
+        {
+          href: '/ai-video-engines/veo-3-1-vs-wan-2-6',
+          label: 'Compare Veo 3.1 vs Wan 2.6',
+        },
+      ],
+      faq: {
+        title: 'FAQ',
+        subtitle: 'Short answers for choosing budget stylized Hailuo or general-purpose Wan.',
+        items: [
+          {
+            question: 'Is Hailuo 02 or Wan 2.6 cheaper?',
+            answer:
+              'Hailuo 02 lists $0.045 per second. Wan 2.6 starts at $0.10 per second at 720p and $0.15 at 1080p, so Hailuo is cheaper when silent lower-resolution output is enough.',
+          },
+          {
+            question: 'Which model supports audio and reference videos?',
+            answer:
+              'Wan 2.6 supports optional audio and reference-to-video with one to three source clips. MiniMax Hailuo 02 Standard supports text or image generation without audio.',
+          },
+          {
+            question: 'When should I choose Wan 2.6 over Hailuo 02?',
+            answer:
+              'Choose Wan when the job needs 1080p, more than 10 seconds, native audio, or reference-video guidance. Choose Hailuo for cheaper stylized exploration and social-format tests.',
+          },
+        ],
+      },
+    },
   } satisfies ComparePageOverridesBySlug;

--- a/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-es.ts
+++ b/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-es.ts
@@ -742,4 +742,674 @@ export const ES_COMPARE_PAGE_OVERRIDES = {
         ],
       },
     },
+    'pika-text-to-video-vs-wan-2-6': {
+      meta: {
+        title: 'Pika 2.2 vs Wan 2.6: precio, audio y mejores usos',
+        description:
+          'Compara Pika 2.2 y Wan 2.6 en precio, duración, audio, resolución y referencias de video para elegir el modelo ideal para tu proyecto.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Compara Pika 2.2 Text & Image to Video con Wan 2.6 Text & Image to Video para decidir entre un loop corto y económico o un flujo más completo con audio. Pika simplifica la animación desde texto o imagen, mientras Wan llega a 15 segundos y admite videos de referencia.',
+      quickVerdict: {
+        title: 'Veredicto rápido',
+        body:
+          'Elige Pika 2.2 para loops silenciosos de 5 o 10 segundos, pruebas estilizadas y animaciones simples a menor precio. Elige Wan 2.6 si la toma necesita hasta 15 segundos, audio nativo o entre uno y tres videos de referencia, aunque el costo en 720p y 1080p sea mayor.',
+      },
+      topCards: [
+        {
+          title: 'Elige Pika 2.2',
+          body:
+            'Úsalo para pruebas económicas en 720p, loops silenciosos y trabajos simples de texto a video o imagen a video.',
+        },
+        {
+          title: 'Elige Wan 2.6',
+          body:
+            'Úsalo para tomas de hasta 15 segundos, audio opcional, entrega 1080p o un flujo guiado por videos de referencia.',
+        },
+        {
+          title: 'Diferencia clave',
+          body:
+            'Pika parte de US$0.04 por segundo en 720p; Wan parte de US$0.10 y agrega duración, audio y control por referencias.',
+        },
+        {
+          title: 'Mejores flujos',
+          body:
+            'Pika funciona para loops sociales y conceptos. Wan funciona para tomas más largas, narradas o guiadas por video.',
+        },
+      ],
+      primaryLinksTitle: 'Siguientes pasos recomendados',
+      primaryLinks: [
+        { href: '/models/pika-text-to-video', label: 'Abrir la página del modelo Pika 2.2' },
+        { href: '/models/wan-2-6', label: 'Abrir la página del modelo Wan 2.6' },
+        {
+          href: '/ai-video-engines/minimax-hailuo-02-text-vs-pika-text-to-video',
+          label: 'Comparar Hailuo 02 y Pika 2.2',
+        },
+      ],
+      faq: {
+        title: 'Preguntas frecuentes',
+        subtitle: 'Respuestas breves para elegir entre Pika 2.2 y Wan 2.6.',
+        items: [
+          {
+            question: '¿Pika 2.2 o Wan 2.6 es más económico para hacer pruebas?',
+            answer:
+              'Pika 2.2 cuesta menos en 720p y funciona bien para loops silenciosos cortos. Wan 2.6 justifica su precio cuando la prueba requiere audio, más duración o videos de referencia.',
+          },
+          {
+            question: '¿Qué puede hacer Wan 2.6 que Pika 2.2 no ofrece?',
+            answer:
+              'Wan 2.6 genera hasta 15 segundos, admite audio opcional y trabaja con uno a tres videos de referencia. Pika 2.2 se concentra en texto a video e imagen a video sin audio.',
+          },
+          {
+            question: '¿Qué modelo conviene para una toma final en 1080p?',
+            answer:
+              'Los dos ofrecen 1080p. Pika sirve para una toma silenciosa simple y más económica; Wan conviene cuando el audio, la duración o la guía por video son esenciales.',
+          },
+        ],
+      },
+    },
+    'kling-2-6-pro-vs-kling-3-pro': {
+      meta: {
+        title: 'Kling 2.6 Pro vs Kling 3 Pro: ¿conviene actualizar?',
+        description:
+          'Compara Kling 2.6 Pro y Kling 3 Pro en duración, audio, precio y control de varias tomas para decidir si vale la pena actualizar.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Compara Kling 2.6 Pro con Kling 3 Pro para saber si tu flujo anterior sigue siendo suficiente o si la generación actual justifica el precio adicional. Ambos entregan video 1080p con audio, pero Kling 3 Pro llega a 15 segundos y apunta a secuencias cinematográficas de varias tomas.',
+      quickVerdict: {
+        title: 'Veredicto rápido',
+        body:
+          'Mantén Kling 2.6 Pro para diálogos conocidos de 5 o 10 segundos y un menor precio con audio. Actualiza a Kling 3 Pro cuando el proyecto necesite hasta 15 segundos, la generación Kling actual y un flujo mejor preparado para secuencias de varias tomas que justifiquen el costo extra.',
+      },
+      topCards: [
+        {
+          title: 'Elige Kling 2.6 Pro',
+          body:
+            'Conserva este modelo anterior para prompts 1080p validados, diálogos cortos y una tarifa de US$0.14 por segundo con audio.',
+        },
+        {
+          title: 'Elige Kling 3 Pro',
+          body:
+            'Usa el Pro actual para clips de hasta 15 segundos y secuencias cinematográficas prioritarias de varias tomas.',
+        },
+        {
+          title: 'Diferencia clave',
+          body:
+            'Ambos ofrecen texto, imagen, 1080p y audio; la decisión es valor del modelo anterior frente a duración y vigencia.',
+        },
+        {
+          title: 'Mejores flujos',
+          body:
+            'Kling 2.6 Pro sirve para diálogos cortos repetibles. Kling 3 Pro sirve para piezas principales y secuencias planeadas.',
+        },
+      ],
+      primaryLinksTitle: 'Siguientes pasos recomendados',
+      primaryLinks: [
+        { href: '/models/kling-2-6-pro', label: 'Abrir la página de Kling 2.6 Pro' },
+        { href: '/models/kling-3-pro', label: 'Abrir la página de Kling 3 Pro' },
+        {
+          href: '/ai-video-engines/kling-3-pro-vs-kling-3-standard',
+          label: 'Comparar Kling 3 Pro y Kling 3 Standard',
+        },
+      ],
+      faq: {
+        title: 'Preguntas frecuentes',
+        subtitle: 'Respuestas breves antes de pasar de Kling 2.6 Pro a Kling 3 Pro.',
+        items: [
+          {
+            question: '¿Kling 3 Pro es una actualización directa de Kling 2.6 Pro?',
+            answer:
+              'Kling 3 Pro es la ruta Pro actual y aumenta la duración máxima de 10 a 15 segundos. Kling 2.6 Pro sigue disponible como opción anterior para flujos cortos ya validados.',
+          },
+          {
+            question: '¿Los dos modelos Kling Pro generan audio?',
+            answer:
+              'Sí. Ambos admiten audio en 1080p desde texto o imagen. Kling 2.6 Pro cuesta US$0.14 por segundo con audio y Kling 3 Pro lista US$0.168 antes del margen de la plataforma.',
+          },
+          {
+            question: '¿Cuándo vale la pena pagar más por Kling 3 Pro?',
+            answer:
+              'Elige Kling 3 Pro para 15 segundos, la generación actual o la planeación de varias tomas. Conserva 2.6 Pro si tu flujo validado de 10 segundos ya resuelve el proyecto.',
+          },
+        ],
+      },
+    },
+    'ltx-2-3-fast-vs-luma-ray-2': {
+      meta: {
+        title: 'LTX 2.3 Fast vs Luma Ray 2: velocidad, 4K y edición',
+        description:
+          'Compara LTX 2.3 Fast y Luma Ray 2 en duración, 4K, audio, transformación de video y reencuadre para elegir tu mejor flujo.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Compara LTX 2.3 Fast con Luma Ray 2 para elegir entre generación rápida con audio y una herramienta Luma anterior enfocada en edición. LTX alcanza 20 segundos en 1080p, 1440p o 4K; Luma se limita a 9 segundos, pero agrega transformación de video y reencuadre.',
+      quickVerdict: {
+        title: 'Veredicto rápido',
+        body:
+          'Elige LTX 2.3 Fast para generar rápidamente desde texto o imagen, con audio, clips más largos y salida hasta 4K. Elige Luma Ray 2 cuando necesites transformar un video existente o adaptarlo a una variedad mayor de formatos y una entrega 1080p sea suficiente.',
+      },
+      topCards: [
+        {
+          title: 'Elige LTX 2.3 Fast',
+          body:
+            'Para conceptos rápidos, audio nativo, clips de hasta 20 segundos y entregas desde 1080p hasta 4K.',
+        },
+        {
+          title: 'Elige Luma Ray 2',
+          body:
+            'Para modificar un video existente o reencuadrarlo en formato ancho, cuadrado, vertical o ultraancho.',
+        },
+        {
+          title: 'Diferencia clave',
+          body:
+            'LTX ofrece más duración, resolución y audio; Luma aporta transformación de una fuente y más relaciones de aspecto.',
+        },
+        {
+          title: 'Mejores flujos',
+          body:
+            'LTX sirve para borradores de campaña y alta resolución. Luma sirve para reutilizar y adaptar material existente.',
+        },
+      ],
+      primaryLinksTitle: 'Siguientes pasos recomendados',
+      primaryLinks: [
+        { href: '/models/ltx-2-3-fast', label: 'Abrir la página de LTX 2.3 Fast' },
+        { href: '/models/luma-ray-2', label: 'Abrir la página de Luma Ray 2' },
+        {
+          href: '/ai-video-engines/ltx-2-3-fast-vs-veo-3-1-fast',
+          label: 'Comparar LTX 2.3 Fast y Veo 3.1 Fast',
+        },
+      ],
+      faq: {
+        title: 'Preguntas frecuentes',
+        subtitle: 'Respuestas breves para elegir entre generación LTX y edición Luma.',
+        items: [
+          {
+            question: '¿Qué modelo conviene para generar video 4K rápidamente?',
+            answer:
+              'LTX 2.3 Fast es la opción clara porque admite 4K, audio y clips de hasta 20 segundos. Luma Ray 2 llega a 1080p y no genera audio.',
+          },
+          {
+            question: '¿Qué permite Luma Ray 2 que LTX 2.3 Fast no hace?',
+            answer:
+              'Luma Ray 2 incluye transformación de video a video y reencuadre de material existente. LTX 2.3 Fast se enfoca en generar desde texto o una imagen.',
+          },
+          {
+            question: '¿Todavía conviene usar Luma Ray 2?',
+            answer:
+              'Sí, cuando la prioridad es modificar una fuente de video o adaptarla a varios formatos. Para generación nueva con audio y alta resolución, usa LTX 2.3 Fast.',
+          },
+        ],
+      },
+    },
+    'kling-2-6-pro-vs-minimax-hailuo-02-text': {
+      meta: {
+        title: 'Kling 2.6 Pro vs Hailuo 02: calidad, audio y precio',
+        description:
+          'Compara Kling 2.6 Pro y MiniMax Hailuo 02 en 1080p, audio, movimiento estilizado y precio por segundo para elegir el modelo correcto.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Compara Kling 2.6 Pro con MiniMax Hailuo 02 Standard para decidir entre diálogo cinematográfico en 1080p y exploración estilizada más económica. Kling agrega audio nativo y mayor resolución, mientras Hailuo produce animaciones silenciosas accesibles en 512P o 768P.',
+      quickVerdict: {
+        title: 'Veredicto rápido',
+        body:
+          'Elige Kling 2.6 Pro para tomas cinematográficas en 1080p, diálogo y audio nativo opcional. Elige MiniMax Hailuo 02 Standard para probar estilos, formatos verticales o cuadrados y movimiento silencioso a menor precio cuando 512P o 768P sean suficientes.',
+      },
+      topCards: [
+        {
+          title: 'Elige Kling 2.6 Pro',
+          body:
+            'Para diálogos cinematográficos en 1080p, audio opcional y tomas donde el acabado importa más que el precio.',
+        },
+        {
+          title: 'Elige Hailuo 02',
+          body:
+            'Para explorar conceptos estilizados a US$0.045 por segundo y producir movimiento silencioso de menor resolución.',
+        },
+        {
+          title: 'Diferencia clave',
+          body:
+            'Kling entrega 1080p y audio por US$0.14 por segundo con sonido; Hailuo cuesta menos, pero es silencioso y llega a 768P.',
+        },
+        {
+          title: 'Mejores flujos',
+          body:
+            'Kling sirve para diálogo y tomas terminadas. Hailuo sirve para ganchos estilizados y lotes de exploración económica.',
+        },
+      ],
+      primaryLinksTitle: 'Siguientes pasos recomendados',
+      primaryLinks: [
+        { href: '/models/kling-2-6-pro', label: 'Abrir la página de Kling 2.6 Pro' },
+        { href: '/models/minimax-hailuo-02-text', label: 'Abrir la página de MiniMax Hailuo 02' },
+        {
+          href: '/ai-video-engines/kling-2-6-pro-vs-wan-2-6',
+          label: 'Comparar Kling 2.6 Pro y Wan 2.6',
+        },
+      ],
+      faq: {
+        title: 'Preguntas frecuentes',
+        subtitle: 'Respuestas breves entre acabado Kling y movimiento Hailuo económico.',
+        items: [
+          {
+            question: '¿Kling 2.6 Pro o Hailuo 02 conviene más para diálogo?',
+            answer:
+              'Kling 2.6 Pro es más adecuado por su audio nativo y salida 1080p. Hailuo 02 genera video silencioso y funciona mejor para pruebas visuales o estilizadas.',
+          },
+          {
+            question: '¿Qué resolución ofrece cada modelo?',
+            answer:
+              'Kling 2.6 Pro entrega 1080p. MiniMax Hailuo 02 Standard ofrece 512P y 768P, por lo que sirve más para explorar conceptos que para terminar en alta resolución.',
+          },
+          {
+            question: '¿Cuándo conviene el menor precio de Hailuo 02?',
+            answer:
+              'Usa Hailuo para multiplicar exploraciones estilizadas silenciosas a US$0.045 por segundo. Paga Kling cuando el audio y una entrega 1080p sean requisitos.',
+          },
+        ],
+      },
+    },
+    'kling-3-standard-vs-kling-o3-standard': {
+      meta: {
+        title: 'Kling 3 Standard vs Omni Standard: ¿cuál elegir?',
+        description:
+          'Compara Kling 3 Standard y Kling 3.0 Omni Standard en referencias, edición de video, 1080p, audio y precio para elegir el flujo correcto.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Compara Kling 3 Standard con Kling 3.0 Omni Standard cuando ambos ofrecen 15 segundos en 1080p con audio al mismo precio base. Standard simplifica la generación desde texto o una imagen inicial; Omni agrega referencias visuales y transformación de un video fuente.',
+      quickVerdict: {
+        title: 'Veredicto rápido',
+        body:
+          'Elige Kling 3 Standard para probar directamente un prompt o una imagen inicial sin complejidad extra. Elige Kling 3.0 Omni Standard cuando personajes, productos, referencias visuales o un video existente deban guiar el resultado mediante referencia a video o video a video.',
+      },
+      topCards: [
+        {
+          title: 'Elige Kling 3 Standard',
+          body:
+            'Para prompts directos, animación de una imagen inicial y borradores 1080p repetibles con audio opcional.',
+        },
+        {
+          title: 'Elige Omni Standard',
+          body:
+            'Para guiar la toma con referencias o transformar un video fuente además de generar desde texto o imagen.',
+        },
+        {
+          title: 'Diferencia clave',
+          body:
+            'Resolución, duración, audio y precio base coinciden; Omni amplía las entradas y Standard mantiene el flujo simple.',
+        },
+        {
+          title: 'Mejores flujos',
+          body:
+            'Standard sirve para pruebas desde una imagen. Omni sirve para continuidad de personajes, productos y fuentes de video.',
+        },
+      ],
+      primaryLinksTitle: 'Siguientes pasos recomendados',
+      primaryLinks: [
+        { href: '/models/kling-3-standard', label: 'Abrir la página de Kling 3 Standard' },
+        { href: '/models/kling-o3-standard', label: 'Abrir la página de Kling 3.0 Omni Standard' },
+        {
+          href: '/ai-video-engines/kling-3-pro-vs-kling-3-standard',
+          label: 'Comparar Kling 3 Pro y Kling 3 Standard',
+        },
+      ],
+      faq: {
+        title: 'Preguntas frecuentes',
+        subtitle: 'Respuestas breves entre los flujos Kling Standard y Omni Standard.',
+        items: [
+          {
+            question: '¿Cuál es la diferencia principal entre Standard y Omni Standard?',
+            answer:
+              'Ambos producen hasta 15 segundos en 1080p con audio. Omni Standard agrega referencia a video y video a video, modos que Kling 3 Standard no incluye.',
+          },
+          {
+            question: '¿Kling 3 Standard y Omni Standard cuestan lo mismo?',
+            answer:
+              'El catálogo indica las mismas tarifas del proveedor: US$0.084 por segundo sin audio y US$0.126 con audio, antes del margen aplicado por MaxVideoAI.',
+          },
+          {
+            question: '¿Qué modelo debo usar con recursos de referencia?',
+            answer:
+              'Elige Kling 3.0 Omni Standard si imágenes de referencia o un video fuente deben guiar el resultado. Kling 3 Standard basta cuando un prompt o imagen inicial resuelven la toma.',
+          },
+        ],
+      },
+    },
+    'seedance-2-0-fast-vs-veo-3-1': {
+      meta: {
+        title: 'Seedance 2.0 Fast vs Veo 3.1: borradores o 4K final',
+        description:
+          'Compara Seedance 2.0 Fast y Google Veo 3.1 en borradores, referencias, edición, duración, audio y salida 4K para tu próximo video.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Compara Seedance 2.0 Fast con Google Veo 3.1 para elegir entre un flujo amplio de borrador y edición o una entrega final de mayor resolución. Seedance llega a 15 segundos con referencias, edición y extensión en 480p o 720p; Veo alcanza 4K para anuncios y B-roll pulidos de 8 segundos.',
+      quickVerdict: {
+        title: 'Veredicto rápido',
+        body:
+          'Elige Seedance 2.0 Fast para planear con rapidez, crear borradores más largos, usar referencias, editar o extender un video cuando 720p sean suficientes. Elige Google Veo 3.1 para anuncios cortos terminados, control de primera y última imagen, y entrega 1080p o 4K.',
+      },
+      topCards: [
+        {
+          title: 'Elige Seedance 2.0 Fast',
+          body:
+            'Para borradores de 4 a 15 segundos, referencias visuales, edición, extensión y una variedad amplia de formatos.',
+        },
+        {
+          title: 'Elige Veo 3.1',
+          body:
+            'Para anuncios o B-roll terminados de 8 segundos, audio, control de imágenes límite y entrega 1080p o 4K.',
+        },
+        {
+          title: 'Diferencia clave',
+          body:
+            'Seedance ofrece más duración y herramientas en 480p/720p; Veo produce clips más cortos con mayor resolución final.',
+        },
+        {
+          title: 'Mejores flujos',
+          body:
+            'Seedance sirve para planeación y ajustes. Veo sirve para tomas aprobadas de campaña y masters de alta resolución.',
+        },
+      ],
+      primaryLinksTitle: 'Siguientes pasos recomendados',
+      primaryLinks: [
+        { href: '/models/seedance-2-0-fast', label: 'Abrir la página de Seedance 2.0 Fast' },
+        { href: '/models/veo-3-1', label: 'Abrir la página de Google Veo 3.1' },
+        {
+          href: '/ai-video-engines/seedance-2-0-fast-vs-veo-3-1-fast',
+          label: 'Comparar Seedance 2.0 Fast y Veo 3.1 Fast',
+        },
+      ],
+      faq: {
+        title: 'Preguntas frecuentes',
+        subtitle: 'Respuestas breves entre borradores Seedance y entregas finales Veo.',
+        items: [
+          {
+            question: '¿Seedance 2.0 Fast o Veo 3.1 conviene más para borradores?',
+            answer:
+              'Seedance 2.0 Fast está diseñado para borradores rápidos, pruebas con referencias y planeación de tomas. También llega a 15 segundos y permite editar o extender video.',
+          },
+          {
+            question: '¿Qué modelo conviene para una entrega final en 4K?',
+            answer:
+              'Google Veo 3.1 es la mejor opción para un master 4K pulido. Seedance 2.0 Fast llega a 720p y funciona mejor como ruta de iteración y edición.',
+          },
+          {
+            question: '¿Los dos modelos admiten audio y referencias?',
+            answer:
+              'Sí. Seedance agrega edición de video y más formatos, mientras Veo agrega control de primera y última imagen junto con una resolución final superior.',
+          },
+        ],
+      },
+    },
+    'ltx-2-fast-vs-minimax-hailuo-02-text': {
+      meta: {
+        title: 'LTX 2 Fast vs Hailuo 02: resolución, audio y usos',
+        description:
+          'Compara LTX Video 2.0 Fast y MiniMax Hailuo 02 en duración, resolución, audio, formatos y precio para clips sociales y estilizados.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Compara LTX Video 2.0 Fast con MiniMax Hailuo 02 Standard para elegir entre clips horizontales largos en alta resolución o formatos estilizados más modestos. LTX alcanza 20 segundos con audio y salida hasta 4K; Hailuo agrega formatos vertical y cuadrado en 512P o 768P sin audio.',
+      quickVerdict: {
+        title: 'Veredicto rápido',
+        body:
+          'Elige LTX Video 2.0 Fast para clips horizontales rápidos, audio nativo, duración de hasta 20 segundos y salida 1080p, 1440p o 4K. Elige MiniMax Hailuo 02 Standard para un concepto estilizado silencioso en vertical, cuadrado u horizontal cuando 512P o 768P sean suficientes.',
+      },
+      topCards: [
+        {
+          title: 'Elige LTX 2 Fast',
+          body:
+            'Para clips sociales 16:9 más largos, generación con audio y entregas desde 1080p hasta 4K.',
+        },
+        {
+          title: 'Elige Hailuo 02',
+          body:
+            'Para movimiento estilizado silencioso en 16:9, 9:16 o 1:1 cuando 512P o 768P cubran el canal.',
+        },
+        {
+          title: 'Diferencia clave',
+          body:
+            'LTX ofrece duración, audio y alta resolución, pero solo 16:9; Hailuo ofrece más formatos sociales con menor resolución.',
+        },
+        {
+          title: 'Mejores flujos',
+          body:
+            'LTX sirve para promociones horizontales con música. Hailuo sirve para ganchos verticales, cuadrados y pruebas visuales.',
+        },
+      ],
+      primaryLinksTitle: 'Siguientes pasos recomendados',
+      primaryLinks: [
+        { href: '/models/ltx-2-fast', label: 'Abrir la página de LTX Video 2.0 Fast' },
+        { href: '/models/minimax-hailuo-02-text', label: 'Abrir la página de MiniMax Hailuo 02' },
+        {
+          href: '/ai-video-engines/ltx-2-3-fast-vs-ltx-2-fast',
+          label: 'Comparar LTX 2.3 Fast y LTX 2 Fast',
+        },
+      ],
+      faq: {
+        title: 'Preguntas frecuentes',
+        subtitle: 'Respuestas breves entre LTX de alta resolución y Hailuo multiformato.',
+        items: [
+          {
+            question: '¿Qué modelo conviene para clips largos en alta resolución?',
+            answer:
+              'LTX Video 2.0 Fast alcanza 20 segundos con audio y salida 1080p, 1440p o 4K. Hailuo 02 se limita a 10 segundos y 768P.',
+          },
+          {
+            question: '¿Qué modelo funciona mejor en vertical o cuadrado?',
+            answer:
+              'MiniMax Hailuo 02 Standard admite 9:16 y 1:1 además de 16:9. LTX Video 2.0 Fast se limita al formato horizontal 16:9.',
+          },
+          {
+            question: '¿LTX 2 Fast y Hailuo 02 generan audio?',
+            answer:
+              'No los dos. LTX Video 2.0 Fast admite audio nativo, mientras Hailuo 02 produce video silencioso que puede sonorizarse después si hace falta.',
+          },
+        ],
+      },
+    },
+    'minimax-hailuo-02-text-vs-veo-3-1-fast': {
+      meta: {
+        title: 'Hailuo 02 vs Veo 3.1 Fast: precio, audio y 4K',
+        description:
+          'Compara MiniMax Hailuo 02 y Google Veo 3.1 Fast en precio, audio, referencias, resolución y duración para pruebas o entregas pulidas.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Compara MiniMax Hailuo 02 Standard con Google Veo 3.1 Fast para decidir entre exploración estilizada económica y un flujo de producción más completo. Hailuo crea movimiento silencioso en 512P o 768P por US$0.045 por segundo; Veo Fast agrega audio, referencias, extensión y salida hasta 4K.',
+      quickVerdict: {
+        title: 'Veredicto rápido',
+        body:
+          'Elige MiniMax Hailuo 02 Standard para conceptos estilizados silenciosos y económicos de hasta 10 segundos cuando 768P sean suficientes. Elige Google Veo 3.1 Fast para anuncios con audio, referencias, control de primera y última imagen, extensiones o una entrega final en 1080p o 4K.',
+      },
+      topCards: [
+        {
+          title: 'Elige Hailuo 02',
+          body:
+            'Para pruebas estilizadas a US$0.045 por segundo, conceptos sociales silenciosos y hasta 10 segundos en 768P.',
+        },
+        {
+          title: 'Elige Veo 3.1 Fast',
+          body:
+            'Para audio, referencias, control de imágenes límite, extensión y entregas desde 720p hasta 4K.',
+        },
+        {
+          title: 'Diferencia clave',
+          body:
+            'Hailuo cuesta menos y ofrece dos segundos más; Veo Fast amplía la resolución, el sonido y los controles.',
+        },
+        {
+          title: 'Mejores flujos',
+          body:
+            'Hailuo sirve para pruebas estilizadas y ganchos económicos. Veo Fast sirve para anuncios, productos y masters pulidos.',
+        },
+      ],
+      primaryLinksTitle: 'Siguientes pasos recomendados',
+      primaryLinks: [
+        { href: '/models/minimax-hailuo-02-text', label: 'Abrir la página de MiniMax Hailuo 02' },
+        { href: '/models/veo-3-1-fast', label: 'Abrir la página de Google Veo 3.1 Fast' },
+        {
+          href: '/ai-video-engines/seedance-2-0-fast-vs-veo-3-1-fast',
+          label: 'Comparar Seedance 2.0 Fast y Veo 3.1 Fast',
+        },
+      ],
+      faq: {
+        title: 'Preguntas frecuentes',
+        subtitle: 'Respuestas breves entre Hailuo económico y Veo Fast más completo.',
+        items: [
+          {
+            question: '¿Hailuo 02 o Veo 3.1 Fast cuesta menos?',
+            answer:
+              'Hailuo 02 cuesta US$0.045 por segundo. Veo 3.1 Fast parte de US$0.10 en 720p con audio y sube con la resolución, por lo que Hailuo es la ruta silenciosa más económica.',
+          },
+          {
+            question: '¿Qué modelo admite audio y salida 4K?',
+            answer:
+              'Google Veo 3.1 Fast admite audio nativo y salida hasta 4K. MiniMax Hailuo 02 Standard es silencioso y llega como máximo a 768P.',
+          },
+          {
+            question: '¿Cuándo conviene elegir Hailuo 02 en vez de Veo Fast?',
+            answer:
+              'Elige Hailuo para explorar estilos a bajo precio sin necesitar sonido ni alta resolución. Veo Fast conviene cuando importan referencias, audio y una entrega terminada.',
+          },
+        ],
+      },
+    },
+    'kling-3-4k-vs-seedance-2-0': {
+      meta: {
+        title: 'Kling 3 4K vs Seedance 2.0: 4K final o más control',
+        description:
+          'Compara Kling 3 4K y Seedance 2.0 en 4K nativo, referencias, edición, extensión, audio y flexibilidad antes de renderizar tu proyecto.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Compara Kling 3 4K con Seedance 2.0: ambos entregan 4K, pero siguen rutas de producción distintas. Kling es una opción de texto o imagen inicial dedicada al render final en 4K nativo; Seedance va de 480p a 4K con referencias, edición, extensión, controles de movimiento y audio.',
+      quickVerdict: {
+        title: 'Veredicto rápido',
+        body:
+          'Elige Kling 3 4K cuando un prompt o imagen aprobados deban renderizarse directamente en 4K nativo. Elige Seedance 2.0 cuando el proyecto necesite iteraciones de menor resolución, varias referencias, edición de video, extensión de clips, más formatos o mayor control antes del master 4K.',
+      },
+      topCards: [
+        {
+          title: 'Elige Kling 3 4K',
+          body:
+            'Para renderizar directamente un prompt o imagen aprobados en 4K nativo, con audio opcional.',
+        },
+        {
+          title: 'Elige Seedance 2.0',
+          body:
+            'Para referencias, edición, extensión, controles de movimiento, varias resoluciones y más relaciones de aspecto.',
+        },
+        {
+          title: 'Diferencia clave',
+          body:
+            'Kling bloquea cada render en 4K nativo; Seedance permite iterar desde 480p con entradas mucho más variadas.',
+        },
+        {
+          title: 'Mejores flujos',
+          body:
+            'Kling sirve para piezas principales ya aprobadas. Seedance sirve para campañas iterativas, secuencias y ajustes.',
+        },
+      ],
+      primaryLinksTitle: 'Siguientes pasos recomendados',
+      primaryLinks: [
+        { href: '/models/kling-3-4k', label: 'Abrir la página de Kling 3 4K' },
+        { href: '/models/seedance-2-0', label: 'Abrir la página de Seedance 2.0' },
+        {
+          href: '/ai-video-engines/kling-3-4k-vs-veo-3-1',
+          label: 'Comparar Kling 3 4K y Veo 3.1',
+        },
+      ],
+      faq: {
+        title: 'Preguntas frecuentes',
+        subtitle: 'Respuestas breves entre 4K nativo dedicado y un flujo Seedance completo.',
+        items: [
+          {
+            question: '¿Kling 3 4K y Seedance 2.0 admiten salida 4K?',
+            answer:
+              'Sí. Kling 3 4K está bloqueado en salida 4K nativa, mientras Seedance 2.0 ofrece 480p, 720p, 1080p y 4K para iterar antes de la entrega final.',
+          },
+          {
+            question: '¿Qué modelo ofrece más control con referencias y edición?',
+            answer:
+              'Seedance 2.0 agrega referencias, edición, extensión, controles de movimiento y varias fuentes de imagen, video o audio. Kling 3 4K se concentra en texto e imagen inicial.',
+          },
+          {
+            question: '¿Qué modelo conviene para una pieza principal final en 4K?',
+            answer:
+              'Kling 3 4K es una ruta directa para renderizar un prompt o imagen aprobados en 4K nativo. Seedance conviene si la toma todavía requiere referencias, ajustes o extensiones.',
+          },
+        ],
+      },
+    },
+    'minimax-hailuo-02-text-vs-wan-2-6': {
+      meta: {
+        title: 'Hailuo 02 vs Wan 2.6: precio, audio y mejores usos',
+        description:
+          'Compara MiniMax Hailuo 02 y Wan 2.6 en precio, duración, 1080p, audio, referencias de video y movimiento estilizado para elegir bien.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Compara MiniMax Hailuo 02 Standard con Wan 2.6 Text & Image to Video para decidir entre movimiento estilizado económico y un flujo de uso general. Hailuo cuesta US$0.045 por segundo para clips silenciosos en 512P o 768P; Wan llega a 15 segundos en 1080p con audio y referencias de video.',
+      quickVerdict: {
+        title: 'Veredicto rápido',
+        body:
+          'Elige MiniMax Hailuo 02 Standard para conceptos estilizados silenciosos más económicos, formatos verticales o cuadrados y hasta 10 segundos cuando 768P sean suficientes. Elige Wan 2.6 para producción general en 1080p, hasta 15 segundos, con audio opcional o entre uno y tres videos de referencia.',
+      },
+      topCards: [
+        {
+          title: 'Elige Hailuo 02',
+          body:
+            'Para movimiento estilizado a US$0.045 por segundo y pruebas silenciosas horizontales, verticales o cuadradas.',
+        },
+        {
+          title: 'Elige Wan 2.6',
+          body:
+            'Para entrega 720p o 1080p, audio opcional, hasta 15 segundos y guía por referencias de video.',
+        },
+        {
+          title: 'Diferencia clave',
+          body:
+            'Hailuo minimiza el costo de contenido estilizado; Wan cuesta más, pero agrega resolución, duración, sonido y referencias.',
+        },
+        {
+          title: 'Mejores flujos',
+          body:
+            'Hailuo sirve para conceptos sociales económicos. Wan sirve para narración, B-roll y secuencias guiadas.',
+        },
+      ],
+      primaryLinksTitle: 'Siguientes pasos recomendados',
+      primaryLinks: [
+        { href: '/models/minimax-hailuo-02-text', label: 'Abrir la página de MiniMax Hailuo 02' },
+        { href: '/models/wan-2-6', label: 'Abrir la página de Wan 2.6' },
+        {
+          href: '/ai-video-engines/veo-3-1-vs-wan-2-6',
+          label: 'Comparar Veo 3.1 y Wan 2.6',
+        },
+      ],
+      faq: {
+        title: 'Preguntas frecuentes',
+        subtitle: 'Respuestas breves entre Hailuo estilizado y Wan de uso general.',
+        items: [
+          {
+            question: '¿Hailuo 02 o Wan 2.6 cuesta menos?',
+            answer:
+              'Hailuo 02 cuesta US$0.045 por segundo. Wan 2.6 parte de US$0.10 en 720p y US$0.15 en 1080p, así que Hailuo es más económico si basta una salida silenciosa de menor resolución.',
+          },
+          {
+            question: '¿Qué modelo admite audio y videos de referencia?',
+            answer:
+              'Wan 2.6 admite audio opcional y entre uno y tres videos de referencia. MiniMax Hailuo 02 Standard genera desde texto o imagen sin audio.',
+          },
+          {
+            question: '¿Cuándo debo elegir Wan 2.6 en vez de Hailuo 02?',
+            answer:
+              'Elige Wan cuando necesites 1080p, más de 10 segundos, audio nativo o guía por video. Elige Hailuo para explorar estilos y formatos sociales a menor precio.',
+          },
+        ],
+      },
+    },
   } satisfies ComparePageOverridesBySlug;

--- a/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-fr.ts
+++ b/frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-fr.ts
@@ -742,4 +742,674 @@ export const FR_COMPARE_PAGE_OVERRIDES = {
         ],
       },
     },
+    'pika-text-to-video-vs-wan-2-6': {
+      meta: {
+        title: 'Pika 2.2 vs Wan 2.6 : prix, audio et usages',
+        description:
+          'Comparez Pika 2.2 et Wan 2.6 sur le prix, la durée, l’audio, la résolution et les vidéos de référence pour choisir le bon modèle.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Comparez Pika 2.2 Text & Image to Video et Wan 2.6 Text & Image to Video pour arbitrer entre une boucle courte et économique ou un workflow plus complet avec audio. Pika simplifie les animations de prompt ou d’image, tandis que Wan atteint 15 secondes et accepte des vidéos de référence.',
+      quickVerdict: {
+        title: 'Verdict rapide',
+        body:
+          'Choisissez Pika 2.2 pour des boucles silencieuses de 5 ou 10 secondes, des essais stylisés et des animations simples à moindre coût. Préférez Wan 2.6 si le plan exige jusqu’à 15 secondes, de l’audio natif ou une à trois vidéos de référence, malgré un tarif supérieur en 720p et 1080p.',
+      },
+      topCards: [
+        {
+          title: 'Choisir Pika 2.2',
+          body:
+            'Idéal pour tester en 720p à petit prix, produire des boucles silencieuses et animer simplement un prompt ou une image.',
+        },
+        {
+          title: 'Choisir Wan 2.6',
+          body:
+            'À privilégier pour des plans de 15 secondes, l’audio optionnel, la livraison 1080p ou le guidage par vidéos de référence.',
+        },
+        {
+          title: 'Différence clé',
+          body:
+            'Pika démarre à 0,04 $ par seconde en 720p ; Wan à 0,10 $, avec davantage de durée, l’audio et le contrôle par référence.',
+        },
+        {
+          title: 'Usages recommandés',
+          body:
+            'Pika convient aux boucles sociales et aux concepts. Wan convient aux plans plus longs, narrés ou guidés par des sources vidéo.',
+        },
+      ],
+      primaryLinksTitle: 'Prochaines étapes recommandées',
+      primaryLinks: [
+        { href: '/models/pika-text-to-video', label: 'Ouvrir la page du modèle Pika 2.2' },
+        { href: '/models/wan-2-6', label: 'Ouvrir la page du modèle Wan 2.6' },
+        {
+          href: '/ai-video-engines/minimax-hailuo-02-text-vs-pika-text-to-video',
+          label: 'Comparer Hailuo 02 et Pika 2.2',
+        },
+      ],
+      faq: {
+        title: 'FAQ',
+        subtitle: 'Réponses courtes pour choisir entre Pika 2.2 et Wan 2.6.',
+        items: [
+          {
+            question: 'Pika 2.2 ou Wan 2.6 : lequel coûte le moins cher pour tester ?',
+            answer:
+              'Pika 2.2 est moins cher en 720p et convient aux courtes boucles silencieuses. Wan 2.6 justifie son prix lorsque le test demande du son, davantage de durée ou des vidéos de référence.',
+          },
+          {
+            question: 'Que permet Wan 2.6 que Pika 2.2 ne propose pas ?',
+            answer:
+              'Wan 2.6 génère jusqu’à 15 secondes, accepte un audio optionnel et peut suivre une à trois vidéos de référence. Pika 2.2 reste centré sur le texte et l’image sans audio.',
+          },
+          {
+            question: 'Quel modèle choisir pour un plan final en 1080p ?',
+            answer:
+              'Les deux proposent le 1080p. Pika suffit pour un plan silencieux simple et moins cher ; Wan est plus adapté si l’audio, la durée ou le guidage vidéo sont essentiels.',
+          },
+        ],
+      },
+    },
+    'kling-2-6-pro-vs-kling-3-pro': {
+      meta: {
+        title: 'Kling 2.6 Pro vs Kling 3 Pro : faut-il évoluer ?',
+        description:
+          'Comparez Kling 2.6 Pro et Kling 3 Pro sur la durée, l’audio, le prix et le contrôle multi-plan pour savoir si la nouvelle version se justifie.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Comparez Kling 2.6 Pro et Kling 3 Pro pour déterminer si votre workflow historique suffit encore ou si la génération actuelle mérite son prix supérieur. Les deux produisent en 1080p avec audio, mais Kling 3 Pro monte à 15 secondes et vise les séquences cinématiques multi-plans plus ambitieuses.',
+      quickVerdict: {
+        title: 'Verdict rapide',
+        body:
+          'Conservez Kling 2.6 Pro pour des dialogues de 5 ou 10 secondes déjà bien maîtrisés et un coût audio inférieur. Passez à Kling 3 Pro lorsque le projet demande jusqu’à 15 secondes, la génération Kling actuelle et un meilleur cadre pour des séquences multi-plans dont l’enjeu justifie le surcoût.',
+      },
+      topCards: [
+        {
+          title: 'Choisir Kling 2.6 Pro',
+          body:
+            'Gardez ce modèle historique pour vos prompts 1080p validés, les dialogues courts et un tarif audio de 0,14 $ par seconde.',
+        },
+        {
+          title: 'Choisir Kling 3 Pro',
+          body:
+            'Utilisez le modèle Pro actuel pour les clips jusqu’à 15 secondes et les séquences cinématiques multi-plans prioritaires.',
+        },
+        {
+          title: 'Différence clé',
+          body:
+            'Les deux offrent texte, image, 1080p et audio ; le choix oppose la valeur d’un modèle historique à la durée du modèle actuel.',
+        },
+        {
+          title: 'Usages recommandés',
+          body:
+            'Kling 2.6 Pro convient aux dialogues courts répétables. Kling 3 Pro vise les héros de campagne et les séquences planifiées.',
+        },
+      ],
+      primaryLinksTitle: 'Prochaines étapes recommandées',
+      primaryLinks: [
+        { href: '/models/kling-2-6-pro', label: 'Ouvrir la page Kling 2.6 Pro' },
+        { href: '/models/kling-3-pro', label: 'Ouvrir la page Kling 3 Pro' },
+        {
+          href: '/ai-video-engines/kling-3-pro-vs-kling-3-standard',
+          label: 'Comparer Kling 3 Pro et Kling 3 Standard',
+        },
+      ],
+      faq: {
+        title: 'FAQ',
+        subtitle: 'Réponses courtes avant de passer de Kling 2.6 Pro à Kling 3 Pro.',
+        items: [
+          {
+            question: 'Kling 3 Pro remplace-t-il directement Kling 2.6 Pro ?',
+            answer:
+              'Kling 3 Pro est la route Pro actuelle et augmente la durée maximale de 10 à 15 secondes. Kling 2.6 Pro reste disponible comme option historique pour les workflows courts déjà validés.',
+          },
+          {
+            question: 'Les deux modèles Kling Pro génèrent-ils de l’audio ?',
+            answer:
+              'Oui. Les deux prennent en charge l’audio en 1080p depuis du texte ou une image. Kling 2.6 Pro coûte 0,14 $ par seconde avec audio, contre 0,168 $ pour Kling 3 Pro avant marge.',
+          },
+          {
+            question: 'Quand le prix supérieur de Kling 3 Pro est-il justifié ?',
+            answer:
+              'Choisissez Kling 3 Pro pour une durée de 15 secondes, la génération Kling actuelle ou une planification multi-plans. Gardez 2.6 Pro si votre workflow de 10 secondes répond déjà au brief.',
+          },
+        ],
+      },
+    },
+    'ltx-2-3-fast-vs-luma-ray-2': {
+      meta: {
+        title: 'LTX 2.3 Fast vs Luma Ray 2 : vitesse, 4K et montage',
+        description:
+          'Comparez LTX 2.3 Fast et Luma Ray 2 sur la durée, la 4K, l’audio, la transformation vidéo et le recadrage pour choisir votre workflow.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Comparez LTX 2.3 Fast et Luma Ray 2 pour choisir entre une génération rapide avec audio et une boîte à outils Luma historique orientée montage. LTX atteint 20 secondes en 1080p, 1440p ou 4K ; Luma reste limité à 9 secondes mais ajoute la transformation vidéo et le recadrage.',
+      quickVerdict: {
+        title: 'Verdict rapide',
+        body:
+          'Choisissez LTX 2.3 Fast pour générer rapidement depuis du texte ou une image, avec audio, clips plus longs et sortie jusqu’en 4K. Choisissez Luma Ray 2 lorsqu’une vidéo existante doit être transformée ou recadrée dans de nombreux formats et qu’une livraison 1080p suffit.',
+      },
+      topCards: [
+        {
+          title: 'Choisir LTX 2.3 Fast',
+          body:
+            'Pour les concepts rapides, l’audio natif, les clips jusqu’à 20 secondes et les livraisons du 1080p à la 4K.',
+        },
+        {
+          title: 'Choisir Luma Ray 2',
+          body:
+            'Pour transformer une vidéo existante ou la recadrer en format large, carré, vertical ou ultra-large.',
+        },
+        {
+          title: 'Différence clé',
+          body:
+            'LTX gagne en durée, résolution et audio ; Luma apporte le travail sur une vidéo source et davantage de formats.',
+        },
+        {
+          title: 'Usages recommandés',
+          body:
+            'LTX vise les brouillons de campagne et la haute résolution. Luma vise le réemploi, l’adaptation et les montages historiques.',
+        },
+      ],
+      primaryLinksTitle: 'Prochaines étapes recommandées',
+      primaryLinks: [
+        { href: '/models/ltx-2-3-fast', label: 'Ouvrir la page LTX 2.3 Fast' },
+        { href: '/models/luma-ray-2', label: 'Ouvrir la page Luma Ray 2' },
+        {
+          href: '/ai-video-engines/ltx-2-3-fast-vs-veo-3-1-fast',
+          label: 'Comparer LTX 2.3 Fast et Veo 3.1 Fast',
+        },
+      ],
+      faq: {
+        title: 'FAQ',
+        subtitle: 'Réponses courtes entre génération LTX rapide et montage Luma Ray 2.',
+        items: [
+          {
+            question: 'Quel modèle choisir pour générer rapidement en 4K ?',
+            answer:
+              'LTX 2.3 Fast est le choix évident : il prend en charge la 4K, l’audio et des clips jusqu’à 20 secondes. Luma Ray 2 s’arrête au 1080p et ne produit pas d’audio.',
+          },
+          {
+            question: 'Que permet Luma Ray 2 que LTX 2.3 Fast ne fait pas ?',
+            answer:
+              'Luma Ray 2 propose la transformation vidéo et le recadrage d’une source existante. LTX 2.3 Fast se concentre sur la génération depuis du texte ou une image.',
+          },
+          {
+            question: 'Le modèle historique Luma Ray 2 reste-t-il pertinent ?',
+            answer:
+              'Oui, si votre priorité est de modifier une source vidéo ou de l’adapter à plusieurs formats. Pour une nouvelle génération avec audio et haute résolution, choisissez LTX 2.3 Fast.',
+          },
+        ],
+      },
+    },
+    'kling-2-6-pro-vs-minimax-hailuo-02-text': {
+      meta: {
+        title: 'Kling 2.6 Pro vs Hailuo 02 : qualité, audio et prix',
+        description:
+          'Comparez Kling 2.6 Pro et MiniMax Hailuo 02 sur le 1080p, l’audio, le mouvement stylisé et le prix par seconde pour choisir votre modèle.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Comparez Kling 2.6 Pro et MiniMax Hailuo 02 Standard pour arbitrer entre un dialogue cinématique en 1080p et une exploration stylisée moins chère. Kling ajoute l’audio natif et une meilleure résolution, tandis que Hailuo produit des animations silencieuses économiques en 512P ou 768P.',
+      quickVerdict: {
+        title: 'Verdict rapide',
+        body:
+          'Choisissez Kling 2.6 Pro pour des plans cinématiques en 1080p, du dialogue et un audio natif optionnel. Choisissez MiniMax Hailuo 02 Standard pour tester à moindre coût des styles, formats verticaux ou carrés et mouvements silencieux lorsque le 512P ou 768P suffit.',
+      },
+      topCards: [
+        {
+          title: 'Choisir Kling 2.6 Pro',
+          body:
+            'Pour les dialogues cinématiques en 1080p, l’audio optionnel et les plans où la finition prime sur le prix.',
+        },
+        {
+          title: 'Choisir Hailuo 02',
+          body:
+            'Pour explorer des concepts stylisés à 0,045 $ par seconde et produire du mouvement silencieux en basse résolution.',
+        },
+        {
+          title: 'Différence clé',
+          body:
+            'Kling fournit le 1080p et l’audio à 0,14 $ par seconde avec son ; Hailuo coûte moins cher mais reste silencieux et limité au 768P.',
+        },
+        {
+          title: 'Usages recommandés',
+          body:
+            'Kling convient au dialogue et aux plans finis. Hailuo convient aux accroches stylisées et aux lots d’exploration économiques.',
+        },
+      ],
+      primaryLinksTitle: 'Prochaines étapes recommandées',
+      primaryLinks: [
+        { href: '/models/kling-2-6-pro', label: 'Ouvrir la page Kling 2.6 Pro' },
+        { href: '/models/minimax-hailuo-02-text', label: 'Ouvrir la page MiniMax Hailuo 02' },
+        {
+          href: '/ai-video-engines/kling-2-6-pro-vs-wan-2-6',
+          label: 'Comparer Kling 2.6 Pro et Wan 2.6',
+        },
+      ],
+      faq: {
+        title: 'FAQ',
+        subtitle: 'Réponses courtes entre finition Kling et mouvement Hailuo économique.',
+        items: [
+          {
+            question: 'Kling 2.6 Pro ou Hailuo 02 : lequel choisir pour du dialogue ?',
+            answer:
+              'Kling 2.6 Pro est plus adapté grâce à son audio natif et sa sortie 1080p. Hailuo 02 produit une vidéo silencieuse et convient mieux aux essais visuels ou stylisés.',
+          },
+          {
+            question: 'Quelle résolution proposent les deux modèles ?',
+            answer:
+              'Kling 2.6 Pro sort en 1080p. MiniMax Hailuo 02 Standard propose le 512P et le 768P, donc il sert davantage à explorer des concepts qu’à finaliser en haute résolution.',
+          },
+          {
+            question: 'Quand le prix inférieur de Hailuo 02 est-il intéressant ?',
+            answer:
+              'Utilisez Hailuo pour multiplier les explorations stylisées silencieuses à 0,045 $ par seconde. Payez Kling lorsque l’audio et une livraison 1080p sont indispensables.',
+          },
+        ],
+      },
+    },
+    'kling-3-standard-vs-kling-o3-standard': {
+      meta: {
+        title: 'Kling 3 Standard vs Omni Standard : lequel choisir ?',
+        description:
+          'Comparez Kling 3 Standard et Kling 3.0 Omni Standard sur les références, le montage vidéo, le 1080p, l’audio et le prix pour bien choisir.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Comparez Kling 3 Standard et Kling 3.0 Omni Standard lorsque les deux offrent 15 secondes en 1080p avec audio au même tarif de base. Standard simplifie la génération depuis un texte ou une image de départ ; Omni ajoute les références visuelles et la transformation d’une vidéo source.',
+      quickVerdict: {
+        title: 'Verdict rapide',
+        body:
+          'Choisissez Kling 3 Standard pour tester directement un prompt ou une image de départ sans complexité inutile. Choisissez Kling 3.0 Omni Standard lorsque des personnages, produits, références visuelles ou une vidéo existante doivent guider le résultat grâce aux modes référence-vers-vidéo ou vidéo-vers-vidéo.',
+      },
+      topCards: [
+        {
+          title: 'Choisir Kling 3 Standard',
+          body:
+            'Pour les prompts directs, l’animation d’une image initiale et des brouillons 1080p répétables avec audio optionnel.',
+        },
+        {
+          title: 'Choisir Omni Standard',
+          body:
+            'Pour guider le plan avec des références ou transformer une vidéo source en plus des modes texte et image.',
+        },
+        {
+          title: 'Différence clé',
+          body:
+            'Résolution, durée, audio et tarif de base sont identiques ; Omni élargit les entrées, Standard reste plus simple.',
+        },
+        {
+          title: 'Usages recommandés',
+          body:
+            'Standard convient aux tests depuis une image. Omni convient à la continuité de personnages, produits et sources vidéo.',
+        },
+      ],
+      primaryLinksTitle: 'Prochaines étapes recommandées',
+      primaryLinks: [
+        { href: '/models/kling-3-standard', label: 'Ouvrir la page Kling 3 Standard' },
+        { href: '/models/kling-o3-standard', label: 'Ouvrir la page Kling 3.0 Omni Standard' },
+        {
+          href: '/ai-video-engines/kling-3-pro-vs-kling-3-standard',
+          label: 'Comparer Kling 3 Pro et Kling 3 Standard',
+        },
+      ],
+      faq: {
+        title: 'FAQ',
+        subtitle: 'Réponses courtes entre les workflows Kling Standard et Omni Standard.',
+        items: [
+          {
+            question: 'Quelle est la différence principale entre Standard et Omni Standard ?',
+            answer:
+              'Les deux produisent jusqu’à 15 secondes en 1080p avec audio. Omni Standard ajoute les modes référence-vers-vidéo et vidéo-vers-vidéo, absents de Kling 3 Standard.',
+          },
+          {
+            question: 'Kling 3 Standard et Omni Standard coûtent-ils le même prix ?',
+            answer:
+              'Le catalogue indique les mêmes tarifs fournisseur : 0,084 $ par seconde sans audio et 0,126 $ avec audio, avant la marge appliquée par MaxVideoAI.',
+          },
+          {
+            question: 'Quel modèle choisir pour travailler avec des références ?',
+            answer:
+              'Choisissez Kling 3.0 Omni Standard si des images de référence ou une vidéo source doivent guider le résultat. Kling 3 Standard suffit avec un prompt ou une image de départ.',
+          },
+        ],
+      },
+    },
+    'seedance-2-0-fast-vs-veo-3-1': {
+      meta: {
+        title: 'Seedance 2.0 Fast vs Veo 3.1 : brouillon ou 4K ?',
+        description:
+          'Comparez Seedance 2.0 Fast et Google Veo 3.1 sur les brouillons, références, montages, durées, audio et sorties 4K pour votre vidéo.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Comparez Seedance 2.0 Fast et Google Veo 3.1 pour choisir entre un workflow complet de brouillon et montage ou une livraison finale en haute résolution. Seedance atteint 15 secondes avec références, édition et extension en 480p ou 720p ; Veo monte en 4K pour des publicités et plans B-roll de 8 secondes.',
+      quickVerdict: {
+        title: 'Verdict rapide',
+        body:
+          'Choisissez Seedance 2.0 Fast pour planifier vite, produire des brouillons plus longs, exploiter des références, modifier ou prolonger une vidéo lorsque le 720p suffit. Choisissez Google Veo 3.1 pour des publicités courtes et finies, le contrôle première-dernière image et une livraison 1080p ou 4K.',
+      },
+      topCards: [
+        {
+          title: 'Choisir Seedance 2.0 Fast',
+          body:
+            'Pour les brouillons de 4 à 15 secondes, les références visuelles, le montage, l’extension et de nombreux formats.',
+        },
+        {
+          title: 'Choisir Veo 3.1',
+          body:
+            'Pour des publicités ou plans B-roll finis de 8 secondes, l’audio, le contrôle des images limites et la 4K.',
+        },
+        {
+          title: 'Différence clé',
+          body:
+            'Seedance offre davantage de durée et d’outils en 480p/720p ; Veo produit des clips plus courts à bien meilleure résolution finale.',
+        },
+        {
+          title: 'Usages recommandés',
+          body:
+            'Seedance convient à la préparation et aux retouches. Veo convient aux plans de campagne validés et aux masters haute résolution.',
+        },
+      ],
+      primaryLinksTitle: 'Prochaines étapes recommandées',
+      primaryLinks: [
+        { href: '/models/seedance-2-0-fast', label: 'Ouvrir la page Seedance 2.0 Fast' },
+        { href: '/models/veo-3-1', label: 'Ouvrir la page Google Veo 3.1' },
+        {
+          href: '/ai-video-engines/seedance-2-0-fast-vs-veo-3-1-fast',
+          label: 'Comparer Seedance 2.0 Fast et Veo 3.1 Fast',
+        },
+      ],
+      faq: {
+        title: 'FAQ',
+        subtitle: 'Réponses courtes entre brouillons Seedance et sorties finales Veo.',
+        items: [
+          {
+            question: 'Seedance 2.0 Fast ou Veo 3.1 : lequel choisir pour les brouillons ?',
+            answer:
+              'Seedance 2.0 Fast est conçu pour les brouillons rapides, les essais de référence et la préparation des plans. Il atteint 15 secondes et permet aussi de modifier ou prolonger une vidéo.',
+          },
+          {
+            question: 'Quel modèle convient le mieux à une livraison finale 4K ?',
+            answer:
+              'Google Veo 3.1 est le meilleur choix pour un master 4K fini. Seedance 2.0 Fast s’arrête au 720p et sert davantage à l’itération et au montage.',
+          },
+          {
+            question: 'Les deux modèles acceptent-ils l’audio et les références ?',
+            answer:
+              'Oui. Seedance ajoute le montage vidéo et davantage de formats, tandis que Veo ajoute le contrôle première-dernière image et une résolution finale supérieure.',
+          },
+        ],
+      },
+    },
+    'ltx-2-fast-vs-minimax-hailuo-02-text': {
+      meta: {
+        title: 'LTX 2 Fast vs Hailuo 02 : résolution, audio et usages',
+        description:
+          'Comparez LTX Video 2.0 Fast et MiniMax Hailuo 02 sur la durée, la résolution, l’audio, les formats et le prix pour vos clips sociaux.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Comparez LTX Video 2.0 Fast et MiniMax Hailuo 02 Standard pour choisir entre de longs clips paysage en haute résolution ou des formats stylisés plus modestes. LTX atteint 20 secondes avec audio et une sortie jusqu’en 4K ; Hailuo ajoute les formats vertical et carré en 512P ou 768P silencieux.',
+      quickVerdict: {
+        title: 'Verdict rapide',
+        body:
+          'Choisissez LTX Video 2.0 Fast pour des clips paysage rapides, l’audio natif, une durée jusqu’à 20 secondes et des sorties 1080p, 1440p ou 4K. Choisissez MiniMax Hailuo 02 Standard pour un concept stylisé silencieux en vertical, carré ou paysage lorsque le 512P ou 768P suffit.',
+      },
+      topCards: [
+        {
+          title: 'Choisir LTX 2 Fast',
+          body:
+            'Pour des clips sociaux 16:9 plus longs, une génération avec audio et des livraisons du 1080p à la 4K.',
+        },
+        {
+          title: 'Choisir Hailuo 02',
+          body:
+            'Pour des mouvements stylisés silencieux en 16:9, 9:16 ou 1:1 lorsque le 512P ou le 768P suffit au canal.',
+        },
+        {
+          title: 'Différence clé',
+          body:
+            'LTX offre durée, audio et haute résolution mais seulement en 16:9 ; Hailuo offre plus de formats sociaux à basse résolution.',
+        },
+        {
+          title: 'Usages recommandés',
+          body:
+            'LTX convient aux promotions paysage avec musique. Hailuo convient aux accroches verticales, carrées et aux essais visuels.',
+        },
+      ],
+      primaryLinksTitle: 'Prochaines étapes recommandées',
+      primaryLinks: [
+        { href: '/models/ltx-2-fast', label: 'Ouvrir la page LTX Video 2.0 Fast' },
+        { href: '/models/minimax-hailuo-02-text', label: 'Ouvrir la page MiniMax Hailuo 02' },
+        {
+          href: '/ai-video-engines/ltx-2-3-fast-vs-ltx-2-fast',
+          label: 'Comparer LTX 2.3 Fast et LTX 2 Fast',
+        },
+      ],
+      faq: {
+        title: 'FAQ',
+        subtitle: 'Réponses courtes entre LTX haute résolution et Hailuo multiformat.',
+        items: [
+          {
+            question: 'Quel modèle choisir pour des clips longs en haute résolution ?',
+            answer:
+              'LTX Video 2.0 Fast atteint 20 secondes avec audio et une sortie 1080p, 1440p ou 4K. Hailuo 02 s’arrête à 10 secondes et au 768P.',
+          },
+          {
+            question: 'Quel modèle fonctionne le mieux en vertical ou en carré ?',
+            answer:
+              'MiniMax Hailuo 02 Standard prend en charge le 9:16 et le 1:1 en plus du 16:9. LTX Video 2.0 Fast est limité au 16:9 paysage.',
+          },
+          {
+            question: 'LTX 2 Fast et Hailuo 02 génèrent-ils tous deux de l’audio ?',
+            answer:
+              'Non. LTX Video 2.0 Fast prend en charge l’audio natif, tandis que Hailuo 02 produit une vidéo silencieuse à sonoriser ensuite si nécessaire.',
+          },
+        ],
+      },
+    },
+    'minimax-hailuo-02-text-vs-veo-3-1-fast': {
+      meta: {
+        title: 'Hailuo 02 vs Veo 3.1 Fast : prix, audio et 4K',
+        description:
+          'Comparez MiniMax Hailuo 02 et Google Veo 3.1 Fast sur le prix, l’audio, les références, la résolution et la durée de génération.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Comparez MiniMax Hailuo 02 Standard et Google Veo 3.1 Fast pour arbitrer entre une exploration stylisée peu coûteuse ou un workflow de production plus complet. Hailuo crée du mouvement silencieux en 512P ou 768P à 0,045 $ par seconde ; Veo Fast ajoute audio, références, extension et 4K.',
+      quickVerdict: {
+        title: 'Verdict rapide',
+        body:
+          'Choisissez MiniMax Hailuo 02 Standard pour des concepts stylisés silencieux et économiques, jusqu’à 10 secondes lorsque le 768P suffit. Choisissez Google Veo 3.1 Fast pour des publicités avec audio, des références, le contrôle première-dernière image, des extensions ou une livraison 1080p ou 4K.',
+      },
+      topCards: [
+        {
+          title: 'Choisir Hailuo 02',
+          body:
+            'Pour des essais stylisés à 0,045 $ par seconde, des concepts sociaux silencieux et jusqu’à 10 secondes en 768P.',
+        },
+        {
+          title: 'Choisir Veo 3.1 Fast',
+          body:
+            'Pour l’audio, les références, les images limites, l’extension et des livraisons du 720p à la 4K.',
+        },
+        {
+          title: 'Différence clé',
+          body:
+            'Hailuo coûte moins cher et offre deux secondes de plus ; Veo Fast élargit la résolution, le son et les contrôles.',
+        },
+        {
+          title: 'Usages recommandés',
+          body:
+            'Hailuo convient aux tests stylisés et accroches économiques. Veo Fast convient aux publicités, produits et masters finis.',
+        },
+      ],
+      primaryLinksTitle: 'Prochaines étapes recommandées',
+      primaryLinks: [
+        { href: '/models/minimax-hailuo-02-text', label: 'Ouvrir la page MiniMax Hailuo 02' },
+        { href: '/models/veo-3-1-fast', label: 'Ouvrir la page Google Veo 3.1 Fast' },
+        {
+          href: '/ai-video-engines/seedance-2-0-fast-vs-veo-3-1-fast',
+          label: 'Comparer Seedance 2.0 Fast et Veo 3.1 Fast',
+        },
+      ],
+      faq: {
+        title: 'FAQ',
+        subtitle: 'Réponses courtes entre Hailuo économique et Veo Fast plus complet.',
+        items: [
+          {
+            question: 'Hailuo 02 ou Veo 3.1 Fast : lequel coûte le moins cher ?',
+            answer:
+              'Hailuo 02 est facturé 0,045 $ par seconde. Veo 3.1 Fast démarre à 0,10 $ en 720p avec audio et augmente avec la résolution : Hailuo reste le choix économique et silencieux.',
+          },
+          {
+            question: 'Quel modèle prend en charge l’audio et la 4K ?',
+            answer:
+              'Google Veo 3.1 Fast prend en charge l’audio natif et la sortie jusqu’en 4K. MiniMax Hailuo 02 Standard est silencieux et s’arrête au 768P.',
+          },
+          {
+            question: 'Quand choisir Hailuo 02 plutôt que Veo Fast ?',
+            answer:
+              'Choisissez Hailuo pour explorer des styles à petit prix sans besoin de son ni de haute résolution. Veo Fast s’impose pour les références, l’audio et une livraison finie.',
+          },
+        ],
+      },
+    },
+    'kling-3-4k-vs-seedance-2-0': {
+      meta: {
+        title: 'Kling 3 4K vs Seedance 2.0 : 4K finale ou contrôle ?',
+        description:
+          'Comparez Kling 3 4K et Seedance 2.0 sur la 4K native, les références, le montage, l’extension, l’audio et la flexibilité du workflow.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Comparez Kling 3 4K et Seedance 2.0 : les deux livrent en 4K, mais leurs workflows diffèrent. Kling est une route texte ou image de départ entièrement dédiée au rendu final 4K natif ; Seedance va du 480p à la 4K avec références, montage vidéo, extension, contrôles de mouvement et audio.',
+      quickVerdict: {
+        title: 'Verdict rapide',
+        body:
+          'Choisissez Kling 3 4K lorsqu’un prompt ou une image déjà validés doivent être rendus directement en 4K native. Choisissez Seedance 2.0 lorsque le projet exige des itérations en basse résolution, plusieurs références, du montage vidéo, une extension de clip, davantage de formats ou plus de contrôle avant le master 4K.',
+      },
+      topCards: [
+        {
+          title: 'Choisir Kling 3 4K',
+          body:
+            'Pour rendre directement un prompt ou une image validés en 4K native, avec audio optionnel.',
+        },
+        {
+          title: 'Choisir Seedance 2.0',
+          body:
+            'Pour les références, le montage, l’extension, les contrôles de mouvement, plusieurs résolutions et davantage de formats.',
+        },
+        {
+          title: 'Différence clé',
+          body:
+            'Kling verrouille chaque rendu en 4K native ; Seedance permet d’itérer dès le 480p avec des entrées beaucoup plus variées.',
+        },
+        {
+          title: 'Usages recommandés',
+          body:
+            'Kling convient aux héros finaux approuvés. Seedance convient aux campagnes itératives, séquences référencées et retouches.',
+        },
+      ],
+      primaryLinksTitle: 'Prochaines étapes recommandées',
+      primaryLinks: [
+        { href: '/models/kling-3-4k', label: 'Ouvrir la page Kling 3 4K' },
+        { href: '/models/seedance-2-0', label: 'Ouvrir la page Seedance 2.0' },
+        {
+          href: '/ai-video-engines/kling-3-4k-vs-veo-3-1',
+          label: 'Comparer Kling 3 4K et Veo 3.1',
+        },
+      ],
+      faq: {
+        title: 'FAQ',
+        subtitle: 'Réponses courtes entre 4K native dédiée et workflow Seedance complet.',
+        items: [
+          {
+            question: 'Kling 3 4K et Seedance 2.0 prennent-ils tous deux en charge la 4K ?',
+            answer:
+              'Oui. Kling 3 4K est verrouillé sur une sortie 4K native, tandis que Seedance 2.0 propose 480p, 720p, 1080p et 4K pour itérer avant la livraison finale.',
+          },
+          {
+            question: 'Quel modèle offre le plus de contrôle par références et montage ?',
+            answer:
+              'Seedance 2.0 ajoute références, montage vidéo, extension, contrôles de mouvement et plusieurs images, vidéos ou audios sources. Kling 3 4K se concentre sur le texte et l’image de départ.',
+          },
+          {
+            question: 'Quel modèle choisir pour un plan héros final en 4K ?',
+            answer:
+              'Kling 3 4K est une route directe pour rendre un prompt ou une image validés en 4K native. Seedance est préférable si le plan demande encore des références, retouches ou extensions.',
+          },
+        ],
+      },
+    },
+    'minimax-hailuo-02-text-vs-wan-2-6': {
+      meta: {
+        title: 'Hailuo 02 vs Wan 2.6 : prix, audio et usages',
+        description:
+          'Comparez MiniMax Hailuo 02 et Wan 2.6 sur le prix, la durée, le 1080p, l’audio, les vidéos de référence et le mouvement stylisé.',
+        titleBranding: 'none',
+      },
+      heroIntro:
+        'Comparez MiniMax Hailuo 02 Standard et Wan 2.6 Text & Image to Video pour arbitrer entre mouvement stylisé économique et workflow généraliste. Hailuo coûte 0,045 $ par seconde pour des clips silencieux en 512P ou 768P ; Wan atteint 15 secondes en 1080p avec audio et références vidéo.',
+      quickVerdict: {
+        title: 'Verdict rapide',
+        body:
+          'Choisissez MiniMax Hailuo 02 Standard pour des concepts stylisés silencieux moins chers, des formats verticaux ou carrés et jusqu’à 10 secondes lorsque le 768P suffit. Choisissez Wan 2.6 pour une production généraliste en 1080p, jusqu’à 15 secondes, avec audio optionnel ou une à trois vidéos de référence.',
+      },
+      topCards: [
+        {
+          title: 'Choisir Hailuo 02',
+          body:
+            'Pour du mouvement stylisé à 0,045 $ par seconde et des tests silencieux en paysage, vertical ou carré.',
+        },
+        {
+          title: 'Choisir Wan 2.6',
+          body:
+            'Pour une livraison 720p ou 1080p, l’audio optionnel, jusqu’à 15 secondes et le guidage par vidéo.',
+        },
+        {
+          title: 'Différence clé',
+          body:
+            'Hailuo minimise le coût des sorties stylisées ; Wan coûte plus cher mais ajoute résolution, durée, son et références.',
+        },
+        {
+          title: 'Usages recommandés',
+          body:
+            'Hailuo convient aux concepts sociaux économiques. Wan convient aux narrations, plans B-roll et séquences guidées.',
+        },
+      ],
+      primaryLinksTitle: 'Prochaines étapes recommandées',
+      primaryLinks: [
+        { href: '/models/minimax-hailuo-02-text', label: 'Ouvrir la page MiniMax Hailuo 02' },
+        { href: '/models/wan-2-6', label: 'Ouvrir la page Wan 2.6' },
+        {
+          href: '/ai-video-engines/veo-3-1-vs-wan-2-6',
+          label: 'Comparer Veo 3.1 et Wan 2.6',
+        },
+      ],
+      faq: {
+        title: 'FAQ',
+        subtitle: 'Réponses courtes entre Hailuo stylisé et Wan généraliste.',
+        items: [
+          {
+            question: 'Hailuo 02 ou Wan 2.6 : lequel coûte le moins cher ?',
+            answer:
+              'Hailuo 02 coûte 0,045 $ par seconde. Wan 2.6 démarre à 0,10 $ en 720p et 0,15 $ en 1080p : Hailuo est moins cher si une sortie silencieuse en basse résolution suffit.',
+          },
+          {
+            question: 'Quel modèle prend en charge l’audio et les vidéos de référence ?',
+            answer:
+              'Wan 2.6 accepte un audio optionnel et une à trois vidéos de référence. MiniMax Hailuo 02 Standard génère depuis du texte ou une image sans audio.',
+          },
+          {
+            question: 'Quand choisir Wan 2.6 plutôt que Hailuo 02 ?',
+            answer:
+              'Choisissez Wan pour le 1080p, plus de 10 secondes, l’audio natif ou le guidage vidéo. Choisissez Hailuo pour explorer des styles et formats sociaux à moindre coût.',
+          },
+        ],
+      },
+    },
   } satisfies ComparePageOverridesBySlug;

--- a/tests/comparison-enrichment-locales.test.ts
+++ b/tests/comparison-enrichment-locales.test.ts
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import engineCatalog from '../frontend/config/engine-catalog.json' with { type: 'json' };
+import { EN_COMPARE_PAGE_OVERRIDES } from '../frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-en.ts';
+import { ES_COMPARE_PAGE_OVERRIDES } from '../frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-es.ts';
+import { FR_COMPARE_PAGE_OVERRIDES } from '../frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-fr.ts';
+import type { ComparePageOverride } from '../frontend/app/(localized)/[locale]/(marketing)/ai-video-engines/[slug]/_lib/compare-page-overrides-types.ts';
+import { isPublishedComparisonSlug } from '../frontend/lib/compare-hub/data.ts';
+
+const TARGET_COMPARISONS = [
+  ['pika-text-to-video-vs-wan-2-6', 'pika-text-to-video', 'wan-2-6'],
+  ['kling-2-6-pro-vs-kling-3-pro', 'kling-2-6-pro', 'kling-3-pro'],
+  ['ltx-2-3-fast-vs-luma-ray-2', 'ltx-2-3-fast', 'luma-ray-2'],
+  ['kling-2-6-pro-vs-minimax-hailuo-02-text', 'kling-2-6-pro', 'minimax-hailuo-02-text'],
+  ['kling-3-standard-vs-kling-o3-standard', 'kling-3-standard', 'kling-o3-standard'],
+  ['seedance-2-0-fast-vs-veo-3-1', 'seedance-2-0-fast', 'veo-3-1'],
+  ['ltx-2-fast-vs-minimax-hailuo-02-text', 'ltx-2-fast', 'minimax-hailuo-02-text'],
+  ['minimax-hailuo-02-text-vs-veo-3-1-fast', 'minimax-hailuo-02-text', 'veo-3-1-fast'],
+  ['kling-3-4k-vs-seedance-2-0', 'kling-3-4k', 'seedance-2-0'],
+  ['minimax-hailuo-02-text-vs-wan-2-6', 'minimax-hailuo-02-text', 'wan-2-6'],
+] as const;
+
+type Locale = 'en' | 'fr' | 'es';
+type OverrideMap = Record<string, ComparePageOverride>;
+
+const OVERRIDES_BY_LOCALE: Record<Locale, OverrideMap> = {
+  en: EN_COMPARE_PAGE_OVERRIDES,
+  fr: FR_COMPARE_PAGE_OVERRIDES,
+  es: ES_COMPARE_PAGE_OVERRIDES,
+};
+
+const CATALOG_BY_SLUG = new Map(engineCatalog.map((entry) => [entry.modelSlug, entry]));
+
+function getEntry(locale: Locale, slug: string): ComparePageOverride {
+  const entry = OVERRIDES_BY_LOCALE[locale][slug];
+  assert.ok(entry, `missing ${locale.toUpperCase()} override for ${slug}`);
+  return entry;
+}
+
+function collectText(entry: ComparePageOverride): string {
+  return [
+    entry.meta?.title,
+    entry.meta?.description,
+    entry.heroIntro,
+    entry.quickVerdict?.title,
+    entry.quickVerdict?.body,
+    ...(entry.topCards ?? []).flatMap((card) => [card.title, card.body]),
+    ...(entry.primaryLinks ?? []).map((link) => link.label),
+    entry.faq?.title,
+    entry.faq?.subtitle,
+    ...(entry.faq?.items ?? []).flatMap((item) => [
+      item.question,
+      ...(Array.isArray(item.answer) ? item.answer : [item.answer]),
+    ]),
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+function assertCompleteOverride(locale: Locale, slug: string): void {
+  const entry = getEntry(locale, slug);
+  const title = entry.meta?.title ?? '';
+  const description = entry.meta?.description ?? '';
+
+  assert.ok(title.length >= 35 && title.length <= 80, `${locale} title length for ${slug}: ${title.length}`);
+  assert.ok(description.length >= 120 && description.length <= 180, `${locale} description length for ${slug}: ${description.length}`);
+  assert.equal(entry.meta?.titleBranding, 'none', `${locale} should disable automatic branding for ${slug}`);
+  assert.ok((entry.heroIntro?.length ?? 0) >= 140, `${locale} hero should be decision-focused for ${slug}`);
+  assert.ok((entry.quickVerdict?.body.length ?? 0) >= 120, `${locale} verdict should be substantive for ${slug}`);
+  assert.equal(entry.topCards?.length, 4, `${locale} should have four decision cards for ${slug}`);
+  assert.ok((entry.primaryLinks?.length ?? 0) >= 3, `${locale} should have at least three internal links for ${slug}`);
+  assert.ok((entry.faq?.items.length ?? 0) >= 3, `${locale} should have at least three FAQ items for ${slug}`);
+  assert.ok((entry.faq?.items.length ?? 0) <= 5, `${locale} should have at most five FAQ items for ${slug}`);
+
+  const faqQuestions = (entry.faq?.items ?? []).map((item) => item.question);
+  assert.equal(new Set(faqQuestions).size, faqQuestions.length, `${locale} FAQ questions should be unique for ${slug}`);
+  const hrefs = (entry.primaryLinks ?? []).map((link) => link.href);
+  assert.equal(new Set(hrefs).size, hrefs.length, `${locale} internal links should be unique for ${slug}`);
+  hrefs.forEach((href) => {
+    assert.match(href, /^\/(models|examples|ai-video-engines)\//, `${locale} unsupported internal href ${href}`);
+    assert.doesNotMatch(href, /^\/(fr|es)\//, `${locale} href must remain locale-neutral: ${href}`);
+  });
+}
+
+for (const locale of ['en', 'fr', 'es'] as const) {
+  test(`${locale.toUpperCase()} comparison enrichment entries satisfy the editorial contract`, () => {
+    const titles = new Set<string>();
+    const descriptions = new Set<string>();
+
+    TARGET_COMPARISONS.forEach(([slug, leftSlug, rightSlug]) => {
+      assert.ok(isPublishedComparisonSlug(slug), `${slug} should remain published`);
+      const left = CATALOG_BY_SLUG.get(leftSlug);
+      const right = CATALOG_BY_SLUG.get(rightSlug);
+      assert.ok(left, `missing catalog entry ${leftSlug}`);
+      assert.ok(right, `missing catalog entry ${rightSlug}`);
+
+      assertCompleteOverride(locale, slug);
+      const entry = getEntry(locale, slug);
+      const pageText = collectText(entry);
+      assert.match(pageText, new RegExp(left.marketingName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'));
+      assert.match(pageText, new RegExp(right.marketingName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'));
+
+      const title = entry.meta?.title ?? '';
+      const description = entry.meta?.description ?? '';
+      assert.ok(!titles.has(title), `${locale} title should be unique: ${title}`);
+      assert.ok(!descriptions.has(description), `${locale} description should be unique: ${description}`);
+      titles.add(title);
+      descriptions.add(description);
+    });
+  });
+}
+
+test('French and LATAM Spanish are localized instead of copying English', () => {
+  TARGET_COMPARISONS.forEach(([slug]) => {
+    const english = getEntry('en', slug);
+    const french = getEntry('fr', slug);
+    const spanish = getEntry('es', slug);
+    assert.notEqual(french.meta?.title, english.meta?.title, `FR title should be localized for ${slug}`);
+    assert.notEqual(spanish.meta?.title, english.meta?.title, `ES title should be localized for ${slug}`);
+    assert.notEqual(french.quickVerdict?.body, english.quickVerdict?.body, `FR verdict should be localized for ${slug}`);
+    assert.notEqual(spanish.quickVerdict?.body, english.quickVerdict?.body, `ES verdict should be localized for ${slug}`);
+  });
+});
+
+test('Spanish comparison copy stays LATAM-neutral', () => {
+  const spainSpecificTerms = /\b(vídeo|vídeos|móvil|móviles|ordenador|ordenadores|monedero|monederos|vosotros)\b/i;
+  TARGET_COMPARISONS.forEach(([slug]) => {
+    assert.doesNotMatch(collectText(getEntry('es', slug)), spainSpecificTerms, `Spain-specific term in ${slug}`);
+  });
+});
+
+test('every comparison enrichment link resolves to a public model or comparison route', () => {
+  for (const locale of ['en', 'fr', 'es'] as const) {
+    TARGET_COMPARISONS.forEach(([slug]) => {
+      for (const link of getEntry(locale, slug).primaryLinks ?? []) {
+        if (link.href.startsWith('/models/')) {
+          const modelSlug = link.href.slice('/models/'.length);
+          const model = CATALOG_BY_SLUG.get(modelSlug);
+          assert.ok(model, `missing model route ${link.href}`);
+          assert.equal(model.surfaces.modelPage.indexable, true, `model route should be public: ${link.href}`);
+        }
+        if (link.href.startsWith('/ai-video-engines/')) {
+          assert.ok(
+            isPublishedComparisonSlug(link.href.slice('/ai-video-engines/'.length)),
+            `comparison route should be published: ${link.href}`,
+          );
+        }
+      }
+    });
+  }
+});


### PR DESCRIPTION
## What changed

- Enriched 10 comparison pages identified from GSC as high-impression, zero-click opportunities.
- Added 30 complete localized overrides across American English, French, and LATAM-neutral Spanish.
- Added pair-specific titles, meta descriptions, hero copy, verdicts, decision cards, internal links, and FAQs.
- Added a focused contract covering metadata bounds, localization, LATAM vocabulary, public links, and publication status.

## Why

These comparison URLs already receive roughly 196–476 impressions each but recorded no clicks in the audit snapshot. The previous generic copy did not clearly communicate the price, resolution, audio, duration, control, and use-case differences between each model pair.

## Impact

The comparison template and SEO architecture remain unchanged. This PR does not alter sitemap inclusion, robots directives, canonical URLs, hreflang routing, JSON-LD builders, pricing data, scorecards, or engine publication rules.

## Validation

- `23/23` focused enrichment and comparison architecture tests passed.
- `1614/1614` repository tests passed.
- Frontend lint passed.
- Public exposure check passed.
- Production build generated all 709 static pages.
- EN, FR, and ES smoke checks returned HTTP 200 with localized metadata, canonical, hreflang, verdict copy, and JSON-LD.
