### PR TITLE
Optimize featured MiniMax H3, Kling and Seedance videos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,8 @@ When adding a selected homepage hero video, register its authored source, prepar
 
 For initial-loading changes, attach comparable before/after performance evidence and block reproducible Core Web Vitals regressions. Functional tests alone do not establish performance gains. Keep repair simulations read-only, make writes explicit and bounded, and update ownership documentation and contracts in the same change.
 
+When extending public rendition coverage beyond the homepage, verify the exact source selected by the rendered model or family page, then use explicit `--asset-id` selections throughout preparation, publication and activation. A configured fallback demo or a page-view count alone does not prove which video is loaded or how often it plays. Verify the owning reader uses the shared projection; extending the catalogue does not automatically optimize comparison, watch or preview-card readers.
+
 Image thumbnail repair must cover stored readers as well as `app_jobs`: `job_outputs`, `media_assets`, and legacy `user_assets`. The operational CLI wires the projection repair owner in `frontend/scripts/_lib/image-thumbnail-projections.ts`; do not replace it with broad media-library upserts. Preserve originals, valid thumbnails, ownership, job/payment status and unrelated metadata. Persist generated thumbnails before synchronizing references, then guard the reference transaction with the current source and exact stored snapshots. A projection failure keeps the conservative resume cursor before that job. Validate this boundary with `tests/image-thumbnail-projections-postgres.test.ts` on disposable PostgreSQL.
 
 ## Architecture Contracts

--- a/docs/engineering/media-delivery.md
+++ b/docs/engineering/media-delivery.md
@@ -85,6 +85,8 @@ Sharp encoding quality and Next's admitted request quality are separate contract
 
 The model launch-asset validator does not enforce rendition readiness. The public rendition command below owns measured byte, metadata, review, and HTTP activation gates. Historical grids and model pages outside the selected homepage set keep exact-original fallback until prepared; the critical-home build check is intentionally not a claim that every historical public video has been transcoded.
 
+For additional public sources, prioritize the exact media observed in the rendered page using recent page exposure and measured file size. A model's fallback demo in configuration may differ from its selected gallery hero. Page views are not video plays or CDN transfer counts. Add each verified original to the same authored catalogue and run the lifecycle with explicit `--asset-id` selections; the default five-asset limit can otherwise leave later entries unprocessed. Confirm the generated URL is actually selected by the owning reader before calling that surface optimized. Model and family hero readers already use the shared resolver; comparison, watch and small-card preview readers require their own integration review. Do not replace full-quality download, editing or schema sources when extending display coverage.
+
 ### Public full-duration rendition command
 
 The public rendition command defaults to a read-only offline coherence check. Preparation is local and resumable; publishing requires explicit review evidence; activation independently requires current public MP4 and Range readiness. The generated projection is the only rendition data imported by browser-safe code.

--- a/docs/operations/public-video-renditions-2026-09-06.md
+++ b/docs/operations/public-video-renditions-2026-09-06.md
@@ -1,0 +1,35 @@
+# Public video rendition review — 6 September 2026
+
+## Scope
+
+Extend the existing public-demo-v1 catalogue to the exact sources observed on `/models/minimax-h3`, `/examples/kling`, and `/models/seedance-2-5`. The reference code is main `77076a03204ac4819a257b8bd2afef639975cdf7`. Selection uses the public media inventory and recent page exposure; page views are not video plays or transferred bytes.
+
+No route, page layout, metadata, original URL, profile setting, playback component or loading policy changes belong to this lot. The authored source list, measured manifest and generated projection extend the existing model/family hero readers. Comparison, watch and preview-card readers are outside this rollout.
+
+## Full-file measurements
+
+| Source | Original | Desktop | Desktop saving | Mobile | Mobile saving |
+|---|---:|---:|---:|---:|---:|
+| kling-family-featured | 18,618,789 B | 7,070,171 B | 62.03% | 2,129,316 B | 88.56% |
+| minimax-h3-model-demo | 36,677,883 B | 14,615,963 B | 60.15% | 5,624,570 B | 84.66% |
+| seedance-2-5-model-demo | 12,402,108 B | 3,788,369 B | 69.45% | 2,982,698 B | 75.95% |
+
+These are complete-file sizes, not initial page transfers or measured Core Web Vitals gains. All six profiles exceed the existing 15% savings gate. Seedance remains 854×480 in both profiles; the pipeline does not upscale.
+
+## Content acceptance
+
+- All three original/desktop/mobile contact sheets were inspected at 10%, 50% and 90% duration. Composition, faces, dark gradients, smoke, snow and moving particles remain representative at the inspected display scale. Mobile is a smaller display rendition, not an archival-quality replacement.
+- All six candidates and their paired originals completed Chrome playback without media errors. Browser frame callbacks confirmed presentation; their callback counts are not a decoded-frame equality or dropped-frame metric.
+- Every candidate preserves the complete original video frame count and timestamp digest, and the exact AAC packet payload, channel/sample-rate metadata, start and duration. Audio is accepted based on byte-identical AAC payload and timing, without audio re-encoding. This is not a new subjective listening assessment.
+- Every file decoded successfully and passed the existing format, aspect-ratio, duration, timing, savings and MP4 faststart gates. No profile exception or omitted candidate was needed.
+- Physical iPhone playback was not tested; the existing lack of access remains documented. Browser playback and measured content acceptance do not certify field Core Web Vitals.
+
+## Release validation
+
+Publication, current HTTP/Range readiness, activation, preview integration and page-performance checks are recorded as they complete. Content acceptance alone does not authorize merging past GitHub review protection.
+
+Local diagnostic artifacts are under `output/audits/public-video-priority-renditions-20260906/`: measured-savings.json, prepared checkpoints, three contact sheets, browser-review.json, and SEO snapshots. They remain outside application bundles. No credential is copied into the worktree or audit directory.
+
+## Continuation
+
+The wider media inventory, initial mobile loading and ambitious visual/product/SEO audit remain open. For later selected assets, use explicit asset IDs throughout the same pipeline and confirm the actual owning reader uses the generated rendition projection. Retain original media and the earlier projection for rollback.

--- a/frontend/config/public-video-renditions.generated.json
+++ b/frontend/config/public-video-renditions.generated.json
@@ -25,6 +25,21 @@
     "https://media.maxvideoai.com/media-assets/by-content/c780259ed79d025b4ac74ccc513f18bf/2506829a4f4f3d7e5d2bd864a701fc6cc2fb7c53182f7a7f5ca10cc580c70aa8.mp4": {
       "assetId": "underwater-swimmer",
       "mobile": "https://media.maxvideoai.com/marketing/video-renditions/2506829a4f4f3d7e5d2bd864a701fc6cc2fb7c53182f7a7f5ca10cc580c70aa8/public-demo-v1/mobile/64e689cb64cceb67ef006622524b5f1183ce00f83749fdf6f7d38d87d28a86c4.mp4"
+    },
+    "https://media.maxvideoai.com/renders/301cc489-d689-477f-94c4-0b051deda0bc/10186dec-e084-4141-8249-8d39331b3a23.mp4": {
+      "assetId": "minimax-h3-model-demo",
+      "desktop": "https://media.maxvideoai.com/marketing/video-renditions/b24035c64a2c2f87be23637337621e0b480dab68499e498eafb2cf0e520e2266/public-demo-v1/desktop/f54a3f128e6da188810eb7c4d955b0211e001d7ddff8e653fbb3b58729de4be6.mp4",
+      "mobile": "https://media.maxvideoai.com/marketing/video-renditions/b24035c64a2c2f87be23637337621e0b480dab68499e498eafb2cf0e520e2266/public-demo-v1/mobile/f46f366b07e5454f5f601710216344ad1216dd3e4a1108621d18adbd7ade1d1c.mp4"
+    },
+    "https://media.maxvideoai.com/renders/301cc489-d689-477f-94c4-0b051deda0bc/6e192457-4607-4ed7-8861-5ccc3ade5e1b.mp4": {
+      "assetId": "kling-family-featured",
+      "desktop": "https://media.maxvideoai.com/marketing/video-renditions/8806d2a9df40337d9c799e04973b2c6cb06e3b7f9115bb0b3bae84dc05537e64/public-demo-v1/desktop/6b44bc2214554294984fe6a855ffa2382f63e0bf075e5109b080a5241908e544.mp4",
+      "mobile": "https://media.maxvideoai.com/marketing/video-renditions/8806d2a9df40337d9c799e04973b2c6cb06e3b7f9115bb0b3bae84dc05537e64/public-demo-v1/mobile/72e0acad94ab5b4c2a89f581c1369bacc6428086e5cd7ab8ecffb35a28f58d5c.mp4"
+    },
+    "https://media.maxvideoai.com/renders/301cc489-d689-477f-94c4-0b051deda0bc/6ab56b7c-bece-4c72-9372-c910bafdc622.mp4": {
+      "assetId": "seedance-2-5-model-demo",
+      "desktop": "https://media.maxvideoai.com/marketing/video-renditions/b9a52e75940a011d8a0af4a7a6754c0ce74125bb5bc2a4532726d777da18176c/public-demo-v1/desktop/229667923d62609fceb0b9aa7c5e4be6cb94588017c5efd787e6b183c32ef2f2.mp4",
+      "mobile": "https://media.maxvideoai.com/marketing/video-renditions/b9a52e75940a011d8a0af4a7a6754c0ce74125bb5bc2a4532726d777da18176c/public-demo-v1/mobile/a71c37c1a37bbb9fc0bfc210b1aef4f01a77e80a351781ed6d1d08896e02cba5.mp4"
     }
   }
 }

--- a/frontend/config/public-video-renditions.manifest.json
+++ b/frontend/config/public-video-renditions.manifest.json
@@ -767,6 +767,519 @@
         }
       ],
       "failures": []
+    },
+    {
+      "assetId": "minimax-h3-model-demo",
+      "role": "public-demo",
+      "original": {
+        "url": "https://media.maxvideoai.com/renders/301cc489-d689-477f-94c4-0b051deda0bc/10186dec-e084-4141-8249-8d39331b3a23.mp4",
+        "sha256": "b24035c64a2c2f87be23637337621e0b480dab68499e498eafb2cf0e520e2266",
+        "bytes": 36677883,
+        "probe": {
+          "width": 2544,
+          "height": 1456,
+          "durationSeconds": 15.083333,
+          "containerDurationSeconds": 15.084,
+          "videoStartSeconds": 0,
+          "videoFrameCount": 362,
+          "cadence": {
+            "kind": "cfr",
+            "frameCount": 362,
+            "firstTimestampSeconds": 0,
+            "lastTimestampSeconds": 15.041667,
+            "minDeltaSeconds": 0.041665999999999315,
+            "maxDeltaSeconds": 0.04166700000000034,
+            "timestampsSha256": "1d485809f35ae94885b989507142024174bcfd80b4aaee7307e171526278ea7f"
+          },
+          "frameRate": {
+            "numerator": 24,
+            "denominator": 1
+          },
+          "videoCodec": "h264",
+          "pixelFormat": "yuv420p",
+          "sampleAspectRatio": {
+            "numerator": 1,
+            "denominator": 1
+          },
+          "colorTransfer": null,
+          "rotationDegrees": 0,
+          "audio": {
+            "codec": "aac",
+            "channels": 2,
+            "sampleRateHz": 32000,
+            "durationSeconds": 15.008,
+            "startSeconds": 0,
+            "packetPayloadSha256": "4e38c6b30422f9fd7197c92cd23eb1fe2b5fe72404231da4a820a2c10fd10519"
+          },
+          "fastStart": true,
+          "decodeOk": true
+        }
+      },
+      "renditions": {
+        "desktop": {
+          "profileVersion": "public-demo-v1",
+          "url": "https://media.maxvideoai.com/marketing/video-renditions/b24035c64a2c2f87be23637337621e0b480dab68499e498eafb2cf0e520e2266/public-demo-v1/desktop/f54a3f128e6da188810eb7c4d955b0211e001d7ddff8e653fbb3b58729de4be6.mp4",
+          "storageKey": "marketing/video-renditions/b24035c64a2c2f87be23637337621e0b480dab68499e498eafb2cf0e520e2266/public-demo-v1/desktop/f54a3f128e6da188810eb7c4d955b0211e001d7ddff8e653fbb3b58729de4be6.mp4",
+          "sha256": "f54a3f128e6da188810eb7c4d955b0211e001d7ddff8e653fbb3b58729de4be6",
+          "bytes": 14615963,
+          "probe": {
+            "width": 1888,
+            "height": 1080,
+            "durationSeconds": 15.083333,
+            "containerDurationSeconds": 15.084,
+            "videoStartSeconds": 0,
+            "videoFrameCount": 362,
+            "cadence": {
+              "kind": "cfr",
+              "frameCount": 362,
+              "firstTimestampSeconds": 0,
+              "lastTimestampSeconds": 15.041667,
+              "minDeltaSeconds": 0.041665999999999315,
+              "maxDeltaSeconds": 0.04166700000000034,
+              "timestampsSha256": "1d485809f35ae94885b989507142024174bcfd80b4aaee7307e171526278ea7f"
+            },
+            "frameRate": {
+              "numerator": 24,
+              "denominator": 1
+            },
+            "videoCodec": "h264",
+            "pixelFormat": "yuv420p",
+            "sampleAspectRatio": {
+              "numerator": 1,
+              "denominator": 1
+            },
+            "colorTransfer": null,
+            "rotationDegrees": 0,
+            "audio": {
+              "codec": "aac",
+              "channels": 2,
+              "sampleRateHz": 32000,
+              "durationSeconds": 15.008,
+              "startSeconds": 0,
+              "packetPayloadSha256": "4e38c6b30422f9fd7197c92cd23eb1fe2b5fe72404231da4a820a2c10fd10519"
+            },
+            "fastStart": true,
+            "decodeOk": true
+          },
+          "visualReview": {
+            "reviewedAt": "2026-09-06T00:36:14.103Z",
+            "evidence": "2026-09-06 content acceptance: three source/desktop/mobile contact sheets at 10/50/90 percent duration inspected for composition, detail, dark gradients, particles and faces; all six variants completed paired Chrome playback with no media errors. Original frame timestamps and exact AAC payload/timing match each output. Audio accepted by payload identity without re-encoding. See docs/operations/public-video-renditions-2026-09-06.md and local public-video-priority-renditions-20260906 review artifacts. This accepts display content, not field CWV or physical iPhone coverage; originals retained."
+          },
+          "httpCheck": {
+            "checkedAt": "2026-09-06T00:37:51.915Z",
+            "contentType": "video/mp4",
+            "bytes": 14615963,
+            "rangeStart": 0,
+            "rangeEnd": 31,
+            "totalBytes": 14615963
+          },
+          "activatedAt": "2026-09-06T00:37:51.738Z"
+        },
+        "mobile": {
+          "profileVersion": "public-demo-v1",
+          "url": "https://media.maxvideoai.com/marketing/video-renditions/b24035c64a2c2f87be23637337621e0b480dab68499e498eafb2cf0e520e2266/public-demo-v1/mobile/f46f366b07e5454f5f601710216344ad1216dd3e4a1108621d18adbd7ade1d1c.mp4",
+          "storageKey": "marketing/video-renditions/b24035c64a2c2f87be23637337621e0b480dab68499e498eafb2cf0e520e2266/public-demo-v1/mobile/f46f366b07e5454f5f601710216344ad1216dd3e4a1108621d18adbd7ade1d1c.mp4",
+          "sha256": "f46f366b07e5454f5f601710216344ad1216dd3e4a1108621d18adbd7ade1d1c",
+          "bytes": 5624570,
+          "probe": {
+            "width": 1258,
+            "height": 720,
+            "durationSeconds": 15.083333,
+            "containerDurationSeconds": 15.084,
+            "videoStartSeconds": 0,
+            "videoFrameCount": 362,
+            "cadence": {
+              "kind": "cfr",
+              "frameCount": 362,
+              "firstTimestampSeconds": 0,
+              "lastTimestampSeconds": 15.041667,
+              "minDeltaSeconds": 0.041665999999999315,
+              "maxDeltaSeconds": 0.04166700000000034,
+              "timestampsSha256": "1d485809f35ae94885b989507142024174bcfd80b4aaee7307e171526278ea7f"
+            },
+            "frameRate": {
+              "numerator": 24,
+              "denominator": 1
+            },
+            "videoCodec": "h264",
+            "pixelFormat": "yuv420p",
+            "sampleAspectRatio": {
+              "numerator": 1,
+              "denominator": 1
+            },
+            "colorTransfer": null,
+            "rotationDegrees": 0,
+            "audio": {
+              "codec": "aac",
+              "channels": 2,
+              "sampleRateHz": 32000,
+              "durationSeconds": 15.008,
+              "startSeconds": 0,
+              "packetPayloadSha256": "4e38c6b30422f9fd7197c92cd23eb1fe2b5fe72404231da4a820a2c10fd10519"
+            },
+            "fastStart": true,
+            "decodeOk": true
+          },
+          "visualReview": {
+            "reviewedAt": "2026-09-06T00:36:14.103Z",
+            "evidence": "2026-09-06 content acceptance: three source/desktop/mobile contact sheets at 10/50/90 percent duration inspected for composition, detail, dark gradients, particles and faces; all six variants completed paired Chrome playback with no media errors. Original frame timestamps and exact AAC payload/timing match each output. Audio accepted by payload identity without re-encoding. See docs/operations/public-video-renditions-2026-09-06.md and local public-video-priority-renditions-20260906 review artifacts. This accepts display content, not field CWV or physical iPhone coverage; originals retained."
+          },
+          "httpCheck": {
+            "checkedAt": "2026-09-06T00:37:52.148Z",
+            "contentType": "video/mp4",
+            "bytes": 5624570,
+            "rangeStart": 0,
+            "rangeEnd": 31,
+            "totalBytes": 5624570
+          },
+          "activatedAt": "2026-09-06T00:37:51.738Z"
+        }
+      },
+      "pendingRenditions": {},
+      "omissions": [],
+      "failures": []
+    },
+    {
+      "assetId": "kling-family-featured",
+      "role": "public-demo",
+      "original": {
+        "url": "https://media.maxvideoai.com/renders/301cc489-d689-477f-94c4-0b051deda0bc/6e192457-4607-4ed7-8861-5ccc3ade5e1b.mp4",
+        "sha256": "8806d2a9df40337d9c799e04973b2c6cb06e3b7f9115bb0b3bae84dc05537e64",
+        "bytes": 18618789,
+        "probe": {
+          "width": 1920,
+          "height": 1080,
+          "durationSeconds": 8.041667,
+          "containerDurationSeconds": 8.081,
+          "videoStartSeconds": 0,
+          "videoFrameCount": 193,
+          "cadence": {
+            "kind": "cfr",
+            "frameCount": 193,
+            "firstTimestampSeconds": 0,
+            "lastTimestampSeconds": 8,
+            "minDeltaSeconds": 0.041665999999999315,
+            "maxDeltaSeconds": 0.04166700000000034,
+            "timestampsSha256": "a1e5c7bba4a1896168248f1f8ba427a33e491a4cd422f7e724e8a32dbee402bd"
+          },
+          "frameRate": {
+            "numerator": 24,
+            "denominator": 1
+          },
+          "videoCodec": "h264",
+          "pixelFormat": "yuv420p",
+          "sampleAspectRatio": {
+            "numerator": 1,
+            "denominator": 1
+          },
+          "colorTransfer": null,
+          "rotationDegrees": 0,
+          "audio": {
+            "codec": "aac",
+            "channels": 2,
+            "sampleRateHz": 44100,
+            "durationSeconds": 8.033991,
+            "startSeconds": 0,
+            "packetPayloadSha256": "da5e9ffdd2b660de3bfe319e34d7d1d5c47fe6105d7f05b4219806c99a502cbb"
+          },
+          "fastStart": true,
+          "decodeOk": true
+        }
+      },
+      "renditions": {
+        "desktop": {
+          "profileVersion": "public-demo-v1",
+          "url": "https://media.maxvideoai.com/marketing/video-renditions/8806d2a9df40337d9c799e04973b2c6cb06e3b7f9115bb0b3bae84dc05537e64/public-demo-v1/desktop/6b44bc2214554294984fe6a855ffa2382f63e0bf075e5109b080a5241908e544.mp4",
+          "storageKey": "marketing/video-renditions/8806d2a9df40337d9c799e04973b2c6cb06e3b7f9115bb0b3bae84dc05537e64/public-demo-v1/desktop/6b44bc2214554294984fe6a855ffa2382f63e0bf075e5109b080a5241908e544.mp4",
+          "sha256": "6b44bc2214554294984fe6a855ffa2382f63e0bf075e5109b080a5241908e544",
+          "bytes": 7070171,
+          "probe": {
+            "width": 1920,
+            "height": 1080,
+            "durationSeconds": 8.041667,
+            "containerDurationSeconds": 8.042,
+            "videoStartSeconds": 0,
+            "videoFrameCount": 193,
+            "cadence": {
+              "kind": "cfr",
+              "frameCount": 193,
+              "firstTimestampSeconds": 0,
+              "lastTimestampSeconds": 8,
+              "minDeltaSeconds": 0.041665999999999315,
+              "maxDeltaSeconds": 0.04166700000000034,
+              "timestampsSha256": "a1e5c7bba4a1896168248f1f8ba427a33e491a4cd422f7e724e8a32dbee402bd"
+            },
+            "frameRate": {
+              "numerator": 24,
+              "denominator": 1
+            },
+            "videoCodec": "h264",
+            "pixelFormat": "yuv420p",
+            "sampleAspectRatio": {
+              "numerator": 1,
+              "denominator": 1
+            },
+            "colorTransfer": null,
+            "rotationDegrees": 0,
+            "audio": {
+              "codec": "aac",
+              "channels": 2,
+              "sampleRateHz": 44100,
+              "durationSeconds": 8.033991,
+              "startSeconds": 0,
+              "packetPayloadSha256": "da5e9ffdd2b660de3bfe319e34d7d1d5c47fe6105d7f05b4219806c99a502cbb"
+            },
+            "fastStart": true,
+            "decodeOk": true
+          },
+          "visualReview": {
+            "reviewedAt": "2026-09-06T00:36:14.103Z",
+            "evidence": "2026-09-06 content acceptance: three source/desktop/mobile contact sheets at 10/50/90 percent duration inspected for composition, detail, dark gradients, particles and faces; all six variants completed paired Chrome playback with no media errors. Original frame timestamps and exact AAC payload/timing match each output. Audio accepted by payload identity without re-encoding. See docs/operations/public-video-renditions-2026-09-06.md and local public-video-priority-renditions-20260906 review artifacts. This accepts display content, not field CWV or physical iPhone coverage; originals retained."
+          },
+          "httpCheck": {
+            "checkedAt": "2026-09-06T00:37:52.255Z",
+            "contentType": "video/mp4",
+            "bytes": 7070171,
+            "rangeStart": 0,
+            "rangeEnd": 31,
+            "totalBytes": 7070171
+          },
+          "activatedAt": "2026-09-06T00:37:51.738Z"
+        },
+        "mobile": {
+          "profileVersion": "public-demo-v1",
+          "url": "https://media.maxvideoai.com/marketing/video-renditions/8806d2a9df40337d9c799e04973b2c6cb06e3b7f9115bb0b3bae84dc05537e64/public-demo-v1/mobile/72e0acad94ab5b4c2a89f581c1369bacc6428086e5cd7ab8ecffb35a28f58d5c.mp4",
+          "storageKey": "marketing/video-renditions/8806d2a9df40337d9c799e04973b2c6cb06e3b7f9115bb0b3bae84dc05537e64/public-demo-v1/mobile/72e0acad94ab5b4c2a89f581c1369bacc6428086e5cd7ab8ecffb35a28f58d5c.mp4",
+          "sha256": "72e0acad94ab5b4c2a89f581c1369bacc6428086e5cd7ab8ecffb35a28f58d5c",
+          "bytes": 2129316,
+          "probe": {
+            "width": 1280,
+            "height": 720,
+            "durationSeconds": 8.041667,
+            "containerDurationSeconds": 8.042,
+            "videoStartSeconds": 0,
+            "videoFrameCount": 193,
+            "cadence": {
+              "kind": "cfr",
+              "frameCount": 193,
+              "firstTimestampSeconds": 0,
+              "lastTimestampSeconds": 8,
+              "minDeltaSeconds": 0.041665999999999315,
+              "maxDeltaSeconds": 0.04166700000000034,
+              "timestampsSha256": "a1e5c7bba4a1896168248f1f8ba427a33e491a4cd422f7e724e8a32dbee402bd"
+            },
+            "frameRate": {
+              "numerator": 24,
+              "denominator": 1
+            },
+            "videoCodec": "h264",
+            "pixelFormat": "yuv420p",
+            "sampleAspectRatio": {
+              "numerator": 1,
+              "denominator": 1
+            },
+            "colorTransfer": null,
+            "rotationDegrees": 0,
+            "audio": {
+              "codec": "aac",
+              "channels": 2,
+              "sampleRateHz": 44100,
+              "durationSeconds": 8.033991,
+              "startSeconds": 0,
+              "packetPayloadSha256": "da5e9ffdd2b660de3bfe319e34d7d1d5c47fe6105d7f05b4219806c99a502cbb"
+            },
+            "fastStart": true,
+            "decodeOk": true
+          },
+          "visualReview": {
+            "reviewedAt": "2026-09-06T00:36:14.103Z",
+            "evidence": "2026-09-06 content acceptance: three source/desktop/mobile contact sheets at 10/50/90 percent duration inspected for composition, detail, dark gradients, particles and faces; all six variants completed paired Chrome playback with no media errors. Original frame timestamps and exact AAC payload/timing match each output. Audio accepted by payload identity without re-encoding. See docs/operations/public-video-renditions-2026-09-06.md and local public-video-priority-renditions-20260906 review artifacts. This accepts display content, not field CWV or physical iPhone coverage; originals retained."
+          },
+          "httpCheck": {
+            "checkedAt": "2026-09-06T00:37:52.363Z",
+            "contentType": "video/mp4",
+            "bytes": 2129316,
+            "rangeStart": 0,
+            "rangeEnd": 31,
+            "totalBytes": 2129316
+          },
+          "activatedAt": "2026-09-06T00:37:51.738Z"
+        }
+      },
+      "pendingRenditions": {},
+      "omissions": [],
+      "failures": []
+    },
+    {
+      "assetId": "seedance-2-5-model-demo",
+      "role": "public-demo",
+      "original": {
+        "url": "https://media.maxvideoai.com/renders/301cc489-d689-477f-94c4-0b051deda0bc/6ab56b7c-bece-4c72-9372-c910bafdc622.mp4",
+        "sha256": "b9a52e75940a011d8a0af4a7a6754c0ce74125bb5bc2a4532726d777da18176c",
+        "bytes": 12402108,
+        "probe": {
+          "width": 854,
+          "height": 480,
+          "durationSeconds": 15.041667,
+          "containerDurationSeconds": 15.104,
+          "videoStartSeconds": 0,
+          "videoFrameCount": 361,
+          "cadence": {
+            "kind": "cfr",
+            "frameCount": 361,
+            "firstTimestampSeconds": 0,
+            "lastTimestampSeconds": 15,
+            "minDeltaSeconds": 0.041665999999999315,
+            "maxDeltaSeconds": 0.04166700000000034,
+            "timestampsSha256": "840795626fa85e208a6ac0bde9f2980e9fee700f89daf9b76006b78017892129"
+          },
+          "frameRate": {
+            "numerator": 24,
+            "denominator": 1
+          },
+          "videoCodec": "h264",
+          "pixelFormat": "yuv420p",
+          "sampleAspectRatio": {
+            "numerator": 1,
+            "denominator": 1
+          },
+          "colorTransfer": null,
+          "rotationDegrees": 0,
+          "audio": {
+            "codec": "aac",
+            "channels": 2,
+            "sampleRateHz": 32000,
+            "durationSeconds": 15.072,
+            "startSeconds": 0,
+            "packetPayloadSha256": "36a517ff1d6a113960118eec9e94a1c0610aeb7eb5d05372435fca70eae1b4d8"
+          },
+          "fastStart": true,
+          "decodeOk": true
+        }
+      },
+      "renditions": {
+        "desktop": {
+          "profileVersion": "public-demo-v1",
+          "url": "https://media.maxvideoai.com/marketing/video-renditions/b9a52e75940a011d8a0af4a7a6754c0ce74125bb5bc2a4532726d777da18176c/public-demo-v1/desktop/229667923d62609fceb0b9aa7c5e4be6cb94588017c5efd787e6b183c32ef2f2.mp4",
+          "storageKey": "marketing/video-renditions/b9a52e75940a011d8a0af4a7a6754c0ce74125bb5bc2a4532726d777da18176c/public-demo-v1/desktop/229667923d62609fceb0b9aa7c5e4be6cb94588017c5efd787e6b183c32ef2f2.mp4",
+          "sha256": "229667923d62609fceb0b9aa7c5e4be6cb94588017c5efd787e6b183c32ef2f2",
+          "bytes": 3788369,
+          "probe": {
+            "width": 854,
+            "height": 480,
+            "durationSeconds": 15.041667,
+            "containerDurationSeconds": 15.072,
+            "videoStartSeconds": 0,
+            "videoFrameCount": 361,
+            "cadence": {
+              "kind": "cfr",
+              "frameCount": 361,
+              "firstTimestampSeconds": 0,
+              "lastTimestampSeconds": 15,
+              "minDeltaSeconds": 0.041665999999999315,
+              "maxDeltaSeconds": 0.04166700000000034,
+              "timestampsSha256": "840795626fa85e208a6ac0bde9f2980e9fee700f89daf9b76006b78017892129"
+            },
+            "frameRate": {
+              "numerator": 24,
+              "denominator": 1
+            },
+            "videoCodec": "h264",
+            "pixelFormat": "yuv420p",
+            "sampleAspectRatio": {
+              "numerator": 1,
+              "denominator": 1
+            },
+            "colorTransfer": null,
+            "rotationDegrees": 0,
+            "audio": {
+              "codec": "aac",
+              "channels": 2,
+              "sampleRateHz": 32000,
+              "durationSeconds": 15.072,
+              "startSeconds": 0,
+              "packetPayloadSha256": "36a517ff1d6a113960118eec9e94a1c0610aeb7eb5d05372435fca70eae1b4d8"
+            },
+            "fastStart": true,
+            "decodeOk": true
+          },
+          "visualReview": {
+            "reviewedAt": "2026-09-06T00:36:14.103Z",
+            "evidence": "2026-09-06 content acceptance: three source/desktop/mobile contact sheets at 10/50/90 percent duration inspected for composition, detail, dark gradients, particles and faces; all six variants completed paired Chrome playback with no media errors. Original frame timestamps and exact AAC payload/timing match each output. Audio accepted by payload identity without re-encoding. See docs/operations/public-video-renditions-2026-09-06.md and local public-video-priority-renditions-20260906 review artifacts. This accepts display content, not field CWV or physical iPhone coverage; originals retained."
+          },
+          "httpCheck": {
+            "checkedAt": "2026-09-06T00:37:52.467Z",
+            "contentType": "video/mp4",
+            "bytes": 3788369,
+            "rangeStart": 0,
+            "rangeEnd": 31,
+            "totalBytes": 3788369
+          },
+          "activatedAt": "2026-09-06T00:37:51.738Z"
+        },
+        "mobile": {
+          "profileVersion": "public-demo-v1",
+          "url": "https://media.maxvideoai.com/marketing/video-renditions/b9a52e75940a011d8a0af4a7a6754c0ce74125bb5bc2a4532726d777da18176c/public-demo-v1/mobile/a71c37c1a37bbb9fc0bfc210b1aef4f01a77e80a351781ed6d1d08896e02cba5.mp4",
+          "storageKey": "marketing/video-renditions/b9a52e75940a011d8a0af4a7a6754c0ce74125bb5bc2a4532726d777da18176c/public-demo-v1/mobile/a71c37c1a37bbb9fc0bfc210b1aef4f01a77e80a351781ed6d1d08896e02cba5.mp4",
+          "sha256": "a71c37c1a37bbb9fc0bfc210b1aef4f01a77e80a351781ed6d1d08896e02cba5",
+          "bytes": 2982698,
+          "probe": {
+            "width": 854,
+            "height": 480,
+            "durationSeconds": 15.041667,
+            "containerDurationSeconds": 15.072,
+            "videoStartSeconds": 0,
+            "videoFrameCount": 361,
+            "cadence": {
+              "kind": "cfr",
+              "frameCount": 361,
+              "firstTimestampSeconds": 0,
+              "lastTimestampSeconds": 15,
+              "minDeltaSeconds": 0.041665999999999315,
+              "maxDeltaSeconds": 0.04166700000000034,
+              "timestampsSha256": "840795626fa85e208a6ac0bde9f2980e9fee700f89daf9b76006b78017892129"
+            },
+            "frameRate": {
+              "numerator": 24,
+              "denominator": 1
+            },
+            "videoCodec": "h264",
+            "pixelFormat": "yuv420p",
+            "sampleAspectRatio": {
+              "numerator": 1,
+              "denominator": 1
+            },
+            "colorTransfer": null,
+            "rotationDegrees": 0,
+            "audio": {
+              "codec": "aac",
+              "channels": 2,
+              "sampleRateHz": 32000,
+              "durationSeconds": 15.072,
+              "startSeconds": 0,
+              "packetPayloadSha256": "36a517ff1d6a113960118eec9e94a1c0610aeb7eb5d05372435fca70eae1b4d8"
+            },
+            "fastStart": true,
+            "decodeOk": true
+          },
+          "visualReview": {
+            "reviewedAt": "2026-09-06T00:36:14.103Z",
+            "evidence": "2026-09-06 content acceptance: three source/desktop/mobile contact sheets at 10/50/90 percent duration inspected for composition, detail, dark gradients, particles and faces; all six variants completed paired Chrome playback with no media errors. Original frame timestamps and exact AAC payload/timing match each output. Audio accepted by payload identity without re-encoding. See docs/operations/public-video-renditions-2026-09-06.md and local public-video-priority-renditions-20260906 review artifacts. This accepts display content, not field CWV or physical iPhone coverage; originals retained."
+          },
+          "httpCheck": {
+            "checkedAt": "2026-09-06T00:37:52.572Z",
+            "contentType": "video/mp4",
+            "bytes": 2982698,
+            "rangeStart": 0,
+            "rangeEnd": 31,
+            "totalBytes": 2982698
+          },
+          "activatedAt": "2026-09-06T00:37:51.738Z"
+        }
+      },
+      "pendingRenditions": {},
+      "omissions": [],
+      "failures": []
     }
   ]
 }

--- a/frontend/config/public-video-sources.json
+++ b/frontend/config/public-video-sources.json
@@ -26,6 +26,21 @@
       "assetId": "underwater-swimmer",
       "url": "https://media.maxvideoai.com/media-assets/by-content/c780259ed79d025b4ac74ccc513f18bf/2506829a4f4f3d7e5d2bd864a701fc6cc2fb7c53182f7a7f5ca10cc580c70aa8.mp4",
       "sha256": "2506829a4f4f3d7e5d2bd864a701fc6cc2fb7c53182f7a7f5ca10cc580c70aa8"
+    },
+    {
+      "assetId": "minimax-h3-model-demo",
+      "url": "https://media.maxvideoai.com/renders/301cc489-d689-477f-94c4-0b051deda0bc/10186dec-e084-4141-8249-8d39331b3a23.mp4",
+      "sha256": "b24035c64a2c2f87be23637337621e0b480dab68499e498eafb2cf0e520e2266"
+    },
+    {
+      "assetId": "kling-family-featured",
+      "url": "https://media.maxvideoai.com/renders/301cc489-d689-477f-94c4-0b051deda0bc/6e192457-4607-4ed7-8861-5ccc3ade5e1b.mp4",
+      "sha256": "8806d2a9df40337d9c799e04973b2c6cb06e3b7f9115bb0b3bae84dc05537e64"
+    },
+    {
+      "assetId": "seedance-2-5-model-demo",
+      "url": "https://media.maxvideoai.com/renders/301cc489-d689-477f-94c4-0b051deda0bc/6ab56b7c-bece-4c72-9372-c910bafdc622.mp4",
+      "sha256": "b9a52e75940a011d8a0af4a7a6754c0ce74125bb5bc2a4532726d777da18176c"
     }
   ]
 }


### PR DESCRIPTION
The MiniMax H3 model hero, Kling family hero and Seedance 2.5 model hero load originals of 36.68 MB, 18.62 MB and 12.40 MB. This adds six reviewed public-demo-v1 renditions through the existing catalogue and shared model/example readers.

Full playback of these three files falls from 67.70 MB to 10.74 MB on mobile (84.1% less) and 25.47 MB on desktop (62.4% less). These are complete-file savings, not initial-page or field Core Web Vitals gains.

Only source/manifest/generated rendition data and operating documentation change. The five earlier catalogue entries remain identical. Routes, metadata, canonical, hreflang, sitemap, original download/edit/schema URLs, layout, loading policy, playback components and encoder profiles are unchanged. Comparison/watch/preview-card readers and the rest of the catalogue remain outside this lot.

Validation:
- All six candidates pass duration, complete frame-timestamp/count, AAC payload/timing identity, full decode, faststart and savings gates. Three contact sheets reviewed; six paired Chrome playbacks finish without media errors.
- Six immutable uploads verified by public HTTP and Range requests before activation; current offline catalogue and five-home-hero coverage check passes.
- Actual preview H3, Kling and Seedance readers select the expected desktop renditions and play with readyState 4 and no media errors.
- All nine EN/FR/ES public SEO snapshots match after deployment-domain normalization, including full JSON-LD and original media URLs.
- Quality CI succeeds at 92a7566: 4,272 unit/contract tests pass (2 skipped), 18 admin browser checks pass (1 skipped); typecheck, lint and Vercel build succeed.

Performance evidence and limits:
- Three paired measurements per case, alternating order, excluded primers, separate LHCI-owned Chrome profiles. Cold browser cache is cleared after temporary Vercel access; server/CDN/connection state can be warm. No user browser data is copied.
- Main comparison includes H3/Kling/Seedance mobile cold, H3 desktop cold, and H3 mobile/desktop warm. CLS is zero throughout. No initial mobile video requests occur. Other surfaces/cache scenarios do not show the H3 cold-mobile pattern.
- H3 simulated cold-mobile LCP increases from 1.614 to 1.917 s initially and 1.623 to 1.923 s in a clean confirmation. These unfavorable results are retained.
- Actual DevTools throttling does not reproduce it: median LCP 1.894 → 1.885 s, CLS 0, median TBT about 17 ms both.
- Replacing the production reference with the existing PR270 preview (identical git tree to main 77076a0) reduces but does not remove the simulated signal: 1.471 → 1.625 s. Preview environment alone does not explain it.
- A causal diagnostic on the same candidate deployment intercepts the same downloaded JS response in both arms and changes only the in-browser generated catalogue (previous five entries vs current eight). All measured responses and successful interceptions are verified. Median simulated LCP is 2.209 → 1.463 s, so it does not reproduce a slowdown caused by the catalogue. Interception changes absolute transfer accounting; these diagnostic timings are not a claim of real-navigation improvement.

The exact cause of the cross-deployment simulated difference is not established. Direct throttling and catalogue-isolation controls do not confirm a catalogue regression; the data-only lot is presented for review with that uncertainty documented. No speculative application fix was introduced. TBT is not INP; no field p75 gain or universal no-regression claim is made. Physical iPhone remains untested.

AGENTS.md and the media guide document rendered-source selection and explicit asset IDs. Content acceptance is recorded in docs/operations/public-video-renditions-2026-09-06.md. Full local measurements, reader evidence and the French report are under output/audits/public-video-priority-renditions-20260906/ (outside application bundles).

Broader mobile loading and the ambitious visual/navigation/conversion/product/SEO audit remain open. The user authorized administrator merge for this PR. It was squash-merged as 0908aaec40d94b57f297f789393d66ca9bc9752f at 2026-09-06T09:20:39Z without modifying branch protection. Production deployment dpl_EchDmTkR1rrP8h4GVmi9rg8qvHoo is READY and serves maxvideoai.com. All three real Chrome readers confirm that deployment and play the exact expected desktop derivatives (readyState 4, no media errors). All nine production SEO snapshots match the baseline exactly. All six public rendition files pass fresh HEAD, exact-size and two-byte Range 206 checks.
