### PR TITLE
fix(workspace): preserve example framing when recreating videos

### DIFF
--- a/frontend/app/(core)/(workspace)/app/AGENTS.md
+++ b/frontend/app/(core)/(workspace)/app/AGENTS.md
@@ -28,6 +28,7 @@ This route is the main signed-in video generation workspace.
 - Keep accepted `runGenerate` response projection and immediate render/preview patches in `_lib`; `AppClient.tsx` should dispatch events and start polling.
 - Keep generation polling projections and poll-delay decisions in `_lib`; `AppClient.tsx` should own `getJobStatus`, timers, and React setters.
 - Keep video settings snapshot parsing and job media patch mapping in `_lib`; route-local hooks should wire those results into React state and own settings hydration requests.
+- Keep derived example framing recovery in `workspace-derived-aspect-ratio.ts`, called only for derived snapshots by `workspace-video-settings.ts`: match measured ratios only to a supported mode ratio within 2%. Saved generation snapshots remain authoritative; do not change original media dimensions or the general engine fallback to fix recreation.
 - Keep workspace request parsing and boot hydration decisions in `_lib`; route-local draft hooks should apply the resolved state and keep browser storage reads/writes out of `AppClient.tsx`.
 - Keep route shell UI in `_components`; `AppClient.tsx` should render named surfaces instead of owning gallery cards, preview dock internals, boot skeleton composition, or runtime modal JSX inline.
 - Keep asset-library selection, reference slot insertion, and Kling library asset mapping in `_lib`; route-local hooks should own bounded asset library state, upload orchestration, and network calls.

--- a/frontend/app/(core)/(workspace)/app/_lib/workspace-derived-aspect-ratio.ts
+++ b/frontend/app/(core)/(workspace)/app/_lib/workspace-derived-aspect-ratio.ts
@@ -1,0 +1,26 @@
+import { parseAspectRatio } from '@/lib/aspect';
+import type { EngineCaps, Mode } from '@/types/engines';
+import { getModeCaps } from './workspace-engine-helpers';
+
+export function resolveDerivedAspectRatio(value: string, engine: EngineCaps, mode: Mode): string {
+  const supported = getModeCaps(engine, mode)?.aspectRatio ?? [];
+  if (supported.includes(value)) return value;
+  const dimensions = parseAspectRatio(value);
+  if (!dimensions) return value;
+  const ratio = dimensions.width / dimensions.height;
+  let closest = value;
+  // Output dimensions can be slightly rounded (H3's 2544x1456 is near 16:9).
+  // Only recover a nearby supported setting; arbitrary framing keeps the existing fallback.
+  let closestDifference = 0.02;
+  for (const option of supported) {
+    const parts = parseAspectRatio(option);
+    if (!parts) continue;
+    const expected = parts.width / parts.height;
+    const difference = Math.abs(ratio - expected) / expected;
+    if (difference < closestDifference) {
+      closest = option;
+      closestDifference = difference;
+    }
+  }
+  return closest;
+}

--- a/frontend/app/(core)/(workspace)/app/_lib/workspace-video-settings.ts
+++ b/frontend/app/(core)/(workspace)/app/_lib/workspace-video-settings.ts
@@ -14,6 +14,7 @@ import {
   resolveAudioDefault,
   resolveBooleanFieldDefault,
 } from './workspace-engine-helpers';
+import { resolveDerivedAspectRatio } from './workspace-derived-aspect-ratio';
 import { MULTI_PROMPT_MIN_SEC } from './workspace-input-helpers';
 
 type MemberTier = 'Member' | 'Plus' | 'Pro';
@@ -300,7 +301,12 @@ export function resolveVideoSettingsSnapshot(
           : undefined,
       numFrames: readInteger(core.numFrames),
       resolution: typeof core.resolution === 'string' ? core.resolution : undefined,
-      aspectRatio: typeof core.aspectRatio === 'string' ? core.aspectRatio : undefined,
+      aspectRatio:
+        typeof core.aspectRatio === 'string'
+          ? meta.derived === true
+            ? resolveDerivedAspectRatio(core.aspectRatio, engine, mode)
+            : core.aspectRatio
+          : undefined,
       fps: readInteger(core.fps),
       iterations:
         typeof core.iterationCount === 'number' && Number.isFinite(core.iterationCount)

--- a/tests/workspace-video-settings-hook-contract.test.ts
+++ b/tests/workspace-video-settings-hook-contract.test.ts
@@ -58,6 +58,7 @@ test('workspace video settings hydration is owned by a route-local hook', () => 
     'the one-shot claim must guard job hydration'
   );
 
+  assert.match(settingsSource, /from '\.\/workspace-derived-aspect-ratio'/);
   assert.match(settingsSource, /from '\.\/workspace-video-job-media'/);
   assert.match(jobMediaSource, /export function buildVideoJobMediaPatch/);
   assert.match(jobMediaSource, /export function buildRequestedJobPreview/);

--- a/tests/workspace-video-settings.test.ts
+++ b/tests/workspace-video-settings.test.ts
@@ -3,9 +3,11 @@ import test from 'node:test';
 
 import type { EngineCaps } from '../frontend/types/engines';
 import type { FormState } from '../frontend/app/(core)/(workspace)/app/_lib/workspace-form-state';
+import { getBaseEngines } from '../frontend/src/lib/engines';
 import {
   buildVideoSettingsFormState,
   buildVideoSettingsSnapshotFromTile,
+  buildVideoSettingsSnapshotFromSharedVideo,
   claimSharedVideoHydration,
   resolveVideoSettingsSnapshot,
 } from '../frontend/app/(core)/(workspace)/app/_lib/workspace-video-settings';
@@ -89,6 +91,68 @@ test('shared video hydration waits for engines and claims the same id only once 
   assert.equal(snapshotApplications, 1);
   assert.equal(jobHydrations, 1);
   assert.equal(prompt, 'visitor edit after recreation');
+});
+
+function resolveForEngine(snapshot: unknown, engine: EngineCaps) {
+  return resolveVideoSettingsSnapshot(snapshot, {
+    engines: [engine],
+    engineMap: new Map([[engine.id, engine]]),
+    createLocalId: (prefix) => `${prefix}-1`,
+    createFallbackScene: () => ({ id: 'scene-1', prompt: '', duration: 5 }),
+    createFallbackKlingElement: () => ({
+      id: 'element-1', frontal: null, references: [null, null, null], video: null,
+    }),
+  });
+}
+
+function sharedSnapshot(aspectRatio: string, engineId = 'minimax-h3') {
+  return buildVideoSettingsSnapshotFromSharedVideo({
+    id: 'example', engineId, engineLabel: 'Example', durationSec: 15,
+    prompt: 'Recreate this shot', aspectRatio, createdAt: '2026-09-06T00:00:00Z',
+  });
+}
+
+test('recreating an H3 example preserves its near-16:9 framing instead of selecting 21:9', () => {
+  const engine = getBaseEngines().find((candidate) => candidate.id === 'minimax-h3');
+  assert.ok(engine);
+  const resolved = resolveForEngine(sharedSnapshot('159:91'), engine);
+  const form = buildVideoSettingsFormState(resolved, previousForm());
+  assert.equal(form.aspectRatio, '16:9');
+  assert.equal(form.durationSec, 15);
+  assert.equal(resolved.prompt, 'Recreate this shot');
+});
+
+test('derived tile ratios use the nearest supported ratio, including portrait and equivalent dimensions', () => {
+  const engine = seedanceEngine();
+  engine.modeCaps!.t2v!.aspectRatio = ['21:9', '16:9', '9:16'];
+  for (const [input, expected] of [['159:91', '16:9'], ['91:159', '9:16'], ['1920/1080', '16:9']]) {
+    const snapshot = buildVideoSettingsSnapshotFromTile({
+      engineId: engine.id, aspectRatio: input, durationSec: 12, iterationCount: 1,
+      prompt: 'Example',
+    } as Parameters<typeof buildVideoSettingsSnapshotFromTile>[0]);
+    assert.equal(buildVideoSettingsFormState(resolveForEngine(snapshot, engine), null).aspectRatio, expected);
+  }
+});
+
+test('derived framing only snaps small differences and respects mode-specific or source-driven ratios', () => {
+  const engine = seedanceEngine();
+  engine.aspectRatios = ['16:9', '9:16'];
+  engine.modeCaps!.t2v!.aspectRatio = ['21:9', '16:9', 'auto'];
+  for (const input of ['21:9', 'auto', '4:3', '1.83:1', '91:159', '0:9', 'invalid']) {
+    assert.equal(resolveForEngine(sharedSnapshot(input, engine.id), engine).formValues.aspectRatio, input);
+  }
+  assert.equal(buildVideoSettingsFormState(resolveForEngine(sharedSnapshot('4:3', engine.id), engine), null).aspectRatio, '21:9');
+  engine.modeCaps!.t2v!.aspectRatio = [];
+  assert.equal(resolveForEngine(sharedSnapshot('159:91', engine.id), engine).formValues.aspectRatio, '159:91');
+});
+
+test('saved generation settings stay authoritative and are not normalized like derived media metadata', () => {
+  const engine = seedanceEngine();
+  const snapshot = {
+    schemaVersion: 1, surface: 'video', engineId: engine.id, inputMode: 't2v',
+    core: { aspectRatio: '159:91' }, meta: {},
+  };
+  assert.equal(resolveForEngine(snapshot, engine).formValues.aspectRatio, '159:91');
 });
 
 test('shared video hydration resets for a changed or cleared shared video id', () => {


### PR DESCRIPTION
Recreating a public MiniMax H3 example with measured dimensions 2544×1456 (159:91) selected 21:9, because its measured ratio did not exactly match a supported setting and the composer fell back to the first option. Derived example snapshots now recover the closest ratio supported by the selected mode when the difference is below 2%, restoring 16:9 in this case.

Saved generation settings remain authoritative. Exact supported values, source-driven modes, and ratios outside the tolerance retain existing behavior. Original media, downloads, public routes, metadata and schemas are unchanged. The matching helper is route-local, with the existing settings architecture limit retained and the workspace agent guide updated.

Validation:
- Reproduced the 21:9 failure in a regression test using the actual H3 catalog before the fix.
- 28 focused workspace checks passed; full validation: 4,302 tests passed.
- Frontend lint, TypeScript and public exposure check passed; `git diff --check` clean.
- Covers landscape, portrait, equivalent dimensions, mode-specific capabilities, invalid values, tolerance and saved snapshots.
- Chrome preview flow verified: watch → Recreate this video → guest workspace retains MiniMax H3, the 1,383-character prompt, 15 seconds and 16:9 after hydration. No generation submitted.
- Vercel production build succeeded: https://maxvideoai-82gpujd09-camgraphes-projects.vercel.app/video/minimax-h3-wildfire-lookout-rescue (commit cf16998974a947b5d228355d0a58400ff2bcb9f2).
