### PR TITLE
fix: restore upscaler thumbnails and remove duplicate preview posters

### DIFF
--- a/frontend/app/api/user-assets/route.ts
+++ b/frontend/app/api/user-assets/route.ts
@@ -36,6 +36,7 @@ export async function GET(req: NextRequest) {
     assets: assets.map((asset) => ({
       id: asset.id,
       url: asset.url,
+      thumbUrl: asset.thumbUrl,
       mime: asset.mimeType,
       width: asset.width,
       height: asset.height,

--- a/frontend/components/groups/CompositePreviewDockTile.tsx
+++ b/frontend/components/groups/CompositePreviewDockTile.tsx
@@ -86,7 +86,6 @@ export function CompositePreviewDockTile({
                 ref={registerVideo(itemKey)}
                 data-preview-video="active"
                 src={inlinePreviewUrl}
-                poster={item.thumb}
                 className={clsx('relative z-0 h-full w-full', mediaFitClass)}
                 muted={isMuted}
                 playsInline

--- a/frontend/components/marketing/ModelHeroMedia.client.tsx
+++ b/frontend/components/marketing/ModelHeroMedia.client.tsx
@@ -51,6 +51,7 @@ export function ModelHeroMedia({
   const lcpReadyRef = useRef(false);
   const lcpObserverRef = useRef<PerformanceObserver | null>(null);
   const [shouldLoadVideo, setShouldLoadVideo] = useState(false);
+  const [isVideoReady, setIsVideoReady] = useState(false);
   const [autoPlayDisabled, setAutoPlayDisabled] = useState(false);
 
   const clearScheduledLoad = useCallback(() => {
@@ -155,6 +156,7 @@ export function ModelHeroMedia({
   }, [autoPlayDelayMs, clearScheduledLoad, scheduleLoad, shouldLoadVideo, videoSrc, waitForLcp]);
 
   useEffect(() => {
+    setIsVideoReady(false);
     if (!shouldLoadVideo) return;
     const node = videoRef.current;
     if (!node) return;
@@ -162,12 +164,13 @@ export function ModelHeroMedia({
       void node.play().catch(() => {});
     };
     if (node.readyState >= 2) {
+      setIsVideoReady(true);
       tryPlay();
       return;
     }
     node.addEventListener('loadeddata', tryPlay, { once: true });
     return () => node.removeEventListener('loadeddata', tryPlay);
-  }, [shouldLoadVideo]);
+  }, [shouldLoadVideo, videoSrc]);
 
   useEffect(() => {
     return clearScheduledLoad;
@@ -201,14 +204,17 @@ export function ModelHeroMedia({
       )}
       {videoSrc && shouldLoadVideo ? (
         <video
+          key={videoSrc}
           ref={videoRef}
-          className={mediaClassName}
+          className={`${mediaClassName} ${isVideoReady ? 'opacity-100' : 'opacity-0'}`}
           autoPlay
           muted
           loop
           playsInline
           preload="metadata"
-          poster={posterSrc ?? undefined}
+          onLoadedData={() => setIsVideoReady(true)}
+          onEmptied={() => setIsVideoReady(false)}
+          onError={() => setIsVideoReady(false)}
           aria-label={alt}
         >
           <source src={videoSrc} type={sourceType} />

--- a/frontend/src/components/tools/upscale/_hooks/useUpscaleLibraryAssets.ts
+++ b/frontend/src/components/tools/upscale/_hooks/useUpscaleLibraryAssets.ts
@@ -100,6 +100,7 @@ export function useUpscaleLibraryAssets({
               return {
                 id: asset.id,
                 url: asset.url,
+                thumbUrl: asset.thumbUrl?.trim() || null,
                 kind: mime?.startsWith('video/') ? 'video' : 'image',
                 width: asset.width ?? null,
                 height: asset.height ?? null,
@@ -125,6 +126,7 @@ export function useUpscaleLibraryAssets({
               .map((job) => ({
                 id: `job:${job.jobId}`,
                 url: job.videoUrl ?? job.readyVideoUrl ?? '',
+                thumbUrl: job.thumbUrl?.trim() || job.previewFrame?.trim() || null,
                 kind: 'video' as const,
                 mime: 'video/mp4',
                 source: 'generated',
@@ -136,10 +138,17 @@ export function useUpscaleLibraryAssets({
         }
 
         const combined = kind === 'video' ? [...filteredAssets, ...generatedVideos] : filteredAssets;
-        const deduped = combined.filter(
-          (asset, index, list) => list.findIndex((entry) => entry.url === asset.url) === index
-        );
-        setLibraryAssets(deduped);
+        const assetsByUrl = new Map<string, AssetBrowserAsset>();
+        for (const asset of combined) {
+          const existing = assetsByUrl.get(asset.url);
+          if (!existing) {
+            assetsByUrl.set(asset.url, asset);
+          } else if (!existing.thumbUrl && asset.thumbUrl) {
+            // Preserve saved asset identity while recovering a missing cover from its job.
+            assetsByUrl.set(asset.url, { ...existing, thumbUrl: asset.thumbUrl });
+          }
+        }
+        setLibraryAssets([...assetsByUrl.values()]);
         setLibraryLoadedKey(requestKey);
       } catch (libraryLoadError) {
         console.error('[upscale] failed to load library assets', libraryLoadError);

--- a/frontend/src/components/tools/upscale/_lib/upscale-workspace-types.ts
+++ b/frontend/src/components/tools/upscale/_lib/upscale-workspace-types.ts
@@ -50,6 +50,7 @@ export type UserAssetsResponse = {
   assets?: Array<{
     id: string;
     url: string;
+    thumbUrl?: string | null;
     mime?: string | null;
     width?: number | null;
     height?: number | null;
@@ -72,6 +73,8 @@ export type JobsLibraryResponse = {
     jobId: string;
     videoUrl?: string | null;
     readyVideoUrl?: string | null;
+    thumbUrl?: string | null;
+    previewFrame?: string | null;
     createdAt?: string;
   }>;
   error?: string;

--- a/tests/preview-thumbnail-loading.test.ts
+++ b/tests/preview-thumbnail-loading.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createRequire } from 'node:module';
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { JSDOM } from 'jsdom';
+import { ModelHeroMedia } from '../frontend/components/marketing/ModelHeroMedia.client';
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+test('the active workspace preview keeps its optimized cover until ready without a native poster', async () => {
+  const require = createRequire(import.meta.url);
+  const previousCssLoader = require.extensions['.css'];
+  require.extensions['.css'] = () => {};
+  let CompositePreviewDockTile;
+  try {
+    ({ CompositePreviewDockTile } = await import('../frontend/components/groups/CompositePreviewDockTile'));
+  } finally {
+    if (previousCssLoader) require.extensions['.css'] = previousCssLoader;
+    else delete require.extensions['.css'];
+  }
+  for (const ready of [false, true]) {
+    const markup = renderToStaticMarkup(React.createElement(CompositePreviewDockTile, {
+      item: { id: 'take', url: '/renders/take.mp4', thumb: '/renders/take.jpg', aspect: '16:9' },
+      itemKey: 'take', activeVideoKey: 'take', index: 0, tileCount: 1,
+      isPlaying: true, isVideoReady: ready, isSingleLayout: true, isMuted: true, isLooping: true,
+      showGroupError: false, markReady() {}, onVideoCanPlay() {}, onVideoLoadedData() {},
+      registerVideo: () => () => {},
+    }));
+    const dom = new JSDOM(markup);
+    try {
+      const image = dom.window.document.querySelector('img')!;
+      const video = dom.window.document.querySelector('video')!;
+      assert.ok(image);
+      assert.ok(video);
+      assert.match(image.src, /^\/_next\/image\?/);
+      assert.equal(image.classList.contains('opacity-0'), ready);
+      assert.equal(video.getAttribute('poster'), null);
+      assert.equal(video.getAttribute('src'), '/renders/take.mp4');
+    } finally {
+      dom.window.close();
+    }
+  }
+});
+
+test('model preview retains its cover during loading and on failure without fetching a native poster', async () => {
+  const dom = new JSDOM('<div id="root"></div>', { url: 'http://localhost' });
+  const globals = { window: dom.window, document: dom.window.document, IS_REACT_ACT_ENVIRONMENT: true };
+  const previous = new Map(Object.keys(globals).map((key) => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+  for (const [key, value] of Object.entries(globals)) {
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value });
+  }
+  dom.window.HTMLMediaElement.prototype.play = async () => {};
+  const container = dom.window.document.querySelector<HTMLElement>('#root')!;
+  const root = createRoot(container);
+  try {
+    await act(async () => root.render(React.createElement(ModelHeroMedia, {
+      posterSrc: '/renders/model.jpg', videoSrc: '/renders/model.mp4', alt: 'Model example', sizes: '100vw',
+    })));
+    assert.equal(container.querySelector('video'), null, 'Manual previews must not mount video before interaction');
+    const image = container.querySelector('img')!;
+    assert.match(image.src, /\/_next\/image\?/);
+    await act(async () => container.querySelector<HTMLButtonElement>('button')!.click());
+    const video = container.querySelector('video')!;
+    assert.ok(video);
+    assert.equal(video.getAttribute('poster'), null);
+    assert.ok(video.classList.contains('opacity-0'), 'The optimized cover stays visible until a frame is available');
+    await act(async () => video.dispatchEvent(new dom.window.Event('loadeddata')));
+    assert.ok(video.classList.contains('opacity-100'), 'A loaded video must become visible');
+    await act(async () => video.dispatchEvent(new dom.window.Event('error')));
+    assert.ok(video.classList.contains('opacity-0'), 'A failed video must reveal its cover');
+    assert.ok(container.contains(image), 'Keep the optimized image as the fallback throughout playback');
+  } finally {
+    await act(async () => root.unmount());
+    dom.window.close();
+    for (const [key, descriptor] of previous) {
+      if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+      else Reflect.deleteProperty(globalThis, key);
+    }
+  }
+});

--- a/tests/upscale-library-thumbnails.test.ts
+++ b/tests/upscale-library-thumbnails.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+import { useUpscaleLibraryAssets } from '../frontend/src/components/tools/upscale/_hooks/useUpscaleLibraryAssets';
+
+test('upscale library preserves available thumbnails and enriches duplicate videos without loading their previews', async () => {
+  const dom = new JSDOM('<div id="root"></div>', { url: 'http://localhost' });
+  const requests: string[] = [];
+  const globals = {
+    window: dom.window, document: dom.window.document, React, IS_REACT_ACT_ENVIRONMENT: true,
+    fetch: async (input: RequestInfo | URL) => {
+      const url = String(input);
+      requests.push(url);
+      if (url.startsWith('/api/user-assets?')) return Response.json({ ok: true, assets: [
+        { id: 'saved', url: '/renders/saved.mp4', thumbUrl: '/renders/saved.jpg', mime: 'video/mp4', source: 'generated' },
+        { id: 'duplicate', url: '/renders/shared.mp4', mime: 'video/mp4', width: 1920, source: 'generated' },
+        { id: 'upload', url: '/renders/imported.mp4', mime: 'video/mp4', source: 'upload' },
+        { id: 'image', url: '/renders/image.png', mime: 'image/png' },
+      ] });
+      if (url.startsWith('/api/jobs?')) return Response.json({ ok: true, jobs: [
+        { jobId: 'same', videoUrl: '/renders/shared.mp4', thumbUrl: '/renders/shared.jpg' },
+        { jobId: 'recent', readyVideoUrl: '/renders/recent.mp4', thumbUrl: '/renders/recent.jpg', previewVideoUrl: '/preview.mp4' },
+        { jobId: 'frame', videoUrl: '/renders/frame.mp4', previewFrame: '/renders/frame.jpg' },
+        { jobId: 'pending' },
+      ] });
+      throw new Error(`Unexpected request: ${url}`);
+    },
+  };
+  const previous = new Map(Object.keys(globals).map((key) => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+  for (const [key, value] of Object.entries(globals)) {
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value });
+  }
+  let library!: ReturnType<typeof useUpscaleLibraryAssets>;
+  function Fixture() {
+    library = useUpscaleLibraryAssets({ mediaType: 'video', libraryErrorCopy: 'Failed', user: 'owner' });
+    return null;
+  }
+  const root = createRoot(dom.window.document.querySelector<HTMLElement>('#root')!);
+  try {
+    await act(async () => root.render(React.createElement(Fixture)));
+    await act(async () => library.fetchLibraryAssets({ kind: 'video', source: 'generated' }));
+    assert.equal(library.libraryError, null);
+    const assets = library.visibleLibraryAssets;
+    assert.equal(assets.length, 5, 'Exclude images, unfinished jobs, and duplicate video URLs');
+    assert.equal(assets.find((asset) => asset.id === 'saved')?.thumbUrl, '/renders/saved.jpg');
+    const shared = assets.find((asset) => asset.url === '/renders/shared.mp4')!;
+    assert.equal(shared.id, 'duplicate', 'Keep the saved asset identity when enriching from a job');
+    assert.equal(shared.width, 1920);
+    assert.equal(shared.thumbUrl, '/renders/shared.jpg');
+    assert.equal(assets.find((asset) => asset.id === 'job:recent')?.thumbUrl, '/renders/recent.jpg');
+    assert.equal(assets.find((asset) => asset.id === 'job:frame')?.thumbUrl, '/renders/frame.jpg');
+    assert.equal(assets.find((asset) => asset.id === 'upload')?.thumbUrl ?? null, null, 'No invented thumbnail for an import without one');
+    assert.ok(assets.every((asset) => !asset.previewUrl), 'Opening the picker must not enable video downloads');
+    assert.deepEqual(requests, ['/api/user-assets?limit=80&source=generated', '/api/jobs?limit=80&type=video']);
+  } finally {
+    await act(async () => root.unmount());
+    dom.window.close();
+    for (const [key, descriptor] of previous) {
+      if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+      else Reflect.deleteProperty(globalThis, key);
+    }
+  }
+});


### PR DESCRIPTION
The upscaler video picker discarded existing thumbnails from saved assets and generation history, leaving generic icons. Return saved thumbnails from `/api/user-assets`, retain job thumbnails (with `previewFrame` fallback), and enrich duplicate video URLs while preserving the saved asset identity. Videos without a thumbnail keep their existing fallback; opening the picker does not enable video previews.

The model hero and active workspace preview also supplied an original native video poster alongside an optimized image. Remove those redundant posters and keep the model cover visible until video data is ready, restoring it on error. The workspace already keeps its cover above the loading video.

Validation:
- 42 focused behavior and architecture tests passed, including regressions first reproduced against the original implementation.
- Frontend lint, public exposure check, `git diff --check`, and full production build passed.
- Chrome against the local production build: desktop model autoplay, mobile manual playback, French/Spanish model routes, workspace sample playback and pause all passed. No video errors or console errors observed; modified players have no native poster and retain their optimized cover.
- The local session is anonymous, so the signed-in upscaler picker is covered by its behavioral regression test; verify the production account's library after deployment.
- GitHub Quality CI on Node 22 passed: 4,089 tests passed, 20 skipped, 0 failed; 18 admin smoke tests passed.
- Vercel preview is READY for commit `50c074c1603f9746e210f4fb108ccf1b690c4cf9`. Chrome playback on the hosted model page passed with `readyState=4`, no native poster, and no observed video or console errors.

This branch includes the existing PNG metadata fix from `main` and changes no billing or generation behavior. No LCP improvement is claimed before new field measurements.
