### PR TITLE
perf(media): optimize Veo and Hailuo public demos

### DIFF
--- a/docs/operations/public-media-secondary-renditions-20260906.md
+++ b/docs/operations/public-media-secondary-renditions-20260906.md
@@ -1,0 +1,35 @@
+# Public demo rendition review — 2026-09-06
+
+This lot adds display renditions for three exact originals observed in production on `/models/veo-3-1`, `/examples/veo`, and `/examples/hailuo`. It uses the existing source catalogue and v1 encoding profiles. It does not replace original media or change routes, model publication, download/edit sources, SEO schema URLs, or reader policy.
+
+| Asset ID | Original bytes | Desktop bytes | Mobile bytes | Desktop saving | Mobile saving |
+|---|---:|---:|---:|---:|---:|
+| veo-3-1-model-demo | 3,433,088 | 2,612,009 | 2,004,063 | 23.9% | 41.6% |
+| veo-family-featured | 6,806,999 | 5,160,302 | 2,038,169 | 24.2% | 70.1% |
+| hailuo-family-featured | 7,414,821 | 2,842,786 | 1,750,267 | 61.7% | 76.4% |
+
+## Content acceptance
+
+All six candidates passed the existing prepare gate: complete decode, faststart, unchanged video duration, frame count, frame cadence and timestamps, preserved aspect ratio, and at least 15% byte savings. There are no failed profiles or omissions in this lot.
+
+Visual comparison sampled each original, desktop and mobile rendition at 0.5 seconds, the midpoint, and 0.5 seconds before the end. The checked subjects were room furnishing (Veo model), a bicycle workshop (Veo family), and a moving dancer on a patterned floor (Hailuo). Composition, color, subject detail and sampled motion positions were accepted for display use. Originals remain the quality reference. This is sampled visual review, not a claim that lossy encodings are pixel-identical.
+
+Audio acceptance is based on exact equality of AAC packet payload SHA-256, channels, sample rate, start and duration in the measured probes for every candidate. The audio is stream-copied; no new perceptual listening result is claimed. Full frame and packet timing gates complement the sampled visual review.
+
+Local preparation checkpoints and comparison frames are retained under `output/audits/public-media-secondary-20260906/` and are not committed to the public repository. The manifest records source/output hashes, measured probes, content acceptance and HTTP evidence.
+
+## Lifecycle and rollback
+
+Use explicit selections for all lifecycle commands, as the default limit is five catalogue entries:
+
+```bash
+pnpm --prefix frontend run media:public-renditions prepare --work-dir=/absolute/path --asset-id=veo-3-1-model-demo --asset-id=veo-family-featured --asset-id=hailuo-family-featured
+pnpm --prefix frontend run media:public-renditions publish --work-dir=/absolute/path --asset-id=veo-3-1-model-demo --asset-id=veo-family-featured --asset-id=hailuo-family-featured --review-evidence="docs/operations/public-media-secondary-renditions-20260906.md"
+pnpm --prefix frontend run media:public-renditions check --http
+pnpm --prefix frontend run media:public-renditions activate --asset-id=veo-3-1-model-demo --asset-id=veo-family-featured --asset-id=hailuo-family-featured
+pnpm --prefix frontend run media:public-renditions:check
+```
+
+Publishing creates immutable derivative objects. Activation changes the browser projection only in this branch until deployed. Reverting the catalogue/manifest/projection commit restores the prior original selection; retain immutable objects and originals. Never delete originals as rollback or restart a whole backfill for this bounded lot.
+
+Before rollout, verify the actual selected reader sources, playback and original actions in preview, and compare production builds under matching mobile/desktop, cold/warm conditions. Smaller files alone do not demonstrate a Core Web Vitals gain. Physical iPhone testing remains unavailable in this session.

--- a/frontend/config/public-video-renditions.generated.json
+++ b/frontend/config/public-video-renditions.generated.json
@@ -40,6 +40,21 @@
       "assetId": "seedance-2-5-model-demo",
       "desktop": "https://media.maxvideoai.com/marketing/video-renditions/b9a52e75940a011d8a0af4a7a6754c0ce74125bb5bc2a4532726d777da18176c/public-demo-v1/desktop/229667923d62609fceb0b9aa7c5e4be6cb94588017c5efd787e6b183c32ef2f2.mp4",
       "mobile": "https://media.maxvideoai.com/marketing/video-renditions/b9a52e75940a011d8a0af4a7a6754c0ce74125bb5bc2a4532726d777da18176c/public-demo-v1/mobile/a71c37c1a37bbb9fc0bfc210b1aef4f01a77e80a351781ed6d1d08896e02cba5.mp4"
+    },
+    "https://media.maxvideoai.com/renders/301cc489-d689-477f-94c4-0b051deda0bc/f01395c1-d0b2-48c3-9263-a55fb3f94417.mp4": {
+      "assetId": "veo-3-1-model-demo",
+      "desktop": "https://media.maxvideoai.com/marketing/video-renditions/48642e1744d63f77bb2d8d9a0fc093d63abc0c0a0ba69a8fc65061fa099e2a8c/public-demo-v1/desktop/077376df28bc24c1969f4fb1ed5996d906e77bc5fc4fab2307b1c6f950739f53.mp4",
+      "mobile": "https://media.maxvideoai.com/marketing/video-renditions/48642e1744d63f77bb2d8d9a0fc093d63abc0c0a0ba69a8fc65061fa099e2a8c/public-demo-v1/mobile/d58d894f1cf252815e95c9d7a4008ffef52ce2855e4af126a048737ea61c6619.mp4"
+    },
+    "https://media.maxvideoai.com/renders/301cc489-d689-477f-94c4-0b051deda0bc/be838954-2f82-4f30-a21e-da15a8e2faab.mp4": {
+      "assetId": "veo-family-featured",
+      "desktop": "https://media.maxvideoai.com/marketing/video-renditions/d31381b47610573ff8abd3c21f3641336b4ca9857db5b1c172e8b3b830ad12e1/public-demo-v1/desktop/3ac9f8cb4ca5de4defe8e68b69fc6b9c2706f30b31b9d8a824929c79f120619f.mp4",
+      "mobile": "https://media.maxvideoai.com/marketing/video-renditions/d31381b47610573ff8abd3c21f3641336b4ca9857db5b1c172e8b3b830ad12e1/public-demo-v1/mobile/295cc887e58f4262929128100f7beb8d366c30913bc55b66d372ebb0f46fff7c.mp4"
+    },
+    "https://media.maxvideoai.com/renders/301cc489-d689-477f-94c4-0b051deda0bc/1b29e9b2-c68d-46a3-8415-7677deed674a.mp4": {
+      "assetId": "hailuo-family-featured",
+      "desktop": "https://media.maxvideoai.com/marketing/video-renditions/418de36009b7617838f463ff189d7d26c4765b61e3772fc2fd488ff4426f2fee/public-demo-v1/desktop/fd15df849b6f9f63789afc0d16cbc110765c6eb8cf4cdc56b094239710436dec.mp4",
+      "mobile": "https://media.maxvideoai.com/marketing/video-renditions/418de36009b7617838f463ff189d7d26c4765b61e3772fc2fd488ff4426f2fee/public-demo-v1/mobile/139eb87b33a64acef57857d520fd79609f74c3d97452855be91ca1ec357ad46d.mp4"
     }
   }
 }

--- a/frontend/config/public-video-renditions.manifest.json
+++ b/frontend/config/public-video-renditions.manifest.json
@@ -1280,6 +1280,519 @@
       "pendingRenditions": {},
       "omissions": [],
       "failures": []
+    },
+    {
+      "assetId": "veo-3-1-model-demo",
+      "role": "public-demo",
+      "original": {
+        "url": "https://media.maxvideoai.com/renders/301cc489-d689-477f-94c4-0b051deda0bc/f01395c1-d0b2-48c3-9263-a55fb3f94417.mp4",
+        "sha256": "48642e1744d63f77bb2d8d9a0fc093d63abc0c0a0ba69a8fc65061fa099e2a8c",
+        "bytes": 3433088,
+        "probe": {
+          "width": 1280,
+          "height": 720,
+          "durationSeconds": 8,
+          "containerDurationSeconds": 8,
+          "videoStartSeconds": 0,
+          "videoFrameCount": 192,
+          "cadence": {
+            "kind": "cfr",
+            "frameCount": 192,
+            "firstTimestampSeconds": 0,
+            "lastTimestampSeconds": 7.958333,
+            "minDeltaSeconds": 0.041665999999999315,
+            "maxDeltaSeconds": 0.04166700000000034,
+            "timestampsSha256": "351ad3324bd08492d67c36a4a346a8cfa8bccc81adf3424cdb7d5f9e0f28241a"
+          },
+          "frameRate": {
+            "numerator": 24,
+            "denominator": 1
+          },
+          "videoCodec": "h264",
+          "pixelFormat": "yuv420p",
+          "sampleAspectRatio": {
+            "numerator": 1,
+            "denominator": 1
+          },
+          "colorTransfer": null,
+          "rotationDegrees": 0,
+          "audio": {
+            "codec": "aac",
+            "channels": 2,
+            "sampleRateHz": 48000,
+            "durationSeconds": 7.902,
+            "startSeconds": 0,
+            "packetPayloadSha256": "9ffb75a10067099a923264f67c5ba4c0c9a8a28d8bd1319bda8e1b97581c5e92"
+          },
+          "fastStart": true,
+          "decodeOk": true
+        }
+      },
+      "renditions": {
+        "desktop": {
+          "profileVersion": "public-demo-v1",
+          "url": "https://media.maxvideoai.com/marketing/video-renditions/48642e1744d63f77bb2d8d9a0fc093d63abc0c0a0ba69a8fc65061fa099e2a8c/public-demo-v1/desktop/077376df28bc24c1969f4fb1ed5996d906e77bc5fc4fab2307b1c6f950739f53.mp4",
+          "storageKey": "marketing/video-renditions/48642e1744d63f77bb2d8d9a0fc093d63abc0c0a0ba69a8fc65061fa099e2a8c/public-demo-v1/desktop/077376df28bc24c1969f4fb1ed5996d906e77bc5fc4fab2307b1c6f950739f53.mp4",
+          "sha256": "077376df28bc24c1969f4fb1ed5996d906e77bc5fc4fab2307b1c6f950739f53",
+          "bytes": 2612009,
+          "probe": {
+            "width": 1280,
+            "height": 720,
+            "durationSeconds": 8,
+            "containerDurationSeconds": 8,
+            "videoStartSeconds": 0,
+            "videoFrameCount": 192,
+            "cadence": {
+              "kind": "cfr",
+              "frameCount": 192,
+              "firstTimestampSeconds": 0,
+              "lastTimestampSeconds": 7.958333,
+              "minDeltaSeconds": 0.041665999999999315,
+              "maxDeltaSeconds": 0.04166700000000034,
+              "timestampsSha256": "351ad3324bd08492d67c36a4a346a8cfa8bccc81adf3424cdb7d5f9e0f28241a"
+            },
+            "frameRate": {
+              "numerator": 24,
+              "denominator": 1
+            },
+            "videoCodec": "h264",
+            "pixelFormat": "yuv420p",
+            "sampleAspectRatio": {
+              "numerator": 1,
+              "denominator": 1
+            },
+            "colorTransfer": null,
+            "rotationDegrees": 0,
+            "audio": {
+              "codec": "aac",
+              "channels": 2,
+              "sampleRateHz": 48000,
+              "durationSeconds": 7.902,
+              "startSeconds": 0,
+              "packetPayloadSha256": "9ffb75a10067099a923264f67c5ba4c0c9a8a28d8bd1319bda8e1b97581c5e92"
+            },
+            "fastStart": true,
+            "decodeOk": true
+          },
+          "visualReview": {
+            "reviewedAt": "2026-09-06T11:57:39.702Z",
+            "evidence": "docs/operations/public-media-secondary-renditions-20260906.md: sampled visual review and exact AAC payload/timing acceptance, 2026-09-06"
+          },
+          "httpCheck": {
+            "checkedAt": "2026-09-06T11:59:38.880Z",
+            "contentType": "video/mp4",
+            "bytes": 2612009,
+            "rangeStart": 0,
+            "rangeEnd": 31,
+            "totalBytes": 2612009
+          },
+          "activatedAt": "2026-09-06T11:59:38.691Z"
+        },
+        "mobile": {
+          "profileVersion": "public-demo-v1",
+          "url": "https://media.maxvideoai.com/marketing/video-renditions/48642e1744d63f77bb2d8d9a0fc093d63abc0c0a0ba69a8fc65061fa099e2a8c/public-demo-v1/mobile/d58d894f1cf252815e95c9d7a4008ffef52ce2855e4af126a048737ea61c6619.mp4",
+          "storageKey": "marketing/video-renditions/48642e1744d63f77bb2d8d9a0fc093d63abc0c0a0ba69a8fc65061fa099e2a8c/public-demo-v1/mobile/d58d894f1cf252815e95c9d7a4008ffef52ce2855e4af126a048737ea61c6619.mp4",
+          "sha256": "d58d894f1cf252815e95c9d7a4008ffef52ce2855e4af126a048737ea61c6619",
+          "bytes": 2004063,
+          "probe": {
+            "width": 1280,
+            "height": 720,
+            "durationSeconds": 8,
+            "containerDurationSeconds": 8,
+            "videoStartSeconds": 0,
+            "videoFrameCount": 192,
+            "cadence": {
+              "kind": "cfr",
+              "frameCount": 192,
+              "firstTimestampSeconds": 0,
+              "lastTimestampSeconds": 7.958333,
+              "minDeltaSeconds": 0.041665999999999315,
+              "maxDeltaSeconds": 0.04166700000000034,
+              "timestampsSha256": "351ad3324bd08492d67c36a4a346a8cfa8bccc81adf3424cdb7d5f9e0f28241a"
+            },
+            "frameRate": {
+              "numerator": 24,
+              "denominator": 1
+            },
+            "videoCodec": "h264",
+            "pixelFormat": "yuv420p",
+            "sampleAspectRatio": {
+              "numerator": 1,
+              "denominator": 1
+            },
+            "colorTransfer": null,
+            "rotationDegrees": 0,
+            "audio": {
+              "codec": "aac",
+              "channels": 2,
+              "sampleRateHz": 48000,
+              "durationSeconds": 7.902,
+              "startSeconds": 0,
+              "packetPayloadSha256": "9ffb75a10067099a923264f67c5ba4c0c9a8a28d8bd1319bda8e1b97581c5e92"
+            },
+            "fastStart": true,
+            "decodeOk": true
+          },
+          "visualReview": {
+            "reviewedAt": "2026-09-06T11:57:39.702Z",
+            "evidence": "docs/operations/public-media-secondary-renditions-20260906.md: sampled visual review and exact AAC payload/timing acceptance, 2026-09-06"
+          },
+          "httpCheck": {
+            "checkedAt": "2026-09-06T11:59:38.983Z",
+            "contentType": "video/mp4",
+            "bytes": 2004063,
+            "rangeStart": 0,
+            "rangeEnd": 31,
+            "totalBytes": 2004063
+          },
+          "activatedAt": "2026-09-06T11:59:38.691Z"
+        }
+      },
+      "pendingRenditions": {},
+      "omissions": [],
+      "failures": []
+    },
+    {
+      "assetId": "veo-family-featured",
+      "role": "public-demo",
+      "original": {
+        "url": "https://media.maxvideoai.com/renders/301cc489-d689-477f-94c4-0b051deda0bc/be838954-2f82-4f30-a21e-da15a8e2faab.mp4",
+        "sha256": "d31381b47610573ff8abd3c21f3641336b4ca9857db5b1c172e8b3b830ad12e1",
+        "bytes": 6806999,
+        "probe": {
+          "width": 1920,
+          "height": 1080,
+          "durationSeconds": 6,
+          "containerDurationSeconds": 6.016,
+          "videoStartSeconds": 0,
+          "videoFrameCount": 144,
+          "cadence": {
+            "kind": "cfr",
+            "frameCount": 144,
+            "firstTimestampSeconds": 0,
+            "lastTimestampSeconds": 5.958333,
+            "minDeltaSeconds": 0.041665999999999315,
+            "maxDeltaSeconds": 0.04166700000000034,
+            "timestampsSha256": "72448aa37d775085a4e4dfdd154c0c05e3953be347052c5585d515667ef97b62"
+          },
+          "frameRate": {
+            "numerator": 24,
+            "denominator": 1
+          },
+          "videoCodec": "h264",
+          "pixelFormat": "yuv420p",
+          "sampleAspectRatio": {
+            "numerator": 1,
+            "denominator": 1
+          },
+          "colorTransfer": null,
+          "rotationDegrees": 0,
+          "audio": {
+            "codec": "aac",
+            "channels": 2,
+            "sampleRateHz": 48000,
+            "durationSeconds": 6.016,
+            "startSeconds": 0,
+            "packetPayloadSha256": "4ec6dcb3bc164abcaffb2c18e6bd89237a18359220853003bbb1c80012e783ed"
+          },
+          "fastStart": true,
+          "decodeOk": true
+        }
+      },
+      "renditions": {
+        "desktop": {
+          "profileVersion": "public-demo-v1",
+          "url": "https://media.maxvideoai.com/marketing/video-renditions/d31381b47610573ff8abd3c21f3641336b4ca9857db5b1c172e8b3b830ad12e1/public-demo-v1/desktop/3ac9f8cb4ca5de4defe8e68b69fc6b9c2706f30b31b9d8a824929c79f120619f.mp4",
+          "storageKey": "marketing/video-renditions/d31381b47610573ff8abd3c21f3641336b4ca9857db5b1c172e8b3b830ad12e1/public-demo-v1/desktop/3ac9f8cb4ca5de4defe8e68b69fc6b9c2706f30b31b9d8a824929c79f120619f.mp4",
+          "sha256": "3ac9f8cb4ca5de4defe8e68b69fc6b9c2706f30b31b9d8a824929c79f120619f",
+          "bytes": 5160302,
+          "probe": {
+            "width": 1920,
+            "height": 1080,
+            "durationSeconds": 6,
+            "containerDurationSeconds": 6.016,
+            "videoStartSeconds": 0,
+            "videoFrameCount": 144,
+            "cadence": {
+              "kind": "cfr",
+              "frameCount": 144,
+              "firstTimestampSeconds": 0,
+              "lastTimestampSeconds": 5.958333,
+              "minDeltaSeconds": 0.041665999999999315,
+              "maxDeltaSeconds": 0.04166700000000034,
+              "timestampsSha256": "72448aa37d775085a4e4dfdd154c0c05e3953be347052c5585d515667ef97b62"
+            },
+            "frameRate": {
+              "numerator": 24,
+              "denominator": 1
+            },
+            "videoCodec": "h264",
+            "pixelFormat": "yuv420p",
+            "sampleAspectRatio": {
+              "numerator": 1,
+              "denominator": 1
+            },
+            "colorTransfer": null,
+            "rotationDegrees": 0,
+            "audio": {
+              "codec": "aac",
+              "channels": 2,
+              "sampleRateHz": 48000,
+              "durationSeconds": 6.016,
+              "startSeconds": 0,
+              "packetPayloadSha256": "4ec6dcb3bc164abcaffb2c18e6bd89237a18359220853003bbb1c80012e783ed"
+            },
+            "fastStart": true,
+            "decodeOk": true
+          },
+          "visualReview": {
+            "reviewedAt": "2026-09-06T11:57:39.702Z",
+            "evidence": "docs/operations/public-media-secondary-renditions-20260906.md: sampled visual review and exact AAC payload/timing acceptance, 2026-09-06"
+          },
+          "httpCheck": {
+            "checkedAt": "2026-09-06T11:59:39.093Z",
+            "contentType": "video/mp4",
+            "bytes": 5160302,
+            "rangeStart": 0,
+            "rangeEnd": 31,
+            "totalBytes": 5160302
+          },
+          "activatedAt": "2026-09-06T11:59:38.691Z"
+        },
+        "mobile": {
+          "profileVersion": "public-demo-v1",
+          "url": "https://media.maxvideoai.com/marketing/video-renditions/d31381b47610573ff8abd3c21f3641336b4ca9857db5b1c172e8b3b830ad12e1/public-demo-v1/mobile/295cc887e58f4262929128100f7beb8d366c30913bc55b66d372ebb0f46fff7c.mp4",
+          "storageKey": "marketing/video-renditions/d31381b47610573ff8abd3c21f3641336b4ca9857db5b1c172e8b3b830ad12e1/public-demo-v1/mobile/295cc887e58f4262929128100f7beb8d366c30913bc55b66d372ebb0f46fff7c.mp4",
+          "sha256": "295cc887e58f4262929128100f7beb8d366c30913bc55b66d372ebb0f46fff7c",
+          "bytes": 2038169,
+          "probe": {
+            "width": 1280,
+            "height": 720,
+            "durationSeconds": 6,
+            "containerDurationSeconds": 6.016,
+            "videoStartSeconds": 0,
+            "videoFrameCount": 144,
+            "cadence": {
+              "kind": "cfr",
+              "frameCount": 144,
+              "firstTimestampSeconds": 0,
+              "lastTimestampSeconds": 5.958333,
+              "minDeltaSeconds": 0.041665999999999315,
+              "maxDeltaSeconds": 0.04166700000000034,
+              "timestampsSha256": "72448aa37d775085a4e4dfdd154c0c05e3953be347052c5585d515667ef97b62"
+            },
+            "frameRate": {
+              "numerator": 24,
+              "denominator": 1
+            },
+            "videoCodec": "h264",
+            "pixelFormat": "yuv420p",
+            "sampleAspectRatio": {
+              "numerator": 1,
+              "denominator": 1
+            },
+            "colorTransfer": null,
+            "rotationDegrees": 0,
+            "audio": {
+              "codec": "aac",
+              "channels": 2,
+              "sampleRateHz": 48000,
+              "durationSeconds": 6.016,
+              "startSeconds": 0,
+              "packetPayloadSha256": "4ec6dcb3bc164abcaffb2c18e6bd89237a18359220853003bbb1c80012e783ed"
+            },
+            "fastStart": true,
+            "decodeOk": true
+          },
+          "visualReview": {
+            "reviewedAt": "2026-09-06T11:57:39.702Z",
+            "evidence": "docs/operations/public-media-secondary-renditions-20260906.md: sampled visual review and exact AAC payload/timing acceptance, 2026-09-06"
+          },
+          "httpCheck": {
+            "checkedAt": "2026-09-06T11:59:39.216Z",
+            "contentType": "video/mp4",
+            "bytes": 2038169,
+            "rangeStart": 0,
+            "rangeEnd": 31,
+            "totalBytes": 2038169
+          },
+          "activatedAt": "2026-09-06T11:59:38.691Z"
+        }
+      },
+      "pendingRenditions": {},
+      "omissions": [],
+      "failures": []
+    },
+    {
+      "assetId": "hailuo-family-featured",
+      "role": "public-demo",
+      "original": {
+        "url": "https://media.maxvideoai.com/renders/301cc489-d689-477f-94c4-0b051deda0bc/1b29e9b2-c68d-46a3-8415-7677deed674a.mp4",
+        "sha256": "418de36009b7617838f463ff189d7d26c4765b61e3772fc2fd488ff4426f2fee",
+        "bytes": 7414821,
+        "probe": {
+          "width": 1344,
+          "height": 768,
+          "durationSeconds": 8,
+          "containerDurationSeconds": 8.032,
+          "videoStartSeconds": 0,
+          "videoFrameCount": 192,
+          "cadence": {
+            "kind": "cfr",
+            "frameCount": 192,
+            "firstTimestampSeconds": 0,
+            "lastTimestampSeconds": 7.958333,
+            "minDeltaSeconds": 0.041665999999999315,
+            "maxDeltaSeconds": 0.04166700000000034,
+            "timestampsSha256": "351ad3324bd08492d67c36a4a346a8cfa8bccc81adf3424cdb7d5f9e0f28241a"
+          },
+          "frameRate": {
+            "numerator": 24,
+            "denominator": 1
+          },
+          "videoCodec": "h264",
+          "pixelFormat": "yuv420p",
+          "sampleAspectRatio": {
+            "numerator": 1,
+            "denominator": 1
+          },
+          "colorTransfer": null,
+          "rotationDegrees": 0,
+          "audio": {
+            "codec": "aac",
+            "channels": 2,
+            "sampleRateHz": 32000,
+            "durationSeconds": 8,
+            "startSeconds": 0,
+            "packetPayloadSha256": "13e07a8cb62f36618e85a181a4fa58766cc769aaa07dbda50a809c737f04a336"
+          },
+          "fastStart": true,
+          "decodeOk": true
+        }
+      },
+      "renditions": {
+        "desktop": {
+          "profileVersion": "public-demo-v1",
+          "url": "https://media.maxvideoai.com/marketing/video-renditions/418de36009b7617838f463ff189d7d26c4765b61e3772fc2fd488ff4426f2fee/public-demo-v1/desktop/fd15df849b6f9f63789afc0d16cbc110765c6eb8cf4cdc56b094239710436dec.mp4",
+          "storageKey": "marketing/video-renditions/418de36009b7617838f463ff189d7d26c4765b61e3772fc2fd488ff4426f2fee/public-demo-v1/desktop/fd15df849b6f9f63789afc0d16cbc110765c6eb8cf4cdc56b094239710436dec.mp4",
+          "sha256": "fd15df849b6f9f63789afc0d16cbc110765c6eb8cf4cdc56b094239710436dec",
+          "bytes": 2842786,
+          "probe": {
+            "width": 1344,
+            "height": 768,
+            "durationSeconds": 8,
+            "containerDurationSeconds": 8,
+            "videoStartSeconds": 0,
+            "videoFrameCount": 192,
+            "cadence": {
+              "kind": "cfr",
+              "frameCount": 192,
+              "firstTimestampSeconds": 0,
+              "lastTimestampSeconds": 7.958333,
+              "minDeltaSeconds": 0.041665999999999315,
+              "maxDeltaSeconds": 0.04166700000000034,
+              "timestampsSha256": "351ad3324bd08492d67c36a4a346a8cfa8bccc81adf3424cdb7d5f9e0f28241a"
+            },
+            "frameRate": {
+              "numerator": 24,
+              "denominator": 1
+            },
+            "videoCodec": "h264",
+            "pixelFormat": "yuv420p",
+            "sampleAspectRatio": {
+              "numerator": 1,
+              "denominator": 1
+            },
+            "colorTransfer": null,
+            "rotationDegrees": 0,
+            "audio": {
+              "codec": "aac",
+              "channels": 2,
+              "sampleRateHz": 32000,
+              "durationSeconds": 8,
+              "startSeconds": 0,
+              "packetPayloadSha256": "13e07a8cb62f36618e85a181a4fa58766cc769aaa07dbda50a809c737f04a336"
+            },
+            "fastStart": true,
+            "decodeOk": true
+          },
+          "visualReview": {
+            "reviewedAt": "2026-09-06T11:57:39.702Z",
+            "evidence": "docs/operations/public-media-secondary-renditions-20260906.md: sampled visual review and exact AAC payload/timing acceptance, 2026-09-06"
+          },
+          "httpCheck": {
+            "checkedAt": "2026-09-06T11:59:39.336Z",
+            "contentType": "video/mp4",
+            "bytes": 2842786,
+            "rangeStart": 0,
+            "rangeEnd": 31,
+            "totalBytes": 2842786
+          },
+          "activatedAt": "2026-09-06T11:59:38.691Z"
+        },
+        "mobile": {
+          "profileVersion": "public-demo-v1",
+          "url": "https://media.maxvideoai.com/marketing/video-renditions/418de36009b7617838f463ff189d7d26c4765b61e3772fc2fd488ff4426f2fee/public-demo-v1/mobile/139eb87b33a64acef57857d520fd79609f74c3d97452855be91ca1ec357ad46d.mp4",
+          "storageKey": "marketing/video-renditions/418de36009b7617838f463ff189d7d26c4765b61e3772fc2fd488ff4426f2fee/public-demo-v1/mobile/139eb87b33a64acef57857d520fd79609f74c3d97452855be91ca1ec357ad46d.mp4",
+          "sha256": "139eb87b33a64acef57857d520fd79609f74c3d97452855be91ca1ec357ad46d",
+          "bytes": 1750267,
+          "probe": {
+            "width": 1260,
+            "height": 720,
+            "durationSeconds": 8,
+            "containerDurationSeconds": 8,
+            "videoStartSeconds": 0,
+            "videoFrameCount": 192,
+            "cadence": {
+              "kind": "cfr",
+              "frameCount": 192,
+              "firstTimestampSeconds": 0,
+              "lastTimestampSeconds": 7.958333,
+              "minDeltaSeconds": 0.041665999999999315,
+              "maxDeltaSeconds": 0.04166700000000034,
+              "timestampsSha256": "351ad3324bd08492d67c36a4a346a8cfa8bccc81adf3424cdb7d5f9e0f28241a"
+            },
+            "frameRate": {
+              "numerator": 24,
+              "denominator": 1
+            },
+            "videoCodec": "h264",
+            "pixelFormat": "yuv420p",
+            "sampleAspectRatio": {
+              "numerator": 1,
+              "denominator": 1
+            },
+            "colorTransfer": null,
+            "rotationDegrees": 0,
+            "audio": {
+              "codec": "aac",
+              "channels": 2,
+              "sampleRateHz": 32000,
+              "durationSeconds": 8,
+              "startSeconds": 0,
+              "packetPayloadSha256": "13e07a8cb62f36618e85a181a4fa58766cc769aaa07dbda50a809c737f04a336"
+            },
+            "fastStart": true,
+            "decodeOk": true
+          },
+          "visualReview": {
+            "reviewedAt": "2026-09-06T11:57:39.702Z",
+            "evidence": "docs/operations/public-media-secondary-renditions-20260906.md: sampled visual review and exact AAC payload/timing acceptance, 2026-09-06"
+          },
+          "httpCheck": {
+            "checkedAt": "2026-09-06T11:59:39.452Z",
+            "contentType": "video/mp4",
+            "bytes": 1750267,
+            "rangeStart": 0,
+            "rangeEnd": 31,
+            "totalBytes": 1750267
+          },
+          "activatedAt": "2026-09-06T11:59:38.691Z"
+        }
+      },
+      "pendingRenditions": {},
+      "omissions": [],
+      "failures": []
     }
   ]
 }

--- a/frontend/config/public-video-sources.json
+++ b/frontend/config/public-video-sources.json
@@ -41,6 +41,21 @@
       "assetId": "seedance-2-5-model-demo",
       "url": "https://media.maxvideoai.com/renders/301cc489-d689-477f-94c4-0b051deda0bc/6ab56b7c-bece-4c72-9372-c910bafdc622.mp4",
       "sha256": "b9a52e75940a011d8a0af4a7a6754c0ce74125bb5bc2a4532726d777da18176c"
+    },
+    {
+      "assetId": "veo-3-1-model-demo",
+      "url": "https://media.maxvideoai.com/renders/301cc489-d689-477f-94c4-0b051deda0bc/f01395c1-d0b2-48c3-9263-a55fb3f94417.mp4",
+      "sha256": "48642e1744d63f77bb2d8d9a0fc093d63abc0c0a0ba69a8fc65061fa099e2a8c"
+    },
+    {
+      "assetId": "veo-family-featured",
+      "url": "https://media.maxvideoai.com/renders/301cc489-d689-477f-94c4-0b051deda0bc/be838954-2f82-4f30-a21e-da15a8e2faab.mp4",
+      "sha256": "d31381b47610573ff8abd3c21f3641336b4ca9857db5b1c172e8b3b830ad12e1"
+    },
+    {
+      "assetId": "hailuo-family-featured",
+      "url": "https://media.maxvideoai.com/renders/301cc489-d689-477f-94c4-0b051deda0bc/1b29e9b2-c68d-46a3-8415-7677deed674a.mp4",
+      "sha256": "418de36009b7617838f463ff189d7d26c4765b61e3772fc2fd488ff4426f2fee"
     }
   ]
 }


### PR DESCRIPTION
Three public demos still selected their full original in visible desktop readers. This adds the exact observed sources from the Veo 3.1 model page and the Veo/Hailuo family galleries to the existing v1 rendition lifecycle.

| Demo | Original | Desktop | Mobile |
|---|---:|---:|---:|
| Veo 3.1 model | 3.43 MB | 2.61 MB (−24%) | 2.00 MB (−42%) |
| Veo family | 6.81 MB | 5.16 MB (−24%) | 2.04 MB (−70%) |
| Hailuo family | 7.41 MB | 2.84 MB (−62%) | 1.75 MB (−76%) |

All six candidates preserve complete video duration/cadence/frame timeline and exact AAC packet payload/timing, decode fully, and use faststart. Sampled visual review is recorded in `docs/operations/public-media-secondary-renditions-20260906.md`. Immutable derivative objects are published and HTTP/Range checked; activation is in this branch's generated projection. Prior catalogue, manifest and projection entries are unchanged.

Original/download/edit/schema URLs, model publication, routes and reader defaults are unchanged. Comparisons still default to Original. Rollback is a revert of this data-only commit; no source deletion is involved.

Validation: 34 focused rendition tests, offline coherence/critical-home coverage, live HTTP/Range checks, exposure check and diff check passed. Quality CI and the Vercel build are green on `9f65991c94363df24766e575b05aa5cb5d8763bb`. [Preview](https://maxvideoai-l4us5pc6t-camgraphes-projects.vercel.app/examples/hailuo).

Chrome preview checks confirm all three hero readers select the expected desktop renditions and play without media errors; the model hero pauses out of view. The two family watch pages also pass Auto playback, end/restart, pause, keyboard seeking and selection of the exact original. MiniMax mute/unmute state changes correctly. Mobile profiles passed HTTP, decode and content gates; no physical iPhone test is claimed.

Three SEO snapshots match after normalizing the known deployment origins and one verified model-image S3/CDN alias (same path, HTTP 200, bytes and ETag). Raw snapshots retain those environment differences; this is a preview comparison, not a post-merge production check.

Performance evidence includes 36 initial Lighthouse navigations across mobile/desktop and cold/warm scenarios, followed by 24 targeted Hailuo mobile confirmations. Desktop cold total transfer changes from 7.489 to 5.903 MB on Veo and 7.973 to 3.458 MB on Hailuo. Initial desktop figures include the preview-only Vercel toolbar; its ~35 KB warm traffic explains the warm transfer difference. No initial video request occurs in the measured mobile pages.

Hailuo's initial mobile LCP medians were 1.592 → 1.902 s. The final six-runs-per-build confirmation, with `vercel.live` blocked on both sides, gives 1.908 → 1.900 s and CLS 0. All values are retained, including one candidate load at 3.276 s (baseline range 1.600–1.986 s; candidate range 1.583–3.276 s). Its cause is not established. These results support the byte savings and do not demonstrate improved field Core Web Vitals or guarantee every mobile load is unaffected. A physical iPhone and longer consented sessions remain outside this verification.

Local evidence: `output/audits/public-media-secondary-20260906/`, especially `performance-summary.md`, all 60 retained reports, `browser/results.json`, and `seo-comparison.json`. Before production rollout, review the mobile variability and perform the usual deployment smoke checks; GitHub approval is still required.
