### PR TITLE
fix: correct Neon cost projections and clean completed previews

### DIFF
--- a/.github/workflows/neon-branch-guard.yml
+++ b/.github/workflows/neon-branch-guard.yml
@@ -11,12 +11,14 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      pull-requests: read
     env:
       NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+      GITHUB_TOKEN: ${{ github.token }}
       NEON_BRANCH_GUARD_PROJECT_ID: shy-flower-71253790
       NEON_BRANCH_LIMIT: '8'
-      NEON_BRANCH_DELETE_ARCHIVED: '1'
-      NEON_BRANCH_DELETE_PATTERN: '^preview/'
+      NEON_BRANCH_DELETE_MERGED: '1'
+      NEON_BRANCH_DELETE_PATTERN: '^preview/codex/'
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -28,4 +30,4 @@ jobs:
           package-manager-cache: false
 
       - name: Run Neon branch guard
-        run: node scripts/neon-branch-guard.mjs --delete-archived
+        run: node scripts/neon-branch-guard.mjs --delete-merged

--- a/docs/operations/neon-branch-maintenance.md
+++ b/docs/operations/neon-branch-maintenance.md
@@ -1,0 +1,31 @@
+# Neon branch maintenance
+
+`scripts/neon-branch-guard.mjs` reports the production Neon project branch count. The daily GitHub workflow uses `--delete-merged` to remove completed Vercel previews after a 24-hour grace period.
+
+## Required credentials
+
+- GitHub Actions secret `NEON_API_KEY`: use an organization API key restricted to project `shy-flower-71253790`.
+- The workflow's own `GITHUB_TOKEN`: `contents: read` and `pull-requests: read` suffice. It verifies the current Git ref and all matching PR pages.
+
+Never log either token. A Vercel environment variable marked sensitive cannot be exported for reuse; provision a dedicated project-scoped Neon key instead. Do not store a personal Neon OAuth access token in Actions, because it expires.
+
+## Deletion policy
+
+A branch must be created by Vercel, named `preview/codex/*`, and be a direct child of the default branch. Primary, default, protected, staging, backup and parent branches are preserved. Computes must be suspended and their last activity must be at least 24 hours old.
+
+Deletion also requires a PR merged into `main` at least 24 hours ago, no currently open PR for that Git branch, and no later Git commits. A Neon branch created after the matching merge is preserved, so reused branch names are not mistaken for finished work. Deleted Git refs still require the matching merged PR. Missing or invalid API data stops cleanup. Branch inventory, computes and GitHub evidence are checked again before each deletion.
+
+`--delete-archived` applies the same checks but only to archived branches. `--delete-pattern` can further restrict candidates; it cannot expand eligibility beyond the policy. `--dry-run` logs the count without deleting. The check-only mode needs only the Neon credential.
+
+```bash
+npm run neon:branches:check
+node scripts/neon-branch-guard.mjs --delete-merged --dry-run
+```
+
+The guard limit of 8 is an operational threshold, separate from Neon's billing allowance. Launch includes 10 branches per project and Scale includes 25. The infra-cost report preserves metered historical branch-hours and projects future excess with `max(project branch count - included allowance, 0)` for each project independently. Branch state does not indicate whether compute is active.
+
+Verified pricing: https://neon.com/pricing (5 September 2026). The API branch list uses `pagination.next` as the next request's opaque `cursor`.
+
+## Staging
+
+Keep `preview/mcp-staging` separate from completed PR previews. Polling schedules can keep its compute active when they run at the five-minute suspension interval. Before pausing staging crons, confirm that no tests or nonterminal jobs depend on them. Preserve the production project and staging database. Record any pause and the resumption procedure in the operational audit.

--- a/frontend/app/(core)/admin/infra-costs/_components/AdminInfraCostsView.tsx
+++ b/frontend/app/(core)/admin/infra-costs/_components/AdminInfraCostsView.tsx
@@ -212,7 +212,7 @@ function buildNeonMetrics(report: InfraCostsReport): AdminMetricItem[] {
     {
       label: 'Branches',
       value: details?.totals.currentBranchCount ?? 'n/a',
-      helper: details ? `Guard limit ${details.branchGuardLimit}` : 'Branch API not available',
+      helper: details ? `${details.includedBranchesPerProject} included per project · guard ${details.branchGuardLimit}` : 'Branch API not available',
       tone: details && details.totals.currentBranchCount !== null && details.totals.currentBranchCount > details.branchGuardLimit ? 'warning' : 'default',
       icon: GitBranch,
     },

--- a/frontend/server/infra-costs-neon.ts
+++ b/frontend/server/infra-costs-neon.ts
@@ -66,6 +66,7 @@ export async function fetchNeonInfraCostReport({
   const projectIds = readCsvEnv(env, 'NEON_USAGE_PROJECT_IDS', 'NEON_PROJECT_ID', 'NEON_BRANCH_GUARD_PROJECT_ID');
   const resolvedProjectIds = projectIds.length ? projectIds : [DEFAULT_NEON_PROJECT_ID];
   const plan = readEnv(env, 'NEON_USAGE_PLAN')?.toLowerCase() === 'scale' ? 'scale' : 'launch';
+  const includedBranchesPerProject = plan === 'scale' ? 25 : 10;
   const rates = readNeonRates(env, plan);
   const branchGuardLimit = readPositiveInteger(env, ['NEON_BRANCH_LIMIT', 'NEON_USAGE_BRANCH_CRITICAL'], 8);
   const apiBaseUrl = readEnv(env, 'NEON_API_BASE_URL') ?? DEFAULT_NEON_API_BASE_URL;
@@ -84,7 +85,9 @@ export async function fetchNeonInfraCostReport({
     );
     const totals = buildNeonTotals(usage, branches);
     const monthHours = Math.max(1, (Date.parse(period.monthEndIso) - Date.parse(period.startIso)) / (1000 * 60 * 60));
-    const currentExtraBranchCount = branches.reduce((sum, branch) => sum + branch.nonPrimary, 0);
+    const currentExtraBranchCount = branches.reduce(
+      (sum, branch) => sum + Math.max(0, branch.total - includedBranchesPerProject), 0
+    );
     const projectedTotals = projectNeonTotals(totals, period, currentExtraBranchCount);
     const costBreakdown = estimateNeonCosts(totals, rates, monthHours);
     const projectedCostBreakdown = estimateNeonCosts(projectedTotals, rates, monthHours);
@@ -92,6 +95,7 @@ export async function fetchNeonInfraCostReport({
       orgId,
       projectIds: resolvedProjectIds,
       plan,
+      includedBranchesPerProject,
       branchGuardLimit,
       includedPublicTransferGb: rates.includedPublicTransferGb,
       rates,
@@ -163,7 +167,7 @@ export function buildNeonAlerts(
         level: 'critical',
         kind: 'branch',
         title: 'Neon branch guard exceeded',
-        detail: `${branchCount} active branches for a guard limit of ${limit}.`,
+        detail: `${branchCount} total branches for a guard limit of ${limit}.`,
       });
     } else if (branchCount >= Math.max(1, limit - 1)) {
       alerts.push({
@@ -171,7 +175,7 @@ export function buildNeonAlerts(
         level: 'warning',
         kind: 'branch',
         title: 'Neon branch count near guard',
-        detail: `${branchCount} active branches for a guard limit of ${limit}.`,
+        detail: `${branchCount} total branches for a guard limit of ${limit}.`,
       });
     }
   }

--- a/frontend/server/infra-costs-types.ts
+++ b/frontend/server/infra-costs-types.ts
@@ -72,6 +72,7 @@ export type NeonInfraCostDetails = {
   orgId: string;
   projectIds: string[];
   plan: 'launch' | 'scale';
+  includedBranchesPerProject: number;
   branchGuardLimit: number;
   includedPublicTransferGb: number;
   rates: {

--- a/scripts/lib/neon-preview-cleanup-policy.mjs
+++ b/scripts/lib/neon-preview-cleanup-policy.mjs
@@ -1,0 +1,59 @@
+const GRACE_MS = 24 * 60 * 60 * 1000;
+
+export async function findCompletedPreviewCandidates({ branches, endpoints, lookupGitBranch, now = Date.now(), archivedOnly = false }) {
+  const primary = branches.find(branch => branch.default === true);
+  if (!primary) throw new Error('Neon default branch could not be identified; refusing cleanup.');
+  const parents = new Set(branches.map(branch => branch.parent_id).filter(Boolean));
+  const candidates = [];
+  for (const branch of branches) {
+    if (branch.primary || branch.default || branch.protected || parents.has(branch.id)) continue;
+    if (branch.creation_source !== 'vercel' || branch.parent_id !== primary.id) continue;
+    if (!branch.name?.startsWith('preview/codex/')) continue;
+    if (!['ready', 'archived'].includes(branch.current_state)) continue;
+    if (archivedOnly && branch.current_state !== 'archived') continue;
+    const created = Date.parse(branch.created_at);
+    if (!Number.isFinite(created) || created > now - GRACE_MS) continue;
+    const computes = endpoints.filter(endpoint => endpoint.branch_id === branch.id);
+    if (computes.some(endpoint => endpoint.current_state !== 'idle' || !Number.isFinite(Date.parse(endpoint.last_active)) || Date.parse(endpoint.last_active) > now - GRACE_MS)) continue;
+
+    const gitBranch = branch.name.slice('preview/'.length);
+    const { head, pulls } = await lookupGitBranch(gitBranch);
+    if (pulls.some(pull => pull.state === 'open')) continue;
+    const merged = pulls.some(pull => {
+      const mergedAt = Date.parse(pull.merged_at);
+      return pull.state === 'closed' && pull.base?.ref === 'main' &&
+        Number.isFinite(mergedAt) && mergedAt >= created && mergedAt <= now - GRACE_MS &&
+        typeof pull.head?.sha === 'string' && (head === null || head === pull.head.sha);
+    });
+    if (merged) candidates.push(branch);
+  }
+  return candidates.sort((a, b) => a.created_at.localeCompare(b.created_at));
+}
+
+export function createGitBranchLookup({ repository, token, fetchFn = fetch }) {
+  if (!/^[\w.-]+\/[\w.-]+$/.test(repository ?? '') || !token) {
+    throw new Error('Set GITHUB_REPOSITORY and GITHUB_TOKEN before deleting completed previews.');
+  }
+  const owner = repository.split('/')[0];
+  async function get(resource, allowMissing = false) {
+    const response = await fetchFn(`https://api.github.com/repos/${repository}/${resource}`, {
+      headers: { accept: 'application/vnd.github+json', authorization: `Bearer ${token}`, 'X-GitHub-Api-Version': '2022-11-28' },
+    });
+    if (response.status === 404 && allowMissing) return null;
+    if (!response.ok) throw new Error(`GitHub cleanup verification failed: HTTP ${response.status}`);
+    return response.json();
+  }
+  return async gitBranch => {
+    const ref = await get(`git/ref/heads/${encodeURIComponent(gitBranch)}`, true);
+    if (ref !== null && typeof ref.object?.sha !== 'string') throw new Error('GitHub returned an invalid branch ref.');
+    const pulls = [];
+    for (let page = 1; ; page++) {
+      const params = new URLSearchParams({ state: 'all', head: `${owner}:${gitBranch}`, per_page: '100', page: String(page) });
+      const rows = await get(`pulls?${params}`);
+      if (!Array.isArray(rows)) throw new Error('GitHub did not return a pull request list.');
+      pulls.push(...rows);
+      if (rows.length < 100) break;
+    }
+    return { head: ref?.object.sha ?? null, pulls };
+  };
+}

--- a/scripts/neon-branch-guard.mjs
+++ b/scripts/neon-branch-guard.mjs
@@ -2,10 +2,11 @@
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { createGitBranchLookup, findCompletedPreviewCandidates } from './lib/neon-preview-cleanup-policy.mjs';
 
 const DEFAULT_PROJECT_ID = 'shy-flower-71253790';
 const DEFAULT_BRANCH_LIMIT = 8;
-const DEFAULT_DELETE_PATTERN = '^preview/';
+const DEFAULT_DELETE_PATTERN = '^preview/codex/';
 const DEFAULT_API_BASE_URL = 'https://console.neon.tech/api/v2';
 
 function parseArgs(argv) {
@@ -13,6 +14,7 @@ function parseArgs(argv) {
     projectId: process.env.NEON_BRANCH_GUARD_PROJECT_ID || process.env.NEON_PROJECT_ID || DEFAULT_PROJECT_ID,
     limit: parsePositiveInteger(process.env.NEON_BRANCH_LIMIT, DEFAULT_BRANCH_LIMIT),
     deleteArchived: process.env.NEON_BRANCH_DELETE_ARCHIVED === '1',
+    deleteMerged: process.env.NEON_BRANCH_DELETE_MERGED === '1',
     deletePattern: process.env.NEON_BRANCH_DELETE_PATTERN || DEFAULT_DELETE_PATTERN,
     dryRun: process.env.NEON_BRANCH_GUARD_DRY_RUN === '1',
     apiBaseUrl: process.env.NEON_API_BASE_URL || DEFAULT_API_BASE_URL,
@@ -20,6 +22,7 @@ function parseArgs(argv) {
 
   argv.forEach((arg, index) => {
     if (arg === '--delete-archived') options.deleteArchived = true;
+    if (arg === '--delete-merged') options.deleteMerged = true;
     if (arg === '--dry-run') options.dryRun = true;
     if (arg === '--project-id') options.projectId = argv[index + 1] ?? options.projectId;
     if (arg.startsWith('--project-id=')) options.projectId = arg.slice('--project-id='.length);
@@ -73,11 +76,26 @@ async function neonApi(options, token, resourcePath, init = {}) {
 }
 
 async function listBranches(options, token) {
-  const payload = await neonApi(options, token, `projects/${options.projectId}/branches`);
-  if (!Array.isArray(payload?.branches)) {
-    throw new Error('Neon API response did not include a branches array.');
-  }
-  return payload.branches;
+  const branches = [];
+  const seen = new Set();
+  let cursor;
+  do {
+    const params = new URLSearchParams({ limit: '100', sort_by: 'created_at', sort_order: 'asc' });
+    if (cursor) params.set('cursor', cursor);
+    const payload = await neonApi(options, token, `projects/${options.projectId}/branches?${params}`);
+    if (!Array.isArray(payload?.branches)) throw new Error('Neon API response did not include a branches array.');
+    branches.push(...payload.branches);
+    cursor = payload.pagination?.next;
+    if (cursor && seen.has(cursor)) throw new Error('Neon branch pagination repeated a cursor.');
+    if (cursor) seen.add(cursor);
+  } while (cursor);
+  return branches;
+}
+
+async function listEndpoints(options, token) {
+  const payload = await neonApi(options, token, `projects/${options.projectId}/endpoints`);
+  if (!Array.isArray(payload?.endpoints)) throw new Error('Neon API response did not include an endpoints array.');
+  return payload.endpoints;
 }
 
 async function deleteBranch(options, token, branchId) {
@@ -100,15 +118,6 @@ function printBranchSummary(label, options, branches) {
   console.log(
     `[neon-branch-guard] ${label}: project=${options.projectId} total=${branches.length} limit=${options.limit} states=${branchStateSummary(branches)}`
   );
-}
-
-function buildDeleteCandidates(branches, deletePattern) {
-  const pattern = new RegExp(deletePattern);
-  return branches
-    .filter((branch) => branch.primary !== true)
-    .filter((branch) => branch.current_state === 'archived')
-    .filter((branch) => pattern.test(branch.name ?? ''))
-    .sort((a, b) => String(a.created_at ?? '').localeCompare(String(b.created_at ?? '')));
 }
 
 function printOverLimitBranches(branches, limit) {
@@ -137,14 +146,26 @@ async function main() {
   let branches = await listBranches(options, token);
   printBranchSummary('before', options, branches);
 
-  if (options.deleteArchived) {
-    const candidates = buildDeleteCandidates(branches, options.deletePattern);
+  if (options.deleteArchived || options.deleteMerged) {
+    const lookupGitBranch = createGitBranchLookup({ repository: process.env.GITHUB_REPOSITORY, token: process.env.GITHUB_TOKEN });
+    const findCandidates = async (currentBranches) => {
+      const endpoints = await listEndpoints(options, token);
+      const candidates = await findCompletedPreviewCandidates({ branches: currentBranches, endpoints, lookupGitBranch, archivedOnly: !options.deleteMerged });
+      return candidates.filter(branch => new RegExp(options.deletePattern).test(branch.name));
+    };
+    const candidates = await findCandidates(branches);
     console.log(
-      `[neon-branch-guard] archived preview branches eligible for deletion=${candidates.length} dry_run=${options.dryRun}`
+      `[neon-branch-guard] completed preview branches eligible for deletion=${candidates.length} dry_run=${options.dryRun}`
     );
 
     for (const [index, branch] of candidates.entries()) {
       if (!options.dryRun) {
+        // Recheck remote state immediately before each destructive operation.
+        const freshCandidates = await findCandidates(await listBranches(options, token));
+        if (!freshCandidates.some(candidate => candidate.id === branch.id && candidate.name === branch.name)) {
+          console.log(`[neon-branch-guard] preserved changed branch id=${branch.id}`);
+          continue;
+        }
         await deleteBranch(options, token, branch.id);
       }
       if ((index + 1) % 25 === 0 || index + 1 === candidates.length) {

--- a/tests/infra-costs-report.test.ts
+++ b/tests/infra-costs-report.test.ts
@@ -183,3 +183,41 @@ test('infra costs report remains readable when provider credentials are missing'
   assert.ok(report.alerts.some((alert) => alert.kind === 'configuration' && alert.provider === 'vercel'));
   assert.ok(report.alerts.some((alert) => alert.kind === 'configuration' && alert.provider === 's3'));
 });
+
+for (const scenario of [
+  { name: 'Launch within allowance', counts: [3], plan: 'launch', futureHours: 0 },
+  { name: 'Launch at allowance', counts: [10], plan: 'launch', futureHours: 0 },
+  { name: 'Launch over allowance', counts: [12], plan: 'launch', futureHours: 720 },
+  { name: 'Scale allowance', counts: [25], plan: 'scale', futureHours: 0 },
+  { name: 'Scale over allowance', counts: [27], plan: 'scale', futureHours: 720 },
+  { name: 'allowance is per project', counts: [12, 3], plan: 'launch', futureHours: 720 },
+]) {
+  test(`Neon branch projection preserves metered history and applies ${scenario.name}`, async () => {
+    const projectIds = scenario.counts.map((_, i) => `project-${i}`);
+    const report = await fetchInfraCostsReport({
+      now: new Date('2026-06-16T00:00:00.000Z'),
+      env: { NEON_API_KEY: 'test-token', NEON_USAGE_PLAN: scenario.plan, NEON_USAGE_PROJECT_IDS: projectIds.join(',') },
+      fetchFn: async (input) => {
+        const url = new URL(String(input));
+        if (url.pathname.includes('consumption_history')) {
+          return jsonResponse({ projects: [{ project_id: projectIds[0], periods: [{ consumption: [{
+            timeframe_start: '2026-06-01T00:00:00Z', metrics: [{ metric_name: 'extra_branches_month', value: 48 }],
+          }] }] }] });
+        }
+        const i = projectIds.findIndex(id => url.pathname === `/api/v2/projects/${id}/branches`);
+        assert.notEqual(i, -1);
+        return jsonResponse({ branches: Array.from({ length: scenario.counts[i] }, (_, n) => ({
+          id: `br-${i}-${n}`, primary: n === 0, current_state: n === 1 ? 'archived' : 'ready',
+        })) });
+      },
+    });
+    const details = report.providers.neon.details!;
+    assert.equal(details.totals.extraBranchesMonth, 48);
+    assert.equal(details.costBreakdown.extraBranchUsd, 0.1);
+    assert.equal(details.projectedTotals.extraBranchesMonth, 48 + scenario.futureHours);
+    assert.equal(details.projectedCostBreakdown.extraBranchUsd, ((48 + scenario.futureHours) / 720) * 1.5);
+    for (const alert of report.alerts.filter(alert => alert.kind === 'branch')) {
+      assert.doesNotMatch(alert.detail, /active branches/);
+    }
+  });
+}

--- a/tests/neon-branch-guard-runtime.test.ts
+++ b/tests/neon-branch-guard-runtime.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createServer } from 'node:http';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+
+test('guard dry run consumes every branch page without issuing deletions', async t => {
+  const requests: string[] = [];
+  const server = createServer((req, res) => {
+    requests.push(`${req.method} ${req.url}`);
+    const url = new URL(req.url!, 'http://localhost');
+    assert.equal(req.method, 'GET');
+    res.setHeader('content-type', 'application/json');
+    if (url.pathname.endsWith('/endpoints')) return res.end(JSON.stringify({ endpoints: [] }));
+    const next = url.searchParams.get('cursor');
+    res.end(JSON.stringify(next ? {
+      branches: [{ id: 'backup', name: 'backup/pre-migration', current_state: 'ready' }],
+    } : {
+      branches: [{ id: 'main', name: 'main', primary: true, default: true, current_state: 'ready' }, { id: 'staging', name: 'preview/mcp-staging', current_state: 'archived' }],
+      pagination: { next: 'second-page' },
+    }));
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  t.after(() => server.close());
+  const address = server.address();
+  assert.ok(address && typeof address !== 'string');
+  const child = spawn(process.execPath, ['scripts/neon-branch-guard.mjs', '--delete-merged', '--dry-run'], {
+    env: { ...process.env, NEON_API_KEY: 'test-neon', NEON_API_BASE_URL: `http://127.0.0.1:${address.port}/api/v2`, GITHUB_TOKEN: 'test-github', GITHUB_REPOSITORY: 'owner/repo', NEON_BRANCH_LIMIT: '8' },
+  });
+  let output = '';
+  child.stdout.on('data', chunk => { output += chunk; });
+  child.stderr.on('data', chunk => { output += chunk; });
+  const [code] = await once(child, 'close');
+  assert.equal(code, 0, output);
+  assert.match(output, /total=3/);
+  assert.match(output, /eligible for deletion=0 dry_run=true/);
+  assert.ok(requests.some(request => request.includes('cursor=second-page')));
+  assert.ok(requests.every(request => request.startsWith('GET ')));
+});

--- a/tests/neon-branch-guard.test.ts
+++ b/tests/neon-branch-guard.test.ts
@@ -11,12 +11,12 @@ test('Neon branch guard scripts are wired into package.json', () => {
   assert.equal(pkg.scripts['neon:branches:prune'], 'node scripts/neon-branch-guard.mjs --delete-archived');
 });
 
-test('Neon branch guard only auto-deletes archived preview branches', () => {
+test('Neon branch guard delegates deletion to the completed-preview policy', () => {
   const source = readFileSync(join(root, 'scripts/neon-branch-guard.mjs'), 'utf8');
   assert.match(source, /const DEFAULT_BRANCH_LIMIT = 8/);
-  assert.match(source, /const DEFAULT_DELETE_PATTERN = '\^preview\/'/);
-  assert.match(source, /branch\.primary !== true/);
-  assert.match(source, /branch\.current_state === 'archived'/);
+  assert.match(source, /const DEFAULT_DELETE_PATTERN = '\^preview\/codex\/'/);
+  assert.match(source, /findCompletedPreviewCandidates/);
+  assert.match(source, /freshCandidates/);
   assert.match(source, /NEON_API_KEY/);
   assert.doesNotMatch(source, /console\.(log|error)\([^)]*token/i);
 });
@@ -27,5 +27,6 @@ test('Neon branch guard runs daily in GitHub Actions', () => {
   assert.match(workflow, /cron: '17 5 \* \* \*'/);
   assert.match(workflow, /NEON_API_KEY: \$\{\{ secrets\.NEON_API_KEY \}\}/);
   assert.match(workflow, /NEON_BRANCH_LIMIT: '8'/);
-  assert.match(workflow, /node scripts\/neon-branch-guard\.mjs --delete-archived/);
+  assert.match(workflow, /node scripts\/neon-branch-guard\.mjs --delete-merged/);
+  assert.match(workflow, /pull-requests: read/);
 });

--- a/tests/neon-preview-cleanup-policy.test.ts
+++ b/tests/neon-preview-cleanup-policy.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createGitBranchLookup, findCompletedPreviewCandidates } from '../scripts/lib/neon-preview-cleanup-policy.mjs';
+
+const now = Date.parse('2026-09-05T12:00:00Z');
+const main = { id: 'br-main', name: 'main', primary: true, default: true };
+const preview = { id: 'br-preview', name: 'preview/codex/done', parent_id: 'br-main', creation_source: 'vercel', current_state: 'ready', created_at: '2026-09-01T00:00:00Z' };
+const endpoint = { branch_id: 'br-preview', current_state: 'idle', last_active: '2026-09-02T00:00:00Z' };
+const pull = { state: 'closed', merged_at: '2026-09-02T12:00:00Z', base: { ref: 'main' }, head: { sha: 'approved-sha' } };
+
+async function candidates(overrides = {}) {
+  return findCompletedPreviewCandidates({
+    branches: [main, preview], endpoints: [endpoint], now,
+    archivedOnly: false,
+    lookupGitBranch: async () => ({ head: 'approved-sha', pulls: [pull] }),
+    ...overrides,
+  });
+}
+
+test('completed previews are eligible after merge and inactivity grace', async () => {
+  assert.deepEqual((await candidates()).map(b => b.id), ['br-preview']);
+  assert.equal((await candidates({ archivedOnly: true })).length, 0);
+  assert.equal((await candidates({ branches: [main, { ...preview, current_state: 'archived' }], archivedOnly: true })).length, 1);
+});
+
+test('production, default, protected, backup, staging and manual branches are always preserved', async () => {
+  for (const change of [{ primary: true }, { default: true }, { protected: true }, { name: 'preview/mcp-staging' }, { name: 'backup/pre-migration' }, { creation_source: 'console' }]) {
+    assert.equal((await candidates({ branches: [main, { ...preview, ...change }] })).length, 0, JSON.stringify(change));
+  }
+  assert.equal((await candidates({ branches: [main, preview, { id: 'br-child', parent_id: preview.id }] })).length, 0);
+});
+
+test('active, recently used, unknown-activity and recently merged previews are preserved', async () => {
+  for (const change of [{ current_state: 'active' }, { last_active: '2026-09-05T11:00:00Z' }, { last_active: undefined }]) {
+    assert.equal((await candidates({ endpoints: [{ ...endpoint, ...change }] })).length, 0);
+  }
+  assert.equal((await candidates({ lookupGitBranch: async () => ({ head: 'approved-sha', pulls: [{ ...pull, merged_at: '2026-09-05T11:00:00Z' }] }) })).length, 0);
+});
+
+test('open, unmerged, changed, reused and other-base Git branches cannot be deleted', async () => {
+  for (const git of [
+    { head: 'approved-sha', pulls: [pull, { ...pull, state: 'open', merged_at: null }] },
+    { head: 'approved-sha', pulls: [{ ...pull, merged_at: null }] },
+    { head: 'new-sha', pulls: [pull] },
+    { head: 'approved-sha', pulls: [{ ...pull, base: { ref: 'develop' } }] },
+    { head: 'approved-sha', pulls: [] },
+  ]) assert.equal((await candidates({ lookupGitBranch: async () => git })).length, 0);
+  assert.equal((await candidates({ branches: [main, { ...preview, created_at: '2026-09-03T00:00:00Z' }] })).length, 0);
+});
+
+test('a deleted Git branch still requires a merged PR and remote failures stop cleanup', async () => {
+  assert.equal((await candidates({ lookupGitBranch: async () => ({ head: null, pulls: [pull] }) })).length, 1);
+  await assert.rejects(candidates({ lookupGitBranch: async () => { throw new Error('GitHub unavailable'); } }), /GitHub unavailable/);
+});
+
+test('GitHub verification checks every PR page so an open PR cannot be hidden', async () => {
+  let calls = 0;
+  const lookup = createGitBranchLookup({ repository: 'owner/repo', token: 'test-token', fetchFn: async input => {
+    calls++;
+    const url = new URL(input);
+    assert.equal(url.hostname, 'api.github.com');
+    if (url.pathname.includes('/git/ref/')) return Response.json({ object: { sha: 'approved-sha' } });
+    assert.equal(url.searchParams.get('head'), 'owner:codex/done');
+    return Response.json(url.searchParams.get('page') === '1' ? Array.from({ length: 100 }, () => pull) : [{ ...pull, state: 'open', merged_at: null }]);
+  } });
+  assert.equal((await candidates({ lookupGitBranch: lookup })).length, 0);
+  assert.equal(calls, 3);
+});
+
+test('GitHub lookup rejects missing configuration and malformed responses', async () => {
+  assert.throws(() => createGitBranchLookup({ repository: 'owner/repo', token: '' }));
+  for (const response of [Response.json({ message: 'denied' }, { status: 403 }), Response.json({ object: {} })]) {
+    const lookup = createGitBranchLookup({ repository: 'owner/repo', token: 'test', fetchFn: async () => response });
+    await assert.rejects(lookup('codex/done'));
+  }
+});


### PR DESCRIPTION
The Neon cost projection counted every non-primary branch as a future paid extra. For a Launch project with 12 branches, it now projects 2 extras after the 10-branch allowance, while preserving already-metered historical usage. The allowance is applied independently per project (10 for Launch, 25 for Scale), and the admin view distinguishes total branches from active compute.

The daily branch guard now cleans Vercel `preview/codex/*` branches only after a PR is merged into main and both the merge and last compute activity are at least 24 hours old. It preserves production, default/protected branches, staging, backups, branches with children, open PRs and changed/reused Git branches. GitHub verification and Neon pagination fail closed, and remote eligibility is checked again before each deletion. The workflow requests only read access to repository contents and PRs.

Validation: 25 focused tests pass, including cost allowance boundaries, multiple projects, historical usage, cleanup exclusions, GitHub pagination and a real HTTP dry-run test. Frontend lint, public exposure guard, diff check and production build pass. Full GitHub CI passes: 4,107 application tests (20 skipped, zero failures) and 18 admin smoke tests (1 skipped). Vercel preview is READY at the PR head. A live dry run against Neon preserved the three remaining branches and proposed zero deletions.

Operational prerequisite: the missing GitHub Actions `NEON_API_KEY` must be restored using a dedicated project-scoped key; this is separate from the code change. No credential is committed.
