### PR TITLE
perf(angle): prepare the responsive images used by the orbit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,8 @@ When extending public rendition coverage beyond the homepage, verify the exact s
 
 Image thumbnail repair must cover stored readers as well as `app_jobs`: `job_outputs`, `media_assets`, and legacy `user_assets`. The operational CLI wires the projection repair owner in `frontend/scripts/_lib/image-thumbnail-projections.ts`; do not replace it with broad media-library upserts. Preserve originals, valid thumbnails, ownership, job/payment status and unrelated metadata. Persist generated thumbnails before synchronizing references, then guard the reference transaction with the current source and exact stored snapshots. A projection failure keeps the conservative resume cursor before that job. Validate this boundary with `tests/image-thumbnail-projections-postgres.test.ts` on disposable PostgreSQL.
 
+When preparing Angle's public orbit images, use the same Next Image responsive URLs and sizing policy as the displayed views. Preserve the deferred scheduling and verify preparation/display parity with `tests/angle-orbit-responsive-preload.test.ts`; do not warm the larger authored source while rendering a different optimized URL.
+
 ## Architecture Contracts
 
 Architecture tests are part of the project design, not incidental test coverage.

--- a/docs/engineering/media-delivery.md
+++ b/docs/engineering/media-delivery.md
@@ -17,6 +17,7 @@ Read this guide when changing image/video presentation, poster URLs, generated m
 | Manual watch/comparison controls | `frontend/components/media/usePublicVideoControls.ts` |
 | Watch / native comparison presentation | `frontend/components/watch/WatchVideoPlayer.tsx` / `frontend/components/media/PublicVideoPlayer.client.tsx` |
 | Optimized poster URLs | `frontend/lib/media-helpers.ts` and `frontend/config/image-optimizer.json` |
+| Angle public orbit display and responsive preparation | `frontend/src/components/tools/angle/landing/AngleOrbitStudio.client.tsx` |
 | Generated image thumbnails | `frontend/server/image-thumbnails.ts` |
 | Uploaded image/video thumbnails | `frontend/server/upload-thumbnails.ts` |
 | Small video previews | `frontend/server/video-preview.ts` |
@@ -41,6 +42,8 @@ Playback hooks stay client-side; encoding, storage and database work stay server
 - Use a representative full-duration rendition for a model demonstration after its derivative has passed the measured media gates, explicit visual/audio review, public HTTP readiness and activation. A profile with a validated savings omission deliberately uses the original.
 - Preserve private/signed URL behavior. Public image optimization does not forward a user's authorization headers; do not strip signatures or publish a private source to make optimization work.
 - Preserve aspect ratio, alpha/transparency when required, orientation, and the distinction between original quality and display quality.
+
+Angle's public orbit prepares the other three views after its existing idle boundary. Derive their `src`, `srcSet` and `sizes` with Next Image's `getImageProps` and the same sizing policy as the displayed image; assign `sizes` and `srcset` before `src`. Loading the authored source URL would warm a different resource and waste a second transfer on selection. Keep the initial view as the only mounted image, preserve scheduled-work cleanup, and check `tests/angle-orbit-responsive-preload.test.ts` when changing this behavior. Future display quality or sizing changes must stay shared with preparation; validate actual browser selection at the relevant viewport and DPR.
 
 ## Playback and Core Web Vitals
 

--- a/frontend/src/components/tools/angle/landing/AngleOrbitStudio.client.tsx
+++ b/frontend/src/components/tools/angle/landing/AngleOrbitStudio.client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Image from 'next/image';
+import Image, { getImageProps } from 'next/image';
 import { useCallback, useEffect, useRef, useState, type KeyboardEvent, type PointerEvent } from 'react';
 import { ANGLE_ORBIT_ASSETS, type AngleLandingContent } from './angle-landing-assets';
 import {
@@ -13,6 +13,7 @@ import {
 import styles from './AngleLanding.module.css';
 
 const INITIAL_VIEW = ANGLE_ORBIT_VIEW_IDS[1];
+const ORBIT_IMAGE_SIZES = '(max-width: 1024px) 100vw, 58vw';
 
 type PointerStart = {
   id: number;
@@ -45,8 +46,16 @@ export function AngleOrbitStudio({ content }: { content: AngleLandingContent['he
     const preload = () => {
       for (const viewId of ANGLE_ORBIT_VIEW_IDS) {
         if (viewId === INITIAL_VIEW) continue;
+        const { props } = getImageProps({
+          src: ANGLE_ORBIT_ASSETS.hero[viewId],
+          alt: '',
+          fill: true,
+          sizes: ORBIT_IMAGE_SIZES,
+        });
         const preloadImage = new window.Image();
-        preloadImage.src = ANGLE_ORBIT_ASSETS.hero[viewId];
+        preloadImage.sizes = props.sizes ?? ORBIT_IMAGE_SIZES;
+        if (props.srcSet) preloadImage.srcset = props.srcSet;
+        preloadImage.src = props.src;
       }
     };
 
@@ -138,7 +147,7 @@ export function AngleOrbitStudio({ content }: { content: AngleLandingContent['he
           alt={viewContent.alt}
           fill
           priority={activeView === INITIAL_VIEW}
-          sizes="(max-width: 1024px) 100vw, 58vw"
+          sizes={ORBIT_IMAGE_SIZES}
           onError={() => markFailed(activeView)}
           className={reducedMotion ? styles.orbitImageReduced : styles.orbitImage}
         />

--- a/tests/angle-orbit-responsive-preload.test.ts
+++ b/tests/angle-orbit-responsive-preload.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+test('Angle idle preparation warms the same responsive images displayed by its controls', async () => {
+  const require = createRequire(import.meta.url);
+  const previousCssLoader = require.extensions['.css'];
+  require.extensions['.css'] = () => {};
+  let AngleOrbitStudio;
+  try {
+    ({ AngleOrbitStudio } = await import('../frontend/src/components/tools/angle/landing/AngleOrbitStudio.client'));
+  } finally {
+    if (previousCssLoader) require.extensions['.css'] = previousCssLoader;
+    else delete require.extensions['.css'];
+  }
+
+  const dom = new JSDOM('<div id="root"></div>', { url: 'http://localhost', pretendToBeVisual: true });
+  const preloaded: HTMLImageElement[] = [];
+  let idleCallback: (() => void) | undefined;
+  const cancelled: number[] = [];
+  Object.defineProperty(dom.window, 'Image', {
+    configurable: true,
+    value: function () {
+      const image = dom.window.document.createElement('img');
+      preloaded.push(image);
+      return image;
+    },
+  });
+  Object.defineProperty(dom.window, 'matchMedia', {
+    configurable: true,
+    value: () => ({ matches: false, addEventListener() {}, removeEventListener() {} }),
+  });
+  Object.defineProperty(dom.window, 'requestIdleCallback', {
+    configurable: true,
+    value: (callback: () => void) => { idleCallback = callback; return 7; },
+  });
+  Object.defineProperty(dom.window, 'cancelIdleCallback', {
+    configurable: true,
+    value: (handle: number) => { cancelled.push(handle); },
+  });
+  const globals = { window: dom.window, document: dom.window.document, navigator: dom.window.navigator, IS_REACT_ACT_ENVIRONMENT: true };
+  const previous = new Map(Object.keys(globals).map((key) => [key, Object.getOwnPropertyDescriptor(globalThis, key)]));
+  for (const [key, value] of Object.entries(globals)) {
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value });
+  }
+  const container = dom.window.document.querySelector<HTMLElement>('#root')!;
+  const root = createRoot(container);
+  const content = JSON.parse(readFileSync('frontend/messages/en.json', 'utf8')).toolMarketing.angle.hero.orbit;
+  try {
+    await act(async () => root.render(React.createElement(AngleOrbitStudio, { content })));
+    const initial = container.querySelector('img')!.getAttribute('src');
+    assert.equal(container.querySelectorAll('img').length, 1);
+    assert.equal(preloaded.length, 0, 'secondary views must wait for the existing idle boundary');
+    assert.ok(idleCallback);
+    await act(async () => idleCallback!());
+    assert.equal(preloaded.length, 3, 'only the three other views are prepared');
+    for (const image of preloaded) {
+      assert.match(image.getAttribute('src')!, /^\/_next\/image\?/, 'prepare the display derivative instead of the source file');
+      assert.ok(image.getAttribute('srcset'), 'preserve responsive selection for viewport and DPR');
+      assert.ok(image.getAttribute('sizes'));
+    }
+    const next = container.querySelector<HTMLButtonElement>(`button[aria-label="${content.nextLabel}"]`)!;
+    for (let index = 0; index < 3; index += 1) {
+      await act(async () => next.click());
+      const displayed = container.querySelector('img')!;
+      const prepared = preloaded.find((image) => image.src === displayed.src);
+      assert.ok(prepared, 'each selected view must reuse an already prepared resource');
+      assert.equal(prepared.getAttribute('srcset'), displayed.getAttribute('srcset'));
+      assert.equal(prepared.getAttribute('sizes'), displayed.getAttribute('sizes'));
+      assert.equal(container.querySelectorAll('img').length, 1);
+    }
+    await act(async () => next.click());
+    assert.equal(container.querySelector('img')!.getAttribute('src'), initial, 'the fourth action returns to the initial view');
+  } finally {
+    await act(async () => root.unmount());
+    dom.window.close();
+    for (const [key, descriptor] of previous) {
+      if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+      else Reflect.deleteProperty(globalThis, key);
+    }
+  }
+  assert.deepEqual(cancelled, [7], 'retain cancellation of scheduled work on unmount');
+});


### PR DESCRIPTION
Angle's public orbit displayed responsive Next Image variants, but its idle preparation downloaded the three authored source files. Switching views then used different display URLs. Prepare the same responsive `src`, `srcSet` and `sizes` as the displayed image, using `getImageProps` and a shared sizing policy. The browser still chooses for viewport and DPR; the four views, quality, geometry, deferred scheduling and interaction handlers stay unchanged.

Measured on `da4ac6a816bbef0496e181d30718622f5b731a91` against main `723f1daebdc350e1b11184f8698cdcefc3dcbd5a`:

| Scenario | Median total transfer before → after |
|---|---|
| Mobile cold | 785,862 → 593,768 bytes (−24%) |
| Desktop cold, initial series | 931,689 → 751,116 bytes (−19%) |
| Mobile warm | 298,847 → 108,052 bytes (−64%) |
| Desktop warm | 299,018 → 118,241 bytes (−60%) |

The three secondary views themselves transfer 272,406 → 78,918 bytes on mobile (−71%). Their actual requested width is 750px on the tested 412px/DPR 1.75 viewport, and 828px in the desktop preset. The source files and existing 750px display responses have matching SHA256 across both deployments: display quality is preserved.

30 retained Lighthouse 12.6.1 observations: 24 across mobile/desktop cold/warm cells, then 6 additional desktop cold visits in reversed build order. Immutable URLs, matching settings, toolbar blocked on both, no analytics consent, cold browser cache reset and excluded warm primers. All samples remain available locally.

This is a transfer reduction, not a demonstrated LCP improvement. Mobile cold LCP stays widely dispersed at roughly 2–5s. Warm medians are close: mobile 1.200 → 1.202s, desktop 0.455 → 0.458s. The initial desktop cold increase (0.942 → 1.230s) did not repeat in the reversed series (1.406 → 1.096s); pooling all six visits per build gives 1.110 → 1.177s. The uncertainty and +67ms pooled difference are retained. CLS is zero throughout, with no Lighthouse warnings.

Validation:

- The mounted-component regression test first reproduced the direct source request, then checked deferred preparation, responsive URL parity through all four views and cleanup. All 8 focused tests, frontend lint, exposure checks, production/TypeScript build and Quality CI pass.
- Chrome desktop: all four images complete after selection, next controls and keyboard navigation work. Native pointer-drag automation was unavailable; state-level drag tests pass and handlers are unchanged. Physical iPhone remains unverified.
- Three EN/FR/ES HTML comparisons preserve SEO, all image attributes and preloads after only deployment-origin normalization. No routing, sitemap, metadata, source-asset, generation or payment files change.
- AGENTS.md and the media delivery guide record the preparation/display contract.

Evidence: `output/audits/angle-responsive-preload-20260906/`, including both raw measurement series, response hashes, HTML snapshots and browser captures. Field CWV and delivered-production behavior still require follow-up after merge. Independent of #275.
