### PR TITLE
fix: avoid duplicate gallery poster downloads

### DIFF
--- a/frontend/components/GroupedJobCardMedia.tsx
+++ b/frontend/components/GroupedJobCardMedia.tsx
@@ -125,9 +125,9 @@ export function GroupPreviewMedia({
   };
 
   if (hasVideo && displayVideoUrl) {
-    const poster = thumbSrc ?? undefined;
     return (
       <div className="relative h-full w-full overflow-hidden rounded-[inherit]">
+        {/* Keep the thumbnail here: video posters eagerly fetch the original, even with preload="none". */}
         {thumbSrc ? (
           <ThumbImage
             src={thumbSrc}
@@ -142,7 +142,6 @@ export function GroupPreviewMedia({
         <video
           ref={videoRef}
           src={displayVideoUrl}
-          poster={poster}
           className={clsx(
             'absolute inset-0 h-full w-full pointer-events-none transition-opacity duration-150 ease-out',
             fit === 'cover' ? 'object-cover scale-[1.06] transform-gpu' : 'object-contain',

--- a/tests/grouped-job-media-loading.test.ts
+++ b/tests/grouped-job-media-loading.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { JSDOM } from 'jsdom';
+import { GroupPreviewMedia } from '../frontend/components/GroupedJobCardMedia';
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+test('idle history media uses a lazy optimized thumbnail without fetching the original as a video poster', () => {
+  const markup = renderToStaticMarkup(React.createElement(GroupPreviewMedia, {
+    preview: { id: 'history-video', videoUrl: '/video.mp4', thumbUrl: '/renders/history-thumb.jpg' },
+    shouldPlay: false,
+    shouldWarm: false,
+  }));
+  const dom = new JSDOM(markup);
+  try {
+    const image = dom.window.document.querySelector('img');
+    const video = dom.window.document.querySelector('video');
+    assert.ok(image, 'The paused card must still display a thumbnail');
+    assert.equal(image.getAttribute('loading'), 'lazy');
+    assert.match(image.getAttribute('src') ?? '', /^\/_next\/image\?/);
+    assert.ok(video);
+    assert.equal(video.getAttribute('preload'), 'none');
+    assert.equal(video.getAttribute('poster'), null, 'A video poster bypasses lazy image loading and fetches the full original');
+  } finally {
+    dom.window.close();
+  }
+});


### PR DESCRIPTION
History cards downloaded each full-size thumbnail twice: once through the lazy optimized Next.js image and once eagerly through the video `poster`, even with `preload="none"`. A production Chrome mobile trace showed 24 redundant original-image requests transferring 1,631,187 bytes while the cards were below the composer.

Remove the redundant video poster and retain the existing optimized thumbnail and transition to the ready video. Playback and video warmup policy remain unchanged.

Validation:
- Regression test fails on the old rendered markup and passes with the fix.
- 24 focused media, gallery, and workspace first-paint tests pass.
- GitHub CI: 4,085 application tests pass, 20 skipped, zero failures; 18 admin smoke tests pass (run 33918575894).
- Frontend lint, public-exposure check, production build (including type checking), and diff check pass.
- Chrome local production build: thumbnails load and selecting a history card plays the existing video.
- Vercel preview at 400 × 934: 11 sample cards with no video poster, lazy images, main preview playback and pause verified via keyboard activation; no browser errors observed. Desktop click playback also verified locally.

The trace identifies redundant bandwidth; it does not establish a field LCP improvement. Browser extensions affected its global LCP score.
