### PR TITLE
fix: restore example costs and harden public video playback

### DIFF
--- a/docs/engineering/pricing-engine.md
+++ b/docs/engineering/pricing-engine.md
@@ -101,6 +101,26 @@ Deterministic browser and marketing projections enter through `frontend/src/lib/
 
 The pricing hub, model decision cards, estimator, chip, model price rows, Product Offer JSON-LD, workspace preflight, and image estimate routes are protected by `tests/pricing-public-authority.test.ts`. The exhaustive 492-row fixture protects the cent-level output of every migrated public surface.
 
+## Historical launch examples
+
+`frontend/server/launch-example-pricing-records.json` preserves the original
+customer totals for 14 accepted P0 demo generations whose production import omitted
+pricing. The amounts were recovered on 2026-09-04 from the same job IDs in
+`preview/mcp-staging`; each `final_price_cents` matched the saved canonical
+`pricing_snapshot.totalCents`, model, duration and currency. These are archived
+generation receipts, not current rate definitions or newly calculated quotes.
+
+`videos-normalization.ts` uses a matching receipt only when the job has no
+stored price. An existing price, including zero, wins; a model, duration or
+currency mismatch rejects the receipt. This changes the gallery/marketing
+projection only. Production billing columns, wallet transactions and refund
+snapshots are never backfilled with staging charges.
+
+For future demo imports, preserve the verified historical display receipt at
+import time. Never estimate a past charge from today's rates or generalize one
+example's amount to another job. When no receipt exists, a new reproduction
+estimate must go through `quote-public.ts` and be labeled as an estimate.
+
 ## Final one-owner state
 
 `quoteCanonicalPricing` is the sole commercial formula. Definition catalogs and provider adapters can derive factual vendor subtotals, units, durations, resolutions, and addons, but they cannot apply margins, membership discounts, customer-total rounding, or settlement allocation. Storyboard and audio use the same canonical quote as every other live surface. The removed compatibility facade, specialized commercial snapshots, legacy audit collector, dead client preflight, and old kernel quote method must not be reintroduced.

--- a/frontend/app/(localized)/[locale]/(marketing)/(home)/_lib/home-route-data/launch-promotions.ts
+++ b/frontend/app/(localized)/[locale]/(marketing)/(home)/_lib/home-route-data/launch-promotions.ts
@@ -8,6 +8,7 @@ import type { AppLocale } from '@/i18n/locales';
 import { normalizeEngineId } from '@/lib/engine-alias';
 import type { AcceptedDurableModelAsset } from '@/server/model-launch-assets-validation';
 import type { GalleryVideo } from '@/server/videos';
+import { formatCurrency } from './formatting';
 import type { HomepageExampleFamily, RedesignContent } from './types';
 
 const P0_PROMOTION_CANDIDATES = [
@@ -102,7 +103,7 @@ export function buildHomepageP0PromotionCards({
       engine: target.label,
       mode: content.modeLabels?.t2v ?? 'Text-to-video',
       duration: `${video.durationSec}${locale === 'fr' ? ' s' : 's'}`,
-      price: null,
+      price: formatCurrency(locale, video.currency, video.finalPriceCents),
       useCase: locale === 'fr' ? 'Nouvelle génération' : locale === 'es' ? 'Nueva generación' : 'New generation',
       imageSrc: video.thumbUrl,
       videoSrc: video.videoUrl,
@@ -113,7 +114,7 @@ export function buildHomepageP0PromotionCards({
       modelHref: { pathname: '/models/[slug]', params: { slug: target.modelId } },
       ctaLabel: content.examples.cta ?? 'View examples',
       examplesCtaVisible: true,
-      modelCtaLabel: content.examples.featuredModelCta ?? 'Specs & pricing',
+      modelCtaLabel: (content.examples.modelCta ?? 'Discover {model}').replace('{model}', target.label),
       cloneLabel: content.examples.viewPrompt,
     }];
   });

--- a/frontend/app/(localized)/[locale]/(marketing)/(home)/_lib/home-route-data/types.ts
+++ b/frontend/app/(localized)/[locale]/(marketing)/(home)/_lib/home-route-data/types.ts
@@ -107,6 +107,8 @@ export type RedesignContent = {
     modelsCta?: string;
     compareLink?: string;
     featuredModelCta: string;
+    modelCta?: string;
+    costUnavailable?: string;
     libraryTitle?: string;
     libraryBody?: string;
     providerLabel?: string;

--- a/frontend/components/marketing/home/HomeRealExamplesPreview.tsx
+++ b/frontend/components/marketing/home/HomeRealExamplesPreview.tsx
@@ -10,7 +10,7 @@ export function RealExamplesPreview({
   examples,
   providers,
 }: {
-  copy: SectionCopy & { viewPrompt?: string; featuredModelCta: string };
+  copy: SectionCopy & { viewPrompt?: string; featuredModelCta: string; costUnavailable?: string };
   examples: HomeExampleCard[];
   providers?: ProviderItem[];
 }) {
@@ -75,7 +75,7 @@ export function RealExamplesPreview({
         <div className="dark-neon-panel mt-7 overflow-hidden rounded-[20px] border border-hairline bg-bg shadow-sm dark:border-white/[0.08]">
           <div className="divide-y divide-hairline dark:divide-white/[0.07]">
             {examples.map((example) => (
-              <HomeExamplePreviewRow key={example.id} example={example} />
+              <HomeExamplePreviewRow key={example.id} example={example} costUnavailable={copy.costUnavailable} />
             ))}
           </div>
         </div>
@@ -86,7 +86,7 @@ export function RealExamplesPreview({
   );
 }
 
-function HomeExamplePreviewRow({ example }: { example: HomeExampleCard }) {
+function HomeExamplePreviewRow({ example, costUnavailable = 'Cost not recorded' }: { example: HomeExampleCard; costUnavailable?: string }) {
   const modeIcon = example.mode.toLowerCase().startsWith('text') ? Type : example.mode.toLowerCase().startsWith('video') ? Video : ImageIcon;
   const showExamplesCta = example.examplesCtaVisible !== false;
   const modelHref = example.modelHref ?? example.href;
@@ -140,7 +140,7 @@ function HomeExamplePreviewRow({ example }: { example: HomeExampleCard }) {
             {example.price}
           </span>
         ) : (
-          <span className="text-sm text-text-muted">—</span>
+          <span className="text-xs text-text-muted">{costUnavailable}</span>
         )}
       </div>
 

--- a/frontend/components/watch/WatchVideoPlayer.tsx
+++ b/frontend/components/watch/WatchVideoPlayer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { CSSProperties } from 'react';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Film, Maximize2, Pause, Play, Volume2, VolumeX } from 'lucide-react';
 
 type WatchVideoPlayerProps = {
@@ -12,6 +12,10 @@ type WatchVideoPlayerProps = {
   hasAudio: boolean;
   containerStyle?: CSSProperties;
   videoStyle?: CSSProperties;
+};
+
+type FullscreenVideoElement = HTMLVideoElement & {
+  webkitEnterFullscreen?: () => void;
 };
 
 function formatTime(value: number) {
@@ -31,11 +35,19 @@ export function WatchVideoPlayer({
   videoStyle,
 }: WatchVideoPlayerProps) {
   const shellRef = useRef<HTMLDivElement>(null);
-  const videoRef = useRef<HTMLVideoElement>(null);
+  const videoRef = useRef<FullscreenVideoElement>(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const [isMuted, setIsMuted] = useState(false);
   const [duration, setDuration] = useState(0);
   const [currentTime, setCurrentTime] = useState(0);
+  const [canFullscreen, setCanFullscreen] = useState(false);
+
+  useEffect(() => {
+    setCanFullscreen(
+      typeof shellRef.current?.requestFullscreen === 'function' ||
+      typeof videoRef.current?.webkitEnterFullscreen === 'function'
+    );
+  }, []);
 
   const togglePlayback = () => {
     const player = videoRef.current;
@@ -62,14 +74,21 @@ export function WatchVideoPlayer({
     setCurrentTime(nextTime);
   };
 
-  const toggleFullscreen = () => {
+  const toggleFullscreen = async () => {
     const shell = shellRef.current;
     if (!shell) return;
-    if (document.fullscreenElement) {
-      void document.exitFullscreen();
-      return;
+    try {
+      if (document.fullscreenElement && typeof document.exitFullscreen === 'function') {
+        await document.exitFullscreen();
+      } else if (typeof shell.requestFullscreen === 'function') {
+        await shell.requestFullscreen();
+      } else {
+        // iPhone Safari exposes fullscreen on the video instead of its container.
+        videoRef.current?.webkitEnterFullscreen?.();
+      }
+    } catch {
+      // A browser can refuse fullscreen or media may not be ready yet. Keep playback usable.
     }
-    void shell.requestFullscreen();
   };
 
   return (
@@ -142,14 +161,16 @@ export function WatchVideoPlayer({
           >
             {isMuted ? <VolumeX className="h-4 w-4" aria-hidden /> : <Volume2 className="h-4 w-4" aria-hidden />}
           </button>
-          <button
-            type="button"
-            aria-label="Fullscreen video"
-            onClick={toggleFullscreen}
-            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-on-inverse transition hover:bg-white/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <Maximize2 className="h-4 w-4" aria-hidden />
-          </button>
+          {canFullscreen ? (
+            <button
+              type="button"
+              aria-label="Fullscreen video"
+              onClick={toggleFullscreen}
+              className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-on-inverse transition hover:bg-white/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <Maximize2 className="h-4 w-4" aria-hidden />
+            </button>
+          ) : null}
         </div>
       </div>
     </div>

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -560,6 +560,8 @@
         "modelsCta": "View all model specs",
         "compareLink": "Compare engines",
         "featuredModelCta": "Discover Seedance 2.5",
+        "modelCta": "Discover {model}",
+        "costUnavailable": "Cost not recorded",
         "providerLabel": "Supported engines:",
         "viewPrompt": "Clone settings",
         "fallbackCards": [

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -663,6 +663,8 @@
         "modelsCta": "Ver todas las especificaciones",
         "compareLink": "Comparar modelos",
         "featuredModelCta": "Descubrir Seedance 2.5",
+        "modelCta": "Descubrir {model}",
+        "costUnavailable": "Coste no registrado",
         "providerLabel": "Modelos compatibles:",
         "viewPrompt": "Clonar ajustes",
         "fallbackCards": [

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -663,6 +663,8 @@
         "modelsCta": "Voir toutes les specs",
         "compareLink": "Comparer les modèles",
         "featuredModelCta": "Découvrir Seedance 2.5",
+        "modelCta": "Découvrir {model}",
+        "costUnavailable": "Coût non renseigné",
         "providerLabel": "Modèles pris en charge :",
         "viewPrompt": "Cloner les réglages",
         "fallbackCards": [

--- a/frontend/server/launch-example-pricing-records.json
+++ b/frontend/server/launch-example-pricing-records.json
@@ -1,0 +1,109 @@
+{
+  "schemaVersion": 1,
+  "source": {
+    "environment": "preview/mcp-staging",
+    "recordedAt": "2026-09-04",
+    "amountField": "app_jobs.final_price_cents",
+    "verifiedAgainst": "pricing_snapshot.totalCents"
+  },
+  "records": [
+    {
+      "jobId": "08ac14de-f53b-46c7-b6db-ae56c0095d7a",
+      "engineId": "flux-3",
+      "durationSec": 5,
+      "totalCents": 102,
+      "currency": "USD"
+    },
+    {
+      "jobId": "abd1a29b-7de8-4bb5-bc24-1c670d3b0a88",
+      "engineId": "flux-3",
+      "durationSec": 5,
+      "totalCents": 102,
+      "currency": "USD"
+    },
+    {
+      "jobId": "34605e6e-0a3a-4b23-ac71-9985b486bd01",
+      "engineId": "flux-3-draft",
+      "durationSec": 5,
+      "totalCents": 36,
+      "currency": "USD"
+    },
+    {
+      "jobId": "b7014d70-b6a7-4e64-b41f-36f836756f76",
+      "engineId": "flux-3-draft",
+      "durationSec": 5,
+      "totalCents": 36,
+      "currency": "USD"
+    },
+    {
+      "jobId": "2b74b648-63f2-4b19-b555-9dad0554ed40",
+      "engineId": "grok-imagine-video-1-5",
+      "durationSec": 5,
+      "totalCents": 84,
+      "currency": "USD"
+    },
+    {
+      "jobId": "4467d48a-8d6a-490c-96ba-09468aea313e",
+      "engineId": "grok-imagine-video-1-5",
+      "durationSec": 5,
+      "totalCents": 84,
+      "currency": "USD"
+    },
+    {
+      "jobId": "7b52c7eb-24fa-45a8-baa9-c675b7f50174",
+      "engineId": "ltx-2-5-fast",
+      "durationSec": 6,
+      "totalCents": 65,
+      "currency": "USD"
+    },
+    {
+      "jobId": "bd943cbc-c500-49ff-baff-d7e1f03fb2dc",
+      "engineId": "ltx-2-5-fast",
+      "durationSec": 6,
+      "totalCents": 65,
+      "currency": "USD"
+    },
+    {
+      "jobId": "5d47efd3-c75c-42c0-91fc-e0e1d8b50357",
+      "engineId": "ltx-2-5-pro",
+      "durationSec": 6,
+      "totalCents": 87,
+      "currency": "USD"
+    },
+    {
+      "jobId": "a30e1f55-27ca-4cd5-9c6b-1cb990a5ca91",
+      "engineId": "ltx-2-5-pro",
+      "durationSec": 6,
+      "totalCents": 87,
+      "currency": "USD"
+    },
+    {
+      "jobId": "322fa03b-47f1-4267-a384-1d04aac27167",
+      "engineId": "wan-3",
+      "durationSec": 5,
+      "totalCents": 60,
+      "currency": "USD"
+    },
+    {
+      "jobId": "e2ef7bdf-e78c-4aca-94b4-d2ba74036dac",
+      "engineId": "wan-3",
+      "durationSec": 10,
+      "totalCents": 120,
+      "currency": "USD"
+    },
+    {
+      "jobId": "f9a9022c-e587-4c6a-b49a-f2985908eee9",
+      "engineId": "wan-3-prime",
+      "durationSec": 5,
+      "totalCents": 84,
+      "currency": "USD"
+    },
+    {
+      "jobId": "feccb90c-11ed-48ef-a96b-b7c80e5fe1c5",
+      "engineId": "wan-3-prime",
+      "durationSec": 10,
+      "totalCents": 168,
+      "currency": "USD"
+    }
+  ]
+}

--- a/frontend/server/launch-example-pricing.ts
+++ b/frontend/server/launch-example-pricing.ts
@@ -1,0 +1,22 @@
+import archive from './launch-example-pricing-records.json';
+
+const receipts = new Map(archive.records.map((record) => [record.jobId, record]));
+
+/** Historical display receipts only; never used for quotes, charges or refunds. */
+export function findLaunchExamplePrice(input: {
+  jobId: string;
+  engineId: string;
+  durationSec: number;
+  currency: string | null;
+}) {
+  const receipt = receipts.get(input.jobId);
+  if (
+    !receipt ||
+    receipt.engineId !== input.engineId ||
+    receipt.durationSec !== input.durationSec ||
+    (input.currency !== null && receipt.currency !== input.currency)
+  ) {
+    return null;
+  }
+  return receipt;
+}

--- a/frontend/server/videos-normalization.ts
+++ b/frontend/server/videos-normalization.ts
@@ -1,6 +1,7 @@
 import { normalizeMediaUrl } from '@/lib/media';
 import { normalizeJobKeyframeUrls, type JobKeyframeUrls } from '@/server/video-keyframes';
 import type { PricingSnapshot } from '@/types/engines';
+import { findLaunchExamplePrice } from './launch-example-pricing';
 
 export type VideoRow = {
   job_id: string;
@@ -64,6 +65,12 @@ function formatPromptExcerpt(prompt: string, maxLength = 160): string {
 }
 
 export function mapGalleryVideoRow(row: VideoRow): GalleryVideo {
+  const historicalPrice = row.final_price_cents == null ? findLaunchExamplePrice({
+    jobId: row.job_id,
+    engineId: row.engine_id,
+    durationSec: row.duration_sec,
+    currency: row.currency,
+  }) : null;
   return {
     id: row.job_id,
     userId: row.user_id ?? null,
@@ -84,8 +91,8 @@ export function mapGalleryVideoRow(row: VideoRow): GalleryVideo {
     indexable: Boolean(row.indexable ?? true),
     hasAudio: Boolean(row.has_audio ?? false),
     canUpscale: Boolean(row.can_upscale ?? false),
-    finalPriceCents: row.final_price_cents ?? undefined,
-    currency: row.currency ?? undefined,
+    finalPriceCents: row.final_price_cents ?? historicalPrice?.totalCents ?? undefined,
+    currency: row.currency ?? historicalPrice?.currency ?? undefined,
     pricingSnapshot: row.pricing_snapshot ?? undefined,
     settingsSnapshot: row.settings_snapshot ?? undefined,
     playlistOrder: typeof row.order_index === 'number' ? row.order_index : null,

--- a/tests/ga4-purchase-transport.test.ts
+++ b/tests/ga4-purchase-transport.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+test('purchase transport preserves the exact consented checkout client and session IDs', async (t) => {
+  const savedMeasurementId = process.env.GA4_MEASUREMENT_ID;
+  const savedSecret = process.env.GA4_API_SECRET;
+  const savedFetch = globalThis.fetch;
+  t.after(() => {
+    if (savedMeasurementId === undefined) delete process.env.GA4_MEASUREMENT_ID;
+    else process.env.GA4_MEASUREMENT_ID = savedMeasurementId;
+    if (savedSecret === undefined) delete process.env.GA4_API_SECRET;
+    else process.env.GA4_API_SECRET = savedSecret;
+    globalThis.fetch = savedFetch;
+  });
+  process.env.GA4_MEASUREMENT_ID = 'G-AUDITTEST';
+  process.env.GA4_API_SECRET = 'audit-dummy';
+  const { readGa4CheckoutContext } = await import('../frontend/lib/analytics/ga-session-browser');
+  const { resolveWalletGa4CheckoutContext } = await import('../frontend/server/wallet-ga4-session');
+  const { sendGa4Event } = await import('../frontend/src/server/ga4');
+  const browser = await readGa4CheckoutContext({
+    measurementId: 'G-AUDITTEST',
+    gtag: (_command, _target, field, callback) => callback(field === 'client_id' ? '123456789.987654321' : '1788255901'),
+  });
+  const checkout = resolveWalletGa4CheckoutContext({
+    analyticsConsentGranted: true,
+    gaClientCookie: null,
+    gaClientId: browser.clientId,
+    gaSessionId: browser.sessionId,
+  });
+  let requestCount = 0;
+  globalThis.fetch = async (input, init) => {
+    requestCount += 1;
+    assert.equal(new URL(String(input)).searchParams.get('measurement_id'), 'G-AUDITTEST');
+    assert.equal(init?.method, 'POST');
+    const payload = JSON.parse(String(init?.body));
+    assert.equal(payload.client_id, '123456789.987654321');
+    assert.equal(payload.user_id, 'test-user');
+    assert.deepEqual(payload.events, [{
+      name: 'purchase',
+      params: { value: 25, currency: 'EUR', transaction_id: 'fixture-purchase', session_id: '1788255901', engagement_time_msec: 1 },
+    }]);
+    return new Response(null, { status: 204 });
+  };
+  assert.equal(await sendGa4Event({
+    name: 'purchase',
+    clientId: checkout.metadata.ga_client_id,
+    sessionId: checkout.metadata.ga_session_id,
+    userId: 'test-user',
+    params: { value: 25, currency: 'EUR', transaction_id: 'fixture-purchase' },
+  }), true);
+  assert.equal(requestCount, 1);
+});

--- a/tests/launch-example-pricing.test.ts
+++ b/tests/launch-example-pricing.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mapGalleryVideoRow, type VideoRow } from '../frontend/server/videos-normalization';
+import archive from '../frontend/server/launch-example-pricing-records.json';
+import accepted from '../frontend/server/model-launch-assets.generated.json';
+
+function importedRow(overrides: Partial<VideoRow> = {}): VideoRow {
+  return {
+    job_id: 'a30e1f55-27ca-4cd5-9c6b-1cb990a5ca91',
+    user_id: null,
+    engine_id: 'ltx-2-5-pro',
+    engine_label: 'LTX 2.5 Pro',
+    duration_sec: 6,
+    prompt: 'Public launch example',
+    thumb_url: '',
+    video_url: null,
+    preview_video_url: null,
+    keyframe_urls: null,
+    aspect_ratio: '16:9',
+    has_audio: false,
+    can_upscale: false,
+    created_at: '2026-09-02T15:44:24.524Z',
+    visibility: 'public',
+    indexable: true,
+    featured: false,
+    featured_order: null,
+    final_price_cents: null,
+    currency: 'USD',
+    ...overrides,
+  };
+}
+
+test('launch example display recovers the original recorded price without mutating billing data', () => {
+  const row = importedRow();
+  const video = mapGalleryVideoRow(row);
+  assert.equal(video.finalPriceCents, 87);
+  assert.equal(video.currency, 'USD');
+  assert.equal(row.final_price_cents, null);
+  assert.equal(video.pricingSnapshot, undefined);
+});
+
+test('the stored job price, including zero, takes precedence over the historical example receipt', () => {
+  for (const cents of [0, 72, 99]) {
+    assert.equal(mapGalleryVideoRow(importedRow({ final_price_cents: cents })).finalPriceCents, cents);
+  }
+});
+
+test('a receipt cannot price another job, model, duration or currency', () => {
+  for (const overrides of [
+    { job_id: 'another-job' },
+    { engine_id: 'ltx-2-5-fast' },
+    { duration_sec: 7 },
+    { currency: 'EUR' },
+  ]) {
+    assert.equal(mapGalleryVideoRow(importedRow(overrides)).finalPriceCents, undefined);
+  }
+});
+
+test('the historical receipt supplies its currency when the imported currency is missing', () => {
+  const video = mapGalleryVideoRow(importedRow({ currency: null }));
+  assert.equal(video.finalPriceCents, 87);
+  assert.equal(video.currency, 'USD');
+});
+
+test('archived prices belong to distinct accepted launch jobs with matching model identities', () => {
+  const jobs = new Set<string>();
+  assert.equal(archive.records.length, 14);
+  for (const receipt of archive.records) {
+    assert.equal(jobs.has(receipt.jobId), false);
+    jobs.add(receipt.jobId);
+    const asset = accepted.assets.find((item) => item.jobId === receipt.jobId);
+    assert.ok(asset, `Missing accepted example ${receipt.jobId}`);
+    assert.equal(asset.engineId, receipt.engineId);
+    assert.equal(Math.round(asset.durationSec), receipt.durationSec);
+    assert.ok(Number.isInteger(receipt.totalCents) && receipt.totalCents > 0);
+    const video = mapGalleryVideoRow(importedRow({
+      job_id: receipt.jobId,
+      engine_id: receipt.engineId,
+      duration_sec: receipt.durationSec,
+    }));
+    assert.equal(video.finalPriceCents, receipt.totalCents);
+    assert.equal(video.currency, receipt.currency);
+  }
+});

--- a/tests/watch-video-fullscreen.test.ts
+++ b/tests/watch-video-fullscreen.test.ts
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { JSDOM } from 'jsdom';
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { WatchVideoPlayer } from '../frontend/components/watch/WatchVideoPlayer';
+
+async function withPlayer(
+  configure: (window: JSDOM['window']) => void,
+  check: (container: HTMLElement, errors: unknown[]) => Promise<void>,
+) {
+  const dom = new JSDOM('<!doctype html><div id="root"></div>');
+  const globals = {
+    window: dom.window,
+    document: dom.window.document,
+    React,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  };
+  const previous = new Map(Object.keys(globals).map((key) => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+  for (const [key, value] of Object.entries(globals)) {
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value });
+  }
+  const errors: unknown[] = [];
+  dom.window.addEventListener('error', (event) => {
+    errors.push(event.error);
+    event.preventDefault();
+  });
+  configure(dom.window);
+  const container = dom.window.document.querySelector<HTMLElement>('#root')!;
+  const root = createRoot(container);
+  try {
+    await act(async () => {
+      root.render(React.createElement(WatchVideoPlayer, {
+        src: '/example.mp4', poster: '/poster.jpg', title: 'Example', engineLabel: 'Model', hasAudio: true,
+      }));
+    });
+    await check(container, errors);
+  } finally {
+    await act(async () => root.unmount());
+    dom.window.close();
+    for (const [key, descriptor] of previous) {
+      if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+      else Reflect.deleteProperty(globalThis, key);
+    }
+  }
+}
+
+async function clickFullscreen(container: HTMLElement) {
+  const button = container.querySelector<HTMLButtonElement>('button[aria-label="Fullscreen video"]');
+  assert.ok(button, 'A supported browser should offer fullscreen');
+  await act(async () => button.click());
+}
+
+test('iPhone Safari enters native video fullscreen when element fullscreen is unavailable', async () => {
+  let nativePlayer: HTMLVideoElement | undefined;
+  await withPlayer((window) => {
+    Object.defineProperty(window.HTMLVideoElement.prototype, 'webkitEnterFullscreen', {
+      configurable: true,
+      value(this: HTMLVideoElement) { nativePlayer = this; },
+    });
+  }, async (container, errors) => {
+    await clickFullscreen(container);
+    assert.ok(nativePlayer === container.querySelector('video'), 'Safari should open the current video');
+    assert.deepEqual(errors, []);
+  });
+});
+
+test('standard fullscreen opens the shell and exits through its document', async () => {
+  let fullscreenTarget: HTMLElement | null = null;
+  let exits = 0;
+  await withPlayer((window) => {
+    window.HTMLElement.prototype.requestFullscreen = async function () { fullscreenTarget = this; };
+    Object.defineProperty(window.document, 'fullscreenElement', { get: () => fullscreenTarget });
+    window.document.exitFullscreen = async function () {
+      assert.equal(this, window.document);
+      fullscreenTarget = null;
+      exits += 1;
+    };
+  }, async (container, errors) => {
+    await clickFullscreen(container);
+    assert.ok(fullscreenTarget === container.firstElementChild, 'Standard fullscreen should open the player shell');
+    await clickFullscreen(container);
+    assert.equal(exits, 1);
+    assert.equal(fullscreenTarget, null);
+    assert.deepEqual(errors, []);
+  });
+});
+
+test('unsupported browsers do not offer a broken fullscreen button', async () => {
+  await withPlayer(() => {}, async (container) => {
+    assert.ok(!container.querySelector('button[aria-label="Fullscreen video"]'), 'Fullscreen should be hidden when unsupported');
+    assert.ok(container.querySelector('button[aria-label="Play video"]'));
+  });
+});
+
+test('a denied fullscreen request does not become an unhandled rejection', async () => {
+  await withPlayer((window) => {
+    window.HTMLElement.prototype.requestFullscreen = () => Promise.reject(new TypeError('Fullscreen denied'));
+  }, async (container, errors) => {
+    await clickFullscreen(container);
+    assert.deepEqual(errors, []);
+  });
+});
+
+test('a rejected fullscreen exit is handled without breaking player controls', async () => {
+  await withPlayer((window) => {
+    window.HTMLElement.prototype.requestFullscreen = async () => {};
+    Object.defineProperty(window.document, 'fullscreenElement', { value: window.document.body });
+    window.document.exitFullscreen = () => Promise.reject(new TypeError('Exit denied'));
+  }, async (container, errors) => {
+    await clickFullscreen(container);
+    assert.deepEqual(errors, []);
+  });
+});
+
+test('Safari refusing native fullscreen before media readiness does not throw from the click', async () => {
+  await withPlayer((window) => {
+    Object.defineProperty(window.HTMLVideoElement.prototype, 'webkitEnterFullscreen', {
+      value() { throw new Error('InvalidStateError'); },
+    });
+  }, async (container, errors) => {
+    await clickFullscreen(container);
+    assert.deepEqual(errors, []);
+  });
+});


### PR DESCRIPTION
Imported launch examples lost their recorded generation prices, homepage discovery links named the wrong model, and the public watch player's fullscreen action failed when the container API was unavailable. Restore verified historical display prices for 14 accepted launch videos, localize each homepage model link, and support native video fullscreen with handled failures.

The archived prices match each original staging job's saved pricing snapshot, model, duration and currency. Existing job prices take precedence. This only restores display data; it does not write production billing records or recalculate current tariffs.

Validation: 52 focused tests pass, including historical price recovery, preservation of existing prices, receipt mismatch rejection, six fullscreen scenarios, and GA4 checkout identifier transport with intercepted HTTP. Frontend lint, type checking, public exposure checks, and production build pass. Safari native fullscreen is simulated in tests; no physical iPhone was used.
