### PR TITLE
Trim New badges in marketing dropdowns

### DIFF
--- a/frontend/config/navigation.ts
+++ b/frontend/config/navigation.ts
@@ -92,13 +92,14 @@ const docLink = (slug: string): LocalizedLinkHref => ({
 const BASE_MODEL_MENU_CANDIDATES: readonly LabeledSlug[] = [
   { slug: 'seedance-2-5', label: 'Seedance 2.5', badge: 'new' },
   { slug: 'minimax-h3', label: 'MiniMax H3', badge: 'new' },
-  { slug: 'ltx-2-5-pro', label: 'LTX 2.5 Pro', badge: 'new' },
+  { slug: 'ltx-2-5-pro', label: 'LTX 2.5 Pro' },
+  { slug: 'wan-3', label: 'Wan 3', badge: 'new' },
   { slug: 'wan-3-prime', label: 'Wan 3 Prime', badge: 'new' },
-  { slug: 'grok-imagine-video-1-5', label: 'Grok Imagine Video 1.5', badge: 'new' },
-  { slug: 'flux-3', label: 'FLUX 3', badge: 'new' },
+  { slug: 'grok-imagine-video-1-5', label: 'Grok Imagine Video 1.5' },
+  { slug: 'flux-3', label: 'FLUX 3' },
   { slug: 'seedance-2-0', label: 'Seedance 2.0' },
   { slug: 'veo-3-1', label: 'Veo 3.1' },
-  { slug: 'gemini-omni-flash', label: 'Gemini Omni Flash 1.1', badge: 'new' },
+  { slug: 'gemini-omni-flash', label: 'Gemini Omni Flash 1.1' },
   { slug: 'kling-o3-pro', label: 'Kling 3.0 Omni Pro' },
   { slug: 'kling-o3-4k', label: 'Kling 3.0 Omni 4K' },
   { slug: 'seedance-2-0-fast', label: 'Seedance 2.0 Fast' },
@@ -110,14 +111,15 @@ const P1_MODEL_MENU_CANDIDATES: readonly LabeledSlug[] = [
   { slug: 'seedance-2-5', label: 'Seedance 2.5', badge: 'new' },
   { slug: 'minimax-h3', label: 'MiniMax H3', badge: 'new' },
   { slug: 'minimax-h3-max', label: 'MiniMax H3 Max', badge: 'new' },
-  { slug: 'kling-3-turbo-pro', label: 'Kling 3.0 Turbo Pro', badge: 'new' },
-  { slug: 'kling-3-turbo-standard', label: 'Kling 3.0 Turbo Standard', badge: 'new' },
+  { slug: 'kling-3-turbo-pro', label: 'Kling 3.0 Turbo Pro' },
+  { slug: 'kling-3-turbo-standard', label: 'Kling 3.0 Turbo Standard' },
   { slug: 'veo-3-1', label: 'Veo 3.1' },
-  { slug: 'gemini-omni-flash', label: 'Gemini Omni Flash 1.1', badge: 'new' },
-  { slug: 'ltx-2-5-pro', label: 'LTX 2.5 Pro', badge: 'new' },
+  { slug: 'gemini-omni-flash', label: 'Gemini Omni Flash 1.1' },
+  { slug: 'ltx-2-5-pro', label: 'LTX 2.5 Pro' },
+  { slug: 'wan-3', label: 'Wan 3', badge: 'new' },
   { slug: 'wan-3-prime', label: 'Wan 3 Prime', badge: 'new' },
-  { slug: 'grok-imagine-video-1-5', label: 'Grok Imagine Video 1.5', badge: 'new' },
-  { slug: 'flux-3', label: 'FLUX 3', badge: 'new' },
+  { slug: 'grok-imagine-video-1-5', label: 'Grok Imagine Video 1.5' },
+  { slug: 'flux-3', label: 'FLUX 3' },
   { slug: 'seedance-2-0', label: 'Seedance 2.0' },
   { slug: 'kling-o3-pro', label: 'Kling 3.0 Omni Pro' },
 ] as const;
@@ -141,7 +143,7 @@ export function buildMarketingModelMenu(models: readonly RuntimeModelEntry[]): L
     if (!model?.publication.model.published || model.lifecycle === 'retired') return false;
     if (model.lifecycle !== 'legacy' || !model.successorId) return true;
     return byId.get(model.successorId)?.publication.model.published !== true;
-  }).slice(0, 10);
+  }).slice(0, 11);
 }
 
 const MODEL_MENU = buildMarketingModelMenu(listRuntimeModels());
@@ -162,22 +164,18 @@ const P1_COMPARE_MENU: LabeledSlug[] = [
   {
     slug: 'minimax-h3-vs-minimax-h3-max',
     label: 'MiniMax H3 vs H3 Max',
-    badge: 'new',
   },
   {
     slug: 'kling-3-turbo-pro-vs-kling-3-turbo-standard',
     label: 'Kling 3 Turbo Pro vs Standard',
-    badge: 'new',
   },
   {
     slug: 'kling-3-pro-vs-kling-3-turbo-pro',
     label: 'Kling 3 Pro vs Turbo Pro',
-    badge: 'new',
   },
   {
     slug: 'gemini-omni-flash-vs-kling-3-turbo-pro',
     label: 'Gemini Omni Flash 1.1 vs Kling 3 Turbo Pro',
-    badge: 'new',
   },
   {
     slug: 'gemini-omni-flash-vs-veo-3-1',
@@ -189,15 +187,13 @@ const COMPARE_MENU: LabeledSlug[] = [
   {
     slug: 'minimax-h3-vs-seedance-2-5',
     label: 'MiniMax H3 vs Seedance 2.5',
-    badge: 'new',
   },
   {
     slug: 'ltx-2-3-pro-vs-ltx-2-5-pro',
     label: 'LTX 2.3 Pro vs LTX 2.5 Pro',
-    badge: 'new',
   },
-  { slug: 'wan-2-6-vs-wan-3', label: 'Wan 2.6 vs Wan 3', badge: 'new' },
-  { slug: 'flux-3-vs-grok-imagine-video-1-5', label: 'FLUX 3 vs Grok Imagine Video 1.5', badge: 'new' },
+  { slug: 'wan-2-6-vs-wan-3', label: 'Wan 2.6 vs Wan 3' },
+  { slug: 'flux-3-vs-grok-imagine-video-1-5', label: 'FLUX 3 vs Grok Imagine Video 1.5' },
   { slug: 'grok-imagine-video-1-5-vs-sora-2', label: 'Grok Imagine Video 1.5 vs Sora 2' },
   { slug: 'kling-o3-pro-vs-minimax-h3', label: 'Kling 3.0 Omni Pro vs MiniMax H3' },
   { slug: 'gemini-omni-flash-vs-veo-3-1', label: 'Gemini Omni Flash 1.1 vs Veo 3.1' },
@@ -282,7 +278,7 @@ const MARKETING_COMPARE_DECISION_GUIDES_SECTION: MarketingNavSection = {
 
 export const MARKETING_NAV_TOOLS: MarketingNavItem[] = [
   ...(getMcpPublicationState(mcpPublication).indexable
-    ? [{ key: 'ai-video-assistant', label: 'Claude, ChatGPT & Codex video assistant', href: '/mcp', badge: 'new' as const }]
+    ? [{ key: 'ai-video-assistant', label: 'Claude, ChatGPT & Codex video assistant', href: '/mcp' as const }]
     : []),
   { key: 'character-builder', label: 'Consistent Character AI', href: toolLink('character-builder') },
   { key: 'angle', label: 'Change Camera Angle', href: toolLink('angle') },

--- a/tests/marketing-navigation.test.ts
+++ b/tests/marketing-navigation.test.ts
@@ -88,14 +88,19 @@ test('marketing top navigation stays clean while Best-For links live inside drop
   assert.match(marketingDesktopNavSource, /font-semibold text-text-primary/);
 });
 
-test('public model menus keep both Seedance 2.5 and MiniMax H3 launch badges', () => {
-  assert.deepEqual(
-    MARKETING_NAV_MODELS.slice(0, 2).map(({ key, badge }) => ({ key, badge })),
-    [
-      { key: 'seedance-2-5', badge: 'new' },
-      { key: 'minimax-h3', badge: 'new' },
-    ],
-  );
+test('public dropdowns limit launch badges to five current models with none on comparisons', () => {
+  const badgedEntries = Object.values(MARKETING_NAV_DROPDOWNS)
+    .flatMap((dropdown) => dropdown?.items ?? [])
+    .filter(({ badge }) => badge === 'new')
+    .map(({ key }) => key);
+
+  assert.deepEqual(badgedEntries, [
+    'seedance-2-5',
+    'minimax-h3',
+    'minimax-h3-max',
+    'wan-3',
+    'wan-3-prime',
+  ]);
 
   for (const [surface, source] of [
     ['marketing desktop', marketingDesktopNavSource],
@@ -117,15 +122,7 @@ test('public model menus keep both Seedance 2.5 and MiniMax H3 launch badges', (
     assert.equal(dictionary.nav.badges.new, label);
   }
 
-  const flagshipComparison = MARKETING_NAV_DROPDOWNS.compare?.items.find(
-    (item) => item.key === 'minimax-h3-vs-seedance-2-5',
-  );
-  assert.equal(flagshipComparison?.key, 'minimax-h3-vs-seedance-2-5');
-  assert.equal(flagshipComparison?.badge, 'new');
-  assert.deepEqual(flagshipComparison?.href, {
-    pathname: '/ai-video-engines/[slug]',
-    params: { slug: 'minimax-h3-vs-seedance-2-5' },
-  });
+  assert.equal(MARKETING_NAV_DROPDOWNS.compare?.items.some(({ badge }) => badge === 'new'), false);
 
   for (const locale of ['en', 'fr', 'es'] as const) {
     const dictionary = JSON.parse(readFileSync(`frontend/messages/${locale}.json`, 'utf8'));

--- a/tests/minimax-h3-seo-discovery.test.ts
+++ b/tests/minimax-h3-seo-discovery.test.ts
@@ -108,7 +108,6 @@ test('bounded discovery surfaces feature H3 immediately after Seedance 2.5', () 
   );
   assert.equal(MARKETING_NAV_COMPARE.length, 10);
   assert.equal(MARKETING_NAV_COMPARE[0]?.key, 'minimax-h3-vs-minimax-h3-max');
-  assert.equal(MARKETING_NAV_COMPARE[0]?.badge, 'new');
   assert.ok(MARKETING_NAV_COMPARE.some(({ key }) => key === 'minimax-h3-vs-seedance-2-5'));
 
   const popular = getPopularComparisons();

--- a/tests/p0-launch-readiness.test.ts
+++ b/tests/p0-launch-readiness.test.ts
@@ -117,7 +117,7 @@ test('the complete P0 graph publishes atomically across public discovery surface
 
   assert.deepEqual(
     MARKETING_NAV_MODELS.filter(({ key }) => P0.includes(key as (typeof P0)[number])).map(({ key }) => key),
-    ['ltx-2-5-pro', 'wan-3-prime', 'grok-imagine-video-1-5'],
+    ['ltx-2-5-pro', 'wan-3', 'wan-3-prime', 'grok-imagine-video-1-5'],
   );
   for (const familyId of ['wan', 'ltx', 'grok', 'flux']) {
     const family = MODEL_FAMILIES.find(({ id }) => id === familyId);

--- a/tests/p0-marketing-discovery.test.ts
+++ b/tests/p0-marketing-discovery.test.ts
@@ -37,9 +37,12 @@ const P0_MENU_REPRESENTATIVES = [
   'grok-imagine-video-1-5',
   'flux-3',
 ] as const;
-const P0_BOUNDED_MENU_REPRESENTATIVES = P0_MENU_REPRESENTATIVES.filter(
-  (modelId) => modelId !== 'flux-3',
-);
+const P0_BOUNDED_NAV_MENU_ENTRIES = [
+  'ltx-2-5-pro',
+  'wan-3',
+  'wan-3-prime',
+  'grok-imagine-video-1-5',
+] as const;
 
 function configuredLaunchSources(
   overrides: Partial<launchAssets.ModelLaunchSourceByWave> = {},
@@ -366,7 +369,7 @@ test('test validation compares both launch projections with source and detects i
   }
 });
 
-test('published P0 identities enter public discovery with one compact menu representative per family', () => {
+test('published P0 identities enter public discovery with the two promoted Wan variants', () => {
   const runtime = listRuntimeModels();
   const selectCatalogSlugs = (
     modelCatalog as typeof modelCatalog & {
@@ -380,7 +383,7 @@ test('published P0 identities enter public discovery with one compact menu repre
   const catalogSlugs = selectCatalogSlugs(runtime);
   assert.deepEqual(
     navigation.MARKETING_MODEL_SLUGS.filter((slug) => P0_IDS.includes(slug as never)),
-    P0_BOUNDED_MENU_REPRESENTATIVES,
+    P0_BOUNDED_NAV_MENU_ENTRIES,
   );
   assert.deepEqual(navigation.MARKETING_NAV_EXAMPLES.map(({ key }) => key), navigation.MARKETING_FOOTER_EXAMPLES.map(({ key }) => key));
   assert.equal(navigation.MARKETING_NAV_EXAMPLES.some(({ key }) => key === 'grok'), true);
@@ -399,7 +402,7 @@ test('published P0 identities enter public discovery with one compact menu repre
   }
 });
 
-test('a published fixture keeps the menu compact and exposes exactly one P0 representative per family', () => {
+test('a published fixture keeps the menu bounded while exposing both promoted Wan variants', () => {
   const buildMarketingModelMenu = (
     navigation as typeof navigation & {
       buildMarketingModelMenu?: (models: readonly RuntimeModelEntry[]) => Array<{ slug: string }>;
@@ -410,10 +413,10 @@ test('a published fixture keeps the menu compact and exposes exactly one P0 repr
   if (!buildMarketingModelMenu) return;
 
   const menu = buildMarketingModelMenu(publishedFixture());
-  assert.ok(menu.length <= 10);
+  assert.ok(menu.length <= 11);
   assert.deepEqual(
     menu.map(({ slug }) => slug).filter((slug) => P0_IDS.includes(slug as never)),
-    P0_BOUNDED_MENU_REPRESENTATIVES,
+    P0_BOUNDED_NAV_MENU_ENTRIES,
   );
 });
 

--- a/tests/p1-navigation-and-linking.test.ts
+++ b/tests/p1-navigation-and-linking.test.ts
@@ -82,7 +82,7 @@ test('the P1 model and comparison menus publish atomically without changing cano
   const modelMenu = buildMarketingModelMenu(models);
   const compareMenu = buildMarketingCompareMenu(models);
 
-  assert.ok(modelMenu.length <= 10);
+  assert.ok(modelMenu.length <= 11);
   for (const id of NEW_MODEL_IDS) assert.ok(modelMenu.some(({ slug }) => slug === id), id);
   assert.ok(modelMenu.some(({ slug, label }) => slug === 'gemini-omni-flash' && label === 'Gemini Omni Flash 1.1'));
   assert.ok(modelMenu.some(({ slug }) => slug === 'minimax-h3'), 'generic H3 canonical stays visible');

--- a/tests/seedance-prelaunch.test.ts
+++ b/tests/seedance-prelaunch.test.ts
@@ -408,6 +408,7 @@ test('Seedance 2.5 and Seedance 2.0 lead the app menu while P1 models enter mark
       'veo-3-1',
       'gemini-omni-flash',
       'ltx-2-5-pro',
+      'wan-3',
       'wan-3-prime',
       'grok-imagine-video-1-5',
     ]
@@ -428,7 +429,6 @@ test('Seedance 2.5 and Seedance 2.0 lead the app menu while P1 models enter mark
     ]
   );
   assert.equal(MARKETING_NAV_COMPARE.length, 10);
-  assert.equal(MARKETING_NAV_COMPARE[0]?.badge, 'new');
   const expectedExampleFamilies = [
     'veo',
     'seedance',
@@ -469,6 +469,7 @@ test('Header model menu keeps H3 and the current P1 representatives in the bound
     'veo-3-1',
     'gemini-omni-flash',
     'ltx-2-5-pro',
+    'wan-3',
     'wan-3-prime',
     'grok-imagine-video-1-5',
   ]);


### PR DESCRIPTION
## Summary
- keep New badges only on Seedance 2.5, MiniMax H3, MiniMax H3 Max, Wan 3, and Wan 3 Prime
- remove New badges from every comparison and other marketing dropdown entry
- keep both Wan 3 variants visible without dropping existing Grok navigation

## Validation
- pnpm test:validate
- npm --prefix frontend run lint
- npm run lint:exposure
- git diff --check