### PR TITLE
fix: optimize the image workspace preview

### DIFF
--- a/frontend/components/groups/ImageCompositePreviewDock.tsx
+++ b/frontend/components/groups/ImageCompositePreviewDock.tsx
@@ -3,13 +3,14 @@
 /* eslint-disable @next/next/no-img-element */
 
 import clsx from 'clsx';
-import { useEffect, useRef, type ReactNode } from 'react';
+import Image from 'next/image';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { Copy, Download, ExternalLink, Minus, Pencil, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
 import { UIIcon } from '@/components/ui/UIIcon';
-import { resolveCssAspectRatio } from '@/lib/aspect';
+import { getAspectRatioNumber, resolveCssAspectRatio } from '@/lib/aspect';
 import { useI18n } from '@/lib/i18n/I18nProvider';
-import { resolveStableMediaUrl } from '@/lib/media';
+import { isSignedMediaUrl, resolveStableMediaUrl } from '@/lib/media';
 
 type PreviewImage = {
   url: string;
@@ -94,6 +95,13 @@ export function ImageCompositePreviewDock({
     height: selected?.height ?? null,
     fallback: '1 / 1',
   });
+  const previewRatio = getAspectRatioNumber(aspectRatioCss.replace(/\s/g, ''), 1);
+  const previewSizes = `(max-width: 639px) min(calc(100vw - 40px), ${Math.ceil((workspaceDensity ? 220 : 320) * previewRatio)}px), min(100vw, ${Math.ceil((workspaceDensity ? 330 : 420) * previewRatio)}px)`;
+  const [failedPreviewUrl, setFailedPreviewUrl] = useState<string | null>(null);
+  // Other sources may require browser credentials or a provider URL unsupported by the optimizer.
+  const canOptimizePreview = Boolean(
+    selectedPreviewUrl?.startsWith('https://media.maxvideoai.com/') && !isSignedMediaUrl(selectedPreviewUrl)
+  );
   const previewRef = useRef<HTMLDivElement | null>(null);
   const toolbarRef = useRef<HTMLDivElement | null>(null);
 
@@ -288,11 +296,16 @@ export function ImageCompositePreviewDock({
             style={{ aspectRatio: aspectRatioCss ?? '1 / 1' }}
           >
             {selected ? (
-              <img
+              <Image
                 src={selectedPreviewUrl ?? selected.url}
                 alt={entry?.prompt ?? ''}
+                fill
+                sizes={previewSizes}
                 className="h-full w-full object-contain"
-                loading="lazy"
+                loading="eager"
+                fetchPriority="high"
+                unoptimized={!canOptimizePreview || failedPreviewUrl === selectedPreviewUrl}
+                onError={() => setFailedPreviewUrl(selectedPreviewUrl)}
                 referrerPolicy="no-referrer"
               />
             ) : (

--- a/tests/image-preview-loading.test.ts
+++ b/tests/image-preview-loading.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { JSDOM } from 'jsdom';
+import { ImageCompositePreviewDock } from '../frontend/components/groups/ImageCompositePreviewDock';
+import { I18nProvider } from '../frontend/lib/i18n/I18nProvider';
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+const frontendRequire = createRequire(new URL('../frontend/package.json', import.meta.url));
+const { ImageConfigContext } = frontendRequire('next/dist/shared/lib/image-config-context.shared-runtime');
+const { imageConfigDefault } = frontendRequire('next/dist/shared/lib/image-config');
+const imageConfig = { ...imageConfigDefault, ...frontendRequire('./next.config.js').images };
+const original = 'https://media.maxvideoai.com/renders/images/portrait.png';
+const thumbnail = 'https://media.maxvideoai.com/renders/thumbs/portrait.webp';
+
+function preview(props: Partial<React.ComponentProps<typeof ImageCompositePreviewDock>> = {}) {
+  return React.createElement(ImageConfigContext.Provider, { value: imageConfig },
+    React.createElement(I18nProvider, { locale: 'en', dictionary: {}, fallback: {} },
+      React.createElement(ImageCompositePreviewDock, {
+        density: 'workspace',
+        entry: { id: 'portrait', engineLabel: 'Seedream', prompt: 'Portrait', createdAt: 1,
+          images: [{ url: original, thumbUrl: thumbnail, width: 1600, height: 2848 }] },
+        selectedIndex: 0, onSelectIndex() {}, ...props,
+      })));
+}
+
+test('the visible image preview requests a responsive optimized image immediately', () => {
+  const dom = new JSDOM(renderToStaticMarkup(preview()));
+  try {
+    const image = dom.window.document.querySelector<HTMLImageElement>('[data-workspace-preview-media] img')!;
+    assert.ok(image.src.startsWith('/_next/image?'), 'The small preview must not download the original PNG directly');
+    assert.equal(new URL(image.src, 'https://maxvideoai.com').searchParams.get('url'), original);
+    assert.match(image.srcset, /w=256&.* 256w/);
+    assert.match(image.sizes, /124px/);
+    assert.match(image.sizes, /186px/);
+    assert.equal(image.getAttribute('loading'), 'eager');
+    assert.equal(image.getAttribute('fetchpriority'), 'high');
+    assert.ok(image.classList.contains('object-contain'));
+  } finally {
+    dom.window.close();
+  }
+});
+
+test('temporary provider results retain their stable preview fallback', () => {
+  const dom = new JSDOM(renderToStaticMarkup(preview({ entry: {
+    id: 'pending-copy', engineLabel: 'Seedream', prompt: 'Portrait', createdAt: 1,
+    images: [{ url: 'https://example.volces.com/seedream-5-0/image.png?X-Tos-Signature=temporary', thumbUrl: thumbnail }],
+  } })));
+  try {
+    const image = dom.window.document.querySelector<HTMLImageElement>('[data-workspace-preview-media] img')!;
+    assert.equal(new URL(image.src, 'https://maxvideoai.com').searchParams.get('url'), thumbnail);
+  } finally {
+    dom.window.close();
+  }
+});
+
+test('local, private, signed and external preview URLs keep direct loading', () => {
+  for (const url of [
+    'blob:https://maxvideoai.com/local-preview',
+    'data:image/png;base64,aW1hZ2U=',
+    '/api/assets/private-image',
+    `${original}?X-Amz-Signature=private`,
+    'https://provider.example/result.png',
+  ]) {
+    const dom = new JSDOM(renderToStaticMarkup(preview({ entry: {
+      id: 'local', engineLabel: 'Seedream', prompt: 'Portrait', createdAt: 1, images: [{ url }],
+    } })));
+    try {
+      const image = dom.window.document.querySelector<HTMLImageElement>('[data-workspace-preview-media] img')!;
+      assert.equal(image.getAttribute('src'), url);
+      assert.equal(image.getAttribute('srcset'), null);
+    } finally {
+      dom.window.close();
+    }
+  }
+});
+
+test('an optimizer error falls back once and preview actions retain the original URL', async () => {
+  const dom = new JSDOM('<div id="root"></div>', { url: 'http://localhost', pretendToBeVisual: true });
+  const globals = { window: dom.window, document: dom.window.document, IS_REACT_ACT_ENVIRONMENT: true,
+    requestAnimationFrame: dom.window.requestAnimationFrame.bind(dom.window),
+    cancelAnimationFrame: dom.window.cancelAnimationFrame.bind(dom.window) };
+  const previous = new Map(Object.keys(globals).map(key => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+  for (const [key, value] of Object.entries(globals)) Object.defineProperty(globalThis, key, { configurable: true, writable: true, value });
+  const container = dom.window.document.querySelector<HTMLElement>('#root')!;
+  const root = createRoot(container);
+  const actions: string[] = [];
+  const props = { onDownload: (url: string) => actions.push(url), onCopyLink: (url: string) => actions.push(url),
+    onEditImage: (url: string) => actions.push(url), onAddToLibrary: (url: string) => actions.push(url) };
+  try {
+    await act(async () => root.render(preview(props)));
+    const image = () => container.querySelector<HTMLImageElement>('[data-workspace-preview-media] img')!;
+    assert.match(image().src, /\/_next\/image\?/);
+    for (const label of ['Download', 'Copy link', 'Edit this image', 'Add to Library']) {
+      await act(async () => container.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`)!.click());
+    }
+    assert.deepEqual(actions, [original, original, original, original]);
+    await act(async () => image().dispatchEvent(new dom.window.Event('error')));
+    assert.equal(image().src, original);
+    assert.equal(image().getAttribute('srcset'), null);
+    await act(async () => image().dispatchEvent(new dom.window.Event('error')));
+    assert.equal(image().src, original, 'A failed original must not restart the optimizer');
+    await act(async () => root.render(preview({ ...props, entry: {
+      id: 'next', engineLabel: 'Seedream', prompt: 'Next portrait', createdAt: 2,
+      images: [{ url: 'https://media.maxvideoai.com/renders/images/next.png' }],
+    } })));
+    assert.match(image().src, /\/_next\/image\?/, 'Another image must still use optimization');
+  } finally {
+    await act(async () => root.unmount());
+    dom.window.close();
+    for (const [key, descriptor] of previous) {
+      if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+      else Reflect.deleteProperty(globalThis, key);
+    }
+  }
+});


### PR DESCRIPTION
The image workspace downloaded a full original PNG for its small main preview. Use a responsive Next Image with eager loading and high fetch priority for public managed media; retain original URLs for download, copy, edit, library and full-size viewing. Keep direct loading for private/signed/local/external URLs and fall back to the original if optimization fails.

On the audited portrait, Chrome selected a 256 px variant for a 122 × 218 px preview: the WebP response is 15,462 bytes versus the 6,298,988-byte original. This is a file-size comparison, not a measured LCP improvement.

Validation:
- 19 focused tests passed, including rendered-image behavior, fallback handling, original action URLs and existing workspace contracts; new regression tests failed before the fix.
- Chrome local checks passed for mobile portrait, landscape, empty state and desktop; no console errors.
- Frontend lint, public-exposure check and diff whitespace check passed.
- Production build passed, including TypeScript validation and 860 generated pages.
- GitHub Quality CI passed on this commit: 4,093 application tests passed, 20 skipped, zero failures; 18 admin smoke tests passed, one skipped.
- Vercel preview is READY on the same commit; `/app/image` guest/empty-state smoke check passed.
