### PR TITLE
Fix workspace gallery jumps during concurrent video renders

### DIFF
--- a/docs/engineering/llm-working-guide.md
+++ b/docs/engineering/llm-working-guide.md
@@ -105,4 +105,5 @@ Keep these boundaries stable when continuing workspace cleanup:
 - `useWorkspaceComposerState` owns prompt/input field state.
 - `useWorkspaceWalletPreflight` owns wallet balance preflight.
 - `useWorkspaceGenerationRunner` owns generation submission, accepted results, and polling.
+- `useWorkspaceRenderState` polls the latest render snapshot on a stable interval, with at most one outstanding request per job. Status/feed updates must not restart that interval. Completed jobs already in history must not be reinserted into local renders. The video rail keeps a single chronological order across active and historical groups; `tests/workspace-render-polling-behavior.test.ts` and `tests/gallery-rail-order-behavior.test.ts` cover these transitions.
 - `useWorkspaceAssetLibrary`, `useWorkspaceReferenceAssets`, and `useWorkspaceKlingElementAssets` own their specific asset concerns.

--- a/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceRenderState.ts
+++ b/frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceRenderState.ts
@@ -146,10 +146,11 @@ export function useWorkspaceRenderState({
     writeScopedStorage(STORAGE_KEYS.pendingRenders, serialized);
   }, [hydratedForScope, renders, storageScope, writeScopedStorage]);
 
+  const hasRendersNeedingStatusRefresh = getRendersNeedingStatusRefresh(renders).length > 0;
+
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    const jobsNeedingRefresh = getRendersNeedingStatusRefresh(renders);
-    if (!jobsNeedingRefresh.length) {
+    if (!hasRendersNeedingStatusRefresh) {
       if (pendingPollRef.current !== null) {
         window.clearInterval(pendingPollRef.current);
         pendingPollRef.current = null;
@@ -157,11 +158,15 @@ export function useWorkspaceRenderState({
       return;
     }
     let cancelled = false;
+    const inFlightJobs = new Set<string>();
 
     const poll = async () => {
+      // Read the latest jobs without restarting this timer on every status/feed update.
+      const jobsNeedingRefresh = getRendersNeedingStatusRefresh(rendersRef.current);
       await Promise.all(
         jobsNeedingRefresh.map(async (render) => {
-          if (!render.jobId) return;
+          if (!render.jobId || inFlightJobs.has(render.jobId)) return;
+          inFlightJobs.add(render.jobId);
           try {
             const providerStatus = await getJobStatus(render.jobId);
             statusErrorCountsRef.current.delete(render.jobId);
@@ -200,6 +205,8 @@ export function useWorkspaceRenderState({
             }
 
             // ignore other transient errors and retry on next tick
+          } finally {
+            inFlightJobs.delete(render.jobId);
           }
         })
       );
@@ -220,7 +227,7 @@ export function useWorkspaceRenderState({
         pendingPollRef.current = null;
       }
     };
-  }, [renders, workspaceCopy]);
+  }, [hasRendersNeedingStatusRefresh, workspaceCopy]);
 
   useEffect(() => {
     if (!recentJobs.length) return;

--- a/frontend/app/(core)/(workspace)/app/_lib/workspace-render-status.ts
+++ b/frontend/app/(core)/(workspace)/app/_lib/workspace-render-status.ts
@@ -235,6 +235,10 @@ export function mergeRecentJobsIntoLocalRenders(
       return;
     }
 
+    // Completed, synced jobs already belong to history. Re-adding them here makes
+    // them flash through the active list before the cleanup effect removes them.
+    if (converted.status === 'completed' && (converted.videoUrl || converted.readyVideoUrl)) return;
+
     next.push(converted);
     if (converted.localKey) {
       byLocalKey.set(converted.localKey, next.length - 1);

--- a/frontend/components/GalleryRail.tsx
+++ b/frontend/components/GalleryRail.tsx
@@ -25,6 +25,7 @@ import {
   DEFAULT_GROUP_PROVIDER,
   INITIAL_EAGER_PREVIEW_COUNT,
   filterGalleryFeedJobs,
+  orderGalleryGroups,
   resolveAspectRatioLabel,
   resolveBackgroundWarmPreviewLimit,
   resolveDisplayedActiveGroup,
@@ -170,9 +171,8 @@ export function GalleryRail({
     const nonCurated = [...normalizedActiveGroups, ...normalizedHistoricalGroups].filter(
       (group) => !group.hero.job?.curated
     );
-    if (nonCurated.length) return nonCurated;
-    return [...normalizedActiveGroups, ...normalizedHistoricalGroups];
-  }, [normalizedActiveGroups, normalizedHistoricalGroups]);
+    return orderGalleryGroups(nonCurated.length ? nonCurated : [...normalizedActiveGroups, ...normalizedHistoricalGroups], feedType);
+  }, [feedType, normalizedActiveGroups, normalizedHistoricalGroups]);
   const renderedGroups = useMemo(() => (hasMounted ? combinedGroups : []), [combinedGroups, hasMounted]);
   useEffect(() => {
     if (feedType !== 'video') return undefined;

--- a/frontend/components/gallery-rail-utils.ts
+++ b/frontend/components/gallery-rail-utils.ts
@@ -7,6 +7,18 @@ import { isPlaceholderMediaUrl, isTemporaryProviderMediaUrl, normalizeMediaUrl }
 export type GalleryVariant = 'desktop' | 'mobile' | 'responsive';
 export type GalleryFeedType = 'video' | 'image';
 
+export function orderGalleryGroups(groups: GroupSummary[], feedType: GalleryFeedType): GroupSummary[] {
+  if (feedType !== 'video') return groups;
+  // A render keeps its chronological position when it moves from local state
+  // to history. Identity breaks timestamp ties independently of either list.
+  return [...groups].sort((a, b) => {
+    const aTime = Date.parse(a.createdAt);
+    const bTime = Date.parse(b.createdAt);
+    const byTime = (Number.isFinite(bTime) ? bTime : 0) - (Number.isFinite(aTime) ? aTime : 0);
+    return byTime || a.id.localeCompare(b.id);
+  });
+}
+
 export const DEFAULT_GALLERY_COPY = {
   title: 'Latest renders',
   viewAll: 'View all',

--- a/tests/gallery-rail-order-behavior.test.ts
+++ b/tests/gallery-rail-order-behavior.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildGalleryFixture } from './helpers/gallery-rail-fixture';
+import { JSDOM } from 'jsdom';
+
+
+test('a newer video finishing before an older render keeps its card and DOM position', async () => {
+  const script = await buildGalleryFixture();
+  const dom = new JSDOM('<div id="root"></div>', { url: 'http://localhost', runScripts: 'outside-only' });
+  const win = dom.window as unknown as Window & {
+    IS_REACT_ACT_ENVIRONMENT: boolean;
+    galleryFixture: { act: (fn: () => void) => void; render: () => void; completeNewer: () => void; refresh: () => void; reset: (type?: string) => void; unmount: () => void };
+  };
+  win.IS_REACT_ACT_ENVIRONMENT = true;
+  dom.window.HTMLMediaElement.prototype.pause = () => {};
+  dom.window.eval(script);
+  const fixture = win.galleryFixture;
+  const cards = () => Array.from(dom.window.document.querySelectorAll('figure[aria-label="Preview"]'));
+  try {
+    fixture.act(fixture.render);
+    const [newer, older] = cards();
+    assert.equal(cards().length, 2);
+    assert.match(newer.parentElement!.parentElement!.textContent!, /5s/);
+    fixture.act(fixture.completeNewer);
+    assert.ok(cards()[0] === newer, 'finishing the newest render must not move its card below older pending renders');
+    assert.ok(cards()[1] === older, 'the older card must not move or remount');
+    fixture.act(fixture.refresh);
+    assert.ok(cards()[0] === newer);
+    assert.ok(cards()[1] === older);
+  } finally {
+    fixture.act(fixture.unmount);
+    dom.window.close();
+  }
+});

--- a/tests/helpers/gallery-rail-fixture.ts
+++ b/tests/helpers/gallery-rail-fixture.ts
@@ -1,0 +1,63 @@
+import path from 'node:path';
+import { build } from 'esbuild';
+
+// Keep the real rail, cards, grouping and media components. Only replace the
+// authenticated data source, localization context and Next's host adapters.
+export async function buildGalleryFixture() {
+  const frontend = path.join(process.cwd(), 'frontend');
+  const stubs: Record<string, string> = {
+    '@/lib/api': `
+      export function useInfiniteJobs() { return window.galleryFeed; }
+      export function useEngines() { return { data: { engines: [] } }; }
+      export async function saveImageToLibrary() {}
+    `,
+    '@/lib/i18n/I18nProvider': `
+      const t = (_key, fallback) => fallback;
+      export function useI18n() { return { t, locale: 'en' }; }
+    `,
+    'next/link': `import React from 'react'; export default function Link({prefetch, ...props}) { return React.createElement('a', props); }`,
+    'next/image': `import React from 'react'; export default function Image({fill, priority, unoptimized, ...props}) { return React.createElement('img', props); }`,
+  };
+  const bundle = await build({
+    absWorkingDir: frontend, bundle: true, format: 'iife', platform: 'browser', jsx: 'automatic',
+    define: { 'process.env.NODE_ENV': '"test"' }, write: false, outfile: 'gallery-fixture.js',
+    tsconfig: path.join(frontend, 'tsconfig.json'),
+    plugins: [{ name: 'gallery-host-adapters', setup(builder) {
+      builder.onResolve({ filter: /.*/ }, (args) => args.path in stubs ? { path: args.path, namespace: 'gallery-host' } : undefined);
+      builder.onLoad({ filter: /.*/, namespace: 'gallery-host' }, (args) => ({ contents: stubs[args.path], loader: 'jsx', resolveDir: frontend }));
+    } }],
+    stdin: { loader: 'tsx', resolveDir: frontend, contents: `
+      import React, { act } from 'react';
+      import { createRoot } from 'react-dom/client';
+      import { GalleryRail } from './components/GalleryRail';
+      import { groupJobsIntoSummaries } from './lib/job-groups';
+      const root = createRoot(document.getElementById('root'));
+      const noop = () => {};
+      const engine = { id: 'fixture', label: 'Fixture' };
+      const newer = { jobId: 'newer', groupId: 'newer', engineId: 'fixture', engineLabel: 'Fixture', durationSec: 5, prompt: 'Newer render', createdAt: '2026-09-06T20:02:00Z', status: 'pending', message: 'IN_PROGRESS' };
+      const older = { ...newer, jobId: 'older', groupId: 'older', durationSec: 8, prompt: 'Older render', createdAt: '2026-09-06T20:01:00Z' };
+      let feedType = 'video';
+      let background = [];
+      let current = [newer, older];
+      let active = [newer, older];
+      function render() {
+        window.galleryFeed = { data: [{ jobs: current }], stableJobs: current, mutate: noop, setSize: noop, isLoading: false, isValidating: false };
+        const activeGroups = groupJobsIntoSummaries(active, { includeSinglesAsGroups: true }).groups.map(group => ({ ...group, source: 'active' }));
+        root.render(<GalleryRail engine={engine} engineRegistry={[engine]} activeGroups={activeGroups} feedType={feedType} variant="desktop" />);
+      }
+      window.galleryFixture = {
+        act,
+        render,
+        completeNewer() { current = [{ ...newer, status: 'completed', videoUrl: '/fixture.mp4' }, older, ...background]; active = [older, ...background]; render(); },
+        refresh() { current = current.map(job => ({ ...job })); render(); },
+        reset(type = 'video', count = 2) {
+          feedType = type;
+          background = Array.from({ length: Math.max(0, count - 2) }, (_, index) => ({ ...older, jobId: 'background-' + index, groupId: 'background-' + index, durationSec: index + 9, createdAt: '2026-09-06T19:0' + (5 - index) + ':00Z' }));
+          current = [newer, older, ...background]; active = current; render();
+        },
+        unmount() { root.unmount(); },
+      };
+    ` },
+  });
+  return bundle.outputFiles[0].text;
+}

--- a/tests/workspace-render-polling-behavior.test.ts
+++ b/tests/workspace-render-polling-behavior.test.ts
@@ -1,0 +1,162 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { JSDOM } from 'jsdom';
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { Job } from '../frontend/types/jobs';
+
+const jobs: Job[] = Array.from({ length: 7 }, (_, index) => ({
+  jobId: `job_${index}`,
+  engineLabel: 'MiniMax H3',
+  durationSec: 5,
+  prompt: 'Polling regression fixture',
+  createdAt: `2026-09-06T20:0${index}:00.000Z`,
+  status: 'pending',
+  message: 'IN_PROGRESS',
+}));
+
+async function mountWorkspace(initialJobs = jobs, localOnly = false) {
+  process.env.NEXT_PUBLIC_SUPABASE_URL ??= 'https://maxvideoai-test.supabase.co';
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= 'test-anon-key';
+  const dom = new JSDOM('<div id="root"></div>', { url: 'http://localhost/app' });
+  const previous = new Map<string, PropertyDescriptor | undefined>();
+  const requests: Array<{ jobId: string; resolve: (response: Response) => void }> = [];
+  const intervals = new Map<number, { callback: () => void; delay: number }>();
+  let timerId = 0;
+  dom.window.setInterval = ((callback: () => void, delay: number) => {
+    intervals.set(++timerId, { callback, delay });
+    return timerId;
+  }) as typeof dom.window.setInterval;
+  dom.window.clearInterval = (id) => { intervals.delete(id); };
+  for (const [key, value] of Object.entries({
+    window: dom.window, document: dom.window.document, navigator: dom.window.navigator,
+    CustomEvent: dom.window.CustomEvent, React, IS_REACT_ACT_ENVIRONMENT: true,
+    BroadcastChannel: undefined,
+    fetch: (url: string) => new Promise<Response>((resolve) => {
+      requests.push({ jobId: decodeURIComponent(url.split('/').pop()!), resolve });
+    }),
+  })) {
+    previous.set(key, Object.getOwnPropertyDescriptor(globalThis, key));
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value });
+  }
+  const { useWorkspaceRenderState } = await import(
+    '../frontend/app/(core)/(workspace)/app/_hooks/useWorkspaceRenderState'
+  );
+  let state!: ReturnType<typeof useWorkspaceRenderState>;
+  let recentJobs = localOnly ? [] : initialJobs;
+  const options = {
+    engineIdByLabel: new Map<string, string>(), provider: 'fal' as const,
+    storageScope: 'test-user', hydratedForScope: 'test-user', formIterations: 1,
+    compositeOverride: null, compositeOverrideSummary: null,
+    writeScopedStorage: () => undefined,
+    workspaceCopy: { messages: { seedanceCopyrightBlocked: 'Blocked', seedanceCopyrightBlockedRefunded: 'Refunded' } },
+  };
+  const commits: string[][] = [];
+  function Fixture() {
+    state = useWorkspaceRenderState({ ...options, recentJobs });
+    React.useLayoutEffect(() => { commits.push(state.renders.map((render) => render.jobId!)); });
+    return null;
+  }
+  const root = createRoot(dom.window.document.getElementById('root')!);
+  await act(async () => root.render(React.createElement(Fixture)));
+  if (localOnly) {
+    const { convertJobToLocalRender } = await import('../frontend/app/(core)/(workspace)/app/_lib/workspace-render-status');
+    await act(async () => state.setRenders(initialJobs.map((job) => convertJobToLocalRender(job))));
+  }
+  return {
+    requests, commits,
+    get state() { return state; },
+    async respond(index: number, payload: Record<string, unknown> = {}, status = 200) {
+      await act(async () => requests[index].resolve(new Response(JSON.stringify({
+        ok: true, jobId: requests[index].jobId, status: 'pending', message: 'IN_PROGRESS', ...payload,
+      }), { status })));
+    },
+    async tick() {
+      await act(async () => {
+        [...intervals.values()].filter((timer) => timer.delay === 4000).forEach((timer) => timer.callback());
+      });
+    },
+    async update(nextJobs: Job[]) {
+      recentJobs = nextJobs;
+      await act(async () => root.render(React.createElement(Fixture)));
+    },
+    async dispose() {
+      await act(async () => root.unmount());
+      dom.window.close();
+      for (const [key, descriptor] of previous) {
+        if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+        else Reflect.deleteProperty(globalThis, key);
+      }
+    },
+  };
+}
+
+test('seven in-flight renders do not restart polling on each status response or feed refresh', async () => {
+  const fixture = await mountWorkspace();
+  try {
+    assert.equal(fixture.requests.length, 7);
+    await fixture.tick();
+    assert.equal(fixture.requests.length, 7, 'slow requests must not overlap with the next interval');
+    await fixture.respond(0);
+    assert.equal(fixture.requests.length, 7, 'a single pending response must not start another seven requests');
+    await fixture.update(jobs.map((job) => ({ ...job })));
+    assert.equal(fixture.requests.length, 7, 'a feed refresh must not restart the polling interval');
+    for (let index = 1; index < 7; index += 1) await fixture.respond(index);
+    await fixture.tick();
+    assert.equal(fixture.requests.length, 14, 'the next interval polls once per still-pending render');
+  } finally { await fixture.dispose(); }
+});
+
+test('polling keeps completion, delayed thumbnails, failures and missing-job cleanup working', async () => {
+  const fixture = await mountWorkspace(jobs.slice(0, 4), true);
+  try {
+    const ids = fixture.requests.map((request) => request.jobId);
+    await fixture.respond(0, { status: 'completed', videoUrl: '/video.mp4', thumbUrl: '/thumb.jpg' });
+    await fixture.respond(1, { status: 'failed', message: 'Provider failed' });
+    await fixture.respond(2, { error: 'Not found' }, 404);
+    await fixture.respond(3, { status: 'completed', videoUrl: '/video.mp4' });
+    assert.equal(fixture.state.renders.find((render) => render.jobId === ids[0])?.status, 'completed');
+    assert.equal(fixture.state.renders.find((render) => render.jobId === ids[1])?.status, 'failed');
+    assert.equal(fixture.state.renders.some((render) => render.jobId === ids[2]), false);
+    await fixture.tick();
+    assert.deepEqual(fixture.requests.slice(4).map((request) => request.jobId), [ids[3]], 'only a missing thumbnail still needs polling');
+    await fixture.respond(4, { status: 'completed', videoUrl: '/video.mp4', thumbUrl: '/thumb.jpg' });
+    await fixture.tick();
+    assert.equal(fixture.requests.length, 5);
+  } finally { await fixture.dispose(); }
+});
+
+test('history refresh does not temporarily reinsert finished jobs into local renders', async () => {
+  const finished = { ...jobs[0], status: 'completed', videoUrl: '/video.mp4', thumbUrl: '/thumb.jpg' };
+  const fixture = await mountWorkspace([jobs[1], finished]);
+  try {
+    await fixture.update([{ ...jobs[1] }, { ...finished }]);
+    assert.equal(fixture.commits.some((ids) => ids.includes('job_0')), false, 'finished history must never flash back into the active list');
+  } finally { await fixture.dispose(); }
+});
+
+test('transient status errors retry and unauthorized renders are removed only after three responses', async () => {
+  const fixture = await mountWorkspace(jobs.slice(0, 1), true);
+  try {
+    await fixture.respond(0, { error: 'Temporary outage' }, 503);
+    assert.equal(fixture.state.renders.length, 1);
+    await fixture.tick();
+    for (let index = 1; index <= 3; index += 1) {
+      await fixture.respond(index, { error: 'Unauthorized' }, 401);
+      assert.equal(fixture.state.renders.length, index < 3 ? 1 : 0);
+      await fixture.tick();
+    }
+    assert.equal(fixture.requests.length, 4, 'removed renders must stop polling');
+  } finally { await fixture.dispose(); }
+});
+
+test('new jobs join the next polling cycle while a slow existing job stays in flight', async () => {
+  const fixture = await mountWorkspace(jobs.slice(0, 1));
+  try {
+    await fixture.update(jobs.slice(0, 2));
+    assert.equal(fixture.requests.length, 1, 'new feed data does not restart the timer');
+    await fixture.tick();
+    assert.deepEqual(fixture.requests.map((request) => request.jobId), ['job_0', 'job_1']);
+  } finally { await fixture.dispose(); }
+});


### PR DESCRIPTION
When several videos are rendering, each status response restarts the workspace polling effect and can issue another request for every pending job. History refreshes also briefly reinsert finished jobs into local state, while the rail moves completed cards below older pending renders.

Keep the polling interval stable, read the current render snapshot at each tick, and skip requests already in flight for the same job. Keep completed history out of local renders and order the video rail chronologically across active and historical groups. Image-feed ordering is preserved.

Validation:
- Full repository suite: 4,328 tests passed.
- Final focused checks: 22 tests passed, including real React hook and gallery DOM regressions.
- Frontend lint, TypeScript, public-exposure check, diff check, and production build passed.
- Chrome fixture with the actual gallery components and project CSS: seven simulated renders, same card DOM identity/order and 0.00 px displacement after newest-job completion and a feed refresh.

The regression was reproduced before the fix: one of seven status responses caused seven additional requests; finished history reappeared in local render commits; completing the newest render moved its existing card below the older pending one. Browser validation uses controlled data and host adapters, not an authenticated production generation.

Work is isolated in codex/workspace-gallery-stability. No production deployment or changes to the other active task.
