### PR TITLE
Fix MCP Fal acceptance and MiniMax H3 validation and timeouts

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   quality:
+    name: Quality CI
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/docs/engineering/mcp-mode-coverage.md
+++ b/docs/engineering/mcp-mode-coverage.md
@@ -6,6 +6,19 @@ of truth; this file explains the MCP projection and must not duplicate prices.
 
 ## Current coverage
 
+Fal-primary MCP video execution uses enqueue-only submission from the trusted
+paid continuation. Provider-ID tracking completes before acceptance; webhook
+and cron owners finish the job. Keep this separate from the site's synchronous
+subscription: MCP's 120-second request lifetime cannot contain long renders.
+`frontend/server/fal-poll-timing.ts` owns the bounded timeout policy (90 minutes
+for H3, 55 minutes for other Fal engines); terminal errors remain refund-eligible.
+
+H3 `ref2v` image fields publish `imageAspectRatio` bounds of 0.4–2.5 and require
+an owned asset. Validate stored dimensions before an exact MCP quote and again
+at execution, using the shared media-field constraint helper. Never trust
+client dimension claims or silently crop references. See the
+[7 September incident audit](../operations/minimax-h3-mcp-incident-20260907.md).
+
 Checked 2026-09-03 against the canonical runtime registry and engine schemas.
 
 MCP catalog and exact hidden-model resolution are read-only database paths. They

--- a/docs/operations/minimax-h3-mcp-incident-20260907.md
+++ b/docs/operations/minimax-h3-mcp-incident-20260907.md
@@ -1,0 +1,52 @@
+# MiniMax H3 MCP incident — 7 September 2026
+
+Snapshot: 01:58 UTC (03:58 Europe/Madrid). Production project `shy-flower-71253790`, branch `br-late-term-aeo22xpz`; Vercel deployment `dpl_Ho7DMj7dTCCfmHmdAvyUdUXrBAJ2`.
+
+## Findings
+
+The production audit joined `app_jobs` to `mcp_generation_quotes` to identify MCP submissions created after 6 September 20:00 UTC. This cohort contains 32 H3 jobs and 3 H3 Max jobs. H3 Max's three jobs completed. H3 had 18 completed, 14 failed and none running at this snapshot. Three completed H3 jobs had already received a timeout refund. The two most recent timeout failures may still receive a late provider result, as the earlier jobs did.
+
+The initial eight-job batch from 7 September contains five long-running H3 renders and three definitive downstream errors. This is not a stalled MCP polling cron: recorded polls kept receiving `IN_PROGRESS`.
+
+1. **Missing reference geometry validation.** Nine H3 requests returned HTTP 422 with `image_aspect_ratio_error`. The provider error specifies an inclusive width/height range of 0.4–2.5. The reused stored image `ma_f0d315f9ccf84640bdecbcb22538d449` is 1920 × 548 (ratio 3.5036). Both the stored metadata and provider result confirm the mismatch. These failures include requests with and without audio.
+2. **Provider failure.** The three newest jobs returned HTTP 500 with `downstream_service_error`; their inference timings were approximately 148, 262 and 316 seconds. This was independently read from Fal's result API, not inferred from the public generic error message. The application cannot repair the upstream service from this repository.
+3. **MCP request lifetime mismatch.** `/api/mcp` has a 120-second runtime, while the Fal submission owner waits up to 240 seconds using `subscribe`. Vercel recorded a 504 timeout even after the provider request ID had been persisted. A slow generation therefore appears as a failed confirmation request.
+4. **Premature timeout refunds.** The shared poll policy allowed 35 minutes plus 20 minutes grace. Two jobs were refunded around 58–59 minutes and then completed around 64–65 minutes. Provider latency therefore exceeds the old policy. Successes in the earlier batch also took roughly 24–50 minutes.
+
+## Latest batch
+
+| Job ID | State at snapshot | Charge USD | Refunded USD |
+| --- | --- | ---: | ---: |
+| `f26c3549-826c-419d-818e-d34fe4434484` | failed | 0.97 | 0.97 |
+| `66c2142f-e691-4dc6-84fd-acc161503dbd` | failed | 0.97 | 0.97 |
+| `5477e9db-141f-46d7-8cdc-6ff6170238f3` | failed | 0.81 | 0.81 |
+| `a63af760-b4a6-41ce-ae74-950b5b33c057` | failed | 1.29 | 1.29 |
+| `f3e645d7-728a-4a69-bdf2-9c7e521c7ab2` | failed | 0.81 | 0.81 |
+| `ed890288-f7d7-495a-b328-5923bb8face0` | completed | 0.81 | 0.81 |
+| `c4d08b37-ef0f-4f8d-8faf-e322affddb1b` | completed | 0.81 | 0.81 |
+| `d1595cd2-7d61-4a10-a4d8-97ad2cbdd88a` | completed | 0.81 | 0.81 |
+
+Across the 35-job audit cohort, 17 refunds total USD 14.57. Each inspected job has exactly one charge; each refund matches that job's full charge, with no duplicate refunds. The three late successes retain their refunds and have no replacement charge. The latest eight-job batch is fully refunded (USD 7.28), with three completed outputs and five current failures. Receipt entries were checked directly; these are wallet credits, not card refunds.
+
+## Corrections
+
+- The trusted MCP video continuation selects enqueue-only execution for Fal-primary requests. It awaits the existing provider-ID tracking hook and returns acceptance, without subscribing until render completion. Ordinary site generation and direct-provider routing retain their current behavior.
+- Accepted enqueue results use the existing asynchronous lifecycle branch, avoiding a later queued finalization overwriting a fast terminal webhook or refund.
+- H3 reference-image fields declare `imageAspectRatio: { min: 0.4, max: 2.5 }`. The common media helper validates trusted dimensions at the site execution boundary and before MCP pricing/confirmation. Missing dimensions and out-of-range images are rejected; model details publish the range and require an owned image asset. The engine catalog was regenerated from its source.
+- H3's poll grace is extended to 55 minutes after the normal 35-minute window, for a bounded total of 90 minutes, evaluated on the next scheduled poll. Other engines keep 55 minutes total. Explicit provider terminal failures remain immediately refund-eligible. This 90-minute cap is an operational choice based on observed successful renders, not a provider latency guarantee.
+
+## Validation and remaining work
+
+Regression tests first reproduced the missing geometry check, blocked MCP subscription and premature H3 timeout. Focused tests cover enqueue rejection without resubmission, awaited tracking, ordinary synchronous results, stored geometry versus spoofed client dimensions, exact ratio boundaries, quote rejection before pricing, model details, quote/charge concurrency on disposable PostgreSQL, and timeout refund policy.
+
+ESLint, TypeScript, public-exposure checks, registry/projection checks and the full production build passed. All 4,345 tests passed in an isolated checkout of the incident patch. The first full run identified a legacy MiniMax fixture that needed owned image dimensions; it was updated. The other initial failure came from untracked local audit reports being scanned by the ghost-subdomain test and did not occur in the isolated checkout. A paid end-to-end generation was not run. Local validation uses Node 23; GitHub CI and the project target Node 22. The build reports a Supabase Edge Runtime warning from the existing dependency path.
+
+The corrections are prepared on `codex/audit-minimax-mcp-jobs`; publication and deployment status belong to its pull request. No production database rows, existing refunds, source images or provider jobs were manually changed. No new paid generation was submitted. Deployment is required for the new validation, MCP acceptance and H3 timeout policy to apply. Provider HTTP 500s and variable latency remain outside this patch.
+
+## Provider support references
+
+- HTTP 500: `01a07962-3f31-7310-9634-f8c9867b6eea`, `01a07961-2395-7ff1-abd2-5ce578017242`, `01a07960-0847-7ac2-b7e1-b4fb687e43a1`.
+- Late successful outputs: `01a07954-bf12-7731-921e-7e7a2912f834`, `01a07956-0b2c-7971-a914-e1e8b070845b`.
+- Ratio rejection example: `01a078a8-d3b3-7f03-9556-1f50fd442b9c`.
+
+No support message has been sent. This report intentionally excludes prompts, private source URLs and credentials.

--- a/frontend/app/api/generate/_lib/fal-submission.ts
+++ b/frontend/app/api/generate/_lib/fal-submission.ts
@@ -147,7 +147,7 @@ export async function submitFalGenerateTask(params: {
             engineId: params.engineId,
             requestId,
           });
-          params.persistProviderJobId(requestId);
+          return params.persistProviderJobId(requestId);
         },
         onQueueUpdate: (status) => {
           if (!status) return;

--- a/frontend/app/api/generate/_lib/generation-media-constraints.ts
+++ b/frontend/app/api/generate/_lib/generation-media-constraints.ts
@@ -3,6 +3,7 @@ import {
   hasFieldSpecificMediaConstraint,
   resolveEngineMediaFieldConstraint,
   validateMediaFileAgainstConstraint,
+  validateImageAspectRatio,
 } from '@/lib/media-field-constraints';
 import type { ReferenceBudgetMediaItem } from '@/lib/reference-budget';
 import { getFalEngineById } from '@/config/falEngines';
@@ -34,6 +35,7 @@ type MediaConstraintError =
   | 'MEDIA_FORMAT_UNSUPPORTED'
   | 'MEDIA_DIMENSIONS_UNVERIFIED'
   | 'MEDIA_DIMENSIONS_TOO_SMALL'
+  | 'MEDIA_ASPECT_RATIO_UNSUPPORTED'
   | 'MEDIA_DURATION_UNVERIFIED'
   | 'MEDIA_DURATION_UNSUPPORTED'
   | 'MEDIA_COMBINED_DURATION_EXCEEDED';
@@ -327,6 +329,16 @@ export async function validateGenerationMediaConstraints(params: {
 
     const trustedWidth = normalizeDimension(stored.width);
     const trustedHeight = normalizeDimension(stored.height);
+    const imageRatio = validateImageAspectRatio(field, trustedWidth, trustedHeight);
+    if (imageRatio !== 'valid') {
+      return failure({
+        error: imageRatio === 'unverified' ? 'MEDIA_DIMENSIONS_UNVERIFIED' : 'MEDIA_ASPECT_RATIO_UNSUPPORTED',
+        fieldId: candidate.fieldId,
+        message: imageRatio === 'unverified'
+          ? 'This image reference has no trusted dimension metadata. Upload it again before generating.'
+          : `This image is ${trustedWidth} x ${trustedHeight} px. ${engine.label} requires an image width/height ratio between ${field.imageAspectRatio!.min} and ${field.imageAspectRatio!.max}. Crop or pad the image before generating.`,
+      });
+    }
     if (
       requiresOwnedMedia
       && (field.type === 'image' || field.type === 'video')

--- a/frontend/app/api/generate/_lib/video-provider-submission.ts
+++ b/frontend/app/api/generate/_lib/video-provider-submission.ts
@@ -254,5 +254,18 @@ export async function submitGenerateProviderTask(params: {
   if (!falSubmission.ok) {
     return { kind: 'error_response', status: falSubmission.status, body: falSubmission.body };
   }
+  if (params.falPayload.submissionMode === 'enqueue') {
+    // The initial job and charge already exist. Do not overwrite a fast terminal webhook
+    // with a queued finalization (including its media and refund state).
+    return {
+      kind: 'accepted_response',
+      body: {
+        ok: true,
+        jobId: params.jobId,
+        providerJobId: falSubmission.generationResult.providerJobId,
+        status: 'queued',
+      },
+    };
+  }
   return { kind: 'generation_result', generationResult: falSubmission.generationResult };
 }

--- a/frontend/config/engine-catalog.json
+++ b/frontend/config/engine-catalog.json
@@ -16826,6 +16826,10 @@
             "minCount": 0,
             "maxCount": 9,
             "maxSizeMB": 30,
+            "imageAspectRatio": {
+              "min": 0.4,
+              "max": 2.5
+            },
             "acceptedMimeTypes": [
               "image/jpeg",
               "image/png",

--- a/frontend/lib/media-field-constraints.ts
+++ b/frontend/lib/media-field-constraints.ts
@@ -7,6 +7,19 @@ export type MediaFieldConstraint = {
   unmappedDeclaredFormats?: string[];
 };
 
+export function validateImageAspectRatio(
+  field: EngineInputField,
+  width: number | null | undefined,
+  height: number | null | undefined,
+): 'valid' | 'unverified' | 'unsupported' {
+  const range = field.type === 'image' ? field.imageAspectRatio : undefined;
+  if (!range) return 'valid';
+  if (!Number.isSafeInteger(width) || !Number.isSafeInteger(height)
+    || Number(width) <= 0 || Number(height) <= 0) return 'unverified';
+  const ratio = Number(width) / Number(height);
+  return ratio >= range.min && ratio <= range.max ? 'valid' : 'unsupported';
+}
+
 export type MediaFileConstraintValidation =
   | { ok: true }
   | {

--- a/frontend/server/fal-poll-timing.ts
+++ b/frontend/server/fal-poll-timing.ts
@@ -1,0 +1,16 @@
+const NORMAL_WINDOW_MS = 35 * 60_000;
+const DEFAULT_GRACE_MS = 20 * 60_000;
+
+export function getFalPollTiming(engineId: string, createdAt: string, now: number) {
+  const createdAtMs = Date.parse(createdAt);
+  const ageMs = Number.isFinite(createdAtMs) ? now - createdAtMs : 0;
+  // H3 delivered successful outputs after 63–65 minutes in the 2026-09-07 audit.
+  // Keep its total wait bounded at 90 minutes; terminal provider errors bypass grace.
+  const graceMs = engineId === 'minimax-h3' ? 55 * 60_000 : DEFAULT_GRACE_MS;
+  return {
+    ageMs,
+    graceMs,
+    timedOut: ageMs > NORMAL_WINDOW_MS,
+    beyondTimeoutGrace: ageMs > NORMAL_WINDOW_MS + graceMs,
+  };
+}

--- a/frontend/server/fal-poll.ts
+++ b/frontend/server/fal-poll.ts
@@ -6,6 +6,7 @@ import { linkFalJob } from '@/server/admin-job-tools';
 import { updateJobFromFalWebhook } from '@/server/fal-webhook-handler';
 import { backfillCompletedMcpJobOutputs } from '@/server/media-library/mcp-output-assets';
 import { toUserFacingFailureMessage } from '@/server/user-facing-failure-messages';
+import { getFalPollTiming } from '@/server/fal-poll-timing';
 
 type FalPendingJob = {
   job_id: string;
@@ -19,8 +20,6 @@ type FalPendingJob = {
 
 const POLL_BASE_DELAYS_MS = [5_000, 15_000, 30_000, 60_000, 120_000];
 const POLL_INITIAL_DELAY_MS = 5_000;
-const POLL_MAX_DURATION_MS = 35 * 60_000;
-const POLL_TIMEOUT_GRACE_MS = 20 * 60_000;
 const FAILURE_STATES = new Set(['FAILED', 'FAIL', 'ERROR', 'ERRORED', 'CANCELLED', 'CANCELED', 'NOT_FOUND', 'MISSING', 'UNKNOWN']);
 const COMPLETED_STATES = new Set(['COMPLETED', 'FINISHED', 'SUCCESS', 'SUCCEEDED', 'OK']);
 
@@ -113,10 +112,7 @@ export async function runFalPoll() {
         continue;
       }
 
-      const createdAtMs = Date.parse(job.created_at);
-      const ageMs = Number.isFinite(createdAtMs) ? now - createdAtMs : 0;
-      const timedOut = Number.isFinite(createdAtMs) && ageMs > POLL_MAX_DURATION_MS;
-      const beyondTimeoutGrace = Number.isFinite(createdAtMs) && ageMs > POLL_MAX_DURATION_MS + POLL_TIMEOUT_GRACE_MS;
+      const { ageMs, timedOut, beyondTimeoutGrace, graceMs } = getFalPollTiming(job.engine_id, job.created_at, now);
 
       const pollHistory = await query<{ attempts: number; last_attempt_at: string | null }>(
         `SELECT COUNT(*)::int AS attempts, MAX(created_at) AS last_attempt_at
@@ -179,7 +175,7 @@ export async function runFalPoll() {
             {
               reason: 'Unable to determine render engine during timeout grace window.',
               ageMs,
-              graceMs: POLL_TIMEOUT_GRACE_MS,
+              graceMs,
             },
             engineIdForLookup
           );
@@ -212,7 +208,7 @@ export async function runFalPoll() {
             {
               reason: 'Render status temporarily unavailable during timeout grace window.',
               ageMs,
-              graceMs: POLL_TIMEOUT_GRACE_MS,
+              graceMs,
             },
             engineIdForLookup
           );
@@ -263,7 +259,7 @@ export async function runFalPoll() {
               reason: 'Render still processing during timeout grace window.',
               falStatus: state,
               ageMs,
-              graceMs: POLL_TIMEOUT_GRACE_MS,
+              graceMs,
             },
             engineIdForLookup
           );
@@ -281,7 +277,7 @@ export async function runFalPoll() {
               reason: 'Render result not ready during timeout grace window.',
               falStatus: state ?? null,
               ageMs,
-              graceMs: POLL_TIMEOUT_GRACE_MS,
+              graceMs,
             },
             engineIdForLookup
           );

--- a/frontend/src/config/fal-engines/minimax-h3.ts
+++ b/frontend/src/config/fal-engines/minimax-h3.ts
@@ -99,6 +99,7 @@ export const MINIMAX_H3_ENGINE: EngineCaps = {
         minCount: 0,
         maxCount: 9,
         maxSizeMB: 30,
+        imageAspectRatio: { min: 0.4, max: 2.5 },
         acceptedMimeTypes: ['image/jpeg', 'image/png', 'image/webp'],
         acceptedFileExtensions: [...IMAGE_FORMATS],
         source: 'either',

--- a/frontend/src/lib/fal-types.ts
+++ b/frontend/src/lib/fal-types.ts
@@ -20,6 +20,8 @@ export type GenerateAttachment = {
 };
 
 export type GeneratePayload = {
+  /** Internal execution policy; MCP returns after queue acceptance. */
+  submissionMode?: 'enqueue';
   engineId: string;
   prompt: string;
   durationSec?: number;

--- a/frontend/src/lib/fal.ts
+++ b/frontend/src/lib/fal.ts
@@ -61,6 +61,19 @@ async function generateViaFal(
   let enqueuedRequestId: string | undefined;
   let result: Awaited<ReturnType<typeof falClient.subscribe>>;
   try {
+    if (payload.submissionMode === 'enqueue') {
+      const queued = await falClient.queue.submit(model, { input: requestBody, webhookUrl });
+      enqueuedRequestId = queued.request_id;
+      if (!enqueuedRequestId) throw new Error('FAL queue response did not contain a request ID');
+      await hooks?.onRequestId?.(enqueuedRequestId);
+      return {
+        provider,
+        thumbUrl: fallbackThumb,
+        providerJobId: enqueuedRequestId,
+        status: 'queued',
+        progress: 0,
+      };
+    }
     result = await falClient.subscribe(model, {
       input: requestBody,
       webhookUrl,

--- a/frontend/src/server/agent-api/generation-capability-validation.ts
+++ b/frontend/src/server/agent-api/generation-capability-validation.ts
@@ -33,6 +33,7 @@ import {
 import {
   resolveEngineMediaFieldConstraint,
   validateMediaFileAgainstConstraint,
+  validateImageAspectRatio,
 } from '@/lib/media-field-constraints';
 
 const VIDEO_FIELD_BY_SETTING: Record<string, string> = {
@@ -758,6 +759,17 @@ function validateReferences(
     );
     if (!fields.length) fail('references', 'reference_invalid');
     validateTrustedReferenceDuration(reference, fields, candidate, options);
+    if (fields.length === 1 && fields[0]!.imageAspectRatio) {
+      if (reference.kind !== 'asset') {
+        // Budget estimates may describe unverified media; executable quotes may not.
+        if (!options.allowUnverifiedReferenceDuration) fail('references', 'reference_invalid');
+      } else if (options.resolvedReferences) {
+        const resolved = resolvedReference(reference, options);
+        if (validateImageAspectRatio(fields[0]!, resolved?.width, resolved?.height) !== 'valid') {
+          fail('references', 'reference_invalid');
+        }
+      }
+    }
     selectedFields.push(fields);
     if (fields.length === 1) {
       const field = fields[0]!;

--- a/frontend/src/server/agent-api/model-details.ts
+++ b/frontend/src/server/agent-api/model-details.ts
@@ -136,7 +136,8 @@ function projectReferences(
     return [Object.freeze({
       type: field.type,
       roles: Object.freeze([...roles]),
-      assetRequired: requiresOwnedReferenceAsset(roles, mode, engine.id, engine) || durationSec !== null,
+      assetRequired: requiresOwnedReferenceAsset(roles, mode, engine.id, engine) || durationSec !== null || Boolean(field.imageAspectRatio),
+      ...(field.imageAspectRatio ? { imageAspectRatio: Object.freeze({ ...field.imageAspectRatio }) } : {}),
       ...(assetRequiredWhen ? { assetRequiredWhen } : {}),
       ...(durationSec ? { durationSec } : {}),
       required: field.requiredInModes

--- a/frontend/src/server/agent-api/types.ts
+++ b/frontend/src/server/agent-api/types.ts
@@ -153,6 +153,7 @@ export type AgentModelReferenceFieldDetails = Readonly<{
   type: 'image' | 'video' | 'audio';
   roles: readonly CanonicalGenerationReferenceRole[];
   assetRequired: boolean;
+  imageAspectRatio?: Readonly<{ min: number; max: number }>;
   assetRequiredWhen?: Readonly<{
     setting: 'resolution';
     values: readonly string[];

--- a/frontend/src/server/generations/paid-provider-execution.ts
+++ b/frontend/src/server/generations/paid-provider-execution.ts
@@ -75,7 +75,17 @@ async function executePaidVideoContinuation(
     requestStartedAt,
     metricState: metric.state,
     logMetric: metric.log,
-    adapters: videoGenerationAdapters,
+    adapters: {
+      ...videoGenerationAdapters,
+      // The MCP route has a 120s lifetime; Fal rendering belongs to webhook/poll recovery.
+      submitGenerateProviderTask: (params: Parameters<typeof videoGenerationAdapters.submitGenerateProviderTask>[0]) =>
+        videoGenerationAdapters.submitGenerateProviderTask({
+          ...params,
+          falPayload: params.providerRoutingPlan.kind === 'fal_only'
+            ? { ...params.falPayload, submissionMode: 'enqueue' }
+            : params.falPayload,
+        }),
+    },
   };
   if ('funding' in options) {
     return executeVideoGeneration({

--- a/frontend/types/engines.ts
+++ b/frontend/types/engines.ts
@@ -169,6 +169,7 @@ export interface EngineInputField {
   minDurationSec?: number;
   maxDurationSec?: number;
   maxSizeMB?: number;
+  imageAspectRatio?: { min: number; max: number };
   acceptedMimeTypes?: string[];
   acceptedFileExtensions?: string[];
   slotLabelPattern?: string;

--- a/tests/fal-enqueue-generation.test.ts
+++ b/tests/fal-enqueue-generation.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { ENV } from '../frontend/src/lib/env';
+import { getFalClient } from '../frontend/src/lib/fal-client';
+import { generateVideo } from '../frontend/src/lib/fal';
+import { FalGenerationError } from '../frontend/src/lib/fal-error';
+
+test('MCP enqueue returns the accepted request without subscribing to a long render and awaits persistence', async (t) => {
+  const previousKey = ENV.FAL_API_KEY;
+  ENV.FAL_API_KEY = 'test-only';
+  t.after(() => { ENV.FAL_API_KEY = previousKey; });
+  const client = getFalClient();
+  let submits = 0;
+  t.mock.method(client.queue, 'submit', async (model: string, options: { input: Record<string, unknown> }) => {
+    submits += 1;
+    assert.equal(model, 'minimax/h3/reference-to-video');
+    assert.equal(options.input.submissionMode, undefined);
+    return { request_id: 'accepted-request' };
+  });
+  t.mock.method(client, 'subscribe', async () => {
+    throw new Error('Must not wait for rendering inside MCP confirmation');
+  });
+  let release!: () => void;
+  const persisted = new Promise<void>((resolve) => { release = resolve; });
+  let enteredPersistence!: () => void;
+  const started = new Promise<void>((resolve) => { enteredPersistence = resolve; });
+  let settled = false;
+  const generation = generateVideo({
+    engineId: 'minimax-h3', prompt: 'Test', mode: 'ref2v',
+    submissionMode: 'enqueue', durationSec: 5, resolution: '2K', aspectRatio: '16:9',
+  }, {
+    onRequestId: async (id) => {
+      assert.equal(id, 'accepted-request');
+      enteredPersistence();
+      await persisted;
+    },
+  });
+  generation.then(() => { settled = true; }, () => { settled = true; enteredPersistence(); });
+  await started;
+  assert.equal(settled, false, 'acceptance must wait for durable request tracking');
+  release();
+  const result = await generation;
+  assert.equal(submits, 1);
+  assert.equal(result.providerJobId, 'accepted-request');
+  assert.equal(result.status, 'queued');
+  assert.equal(result.videoUrl, undefined);
+});
+
+test('an enqueue rejection preserves the provider error and never submits a replacement', async (t) => {
+  const previousKey = ENV.FAL_API_KEY;
+  ENV.FAL_API_KEY = 'test-only';
+  t.after(() => { ENV.FAL_API_KEY = previousKey; });
+  const client = getFalClient();
+  let submits = 0;
+  t.mock.method(client.queue, 'submit', async () => {
+    submits += 1;
+    throw Object.assign(new Error('Rejected input'), { status: 422, body: { detail: 'Invalid reference' } });
+  });
+  t.mock.method(client, 'subscribe', async () => { throw new Error('Unexpected subscription'); });
+  await assert.rejects(generateVideo({
+    engineId: 'minimax-h3', prompt: 'Test', mode: 't2v', submissionMode: 'enqueue',
+  }), (error: unknown) => {
+    assert.ok(error instanceof FalGenerationError);
+    assert.equal(error.status, 422);
+    assert.equal(error.providerJobId, undefined);
+    return true;
+  });
+  assert.equal(submits, 1);
+});
+
+test('ordinary video requests retain synchronous completion', async (t) => {
+  const previousKey = ENV.FAL_API_KEY;
+  ENV.FAL_API_KEY = 'test-only';
+  t.after(() => { ENV.FAL_API_KEY = previousKey; });
+  const client = getFalClient();
+  t.mock.method(client.queue, 'submit', async () => { throw new Error('Unexpected enqueue-only path'); });
+  t.mock.method(client, 'subscribe', async () => ({
+    requestId: 'completed-request', data: { video_url: 'https://example.test/output.mp4' },
+  }));
+  const result = await generateVideo({ engineId: 'minimax-h3', prompt: 'Test', mode: 't2v' });
+  assert.equal(result.status, 'completed');
+  assert.equal(result.videoUrl, 'https://example.test/output.mp4');
+});

--- a/tests/fal-poll-refund-policy.test.ts
+++ b/tests/fal-poll-refund-policy.test.ts
@@ -8,6 +8,7 @@ const falPollPath = join(root, 'frontend/server/fal-poll.ts');
 const falPollSource = readFileSync(falPollPath, 'utf8');
 
 test('Fal poll timeout failures remain wallet-refund eligible', () => {
+  assert.match(falPollSource, /getFalPollTiming\(job\.engine_id, job\.created_at, now\)/);
   assert.match(
     falPollSource,
     /const markRefundEligiblePollFailure = async \(reason: string\) => \{[\s\S]*autoRefundEligible: true,[\s\S]*failureOrigin: 'poll_internal'/,

--- a/tests/fal-poll-timing.test.ts
+++ b/tests/fal-poll-timing.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getFalPollTiming } from '../frontend/server/fal-poll-timing';
+
+test('H3 stays recoverable through observed 65-minute renders but has a bounded 90-minute deadline', () => {
+  const createdAt = '2026-09-07T00:00:00Z';
+  const timing = (minutes: number, engine = 'minimax-h3') =>
+    getFalPollTiming(engine, createdAt, Date.parse(createdAt) + minutes * 60_000);
+  assert.equal(timing(65).beyondTimeoutGrace, false);
+  assert.equal(timing(90).beyondTimeoutGrace, false);
+  assert.equal(timing(90.01).beyondTimeoutGrace, true);
+  for (const engine of ['minimax-h3-max', 'luma-ray-2', 'other']) {
+    assert.equal(timing(55, engine).beyondTimeoutGrace, false);
+    assert.equal(timing(55.01, engine).beyondTimeoutGrace, true);
+  }
+  assert.equal(timing(34).timedOut, false);
+  assert.equal(timing(36).timedOut, true);
+});

--- a/tests/generate-fal-submission.test.ts
+++ b/tests/generate-fal-submission.test.ts
@@ -92,6 +92,7 @@ test('submitFalGenerateTask returns generation results and persists request ids'
     getLastProviderJobId: () => null,
     setLastProviderJobId: () => undefined,
     persistProviderJobId: async (providerJobId) => {
+      await new Promise<void>((resolve) => setImmediate(resolve));
       persisted.push(providerJobId);
     },
     logMetricFn: () => undefined,

--- a/tests/mcp-generation-capabilities.test.ts
+++ b/tests/mcp-generation-capabilities.test.ts
@@ -274,12 +274,7 @@ test('Seedance source and reference fields enforce canonical HTTPS media kinds',
 
 test('MiniMax H3 provider constraints receive references in their canonical media fields', () => {
   const minimax = registryCapability('minimax-h3');
-  const reference = (id: string, mediaKind: 'image' | 'video' | 'audio') => ({
-    kind: 'https' as const,
-    url: `https://cdn.example.com/${id}`,
-    role: 'reference' as const,
-    mediaKind,
-  });
+  const image = { kind: 'asset' as const, assetId: 'owned-image', role: 'reference' as const };
   const audio = { kind: 'asset' as const, assetId: 'owned-voice', role: 'reference' as const };
   const resolvedAudio = [{
     assetId: audio.assetId,
@@ -304,9 +299,18 @@ test('MiniMax H3 provider constraints receive references in their canonical medi
     { resolvedReferences: resolvedAudio },
   ));
   assert.doesNotThrow(() => validateCanonicalGenerationCapabilities(
-    { ...ref2v, references: [reference('subject.png', 'image'), audio] },
+    { ...ref2v, references: [image, audio] },
     minimax,
-    { resolvedReferences: resolvedAudio },
+    { resolvedReferences: [...resolvedAudio, {
+      assetId: image.assetId,
+      role: image.role,
+      mediaKind: 'image',
+      storageUrl: 'https://assets.example.com/subject.png',
+      width: 1024,
+      height: 1024,
+      durationSec: null,
+      mimeType: 'image/png',
+    }] },
   ));
 });
 

--- a/tests/mcp-model-details.test.ts
+++ b/tests/mcp-model-details.test.ts
@@ -357,6 +357,14 @@ test('LTX audio-to-video details expose trusted per-file duration limits', async
   assert.deepEqual(source.durationSec, { min: 2, max: 20, combinedMax: null });
 });
 
+test('MiniMax reference image details require verified assets and publish the accepted geometry', async () => {
+  const details = await getAgentModelDetails('minimax-h3', realRegistryDetailsDeps());
+  const field = details.modes.find((mode) => mode.mode === 'ref2v')?.references.find((reference) => reference.type === 'image');
+  assert.ok(field);
+  assert.equal(field.assetRequired, true);
+  assert.deepEqual(field.imageAspectRatio, { min: 0.4, max: 2.5 });
+});
+
 test('Luma Ray 2 V2V details explain source-derived duration and fixed pricing resolution', async () => {
   const details = await getAgentModelDetails('lumaRay2', realRegistryDetailsDeps());
   const mode = details.modes.find((candidate) => candidate.mode === 'v2v');

--- a/tests/mcp-prepare-generation.test.ts
+++ b/tests/mcp-prepare-generation.test.ts
@@ -1158,6 +1158,28 @@ test('generation pricing forwards MiniMax H3 reference counts to both canonical 
   }
 });
 
+test('MiniMax reference geometry is rejected before pricing or quote creation', async () => {
+  const candidate = registryCapability('minimax-h3');
+  const { deps } = baseDependencies({
+    listPublicEngines: async () => [candidate],
+    resolveGenerationReferences: async () => [{
+      assetId: 'wide-image', role: 'reference', mediaKind: 'image',
+      storageUrl: 'https://assets.example.com/wide.png', mimeType: 'image/png',
+      originalName: 'wide.png', sizeBytes: 1000, width: 1920, height: 548, durationSec: null,
+    }],
+    priceGeneration: async () => { throw new Error('Invalid geometry reached pricing'); },
+  });
+  await assert.rejects(prepareGeneration({
+    surface: 'video', engineId: 'minimax-h3', mode: 'ref2v', prompt: 'Test reference',
+    settings: { durationSec: 5, resolution: '2K', aspectRatio: '16:9' },
+    references: [{ kind: 'asset', assetId: 'wide-image', role: 'reference' }], outputCount: 1,
+  }, principal, deps), (error: unknown) => {
+    assert.ok(error instanceof AgentApiError);
+    assert.equal(error.code, 'REFERENCE_INVALID');
+    return true;
+  });
+});
+
 test('generation pricing forwards resolved LTX source-audio duration to prepare and confirmation pricing', async () => {
   const candidate = registryCapability('ltx-2-5-fast');
   const request: CanonicalGenerationRequest = {

--- a/tests/minimax-h3-media-constraints.test.ts
+++ b/tests/minimax-h3-media-constraints.test.ts
@@ -63,6 +63,8 @@ function mediaFixture(params: {
     mime_type: attachment.type,
     size_bytes: params.sizeMB * MB,
     duration_sec: params.durationSec ?? null,
+    width: params.kind === 'image' ? 1024 : null,
+    height: params.kind === 'image' ? 1024 : null,
   };
   return { attachment, reference, row };
 }
@@ -88,6 +90,23 @@ test('MiniMax H3 enforces exact stored media size boundaries', async () => {
   assert.equal((await validate([mediaFixture({ kind: 'video', sizeMB: 50 + 1 / MB, durationSec: 2 })])).ok, false);
   assert.equal((await validate([mediaFixture({ kind: 'audio', sizeMB: 15, durationSec: 15 })])).ok, true);
   assert.equal((await validate([mediaFixture({ kind: 'audio', sizeMB: 15 + 1 / MB, durationSec: 15 })])).ok, false);
+});
+
+test('MiniMax H3 rejects the incident reference ratio using stored dimensions, not client claims', async () => {
+  for (const [width, height, allowed] of [
+    [1920, 548, false], [399, 1000, false], [400, 1000, true],
+    [2500, 1000, true], [2501, 1000, false], [1672, 941, true],
+  ] as const) {
+    const fixture = mediaFixture({ kind: 'image', sizeMB: 1 });
+    Object.assign(fixture.row, { width, height });
+    Object.assign(fixture.attachment, { width: 1024, height: 1024 });
+    const result = await validate([fixture]);
+    assert.equal(result.ok, allowed, `${width} x ${height}`);
+    if (!result.ok) assert.equal(result.body.error, 'MEDIA_ASPECT_RATIO_UNSUPPORTED');
+  }
+  const missing = mediaFixture({ kind: 'image', sizeMB: 1 });
+  Object.assign(missing.row, { width: null, height: null });
+  assert.equal((await validate([missing])).ok, false);
 });
 
 test('MiniMax H3 enforces trusted individual video and audio durations', async () => {


### PR DESCRIPTION
MCP confirmations could time out after 120 seconds while Fal was still rendering, H3 reference images outside the provider's accepted ratio were charged before rejection, and successful H3 renders arriving after 64–65 minutes had already been refunded by the 55-minute poll policy.

This change returns MCP acceptance after Fal queue submission and awaited request-ID tracking, leaving completion to webhooks and polling. Accepted responses bypass synchronous finalization so a fast terminal webhook cannot be overwritten. It also validates H3 reference-image ratios of 0.4–2.5 from owned asset dimensions before executable quotes and generation, publishes the constraint in model details, and gives H3 a bounded 90-minute polling window. Explicit provider failures remain immediately refund-eligible.

Ordinary site submissions, direct-provider routing, other engines' timeout windows and existing refunds retain their behavior. Provider HTTP 500 errors remain upstream issues. The incident report records the audited jobs and wallet receipt reconciliation.

Validation:
- All 4,345 tests passed in an isolated checkout, including PostgreSQL concurrency tests.
- Full production build, TypeScript, ESLint, public-exposure and model registry/projection checks passed.
- Local validation used Node 23; GitHub CI validates Node 22. The build has the existing Supabase Edge Runtime warning.
- No paid generation or manual production data changes were performed.

The initial full test run exposed an outdated MiniMax test fixture, now updated to use an owned image with trusted dimensions; an unrelated failure from untracked local audit reports disappeared in the isolated checkout.

Integration check: `main` requires the status context `Quality CI`, while this workflow previously emitted `quality`. The job now explicitly uses the required name so its real results satisfy branch protection. The existing workflow contract tests pass; branch protection is unchanged.
