### PR TITLE
fix(media): synchronize image thumbnail backfill references

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -70,10 +70,11 @@ jobs:
       - name: Install Playwright browser
         run: pnpm exec playwright install --with-deps chromium
 
-      - name: Install media validation tools
+      - name: Install media and database validation tools
         run: |
           sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends ffmpeg
+          sudo apt-get install --yes --no-install-recommends ffmpeg postgresql
+          pg_config --bindir >> "$GITHUB_PATH"
           ffmpeg -hide_banner -version
 
       - name: Validate tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,8 @@ When adding a selected homepage hero video, register its authored source, prepar
 
 For initial-loading changes, attach comparable before/after performance evidence and block reproducible Core Web Vitals regressions. Functional tests alone do not establish performance gains. Keep repair simulations read-only, make writes explicit and bounded, and update ownership documentation and contracts in the same change.
 
+Image thumbnail repair must cover stored readers as well as `app_jobs`: `job_outputs`, `media_assets`, and legacy `user_assets`. The operational CLI wires the projection repair owner in `frontend/scripts/_lib/image-thumbnail-projections.ts`; do not replace it with broad media-library upserts. Preserve originals, valid thumbnails, ownership, job/payment status and unrelated metadata. Persist generated thumbnails before synchronizing references, then guard the reference transaction with the current source and exact stored snapshots. A projection failure keeps the conservative resume cursor before that job. Validate this boundary with `tests/image-thumbnail-projections-postgres.test.ts` on disposable PostgreSQL.
+
 ## Architecture Contracts
 
 Architecture tests are part of the project design, not incidental test coverage.

--- a/docs/engineering/media-delivery.md
+++ b/docs/engineering/media-delivery.md
@@ -26,6 +26,7 @@ Read this guide when changing image/video presentation, poster URLs, generated m
 | Offline coherence and critical-home coverage | `frontend/scripts/check-public-video-coverage.ts` and `_lib/public-video-coverage.ts` |
 | Storage and reusable assets | `frontend/server/storage.ts` and `frontend/server/media-library/` |
 | Image thumbnail repair entry | `frontend/scripts/backfill-image-thumbnails.ts` |
+| Image repair inventory, references and guarded transactions | `frontend/scripts/_lib/image-thumbnail-projections.ts` |
 
 Playback hooks stay client-side; encoding, storage and database work stay server-side. Pages compose these owners. Do not put provider, pricing, storage or encoding responsibilities in a playback component. Route-specific workspace behavior stays under its existing `_hooks`, `_lib` and `_components` boundaries.
 
@@ -118,7 +119,7 @@ Keep scan order stable when repairs update rows. Preserve valid originals and th
 
 ### Image thumbnail repair command
 
-`frontend/scripts/backfill-image-thumbnails.ts` owns the CLI and deferred I/O imports; `frontend/scripts/_lib/image-thumbnail-backfill.ts` owns option validation and the injected scan/update orchestration. The default is a read-only inventory. With pnpm, pass flags directly, without a separating `--`:
+`frontend/scripts/backfill-image-thumbnails.ts` owns the CLI and deferred I/O imports; `frontend/scripts/_lib/image-thumbnail-backfill.ts` owns option validation and the injected scan/update orchestration. `image-thumbnail-projections.ts` in the same directory owns the stored-reader inventory, conservative matching, and reference transaction. The CLI always wires it: a healthy `app_jobs` row can still be a candidate when its API/library references need repair. The default is a read-only inventory. With pnpm, pass flags directly, without a separating `--`:
 
 ```sh
 pnpm --prefix frontend run thumbs:image-backfill --dry-run --after-id=0 --max=100 --batch-size=25
@@ -128,9 +129,21 @@ pnpm --prefix frontend run thumbs:image-backfill --apply --after-id=0 --max=100 
 
 Apply requires an authorized bounded repair. Batch size is 1–100 (default 25 or `IMAGE_THUMB_BACKFILL_BATCH`); maximum scanned rows per invocation is 1–10,000 (default 100 or `IMAGE_THUMB_BACKFILL_MAX`). `--after-id` accepts 0 through PostgreSQL's signed bigint maximum, defaults to 0, and is retained as a string. Unknown/conflicting flags fail before database/encoding modules load.
 
+An explicitly supplied environment variable, including `DATABASE_URL`, takes precedence over `.env.local`, then `.env`. Keep connection strings outside logs and command arguments. The inventory performs SELECTs only and can run with PostgreSQL `default_transaction_read_only=on`; it never creates missing tables. Install the application's normal migrations before using the repair tool.
+
+For each eligible job, the adapter inventories image `job_outputs`, undeleted image `media_assets` linked to the job or one of its outputs, and image `user_assets` linked by legacy job metadata. Ownership must match, including a null owner. Each table is capped at 1,000 references per job; an oversized inventory fails explicitly rather than silently omitting references. Hidden/video jobs, deleted records, foreign owners and other jobs remain outside the repair scope.
+
+Match output positions and original URLs before copying a thumbnail. A saved asset with an explicit output link must agree with that output; other saved assets need an unambiguous original-to-thumbnail match. Valid existing thumbnails win and are not replaced, even when they differ from the job thumbnail. A saved asset's existing valid column/metadata thumbnail can fill its own missing counterpart. Unknown or ambiguous originals fail the reference phase and remain operator-review items; never guess a match from a model name or generate another original.
+
+After thumbnail creation, the runner first durably updates the job with its optimistic predicate. The adapter then uses a separate, short transaction for the references: lock and validate the current job source, reread the references, and guard every UPDATE with the exact `to_jsonb(record)::text` snapshot. This preserves timestamp and numeric precision. Change only missing thumbnail fields and the relevant update timestamp; metadata updates use `jsonb_set` in PostgreSQL so unrelated fields remain intact. No upserts, record creation, originals, status/payment changes or storage deletion belong in this phase. A conflict rolls back all reference writes for that job. Transaction statement and lock waits are limited to 15 seconds and 2 seconds respectively.
+
 The summary reports actual `lastScannedId` and a separate conservative `resumeAfterId`. Use the latter to continue a run in the **same mode**: it freezes before the first failed or partially failed apply row. A dry-run cursor only continues inventory; switching to apply must use that inventory range's original starting cursor, or candidates would be skipped. Existing repaired rows are reread and skipped without regenerating their thumbnails.
 
 An apply row can increment both `updated` and `failed` after a partial repair; remaining missing thumbnails remain retryable. Apply exits nonzero if any row failed, and conflicts never overwrite a newer row. The optimistic predicate uses exact `updated_at::text`, prior JSONB renders and the previous hero URL, preserving PostgreSQL timestamp precision.
+
+`updated` counts jobs changed in either phase, once per job; it is not an upload or reference-row count. If references fail after the job thumbnail was committed, that job is both updated and failed. Retry the saved range: the existing thumbnail is reused and only the remaining references are repaired. A repair affecting references alone does not rewrite the healthy job or its timestamp. A successful retry becomes a zero-candidate inventory once all eligible representations are healthy.
+
+`tests/image-thumbnail-projections-postgres.test.ts` exercises the actual CLI and SQL against disposable PostgreSQL, including read-only inventory, healthy-job/stale-library detection, environment target precedence, reference rollback, retry without duplicate encoding, concurrent edits, bounded scope and metadata preservation. Quality CI installs PostgreSQL binaries for these checks. These operational tests do not measure page speed or alter public routes, metadata, canonicals, hreflang, sitemaps, or browser loading behavior.
 
 No checkpoint file is written. A hard process kill can prevent the final summary from printing; restart from the prior saved starting cursor. Tests simulate rejected operations/lost acknowledgments before upload, after upload and after database update, rather than OS signal handling. An uncertain upload can leave an unreferenced derivative and a retry can upload again. Do not claim exactly-once processing or delete originals/other assets to compensate. A lost database acknowledgment is treated as failure; retry rereads stored state before deciding whether repair is still needed.
 

--- a/docs/engineering/project-structure.md
+++ b/docs/engineering/project-structure.md
@@ -80,6 +80,8 @@ Media presentation and server processing follow `docs/engineering/media-delivery
 
 `frontend/config/public-video-sources.json` is the authored public-demo source catalogue. `frontend/scripts/check-public-video-coverage.ts` is the offline build entry for full public-rendition coherence and selected homepage coverage, exposed as `pnpm --prefix frontend run media:public-renditions:check`. Its injected pure coverage logic belongs under `frontend/scripts/_lib`. It reads the exported homepage selection and media constants instead of owning a second hero/model list.
 
+Image repair orchestration belongs in `frontend/scripts/_lib/image-thumbnail-backfill.ts`. Its projection adapter, `image-thumbnail-projections.ts` in the same directory, inventories and conservatively synchronizes the stored API/library representations. It accepts query/transaction executors and must not import schema initializers, broad library upserts, encoding, or storage. The CLI always supplies this adapter; the low-level injected runner can still be used against isolated fixtures without a library. Public routes and browser readers do not import these operational helpers.
+
 ## Naming Conventions
 
 - `*.client.tsx`: browser-only component.

--- a/frontend/scripts/_lib/image-thumbnail-backfill.ts
+++ b/frontend/scripts/_lib/image-thumbnail-backfill.ts
@@ -1,5 +1,6 @@
 import { buildStoredImageRenderEntries, parseStoredImageRenders } from '../../lib/image-renders';
 import { normalizeMediaUrl } from '../../lib/media';
+import type { ImageThumbnailProjectionRepair } from './image-thumbnail-projections';
 
 export type BackfillRow = {
   id: number | string;
@@ -32,6 +33,7 @@ type ThumbnailBatchInput = { jobId: string; userId: string | null; imageUrls: st
 export type ImageThumbnailBackfillDependencies = {
   query<T>(sql: string, params?: ReadonlyArray<unknown>): Promise<T[]>;
   createThumbnails?: (input: ThumbnailBatchInput) => Promise<Array<string | null>>;
+  projections?: ImageThumbnailProjectionRepair;
   onCandidate?: (row: BackfillRow, reasons: string[]) => void;
   onFailure?: (row: BackfillRow, error: unknown) => void;
 };
@@ -198,11 +200,13 @@ export async function runImageThumbnailBackfill(
         return indexes;
       }, []);
       const existingHero = validExistingHero(row, parsed.entries[0]!.url);
-      const reasons = [
+      const jobReasons = [
         ...(!parsed.hasStructuredEntries ? ['render format'] : []),
         ...(missingIndexes.length ? ['missing thumbnails'] : []),
         ...(!existingHero ? ['hero thumbnail'] : []),
       ];
+      const projectionCount = await dependencies.projections?.inspect(row) ?? 0;
+      const reasons = [...jobReasons, ...(projectionCount ? ['library thumbnails'] : [])];
       if (!reasons.length) {
         summary.skipped += 1;
         if (checkpointCanAdvance) summary.resumeAfterId = rowId;
@@ -246,33 +250,38 @@ export async function runImageThumbnailBackfill(
         const firstEntry = mergedEntries[0];
         const heroThumb =
           existingHero ?? normalizeMediaUrl(firstEntry?.thumbUrl) ?? normalizeMediaUrl(firstEntry?.url) ?? null;
-        const updatedRows = await dependencies.query<{ id: number | string }>(
-          `UPDATE app_jobs
-           SET render_ids = $2::jsonb,
-               thumb_url = COALESCE($3, thumb_url),
-               preview_frame = COALESCE(preview_frame, $3),
-               updated_at = NOW()
-           WHERE id = $1
-             AND updated_at IS NOT DISTINCT FROM $4::timestamptz
-             AND render_ids IS NOT DISTINCT FROM $5::jsonb
-             AND thumb_url IS NOT DISTINCT FROM $6::text
-           RETURNING id`,
-          [
-            row.id,
-            JSON.stringify(buildStoredImageRenderEntries(mergedEntries)),
-            heroThumb,
-            row.updated_at,
-            JSON.stringify(row.render_ids),
-            row.thumb_url,
-          ]
-        );
-        if (!updatedRows.length) {
-          summary.failed += 1;
-          checkpointCanAdvance = false;
-          dependencies.onFailure?.(row, new Error('row changed during repair'));
-          continue;
+        if (jobReasons.length) {
+          const updatedRows = await dependencies.query<{ id: number | string }>(
+            `UPDATE app_jobs
+             SET render_ids = $2::jsonb,
+                 thumb_url = COALESCE($3, thumb_url),
+                 preview_frame = COALESCE(preview_frame, $3),
+                 updated_at = NOW()
+             WHERE id = $1
+               AND updated_at IS NOT DISTINCT FROM $4::timestamptz
+               AND render_ids IS NOT DISTINCT FROM $5::jsonb
+               AND thumb_url IS NOT DISTINCT FROM $6::text
+               AND hidden IS NOT TRUE AND video_url IS NULL
+             RETURNING id`,
+            [
+              row.id,
+              JSON.stringify(buildStoredImageRenderEntries(mergedEntries)),
+              heroThumb,
+              row.updated_at,
+              JSON.stringify(row.render_ids),
+              row.thumb_url,
+            ]
+          );
+          if (!updatedRows.length) throw new Error('row changed during repair');
+          summary.updated += 1;
         }
-        summary.updated += 1;
+        if (!candidateFailed && dependencies.projections) {
+          const repaired = await dependencies.projections.repair(row, mergedEntries);
+          if (!jobReasons.length) {
+            if (repaired) summary.updated += 1;
+            else summary.skipped += 1;
+          }
+        }
         if (candidateFailed) {
           summary.failed += 1;
           checkpointCanAdvance = false;

--- a/frontend/scripts/_lib/image-thumbnail-projections.ts
+++ b/frontend/scripts/_lib/image-thumbnail-projections.ts
@@ -1,0 +1,153 @@
+import type { ImageRenderEntry } from '../../lib/image-renders';
+import { buildStoredImageRenderEntries, parseStoredImageRenders } from '../../lib/image-renders';
+import { normalizeMediaUrl } from '../../lib/media';
+import type { QueryExecutor } from '../../src/lib/db';
+import type { BackfillRow } from './image-thumbnail-backfill';
+
+type Table = 'job_outputs' | 'media_assets' | 'user_assets';
+type Projection = {
+  table_name: Table;
+  id: string;
+  url: string;
+  thumb_url: string | null;
+  metadata_thumb_url: string | null;
+  metadata_editable: boolean;
+  position: number | null;
+  source_output_id: string | null;
+  snapshot: string;
+};
+type Repair = { projection: Projection; thumbnail: string | null; column: boolean; metadata: boolean };
+
+export type ImageThumbnailProjectionRepair = {
+  inspect(row: BackfillRow): Promise<number>;
+  repair(row: BackfillRow, entries: ImageRenderEntry[]): Promise<number>;
+};
+
+type Dependencies = QueryExecutor & {
+  transaction<T>(work: (executor: QueryExecutor) => Promise<T>): Promise<T>;
+};
+
+const MAX_ROWS_PER_TABLE = 1000;
+
+function validThumbnail(original: string, thumbnail: string | null | undefined): string | null {
+  const normalized = normalizeMediaUrl(thumbnail);
+  return normalized && normalized !== normalizeMediaUrl(original) ? thumbnail! : null;
+}
+
+async function loadProjections(query: QueryExecutor['query'], row: BackfillRow): Promise<Projection[]> {
+  const params = [row.job_id, row.user_id, MAX_ROWS_PER_TABLE + 1];
+  const outputs = await query<Projection>(
+    `SELECT 'job_outputs' AS table_name, o.id::text AS id, o.url, o.thumb_url,
+            NULL::text AS metadata_thumb_url, false AS metadata_editable,
+            o.position, NULL::text AS source_output_id, to_jsonb(o)::text AS snapshot
+       FROM job_outputs o
+      WHERE o.job_id = $1 AND o.user_id IS NOT DISTINCT FROM $2::text
+        AND o.kind = 'image' AND o.status <> 'deleted'
+      ORDER BY o.id LIMIT $3`, params
+  );
+  const assets = await query<Projection>(
+    `SELECT 'media_assets' AS table_name, a.id::text AS id, a.url, a.thumb_url,
+            a.metadata->>'thumbUrl' AS metadata_thumb_url,
+            COALESCE(jsonb_typeof(a.metadata) = 'object', true) AS metadata_editable,
+            NULL::integer AS position, a.source_output_id, to_jsonb(a)::text AS snapshot
+       FROM media_assets a
+      WHERE a.user_id IS NOT DISTINCT FROM $2::text AND a.kind = 'image'
+        AND a.deleted_at IS NULL AND a.status <> 'deleted'
+        AND (a.source_job_id = $1 OR (a.source_job_id IS NULL AND EXISTS (
+          SELECT 1 FROM job_outputs o WHERE o.id = a.source_output_id AND o.job_id = $1
+            AND o.user_id IS NOT DISTINCT FROM $2::text AND o.kind = 'image' AND o.status <> 'deleted'
+        )))
+      ORDER BY a.id LIMIT $3`, params
+  );
+  const legacy = await query<Projection>(
+    `SELECT 'user_assets' AS table_name, a.id::text AS id, a.url,
+            NULL::text AS thumb_url, a.metadata->>'thumbUrl' AS metadata_thumb_url,
+            true AS metadata_editable, NULL::integer AS position,
+            NULL::text AS source_output_id, to_jsonb(a)::text AS snapshot
+       FROM user_assets a
+      WHERE a.user_id IS NOT DISTINCT FROM $2::text
+        AND COALESCE(a.metadata->>'jobId', a.metadata->>'sourceJobId') = $1
+        AND LOWER(COALESCE(a.mime_type, '')) NOT LIKE 'video/%'
+        AND LOWER(COALESCE(a.mime_type, '')) NOT LIKE 'audio/%'
+        AND split_part(split_part(a.url, '?', 1), '#', 1) !~* '[.](mp4|webm|mov|m4v|avi|mkv|mp3|wav|ogg|m4a|aac|flac)$'
+      ORDER BY a.id LIMIT $3`, params
+  );
+  if ([outputs, assets, legacy].some((records) => records.length > MAX_ROWS_PER_TABLE)) {
+    throw new Error(`Image projection inventory exceeds ${MAX_ROWS_PER_TABLE} rows per table for one job`);
+  }
+  return [...outputs, ...assets, ...legacy];
+}
+
+function planRepairs(projections: Projection[], entries: ImageRenderEntry[]): Repair[] {
+  const matches = (url: string, entry: ImageRenderEntry) => normalizeMediaUrl(url) === entry.url;
+  return projections.flatMap((projection): Repair[] => {
+    const columnThumb = validThumbnail(projection.url, projection.thumb_url);
+    const metadataThumb = validThumbnail(projection.url, projection.metadata_thumb_url);
+    const column = projection.table_name !== 'user_assets' && !columnThumb;
+    const metadata = projection.metadata_editable && !metadataThumb;
+    if (!column && !metadata) return [];
+
+    let candidates: ImageRenderEntry[];
+    if (projection.table_name === 'job_outputs') {
+      const entry = projection.position === null ? undefined : entries[projection.position];
+      candidates = entry && matches(projection.url, entry) ? [entry] : [];
+    } else if (projection.source_output_id) {
+      const output = projections.find((item) => item.table_name === 'job_outputs' && item.id === projection.source_output_id);
+      const entry = output?.position === null || output?.position === undefined ? undefined : entries[output.position];
+      candidates = output && entry && matches(output.url, entry) && matches(projection.url, entry) ? [entry] : [];
+    } else {
+      candidates = entries.filter((entry) => matches(projection.url, entry));
+    }
+    const thumbnails = new Set(candidates.map((entry) => validThumbnail(entry.url, entry.thumbUrl)).filter(Boolean));
+    const thumbnail = columnThumb ?? metadataThumb ?? (thumbnails.size === 1 ? [...thumbnails][0]! : null);
+    return [{ projection, thumbnail, column, metadata }];
+  });
+}
+
+async function applyRepair(executor: QueryExecutor, repair: Repair): Promise<void> {
+  const { projection, thumbnail, column, metadata } = repair;
+  if (!thumbnail) throw new Error(`Cannot unambiguously map image thumbnail for ${projection.table_name} ${projection.id}`);
+  const metadataSql = "metadata = jsonb_set(COALESCE(metadata, '{}'::jsonb), '{thumbUrl}', to_jsonb($2::text), true)";
+  // Table names and assignments come only from these fixed script-owned branches.
+  const updates: Record<Table, string[]> = {
+    job_outputs: ['thumb_url = $2::text', 'updated_at = NOW()'],
+    media_assets: [...(column ? ['thumb_url = $2::text'] : []), ...(metadata ? [metadataSql] : []), 'updated_at = NOW()'],
+    user_assets: [metadataSql],
+  };
+  const rows = await executor.query<{ id: string }>(
+    `UPDATE ${projection.table_name} AS target SET ${updates[projection.table_name].join(', ')}
+      WHERE id = $1 AND to_jsonb(target) IS NOT DISTINCT FROM $3::jsonb RETURNING id`,
+    [projection.id, thumbnail, projection.snapshot]
+  );
+  if (rows.length !== 1) throw new Error('Image projection changed during repair');
+}
+
+export function createImageThumbnailProjectionRepair(dependencies: Dependencies): ImageThumbnailProjectionRepair {
+  return {
+    async inspect(row) {
+      const projections = await loadProjections(dependencies.query, row);
+      return planRepairs(projections, parseStoredImageRenders(row.render_ids).entries).length;
+    },
+    async repair(row, entries) {
+      return dependencies.transaction(async (executor) => {
+        await executor.query("SET LOCAL statement_timeout = '15s'");
+        await executor.query("SET LOCAL lock_timeout = '2s'");
+        // Hold the source stable while applying its references, after slow encoding/storage has finished.
+        const current = await executor.query<BackfillRow>(
+          `SELECT id, job_id, user_id, thumb_url, render_ids, updated_at::text AS updated_at
+             FROM app_jobs WHERE id = $1 AND job_id = $2
+               AND user_id IS NOT DISTINCT FROM $3::text AND hidden IS NOT TRUE AND video_url IS NULL
+             FOR SHARE`, [row.id, row.job_id, row.user_id]
+        );
+        if (current.length !== 1 || JSON.stringify(buildStoredImageRenderEntries(parseStoredImageRenders(current[0]!.render_ids).entries)) !== JSON.stringify(buildStoredImageRenderEntries(entries))) {
+          throw new Error('Image source changed before projection repair');
+        }
+        const projections = await loadProjections(executor.query, row);
+        const repairs = planRepairs(projections, entries);
+        if (repairs.some((repair) => !repair.thumbnail)) throw new Error('Image projection has an ambiguous or unmatched original');
+        for (const repair of repairs) await applyRepair(executor, repair);
+        return repairs.length;
+      });
+    },
+  };
+}

--- a/frontend/scripts/backfill-image-thumbnails.ts
+++ b/frontend/scripts/backfill-image-thumbnails.ts
@@ -6,22 +6,24 @@ import {
   parseImageThumbnailBackfillOptions,
   runImageThumbnailBackfill,
 } from './_lib/image-thumbnail-backfill';
+import { createImageThumbnailProjectionRepair } from './_lib/image-thumbnail-projections';
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   parseImageThumbnailBackfillOptions(args, process.env);
 
   const { config: loadEnv } = await import('dotenv');
-  loadEnv({ path: path.resolve(process.cwd(), '.env.local'), override: true });
+  loadEnv({ path: path.resolve(process.cwd(), '.env.local'), override: false });
   loadEnv({ path: path.resolve(process.cwd(), '.env'), override: false });
   const options = parseImageThumbnailBackfillOptions(args, process.env);
 
   await import('tsconfig-paths/lib/register');
-  const { query, getDb } = await import('../src/lib/db');
+  const { query, getDb, withDbTransaction } = await import('../src/lib/db');
 
   try {
     const dependencies = {
       query,
+      projections: createImageThumbnailProjectionRepair({ query, transaction: withDbTransaction }),
       onCandidate: (row: { job_id: string }, reasons: string[]) => {
         const prefix = options.mode === 'dry-run' ? '[image-thumb-backfill][dry-run]' : '[image-thumb-backfill]';
         console.log(`${prefix} ${row.job_id}: ${reasons.join(', ')}`);

--- a/tests/image-thumbnail-projections-postgres.test.ts
+++ b/tests/image-thumbnail-projections-postgres.test.ts
@@ -1,0 +1,219 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { promisify } from 'node:util';
+
+import { missingDisposablePostgresCommand, startDisposablePostgres } from './helpers/disposable-postgres';
+import { createQueryExecutor, type QueryExecutor } from '../frontend/src/lib/db';
+import { createImageThumbnailProjectionRepair } from '../frontend/scripts/_lib/image-thumbnail-projections';
+import { parseImageThumbnailBackfillOptions, runImageThumbnailBackfill, type BackfillRow } from '../frontend/scripts/_lib/image-thumbnail-backfill';
+import { parseStoredImageRenders } from '../frontend/lib/image-renders';
+
+const exec = promisify(execFile);
+const require = createRequire(import.meta.url);
+const root = process.cwd();
+const original = 'https://media.example/original.png';
+const thumbnail = 'https://media.example/thumbnail.webp';
+
+test('image repair includes stored library projections on real PostgreSQL', { timeout: 90_000 }, async (t) => {
+  const missing = missingDisposablePostgresCommand();
+  if (missing) return t.skip(`local PostgreSQL command unavailable: ${missing}`);
+  const database = await startDisposablePostgres('image-projections');
+  const cwd = mkdtempSync(path.join(tmpdir(), 'image-backfill-cli-'));
+  t.after(async () => { await database.cleanup(); rmSync(cwd, { recursive: true, force: true }); });
+  await database.pool.query(`
+    CREATE TABLE app_jobs (
+      id bigint PRIMARY KEY, job_id text UNIQUE NOT NULL, user_id text, thumb_url text,
+      render_ids jsonb, preview_frame text, video_url text, hidden boolean DEFAULT false,
+      status text DEFAULT 'completed', payment_status text DEFAULT 'paid_wallet',
+      updated_at timestamptz DEFAULT '2026-01-01 00:00:00.123456+00'
+    );
+    CREATE TABLE job_outputs (
+      id text PRIMARY KEY, job_id text, user_id text, kind text DEFAULT 'image',
+      url text, thumb_url text, position integer, status text DEFAULT 'ready',
+      metadata jsonb, updated_at timestamptz DEFAULT '2026-01-01 00:00:00.123456+00'
+    );
+    CREATE TABLE media_assets (
+      id text PRIMARY KEY, user_id text, kind text DEFAULT 'image', url text,
+      thumb_url text, source_job_id text, source_output_id text, status text DEFAULT 'ready',
+      deleted_at timestamptz, metadata jsonb, updated_at timestamptz DEFAULT '2026-01-01 00:00:00.123456+00'
+    );
+    CREATE TABLE user_assets (
+      id bigint PRIMARY KEY, user_id text, url text, mime_type text DEFAULT 'image/png', metadata jsonb
+    );
+  `);
+  async function seed() {
+    await database.pool.query('TRUNCATE app_jobs, job_outputs, media_assets, user_assets');
+    await database.pool.query(`INSERT INTO app_jobs (id,job_id,user_id,thumb_url,render_ids,preview_frame)
+      VALUES (1,'job-1','user-1',$1,$2::jsonb,'existing-preview')`, [thumbnail, JSON.stringify([{url:original,thumb_url:thumbnail,width:2048,height:1024,mime_type:'image/png'}])]);
+    await database.pool.query(`INSERT INTO job_outputs (id,job_id,user_id,url,thumb_url,position,metadata)
+      VALUES ('output-1','job-1','user-1',$1,$1,0,'{"keep":"output","large":9007199254740993}')`, [original]);
+    await database.pool.query(`INSERT INTO media_assets (id,user_id,url,thumb_url,source_job_id,source_output_id,metadata)
+      VALUES ('asset-1','user-1',$1,$1,'job-1','output-1',jsonb_build_object('thumbUrl',$1::text,'keep','asset'))`, [original]);
+    await database.pool.query(`INSERT INTO user_assets (id,user_id,url,metadata)
+      VALUES (1,'user-1',$1,jsonb_build_object('jobId','job-1','thumbUrl',$1::text,'keep','legacy'))`, [original]);
+  }
+  async function command(mode: 'dry-run' | 'apply', readOnly = false) {
+    const url = new URL(database.databaseUrl);
+    if (readOnly) url.searchParams.set('options', '-c default_transaction_read_only=on');
+    return exec(process.execPath, [require.resolve('tsx/cli'), '--tsconfig', path.join(root,'frontend/tsconfig.json'), path.join(root,'frontend/scripts/backfill-image-thumbnails.ts'), `--${mode}`, '--max=1'], {
+      cwd, timeout: 30_000,
+      env: {...process.env, DATABASE_URL:url.toString(), TS_NODE_PROJECT:path.join(root,'frontend/tsconfig.json'), S3_BUCKET:'', S3_PUBLIC_BASE_URL:''},
+    });
+  }
+  function projectionDependencies(beforeWrite?: () => Promise<void>) {
+    const query: QueryExecutor['query'] = async (sql, params) => (await database.pool.query(sql, params ? [...params] : [])).rows;
+    return {
+      query,
+      async transaction<T>(work: (executor: QueryExecutor) => Promise<T>) {
+        const client = await database.pool.connect();
+        try {
+          await client.query('BEGIN');
+          const executor = createQueryExecutor(client);
+          const result = await work({query: async (sql, params) => {
+            if (/^UPDATE /i.test(sql) && beforeWrite) await beforeWrite();
+            return executor.query(sql, params);
+          }});
+          await client.query('COMMIT');
+          return result;
+        } catch (error) { await client.query('ROLLBACK'); throw error; }
+        finally { client.release(); }
+      },
+    };
+  }
+  await t.test('dry-run detects stale projections when the generation already has a thumbnail', async () => {
+    await seed();
+    const before = await database.pool.query('SELECT to_jsonb(o)::text AS row FROM job_outputs o');
+    const result = await command('dry-run', true);
+    assert.match(result.stdout, /candidates=1/);
+    assert.match(result.stdout, /updated=0/);
+    assert.deepEqual((await database.pool.query('SELECT to_jsonb(o)::text AS row FROM job_outputs o')).rows, before.rows);
+  });
+  await t.test('an explicit database target is not overridden by a local environment file', async () => {
+    await seed();
+    writeFileSync(path.join(cwd,'.env.local'),'DATABASE_URL=postgresql://invalid@127.0.0.1:1/wrong_database\n');
+    try { assert.match((await command('dry-run',true)).stdout,/candidates=1 updated=0/); }
+    finally { rmSync(path.join(cwd,'.env.local')); }
+  });
+  await t.test('legacy images without a MIME type are repaired while linked audio and video stay untouched', async () => {
+    await seed();
+    await database.pool.query(`UPDATE user_assets SET mime_type=NULL;
+      UPDATE media_assets SET source_job_id=NULL;
+      INSERT INTO user_assets (id,user_id,url,mime_type,metadata) VALUES
+        (2,'user-1','https://media.example/video.mp4',NULL,'{"jobId":"job-1"}'),
+        (3,'user-1','https://media.example/no-extension','audio/wav','{"jobId":"job-1"}')`);
+    await command('apply');
+    assert.deepEqual((await database.pool.query("SELECT id::text,metadata->>'thumbUrl' AS thumb FROM user_assets ORDER BY id")).rows,[
+      {id:'1',thumb:thumbnail},{id:'2',thumb:null},{id:'3',thumb:null},
+    ]);
+    assert.equal((await database.pool.query('SELECT thumb_url FROM media_assets')).rows[0].thumb_url,thumbnail);
+  });
+  await t.test('apply synchronizes all readers without rewriting the healthy generation or metadata', async () => {
+    await seed();
+    const before = (await database.pool.query('SELECT to_jsonb(j)::text AS row FROM app_jobs j')).rows;
+    const result = await command('apply');
+    assert.match(result.stdout, /updated=1 skipped=0 failed=0/);
+    assert.deepEqual((await database.pool.query('SELECT to_jsonb(j)::text AS row FROM app_jobs j')).rows,before);
+    assert.deepEqual((await database.pool.query('SELECT url,thumb_url,metadata::text FROM job_outputs')).rows,[{
+      url:original,thumb_url:thumbnail,metadata:'{"keep": "output", "large": 9007199254740993}',
+    }]);
+    assert.deepEqual((await database.pool.query("SELECT url,thumb_url,metadata->>'thumbUrl' AS metadata_thumb,metadata->>'keep' AS retained FROM media_assets")).rows,[{url:original,thumb_url:thumbnail,metadata_thumb:thumbnail,retained:'asset'}]);
+    assert.deepEqual((await database.pool.query("SELECT url,metadata->>'thumbUrl' AS thumb_url,metadata->>'keep' AS retained FROM user_assets")).rows,[{url:original,thumb_url:thumbnail,retained:'legacy'}]);
+    const again = await command('apply');
+    assert.match(again.stdout,/candidates=0 updated=0 skipped=1 failed=0/);
+  });
+  await t.test('a projection conflict rolls back all reference writes and leaves a resumable cursor', async () => {
+    await seed();
+    await database.pool.query(`CREATE FUNCTION reject_asset_update() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NULL; END $$;
+      CREATE TRIGGER reject_asset BEFORE UPDATE ON media_assets FOR EACH ROW EXECUTE FUNCTION reject_asset_update()`);
+    try {
+      await assert.rejects(command('apply'), (error: Error & {stdout?:string}) => {
+        assert.match(error.stdout??'',/updated=0 skipped=0 failed=1/);
+        assert.match(error.stdout??'',/resumeAfterId=0/);
+        return true;
+      });
+      assert.equal((await database.pool.query('SELECT thumb_url FROM job_outputs')).rows[0].thumb_url,original);
+    } finally { await database.pool.query('DROP TRIGGER reject_asset ON media_assets; DROP FUNCTION reject_asset_update()'); }
+    assert.match((await command('apply')).stdout,/updated=1 skipped=0 failed=0/);
+  });
+  await t.test('retry after a library failure reuses a durably generated thumbnail and preserves failed job billing', async () => {
+    await seed();
+    await database.pool.query(`UPDATE app_jobs SET thumb_url=NULL,render_ids=$1::jsonb,status='failed',payment_status='refunded_wallet'`,[JSON.stringify([original])]);
+    await database.pool.query(`CREATE FUNCTION reject_asset_update() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NULL; END $$;
+      CREATE TRIGGER reject_asset BEFORE UPDATE ON media_assets FOR EACH ROW EXECUTE FUNCTION reject_asset_update()`);
+    const dependencies = projectionDependencies();
+    let uploads = 0;
+    const run = () => runImageThumbnailBackfill(parseImageThumbnailBackfillOptions(['--apply','--max=1'],{}),{
+      query:dependencies.query, projections:createImageThumbnailProjectionRepair(dependencies),
+      createThumbnails:async () => { uploads++; return [thumbnail]; },
+    });
+    try {
+      const interrupted = await run();
+      assert.equal(interrupted.updated,1);assert.equal(interrupted.failed,1);assert.equal(interrupted.resumeAfterId,'0');
+      assert.equal((await database.pool.query('SELECT thumb_url FROM app_jobs')).rows[0].thumb_url,thumbnail);
+      assert.equal((await database.pool.query('SELECT thumb_url FROM job_outputs')).rows[0].thumb_url,original);
+    } finally { await database.pool.query('DROP TRIGGER reject_asset ON media_assets; DROP FUNCTION reject_asset_update()'); }
+    const retried = await run();
+    assert.equal(retried.updated,1);assert.equal(retried.failed,0);assert.equal(uploads,1);
+    assert.deepEqual((await database.pool.query('SELECT status,payment_status,preview_frame FROM app_jobs')).rows,[{status:'failed',payment_status:'refunded_wallet',preview_frame:'existing-preview'}]);
+  });
+  await t.test('valid thumbnails, foreign owners, deleted assets and jobs beyond the scan limit stay untouched', async () => {
+    await seed();
+    await database.pool.query(`UPDATE job_outputs SET thumb_url='https://media.example/curated.webp';
+      UPDATE media_assets SET thumb_url='https://media.example/saved.webp';
+      UPDATE user_assets SET metadata=jsonb_set(metadata,'{thumbUrl}','"https://media.example/legacy.webp"');
+      INSERT INTO job_outputs (id,job_id,user_id,url,thumb_url,position) VALUES ('foreign','job-1','user-2','https://media.example/original.png',NULL,1);
+      INSERT INTO media_assets (id,user_id,url,source_job_id,deleted_at) VALUES
+        ('foreign','user-2','https://media.example/original.png','job-1',NULL),
+        ('deleted','user-1','https://media.example/original.png','job-1',NOW());
+      INSERT INTO app_jobs (id,job_id,user_id,thumb_url,render_ids) SELECT 2,'job-2',user_id,thumb_url,render_ids FROM app_jobs WHERE id=1;
+      INSERT INTO job_outputs (id,job_id,user_id,url,position) VALUES ('later','job-2','user-1','https://media.example/original.png',0)`);
+    const before = (await database.pool.query('SELECT to_jsonb(o)::text AS row FROM job_outputs o ORDER BY id')).rows;
+    assert.match((await command('apply')).stdout,/scanned=1 candidates=1 updated=1/);
+    assert.deepEqual((await database.pool.query('SELECT to_jsonb(o)::text AS row FROM job_outputs o ORDER BY id')).rows,before);
+    assert.deepEqual((await database.pool.query("SELECT thumb_url,metadata->>'thumbUrl' AS metadata_thumb FROM media_assets WHERE id='asset-1'")).rows,[{thumb_url:'https://media.example/saved.webp',metadata_thumb:'https://media.example/saved.webp'}]);
+    assert.equal((await database.pool.query("SELECT metadata->>'thumbUrl' AS thumb FROM user_assets")).rows[0].thumb,'https://media.example/legacy.webp');
+    assert.ok((await database.pool.query("SELECT thumb_url FROM media_assets WHERE id IN ('foreign','deleted')")).rows.every(r=>r.thumb_url===null));
+  });
+  await t.test('an unmatched saved original is reported instead of being assigned another image thumbnail', async () => {
+    await seed();
+    await database.pool.query("UPDATE media_assets SET url='https://media.example/different.png',thumb_url=NULL,metadata=jsonb_set(metadata,'{thumbUrl}','null')");
+    await assert.rejects(command('apply'),(error:Error & {stdout?:string})=>{assert.match(error.stdout??'',/updated=0 skipped=0 failed=1/);return true;});
+    assert.equal((await database.pool.query('SELECT thumb_url FROM job_outputs')).rows[0].thumb_url,original);
+  });
+  await t.test('source changes between inventory and projection repair are not propagated', async () => {
+    await seed();
+    const dependencies = projectionDependencies();
+    const repair = createImageThumbnailProjectionRepair(dependencies);
+    const row = (await dependencies.query<BackfillRow>('SELECT *,updated_at::text AS updated_at FROM app_jobs'))[0]!;
+    assert.equal(await repair.inspect(row),3);
+    await database.pool.query('UPDATE app_jobs SET hidden=true');
+    await assert.rejects(repair.repair(row,parseStoredImageRenders(row.render_ids).entries),/source changed/i);
+    await database.pool.query('UPDATE app_jobs SET hidden=false,render_ids=$1::jsonb',[JSON.stringify([{url:'https://media.example/changed.png',thumb_url:thumbnail}])]);
+    await assert.rejects(repair.repair(row,parseStoredImageRenders(row.render_ids).entries),/source changed/i);
+    assert.equal((await database.pool.query('SELECT thumb_url FROM job_outputs')).rows[0].thumb_url,original);
+  });
+  await t.test('an exact projection snapshot preserves concurrent metadata edits', async () => {
+    await seed();
+    let changed = false;
+    const dependencies = projectionDependencies(async () => {
+      if (changed) return;changed=true;
+      await database.pool.query("UPDATE job_outputs SET metadata=metadata || '{\"concurrent\":true}'::jsonb");
+    });
+    const repair = createImageThumbnailProjectionRepair(dependencies);
+    const row = (await dependencies.query<BackfillRow>('SELECT *,updated_at::text AS updated_at FROM app_jobs'))[0]!;
+    await assert.rejects(repair.repair(row,parseStoredImageRenders(row.render_ids).entries),/projection changed/i);
+    assert.deepEqual((await database.pool.query("SELECT thumb_url,metadata->>'concurrent' AS edit FROM job_outputs")).rows,[{thumb_url:original,edit:'true'}]);
+  });
+  await t.test('an oversized projection inventory fails explicitly without schema or media writes', async () => {
+    await seed();
+    await database.pool.query(`INSERT INTO media_assets (id,user_id,url,source_job_id)
+      SELECT 'many-' || n,'user-1','https://media.example/original.png','job-1' FROM generate_series(1,1000) n`);
+    await assert.rejects(command('dry-run',true),/exceeds 1000 rows per table/);
+    assert.equal((await database.pool.query('SELECT thumb_url FROM job_outputs')).rows[0].thumb_url,original);
+  });
+});

--- a/tests/mcp-paid-migration.test.ts
+++ b/tests/mcp-paid-migration.test.ts
@@ -126,7 +126,7 @@ test('migration 30 constraints, state machine, immutability, indexes, row locks,
   });
 
   const psql = (...args: string[]) => spawnSync('psql', [
-    '-X', '-h', socketDirectory, '-U', 'postgres', '-d', 'postgres', ...args,
+    '-X', '-q', '-h', socketDirectory, '-U', 'postgres', '-d', 'postgres', ...args,
   ], { encoding: 'utf8' });
   for (let attempt = 0; attempt < 2; attempt += 1) {
     const migration = psql(

--- a/tests/mcp-trial-migration.test.ts
+++ b/tests/mcp-trial-migration.test.ts
@@ -96,7 +96,7 @@ test('migration 31 constraints, transitions, immutability, indexes and races exe
   });
 
   const psql = (...args: string[]) => spawnSync('psql', [
-    '-X', '-h', socketDirectory, '-U', 'postgres', '-d', 'postgres', ...args,
+    '-X', '-q', '-h', socketDirectory, '-U', 'postgres', '-d', 'postgres', ...args,
   ], { encoding: 'utf8' });
   const applyTrialAlone = psql(
     '--single-transaction', '-v', 'ON_ERROR_STOP=1', '-f', join(root, trialMigrationPath),


### PR DESCRIPTION
The image thumbnail backfill previously skipped generations whose `app_jobs` thumbnails were already healthy, even when the API or media library still referenced the original image. The CLI now inventories and repairs `job_outputs`, `media_assets`, and legacy `user_assets` alongside each eligible generation.

Repairs preserve original URLs, valid thumbnails, ownership, deletion state, job/payment status, and unrelated metadata. Generated thumbnails are persisted before a separate guarded reference transaction, so a reference failure can be retried without repeating a successful encoding step. Explicit environment variables take precedence over local environment files. The engineering guides and AGENTS.md document these boundaries and restart behavior.

Validation: 4,268 tests passed with no failures or skips, including actual CLI/SQL tests on disposable PostgreSQL for read-only inventory, rollback, retry, concurrent edits, limits, and metadata precision. Frontend build, TypeScript, lint, exposure checks, and diff checks passed. Quality CI now installs PostgreSQL binaries to run these integration checks.

Enabling PostgreSQL in CI also exercises previously skipped migration tests. Their psql helpers now explicitly suppress command-status messages with `-q`, so Linux assertions compare the same query results as local runs; the SQL, assertions, and application migrations remain unchanged.

At final candidate `1c29ee48e3046ae0c81d1c0c91c173f14d896cd1`, the 18 focused local PostgreSQL checks pass. [Quality CI](https://github.com/camgraphe/MaxVideoAi/actions/runs/33999304217) passes with 4,266 tests, zero failures and two environment/platform skips; admin smoke passes 18 tests with one skip. The final Vercel preview deployment also succeeds.

This change is limited to operational scripts, tests, CI, and documentation. It changes no application routes, public URLs, redirects, canonical/hreflang tags, sitemaps, JSON-LD, or browser loading behavior. No production backfill is triggered by this PR; the historical repair was completed separately.

Production result: merged as `9e3e0003f1a660449c315dad52bee17771278dfc` with the owner's explicit authorization for this PR's admin merge; branch protections remain unchanged. Vercel production deployment `dpl_Eye3H8r1oc7gvX1kDVu6F8SJxN79` is READY and serves maxvideoai.com. [Main Quality CI](https://github.com/camgraphe/MaxVideoAi/actions/runs/33999906429) passes 4,266 tests with zero failures and two environment/platform skips; admin smoke passes 18 with one skip. [Main Lighthouse CI](https://github.com/camgraphe/MaxVideoAi/actions/runs/33999906437) and pages build/deployment pass. Ten public/localized pages return 200 and retain the previously observed titles, canonicals, hreflang, robots, H1 counts and JSON-LD counts/types. The sitemap index returns 200 with six children. Deployment-scoped error/fatal logs show no occurrences in the short post-deploy observation window. No additional production backfill was run.
