### PR TITLE
Keep long-running Fal video jobs recoverable

### DIFF
--- a/docs/engineering/long-running-generations.md
+++ b/docs/engineering/long-running-generations.md
@@ -1,0 +1,42 @@
+# Long-running Fal video generations
+
+## Invariants
+
+- Video upscale and the public Fal video submission route enqueue work and return acceptance. A web request must not wait for the render to finish.
+- `src/lib/fal-queue-submit.ts` makes one queue POST. It intentionally bypasses SDK submission retries: losing the acknowledgment does not prove that a paid request was rejected.
+- Video upscale requires a client request ID. Its user-scoped job ID and request fingerprint are reserved under a PostgreSQL advisory transaction lock, together with the wallet debit. Only the winning reservation submits. Replaying that intent, including after a refund, never submits again.
+- The browser retains that intent through ambiguous network errors and refreshes. Separate devices or explicitly different request IDs are separate intents; this is not a universal provider-level exactly-once guarantee.
+- Persist the provider request ID before returning acceptance. A token-authenticated webhook can also recover a lost acknowledgment through its app-job correlation parameter. An unresolved submission stays pending for reconciliation, never automatic replacement.
+- Polling read errors, unknown statuses and elapsed attention thresholds are not terminal provider failures. Continue checking the same provider request. The 55/90-minute thresholds do not authorize refunding or rerunning it.
+- Late nonterminal events cannot downgrade completed or failed jobs. Completion must preserve a previously refunded payment status.
+
+## Media integrity
+
+`server/upscale-duration-integrity.ts` compares probed video-stream duration with the saved source duration. Its tolerance is two frames, not a percentage that could hide seconds missing from long clips. Failed metadata inspection remains retryable. Legacy jobs without source metadata cannot receive this validation retroactively.
+
+A shortened output is retained as private diagnostic evidence in the job settings, not delivered as a successful upscale. The failure and exact original-wallet-charge refund commit in one transaction. Failed refund persistence rolls back the failure, so normal reconciliation can retry it. Concurrent settlement produces one refund.
+
+`src/server/audio/video-mux-args.ts` pads the audio before `-shortest`; the original video stream determines the end. It copies video without inventing frames, trimming silent tails, or re-encoding the video. This cannot repair frames already missing in a provider output.
+
+Outputs larger than the 80 MiB remux budget, or without a declared size, take a bounded disk-streaming exact-original copy path. The current direct-copy budget is 450 MiB, with a 120-second source-body deadline. These are infrastructure limits, not trimming instructions. Oversized/incomplete bodies must never publish a partial original. Files above this budget still require a larger/streaming worker; this change does not promise unlimited file support.
+
+## Verification and release checklist
+
+1. Run focused upscale/Fal tests, including disposable PostgreSQL concurrency and refund rollback tests, and real ffmpeg mux-duration tests.
+2. Run frontend lint, exposure check, TypeScript, production build and `git diff --check`.
+3. Verify the deployed webhook token, callback URL and Fal polling cron. Do not print tokens. A deployment without a callback can poll known IDs, but cannot automatically recover a lost acknowledgment.
+4. After release, run one explicitly budgeted small video upscale. Confirm one app job, one debit and one Fal request; refresh/retry the same intent during processing. Compare source/output video duration and frame count, durable output and final payment status.
+5. Exercise a simulated long-running provider in tests; do not deliberately pay for duplicate production renders to test retry logic.
+
+## Remaining audited risks
+
+- The multi-step audio generation pipeline and some image tools still wait synchronously for Fal. They need resumable per-stage provider request IDs and asynchronous continuation before being described as safe for arbitrarily long processing. Disabling fallback alone does not fix serverless termination.
+- Direct video-provider paths already describe stalled renders as requiring manual review before retry/refund; this audit did not redesign their workers.
+- New upscale intents without a durable provider ID are excluded from legacy stale-provisional automatic refunds. Support must reconcile ambiguous acceptance before deciding refund/retry. This intentionally trades automatic recovery for duplicate-charge prevention when both acknowledgment and webhook are unavailable.
+- Ordinary provider-terminal-failure refunds still use the pre-existing shared refund path; the new transactional duration rejection does not certify every legacy refund writer.
+
+## Incident reference, 11 September 2026
+
+App job `tool_upscale_7564ceba-d0d7-4ba0-ad71-ae4daf713295`, Fal request `01a08df0-6c51-7882-a9ba-06e6c0903165`: provider success after approximately 15m23s despite a 300-second application timeout. Original video had 145 frames; Fal output had 136. The provider original was already shorter, so application storage was not the source of those nine missing frames. The mechanism inside Fal is not established.
+
+Wallet charge receipt 10462: USD 5.58. Manual refund receipt 10505: USD 5.58. Estimated provider cost is about USD 1.20 based on source-frame output megapixels; this is not a verified per-request billing-event amount. No replacement render is needed merely to establish these facts.

--- a/frontend/app/api/fal/webhook/route.ts
+++ b/frontend/app/api/fal/webhook/route.ts
@@ -37,6 +37,11 @@ export async function POST(req: Request) {
   }
 
   try {
+    // A configured shared token authenticates the callback correlation, including a lost submit acknowledgment.
+    const jobId = url.searchParams.get('jobId');
+    if (expectedToken && jobId && /^(tool_upscale_|job_)[a-zA-Z0-9_-]+$/.test(jobId) && payload && typeof payload === 'object') {
+      payload = { ...payload, job_id: jobId };
+    }
     await updateJobFromFalWebhook(payload);
     return NextResponse.json({ ok: true });
   } catch (error) {

--- a/frontend/app/api/generate/_lib/fal-submission.ts
+++ b/frontend/app/api/generate/_lib/fal-submission.ts
@@ -249,7 +249,9 @@ export async function submitFalGenerateTask(params: {
         providerJobId,
       });
 
-    if (isTimeoutError) {
+    const uncertainSubmission = params.falPayload.submissionMode === 'enqueue' &&
+      (providerJobId || !status || status >= 500 || status === 408);
+    if (isTimeoutError || uncertainSubmission) {
       const progressFloor = Math.min(95, FAL_PROGRESS_FLOOR + FAL_RETRY_DELAYS_MS.length * 5);
       const waitingMessage =
         'Rendering is still in progress. We will refresh as soon as the next status arrives.';

--- a/frontend/app/api/generate/_lib/video-provider-submission.ts
+++ b/frontend/app/api/generate/_lib/video-provider-submission.ts
@@ -235,7 +235,7 @@ export async function submitGenerateProviderTask(params: {
     inputSummary: params.falInputSummary,
   });
   const falSubmission = await submitFalGenerateTask({
-    falPayload: params.falPayload,
+    falPayload: { ...params.falPayload, submissionMode: 'enqueue' },
     jobId: params.jobId,
     engineId: params.engineId,
     engineLabel: params.engineLabel,
@@ -254,7 +254,7 @@ export async function submitGenerateProviderTask(params: {
   if (!falSubmission.ok) {
     return { kind: 'error_response', status: falSubmission.status, body: falSubmission.body };
   }
-  if (params.falPayload.submissionMode === 'enqueue') {
+  if (falSubmission.generationResult.providerJobId) {
     // The initial job and charge already exist. Do not overwrite a fast terminal webhook
     // with a queued finalization (including its media and refund state).
     return {

--- a/frontend/app/api/jobs/[jobId]/route.ts
+++ b/frontend/app/api/jobs/[jobId]/route.ts
@@ -275,7 +275,7 @@ export async function GET(_req: NextRequest, props: { params: Promise<{ jobId: s
         let thumbUrl = normalizedThumbUrl ?? null;
         let message = job.message ?? null;
         let providerVideoCopyStateJson: string | null = null;
-        if (vUrl) {
+        if (vUrl && !queueResult && surface !== 'upscale') {
           const normalizedProviderVideoUrl = normalizeMediaUrl(vUrl) ?? vUrl;
           const strictCopyRequired = shouldFailVideoJobOnProviderCopyMiss({
             provider: job.provider ?? 'fal',

--- a/frontend/app/api/tools/upscale/_shared.ts
+++ b/frontend/app/api/tools/upscale/_shared.ts
@@ -125,6 +125,7 @@ export async function handleUpscaleToolRequest(
   try {
     const result = await runUpscale({
       userId,
+      requestId: typeof body?.requestId === 'string' ? body.requestId : undefined,
       acceptedQuote: body?.acceptedQuote,
       mediaType,
       mediaUrl,
@@ -139,7 +140,7 @@ export async function handleUpscaleToolRequest(
       imageHeight: optionalNumber(body?.imageHeight),
     });
 
-    return NextResponse.json(result);
+    return NextResponse.json(result, { status: result.status === 'pending' ? 202 : 200 });
   } catch (error) {
     const status = error instanceof UpscaleToolError ? error.status : 502;
     const code = error instanceof UpscaleToolError ? error.code : 'upscale_tool_error';

--- a/frontend/lib/api-generation.ts
+++ b/frontend/lib/api-generation.ts
@@ -13,6 +13,7 @@ import type { ImageGenerationRequest, ImageGenerationResponse } from '@/types/im
 import type { AngleToolRequest, AngleToolResponse } from '@/types/tools-angle';
 import type { BackgroundRemovalToolRequest, BackgroundRemovalToolResponse } from '@/types/tools-background-removal';
 import type { UpscaleToolRequest, UpscaleToolResponse } from '@/types/tools-upscale';
+import { upscaleClientAttempt, waitForAcceptedUpscale } from '@/lib/upscale-client-lifecycle';
 
 type PrimitiveValue = string | number | boolean | null | undefined;
 
@@ -294,10 +295,11 @@ export async function runAngleTool(payload: AngleToolRequest): Promise<AngleTool
 }
 
 export async function runUpscaleTool(payload: UpscaleToolRequest): Promise<UpscaleToolResponse> {
+  const attempt = payload.mediaType === 'video' ? await upscaleClientAttempt(payload) : null;
   const response = await authFetch(`/api/tools/upscale/${payload.mediaType}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', [PRICING_POLICY_HEADER]: LIVE_PRICING_POLICY_REVISION },
-    body: JSON.stringify(payload),
+    body: JSON.stringify({ ...payload, ...(attempt ? { requestId: attempt.requestId } : {}) }),
   });
   const data = (await response.json().catch(() => null)) as
     | (UpscaleToolResponse & { error?: { code?: string; message?: string; detail?: unknown } })
@@ -308,6 +310,7 @@ export async function runUpscaleTool(payload: UpscaleToolRequest): Promise<Upsca
   }
 
   if (!response.ok || !data.ok) {
+    if ([400, 401, 403, 404, 409, 422].includes(response.status)) attempt?.finish();
     const error = new Error(data.error?.message ?? `Upscale tool failed (${response.status})`);
     Object.assign(error, {
       code: data.error?.code ?? 'upscale_tool_failed',
@@ -317,7 +320,7 @@ export async function runUpscaleTool(payload: UpscaleToolRequest): Promise<Upsca
     throw error;
   }
 
-  return data;
+  return attempt ? waitForAcceptedUpscale(data, attempt) : data;
 }
 
 export async function runBackgroundRemovalTool(

--- a/frontend/lib/upscale-client-lifecycle.ts
+++ b/frontend/lib/upscale-client-lifecycle.ts
@@ -1,0 +1,61 @@
+import type { UpscaleToolRequest, UpscaleToolResponse } from '@/types/tools-upscale';
+import { getJobStatus, type JobStatusResult } from '@/lib/api-job-status';
+import { readLastKnownUserId } from '@/lib/last-known';
+
+const attempts = new Map<string, string>();
+export async function upscaleClientAttempt(payload: UpscaleToolRequest) {
+  const principal = readLastKnownUserId();
+  const settings = Object.fromEntries(Object.entries(payload).filter(([key]) => !['acceptedQuote', 'requestId'].includes(key)).sort(([a], [b]) => a.localeCompare(b)));
+  const bytes = new TextEncoder().encode(JSON.stringify([principal, settings]));
+  const hash = await crypto.subtle.digest('SHA-256', bytes);
+  const key = `upscale-attempt:${Array.from(new Uint8Array(hash), byte => byte.toString(16).padStart(2, '0')).join('')}`;
+  const reserve = () => {
+    let stored: string | null = null;
+    try { stored = localStorage.getItem(key); } catch { /* Memory still protects this page. */ }
+    const requestId = payload.requestId ?? attempts.get(key) ?? stored ?? crypto.randomUUID();
+    attempts.set(key, requestId);
+    try { localStorage.setItem(key, requestId); } catch { /* Storage may be unavailable. */ }
+    return { requestId, principal, finish() {
+      if (attempts.get(key) === requestId) attempts.delete(key);
+      try { if (localStorage.getItem(key) === requestId) localStorage.removeItem(key); } catch { /* Optional storage. */ }
+    } };
+  };
+  return navigator.locks ? navigator.locks.request(key, reserve) : reserve();
+}
+
+export async function waitForUpscale(
+  accepted: UpscaleToolResponse,
+  dependencies: {
+    getStatus(jobId: string): Promise<JobStatusResult>;
+    sleep(): Promise<void>;
+    isCurrent(): boolean;
+    onTerminal(): void;
+  }
+): Promise<UpscaleToolResponse> {
+  let result = accepted;
+  for (;;) {
+    if (!dependencies.isCurrent()) throw new Error('The account changed. Find this upscale in its original account.');
+    if (result.status === 'failed') {
+      dependencies.onTerminal();
+      throw new Error(result.error?.message ?? 'Upscale failed.');
+    }
+    if (result.output?.url) { dependencies.onTerminal(); return result; }
+    if (!result.jobId) throw new Error('Upscale acceptance did not include a job ID.');
+    await dependencies.sleep();
+    let status: JobStatusResult;
+    try { status = await dependencies.getStatus(result.jobId); } catch { continue; }
+    result = { ...result, status: status.status,
+      output: status.status === 'completed' && status.videoUrl ? { url: status.videoUrl, thumbUrl: status.thumbUrl } : null,
+      error: status.status === 'failed' ? { code: 'upscale_failed', message: status.message ?? 'Upscale failed.' } : undefined };
+  }
+}
+
+export function waitForAcceptedUpscale(accepted: UpscaleToolResponse, attempt: Awaited<ReturnType<typeof upscaleClientAttempt>>) {
+  window.dispatchEvent(new CustomEvent('upscale:accepted', { detail: { jobId: accepted.jobId } }));
+  return waitForUpscale(accepted, {
+    getStatus: getJobStatus,
+    sleep: () => new Promise(resolve => setTimeout(resolve, 5_000)),
+    isCurrent: () => readLastKnownUserId() === attempt.principal,
+    onTerminal: attempt.finish,
+  });
+}

--- a/frontend/server/fal-poll-timing.ts
+++ b/frontend/server/fal-poll-timing.ts
@@ -5,7 +5,7 @@ export function getFalPollTiming(engineId: string, createdAt: string, now: numbe
   const createdAtMs = Date.parse(createdAt);
   const ageMs = Number.isFinite(createdAtMs) ? now - createdAtMs : 0;
   // H3 delivered successful outputs after 63–65 minutes in the 2026-09-07 audit.
-  // Keep its total wait bounded at 90 minutes; terminal provider errors bypass grace.
+  // 90 minutes is an attention threshold, not permission to fail, refund or resubmit.
   const graceMs = engineId === 'minimax-h3' ? 55 * 60_000 : DEFAULT_GRACE_MS;
   return {
     ageMs,

--- a/frontend/server/fal-poll.ts
+++ b/frontend/server/fal-poll.ts
@@ -22,13 +22,13 @@ type FalPendingJob = {
 
 const POLL_BASE_DELAYS_MS = [5_000, 15_000, 30_000, 60_000, 120_000];
 const POLL_INITIAL_DELAY_MS = 5_000;
-const FAILURE_STATES = new Set(['FAILED', 'FAIL', 'ERROR', 'ERRORED', 'CANCELLED', 'CANCELED', 'NOT_FOUND', 'MISSING', 'UNKNOWN']);
+const FAILURE_STATES = new Set(['FAILED', 'FAIL', 'ERROR', 'ERRORED', 'CANCELLED', 'CANCELED']);
 const COMPLETED_STATES = new Set(['COMPLETED', 'FINISHED', 'SUCCESS', 'SUCCEEDED', 'OK']);
 
-const defaults = { query, getFalClient, linkFalJob, updateJobFromFalWebhook, backfillCompletedMcpJobOutputs, reconcileFinishingJobs };
+const defaults = { query, getFalClient, linkFalJob, updateJobFromFalWebhook, backfillCompletedMcpJobOutputs, reconcileFinishingJobs, reconcileStaleFalProvisionals };
 
 export async function runFalPoll(dependencies: Partial<typeof defaults> = {}) {
-  const { query, getFalClient, linkFalJob, updateJobFromFalWebhook, backfillCompletedMcpJobOutputs, reconcileFinishingJobs } = { ...defaults, ...dependencies };
+  const { query, getFalClient, linkFalJob, updateJobFromFalWebhook, backfillCompletedMcpJobOutputs, reconcileFinishingJobs, reconcileStaleFalProvisionals } = { ...defaults, ...dependencies };
   const rows = await query<FalPendingJob>(
     `SELECT job_id, surface, engine_id, provider_job_id, status, updated_at, created_at
 	     FROM app_jobs
@@ -137,13 +137,14 @@ export async function runFalPoll(dependencies: Partial<typeof defaults> = {}) {
       if (lastAttemptAtMs && now - lastAttemptAtMs < backoffMs) {
         continue;
       }
+      // Every attempted row moves behind other pending jobs, including grace/unknown paths.
+      await query(`UPDATE app_jobs SET updated_at = NOW() WHERE job_id = $1 AND status IN ('pending','queued','running','processing','in_progress')`, [job.job_id]);
 
       let engineIdForLookup = job.engine_id;
-      const markRefundEligiblePollFailure = async (reason: string) => {
-        await markJobFailed(reason, {
-          autoRefundEligible: true,
-          failureOrigin: 'poll_internal',
-        });
+      const deferPoll = async (reason: string) => {
+        await recordPollEvent('poll:deferred', { reason, ageMs, beyondTimeoutGrace });
+        // Rotate the bounded cron batch even when a provider is unavailable.
+        await query(`UPDATE app_jobs SET updated_at = NOW() WHERE job_id = $1 AND status IN ('pending','queued','running','processing','in_progress')`, [job.job_id]);
       };
 
       if (!engineIdForLookup || engineIdForLookup === 'fal-unknown') {
@@ -187,7 +188,7 @@ export async function runFalPoll(dependencies: Partial<typeof defaults> = {}) {
           );
           continue;
         }
-        await markRefundEligiblePollFailure('Unable to determine render engine for this job.');
+        await deferPoll('Unable to determine render engine for this job.');
         continue;
       }
 
@@ -221,10 +222,10 @@ export async function runFalPoll(dependencies: Partial<typeof defaults> = {}) {
           continue;
         }
         if (timedOut && beyondTimeoutGrace) {
-          await markRefundEligiblePollFailure('Render status remained unavailable after timeout grace period.');
+          await deferPoll('Render status remained unavailable after timeout grace period.');
           continue;
         }
-        await markJobFailed('Render status unavailable.');
+        await deferPoll('Render status unavailable.');
         continue;
       }
 
@@ -250,7 +251,7 @@ export async function runFalPoll(dependencies: Partial<typeof defaults> = {}) {
 
       if (state && !COMPLETED_STATES.has(state)) {
         if (timedOut && beyondTimeoutGrace) {
-          await markRefundEligiblePollFailure('Render polling exceeded expected window after timeout grace period.');
+          await deferPoll('Render still processing beyond the expected window.');
           continue;
         }
         await updateJobFromFalWebhook({
@@ -290,10 +291,10 @@ export async function runFalPoll(dependencies: Partial<typeof defaults> = {}) {
           continue;
         }
         if (timedOut && beyondTimeoutGrace) {
-          await markRefundEligiblePollFailure(providerError ?? 'Render returned no result after timeout grace period.');
+          await deferPoll(providerError ?? 'Render returned no result after timeout grace period.');
           continue;
         }
-        await markJobFailed(providerError ?? 'Render returned no result for this job.');
+        await deferPoll(providerError ?? 'Render returned no result for this job.');
         continue;
       }
       await recordPollEvent(
@@ -323,7 +324,8 @@ export async function runFalPoll(dependencies: Partial<typeof defaults> = {}) {
       updates += 1;
     } catch (error) {
       console.warn('[fal-poll] failed to sync job', job.job_id, error);
-      await markJobFailed('Render sync failed.');
+      await recordPollEvent('poll:deferred', { reason: 'Render sync failed.' });
+      await query(`UPDATE app_jobs SET updated_at = NOW() WHERE job_id = $1 AND status IN ('pending','queued','running','processing','in_progress')`, [job.job_id]);
     }
   }
 

--- a/frontend/server/fal-poll.ts
+++ b/frontend/server/fal-poll.ts
@@ -8,6 +8,7 @@ import { updateJobFromFalWebhook } from '@/server/fal-webhook-handler';
 import { backfillCompletedMcpJobOutputs } from '@/server/media-library/mcp-output-assets';
 import { toUserFacingFailureMessage } from '@/server/user-facing-failure-messages';
 import { getFalPollTiming } from '@/server/fal-poll-timing';
+import { reconcileStaleFalProvisionals } from '@/server/fal-stale-provisionals';
 
 type FalPendingJob = {
   job_id: string;
@@ -368,55 +369,7 @@ export async function runFalPoll(dependencies: Partial<typeof defaults> = {}) {
     console.warn('[fal-poll] MCP output library backfill deferred', { error });
   }
 
-  let provisionalFailures = 0;
-  const staleProvisionals = await query<{ job_id: string; created_at: string }>(
-    `SELECT job_id, created_at
-       FROM app_jobs
-	      WHERE provider_job_id IS NULL
-	        AND COALESCE(provider, 'fal') = 'fal'
-	        AND engine_id IS DISTINCT FROM 'toolbox-finishing'
-	        AND status = 'pending'
-        AND created_at < NOW() - INTERVAL '5 minutes'
-      ORDER BY created_at ASC
-      LIMIT 20`
-  );
-
-  for (const stale of staleProvisionals) {
-    try {
-      await query(
-        `UPDATE app_jobs
-            SET status = 'failed',
-                progress = 0,
-                message = 'MaxVideoAI could not start this render. Please retry in a few moments.',
-                provisional = FALSE,
-                updated_at = NOW()
-	          WHERE job_id = $1
-	            AND status = 'pending'
-	            AND provider_job_id IS NULL
-	            AND COALESCE(provider, 'fal') = 'fal'
-	            AND engine_id IS DISTINCT FROM 'toolbox-finishing'`,
-        [stale.job_id]
-      );
-      await query(
-        `INSERT INTO fal_queue_log (job_id, provider, provider_job_id, engine_id, status, payload)
-         VALUES ($1,$2,$3,$4,$5,$6::jsonb)`,
-        [
-          stale.job_id,
-          'fal',
-          null,
-          'fal-unknown',
-          'poll:not-started',
-          JSON.stringify({
-            at: new Date().toISOString(),
-            note: 'Job never started at Fal; marked as failed.',
-          }),
-        ]
-      );
-      provisionalFailures += 1;
-    } catch (error) {
-      console.warn('[fal-poll] failed to mark provisional job as failed', stale.job_id, error);
-    }
-  }
+  const { failed: provisionalFailures } = await reconcileStaleFalProvisionals();
 
   let finishing = { checked: 0, reconciled: 0, failures: 0 };
   try {

--- a/frontend/server/fal-stale-provisionals.ts
+++ b/frontend/server/fal-stale-provisionals.ts
@@ -122,6 +122,7 @@ async function settleStaleFalProvisional(jobId: string): Promise<boolean> {
           AND COALESCE(provider, 'fal') = 'fal'
           AND engine_id IS DISTINCT FROM 'toolbox-finishing'
           AND status = 'pending'
+          AND NOT (COALESCE(settings_snapshot, '{}'::jsonb) ? 'requestFingerprint')
           AND created_at < NOW() - INTERVAL '5 minutes'
         FOR UPDATE`,
       [jobId]
@@ -172,6 +173,7 @@ export async function reconcileStaleFalProvisionals(
     `SELECT job_id
        FROM app_jobs
       WHERE provider_job_id IS NULL
+        AND NOT (COALESCE(settings_snapshot, '{}'::jsonb) ? 'requestFingerprint')
         AND COALESCE(provider, 'fal') = 'fal'
         AND engine_id IS DISTINCT FROM 'toolbox-finishing'
         AND status = 'pending'

--- a/frontend/server/fal-stale-provisionals.ts
+++ b/frontend/server/fal-stale-provisionals.ts
@@ -1,0 +1,196 @@
+import { query, withDbTransaction, type TransactionQueryExecutor } from '@/lib/db';
+import { buildUserFacingRefundDescription } from '@/server/user-facing-failure-messages';
+
+const STALE_PROVISIONAL_MESSAGE =
+  'MaxVideoAI could not start this render. Please retry in a few moments.';
+
+type StaleProvisionalJob = {
+  job_id: string;
+  user_id: string | null;
+  engine_id: string;
+  engine_label: string | null;
+  duration_sec: number | string | null;
+  payment_status: string | null;
+  pricing_snapshot: unknown;
+  currency: string | null;
+  vendor_account_id: string | null;
+  surface: string | null;
+  billing_product_key: string | null;
+};
+
+type ChargeReceipt = {
+  id: number;
+  user_id: string | null;
+  amount_cents: number | string | null;
+  currency: string | null;
+  pricing_snapshot: unknown;
+  vendor_account_id: string | null;
+  surface: string | null;
+  billing_product_key: string | null;
+};
+
+function positiveInteger(value: number | string | null | undefined): number {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.round(parsed) : 0;
+}
+
+async function refundChargedStaleJob(
+  executor: TransactionQueryExecutor,
+  job: StaleProvisionalJob
+): Promise<void> {
+  if (job.payment_status !== 'paid_wallet') return;
+
+  const existingRefund = await executor.query<{ id: number }>(
+    `SELECT id FROM app_receipts WHERE job_id = $1 AND type = 'refund' LIMIT 1`,
+    [job.job_id]
+  );
+  if (existingRefund.length) return;
+
+  const charges = await executor.query<ChargeReceipt>(
+    `SELECT id, user_id, amount_cents, currency, pricing_snapshot, vendor_account_id,
+            surface, billing_product_key
+       FROM app_receipts
+      WHERE job_id = $1
+        AND type = 'charge'
+      ORDER BY created_at DESC
+      LIMIT 1
+      FOR UPDATE`,
+    [job.job_id]
+  );
+  const charge = charges.at(0);
+  const amountCents = positiveInteger(charge?.amount_cents);
+  if (!charge || !amountCents) {
+    throw new Error(`Charged stale Fal job ${job.job_id} has no refundable receipt.`);
+  }
+
+  const pricingSnapshot = charge.pricing_snapshot ?? job.pricing_snapshot;
+  const vendorAccountId = charge.vendor_account_id ?? job.vendor_account_id;
+  const description = buildUserFacingRefundDescription({
+    engineLabel: job.engine_label ?? job.engine_id,
+    durationSec: job.duration_sec,
+    reason: STALE_PROVISIONAL_MESSAGE,
+  });
+  const inserted = await executor.query<{ id: number }>(
+    `INSERT INTO app_receipts (
+       user_id, type, amount_cents, currency, description, job_id,
+       surface, billing_product_key, pricing_snapshot, application_fee_cents,
+       vendor_account_id, stripe_payment_intent_id, stripe_charge_id,
+       platform_revenue_cents, destination_acct, metadata
+     )
+     VALUES ($1,'refund',$2,$3,$4,$5,$6,$7,$8::jsonb,0,$9,NULL,NULL,0,$9,$10::jsonb)
+     ON CONFLICT DO NOTHING
+     RETURNING id`,
+    [
+      charge.user_id ?? job.user_id,
+      amountCents,
+      (charge.currency ?? job.currency ?? 'USD').toUpperCase(),
+      description,
+      job.job_id,
+      charge.surface ?? job.surface,
+      charge.billing_product_key ?? job.billing_product_key,
+      pricingSnapshot == null ? null : JSON.stringify(pricingSnapshot),
+      vendorAccountId,
+      JSON.stringify({
+        reason: 'auto_render_failure_refund',
+        original_receipt_id: charge.id,
+        provider_job_id: null,
+        failure_origin: 'poll_internal',
+        note: STALE_PROVISIONAL_MESSAGE,
+      }),
+    ]
+  );
+  if (!inserted.length) {
+    const concurrentRefund = await executor.query<{ id: number }>(
+      `SELECT id FROM app_receipts WHERE job_id = $1 AND type = 'refund' LIMIT 1`,
+      [job.job_id]
+    );
+    if (!concurrentRefund.length) {
+      throw new Error(`Refund for stale Fal job ${job.job_id} was not persisted.`);
+    }
+  }
+}
+
+async function settleStaleFalProvisional(jobId: string): Promise<boolean> {
+  return withDbTransaction(async (executor) => {
+    await executor.query(`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, [jobId]);
+    const jobs = await executor.query<StaleProvisionalJob>(
+      `SELECT job_id, user_id, engine_id, engine_label, duration_sec, payment_status,
+              pricing_snapshot, currency, vendor_account_id, surface, billing_product_key
+         FROM app_jobs
+        WHERE job_id = $1
+          AND provider_job_id IS NULL
+          AND COALESCE(provider, 'fal') = 'fal'
+          AND engine_id IS DISTINCT FROM 'toolbox-finishing'
+          AND status = 'pending'
+          AND created_at < NOW() - INTERVAL '5 minutes'
+        FOR UPDATE`,
+      [jobId]
+    );
+    const job = jobs.at(0);
+    if (!job) return false;
+
+    await refundChargedStaleJob(executor, job);
+    await executor.query(
+      `UPDATE app_jobs
+          SET status = 'failed',
+              progress = 0,
+              payment_status = CASE
+                WHEN payment_status = 'paid_wallet' THEN 'refunded_wallet'
+                ELSE payment_status
+              END,
+              message = $2,
+              provisional = FALSE,
+              updated_at = NOW()
+        WHERE job_id = $1`,
+      [job.job_id, STALE_PROVISIONAL_MESSAGE]
+    );
+    await executor.query(
+      `INSERT INTO fal_queue_log (job_id, provider, provider_job_id, engine_id, status, payload)
+       VALUES ($1,$2,$3,$4,$5,$6::jsonb)`,
+      [
+        job.job_id,
+        'fal',
+        null,
+        job.engine_id,
+        'poll:not-started',
+        JSON.stringify({
+          at: new Date().toISOString(),
+          note: 'Job never started at Fal; marked as failed.',
+          autoRefundEligible: job.payment_status === 'paid_wallet',
+        }),
+      ]
+    );
+    return true;
+  });
+}
+
+export async function reconcileStaleFalProvisionals(
+  options: { limit?: number } = {}
+): Promise<{ failed: number }> {
+  const limit = Math.max(1, Math.min(100, Math.floor(options.limit ?? 20)));
+  const staleJobs = await query<{ job_id: string }>(
+    `SELECT job_id
+       FROM app_jobs
+      WHERE provider_job_id IS NULL
+        AND COALESCE(provider, 'fal') = 'fal'
+        AND engine_id IS DISTINCT FROM 'toolbox-finishing'
+        AND status = 'pending'
+        AND created_at < NOW() - INTERVAL '5 minutes'
+      ORDER BY created_at ASC
+      LIMIT $1`,
+    [limit]
+  );
+
+  let failed = 0;
+  for (const stale of staleJobs) {
+    try {
+      if (await settleStaleFalProvisional(stale.job_id)) failed += 1;
+    } catch (error) {
+      console.warn('[fal-poll] failed to settle stale provisional job', {
+        jobId: stale.job_id,
+        error,
+      });
+    }
+  }
+  return { failed };
+}

--- a/frontend/server/fal-webhook-handler.ts
+++ b/frontend/server/fal-webhook-handler.ts
@@ -24,6 +24,7 @@ import { fetchFalJobMedia } from '@/server/fal-job-sync';
 import { toUserFacingFailureMessage } from '@/server/user-facing-failure-messages';
 import { detectHasAudioStream, detectVideoDimensions } from '@/server/media/detect-has-audio';
 import { upsertLegacyJobOutputs } from '@/server/media-library';
+import { checkUpscaleDuration, rejectTruncatedUpscale } from './upscale-duration-integrity';
 import {
   extractFalErrorMessage,
   extractIdentifiersFromPayload,
@@ -38,7 +39,6 @@ import {
   normalizeRenderIdList,
   normalizeStatus,
   type FalWebhookPayload,
-  type WebhookIdentifiers,
 } from './fal-webhook-mapping';
 
 export async function updateJobFromFalWebhook(rawPayload: unknown): Promise<void> {
@@ -111,6 +111,11 @@ export async function updateJobFromFalWebhook(rawPayload: unknown): Promise<void
   }
 
   const originalEngineId = job.engine_id;
+  // Correlation can recover a submission whose acknowledgment or DB write was lost.
+  if (identifiers.jobId === job.job_id && job.job_id.startsWith('tool_upscale_')) {
+    await query(`UPDATE app_jobs SET provider_job_id = COALESCE(provider_job_id, $2), provider = 'fal',
+      provisional = FALSE, updated_at = NOW() WHERE job_id = $1`, [job.job_id, requestId]);
+  }
   const originalEngineLabel = job.engine_label;
   let effectiveEngineId = job.engine_id;
   let effectiveEngineLabel = job.engine_label;
@@ -275,6 +280,13 @@ export async function updateJobFromFalWebhook(rawPayload: unknown): Promise<void
   }
 
   const rawVideoSource = nextVideoUrl ?? media.videoUrl ?? job.video_url;
+  if (upscaleToolMediaType === 'video' && job.status !== 'completed' && nextStatus === 'completed' && rawVideoSource) {
+    const integrity = await checkUpscaleDuration(rawVideoSource, job.settings_snapshot);
+    if (integrity === 'truncated') {
+      await rejectTruncatedUpscale(job.job_id, requestId, rawVideoSource);
+      return;
+    }
+  }
   let resolvedThumbUrl = nextThumbUrl ?? job.thumb_url;
   if (!resolvedThumbUrl) {
     resolvedThumbUrl = fallbackThumbnail(job.aspect_ratio);
@@ -490,7 +502,7 @@ export async function updateJobFromFalWebhook(rawPayload: unknown): Promise<void
     });
   }
 
-  await query(
+  const applied = await query<{ job_id: string }>(
     `UPDATE app_jobs
      SET status = $2,
          progress = $3,
@@ -516,7 +528,10 @@ export async function updateJobFromFalWebhook(rawPayload: unknown): Promise<void
            ELSE settings_snapshot
          END,
          updated_at = NOW()
-     WHERE job_id = $1`,
+     WHERE job_id = $1
+       AND NOT (status = 'completed' AND $2 <> 'completed')
+       AND NOT (status = 'failed' AND $2 IN ('pending','queued','running','processing'))
+     RETURNING job_id`,
     [
       job.job_id,
       nextStatus,
@@ -537,6 +552,7 @@ export async function updateJobFromFalWebhook(rawPayload: unknown): Promise<void
       providerVideoCopyStateJson,
     ]
   );
+  if (!applied.length) return;
 
   await upsertLegacyJobOutputs({
     job_id: job.job_id,

--- a/frontend/server/media/detect-has-audio.ts
+++ b/frontend/server/media/detect-has-audio.ts
@@ -362,7 +362,7 @@ export async function detectVideoMetadata(
     '-select_streams',
     'v:0',
     '-show_entries',
-    'stream=width,height,r_frame_rate:format=duration',
+    'stream=width,height,r_frame_rate,duration:format=duration',
     '-of',
     'json',
     videoUrl,
@@ -371,13 +371,14 @@ export async function detectVideoMetadata(
   try {
     const { stdout } = await execFileAsync(ffprobe.path, args, { timeout: timeoutMs, maxBuffer: 1024 * 1024 });
     const parsed = JSON.parse(stdout) as {
-      streams?: Array<{ width?: number; height?: number; r_frame_rate?: string }>;
+      streams?: Array<{ width?: number; height?: number; r_frame_rate?: string; duration?: string }>;
       format?: { duration?: string };
     };
     const stream = parsed.streams?.[0];
     const width = Number(stream?.width);
     const height = Number(stream?.height);
-    const durationSec = Number(parsed.format?.duration);
+    const streamDuration = Number(stream?.duration);
+    const durationSec = Number.isFinite(streamDuration) && streamDuration > 0 ? streamDuration : Number(parsed.format?.duration);
     const fps = parseFrameRate(stream?.r_frame_rate ?? '') ?? 30;
     if (
       !Number.isFinite(width) ||

--- a/frontend/server/provider-video-original-copy.ts
+++ b/frontend/server/provider-video-original-copy.ts
@@ -1,0 +1,36 @@
+import { mkdtemp, open, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { uploadFilePath } from './storage';
+
+const MAX_COPY_BYTES = 450 * 1024 * 1024; // One file within the serverless temporary disk budget.
+
+/** Bounded disk streaming; the provider original is uploaded byte-for-byte. */
+export async function copyProviderVideoOriginal(response: Response, options: { jobId: string; userId?: string | null },
+  dependencies = { upload: uploadFilePath, maxBytes: MAX_COPY_BYTES }): Promise<string> {
+  const declared = Number(response.headers.get('content-length'));
+  if (declared > dependencies.maxBytes) throw new Error('Provider video exceeds the direct-copy disk budget.');
+  if (!response.body) throw new Error('Provider video body is missing.');
+  const directory = await mkdtemp(join(tmpdir(), 'provider-original-'));
+  const filePath = join(directory, 'original.mp4');
+  const file = await open(filePath, 'w');
+  const reader = response.body.getReader();
+  let bytes = 0;
+  try {
+    for (;;) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      bytes += chunk.value.byteLength;
+      if (bytes > dependencies.maxBytes) throw new Error('Provider video exceeds the direct-copy disk budget.');
+      await file.writeFile(chunk.value);
+    }
+    await file.close();
+    if (!bytes || (declared > 0 && declared !== bytes)) throw new Error('Provider video download is incomplete.');
+    return (await dependencies.upload({ path: filePath, sizeBytes: bytes, mime: 'video/mp4',
+      userId: options.userId, prefix: 'renders', fileName: `${options.jobId}-original.mp4` })).url;
+  } finally {
+    await reader.cancel().catch(() => undefined);
+    await file.close().catch(() => undefined);
+    await rm(directory, { recursive: true, force: true });
+  }
+}

--- a/frontend/server/upscale-duration-integrity.ts
+++ b/frontend/server/upscale-duration-integrity.ts
@@ -1,0 +1,43 @@
+import { detectVideoMetadata } from '@/server/media/detect-has-audio';
+import { withDbTransaction } from '@/lib/db';
+
+export function upscaleDurationIsComplete(sourceDuration: number, outputDuration: number, fps: number): boolean {
+  // Two frames accommodate container rounding, never a percentage of a long clip.
+  return Number.isFinite(outputDuration) && outputDuration > 0 && outputDuration + 2 / Math.max(1, fps) >= sourceDuration;
+}
+
+export async function checkUpscaleDuration(videoUrl: string, snapshot: unknown, probe = detectVideoMetadata) {
+  const settings = snapshot as { source?: { metadata?: { durationSec?: number; fps?: number } } } | null;
+  const source = settings?.source?.metadata;
+  if (!source?.durationSec) return 'legacy' as const;
+  const output = await probe(videoUrl);
+  if (!output) throw new Error('Upscale output duration is temporarily unavailable.');
+  return upscaleDurationIsComplete(source.durationSec, output.durationSec, source.fps ?? output.fps) ? 'complete' as const : 'truncated' as const;
+}
+
+/** Failure and wallet restitution commit together; a database failure leaves the job recoverable. */
+export async function rejectTruncatedUpscale(jobId: string, providerJobId: string | null, outputUrl: string) {
+  return withDbTransaction(async executor => {
+    const [job] = await executor.query<{ status: string; payment_status: string }>(
+      'SELECT status, payment_status FROM app_jobs WHERE job_id = $1 FOR UPDATE', [jobId]);
+    if (!job || job.status === 'completed') return;
+    if (job.payment_status === 'paid_wallet') {
+      await executor.query(`INSERT INTO app_receipts
+        (user_id, type, amount_cents, currency, description, job_id, surface, billing_product_key,
+         pricing_snapshot, application_fee_cents, vendor_account_id, platform_revenue_cents, destination_acct)
+        SELECT user_id, 'refund', amount_cents, currency, 'Refund: upscale output shorter than original',
+          job_id, surface, billing_product_key, pricing_snapshot, 0, vendor_account_id, 0, vendor_account_id
+        FROM app_receipts WHERE job_id = $1 AND type = 'charge'
+        ORDER BY created_at DESC LIMIT 1 ON CONFLICT DO NOTHING`, [jobId]);
+      const refunds = await executor.query<{ id: number }>(
+        "SELECT id FROM app_receipts WHERE job_id = $1 AND type = 'refund'", [jobId]);
+      if (refunds.length !== 1) throw new Error('Truncated upscale refund could not be confirmed.');
+    }
+    await executor.query(`UPDATE app_jobs SET status = 'failed', progress = 0, message = $2,
+      payment_status = CASE WHEN payment_status = 'paid_wallet' THEN 'refunded_wallet' ELSE payment_status END,
+      settings_snapshot = jsonb_set(COALESCE(settings_snapshot, '{}'::jsonb), '{upscaleDurationIntegrity}', $3::jsonb),
+      updated_at = NOW() WHERE job_id = $1`, [jobId,
+      'The upscaled video is shorter than the original. Contact support before retrying.',
+      JSON.stringify({ status: 'truncated', providerJobId, outputUrl })]);
+  });
+}

--- a/frontend/server/video-faststart.ts
+++ b/frontend/server/video-faststart.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 import { normalizeMediaUrl } from '@/lib/media';
 import { ensureExecutableFfmpegPath } from '@/server/ffmpeg-runtime';
 import { isStorageConfigured, uploadFileBuffer } from '@/server/storage';
+import { copyProviderVideoOriginal } from './provider-video-original-copy';
 
 type EnsureFastStartVideoOptions = {
   jobId: string;
@@ -135,9 +136,9 @@ export async function ensureFastStartVideo(
 
     const lengthHeader = response.headers.get('content-length');
     const maxBytes = getMaxBytes();
-    if (lengthHeader && Number(lengthHeader) > maxBytes) {
-      console.warn('[video-faststart] source too large', { jobId: options.jobId, size: Number(lengthHeader), maxBytes });
-      return null;
+    if (!lengthHeader || !Number.isFinite(Number(lengthHeader)) || Number(lengthHeader) > maxBytes) {
+      bodyTimeout = setTimeout(() => controller.abort(), DOWNLOAD_BODY_TIMEOUT_MS);
+      return await copyProviderVideoOriginal(response, options);
     }
 
     bodyTimeout = setTimeout(() => controller.abort(), DOWNLOAD_BODY_TIMEOUT_MS);

--- a/frontend/src/components/tools/upscale/_hooks/useUpscaleRecentJobs.ts
+++ b/frontend/src/components/tools/upscale/_hooks/useUpscaleRecentJobs.ts
@@ -41,6 +41,11 @@ export function useUpscaleRecentJobs({
   const defaultGeneratedImageAppliedRef = useRef(false);
   const { stableJobs: recentJobs, mutate } = useInfiniteJobs(12, { surface: 'upscale' });
   const { stableJobs: recentGeneratedImageJobs } = useInfiniteJobs(8, { surface: 'image' });
+  useEffect(() => {
+    const refresh = () => { void mutate(); };
+    window.addEventListener('upscale:accepted', refresh);
+    return () => window.removeEventListener('upscale:accepted', refresh);
+  }, [mutate]);
 
   const recentGroups = useMemo(() => {
     const jobs = recentJobs.map((job) => (!job.videoUrl && job.readyVideoUrl ? { ...job, videoUrl: job.readyVideoUrl } : job));
@@ -74,9 +79,13 @@ export function useUpscaleRecentJobs({
   useEffect(() => {
     if (typeof window === 'undefined' || !pendingRecentJobKey) return undefined;
     let cancelled = false;
+    let polling = false;
     const jobIds = pendingRecentJobKey.split('|').filter(Boolean);
     const pollPendingJobs = async () => {
-      await Promise.all(jobIds.map((jobId) => getJobStatus(jobId).catch(() => null)));
+      if (polling) return;
+      polling = true;
+      try { await Promise.all(jobIds.map((jobId) => getJobStatus(jobId).catch(() => null))); }
+      finally { polling = false; }
       if (!cancelled) {
         void mutate();
       }

--- a/frontend/src/lib/fal-queue-submit.ts
+++ b/frontend/src/lib/fal-queue-submit.ts
@@ -1,0 +1,22 @@
+import { ApiError } from '@fal-ai/client';
+import { ENV } from '@/lib/env';
+import { getFalWebhookUrl } from '@/lib/fal-webhook-url';
+
+// The SDK retries queue POSTs. An ambiguous acknowledgment must never submit a second paid request.
+export async function submitFalQueueOnce(modelId: string, input: Record<string, unknown>, jobId?: string, fetchFn = fetch): Promise<string> {
+  const url = new URL(`https://queue.fal.run/${modelId}`);
+  const webhook = getFalWebhookUrl();
+  if (webhook) {
+    const callback = new URL(webhook);
+    if (jobId) callback.searchParams.set('jobId', jobId);
+    url.searchParams.set('fal_webhook', callback.toString());
+  }
+  const response = await fetchFn(url, {
+    method: 'POST', headers: { Authorization: `Key ${ENV.FAL_API_KEY}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(input), signal: AbortSignal.timeout(30_000),
+  });
+  const body = await response.json().catch(() => null);
+  if (!response.ok) throw new ApiError({ status: response.status, message: 'Generation submission could not be confirmed.', body });
+  if (typeof body?.request_id !== 'string' || !body.request_id.trim()) throw new Error('Missing generation request acknowledgment.');
+  return body.request_id.trim();
+}

--- a/frontend/src/lib/fal.ts
+++ b/frontend/src/lib/fal.ts
@@ -16,6 +16,7 @@ import {
   unwrapFalResponse,
 } from '@/lib/fal-response';
 import { getFalWebhookUrl } from '@/lib/fal-webhook-url';
+import { submitFalQueueOnce } from '@/lib/fal-queue-submit';
 import type { GenerateHooks, GeneratePayload, GenerateResult } from '@/lib/fal-types';
 
 export { FalGenerationError } from '@/lib/fal-error';
@@ -62,8 +63,7 @@ async function generateViaFal(
   let result: Awaited<ReturnType<typeof falClient.subscribe>>;
   try {
     if (payload.submissionMode === 'enqueue') {
-      const queued = await falClient.queue.submit(model, { input: requestBody, webhookUrl });
-      enqueuedRequestId = queued.request_id;
+      enqueuedRequestId = await submitFalQueueOnce(model, requestBody, payload.jobId);
       if (!enqueuedRequestId) throw new Error('FAL queue response did not contain a request ID');
       await hooks?.onRequestId?.(enqueuedRequestId);
       return {

--- a/frontend/src/server/audio/media.ts
+++ b/frontend/src/server/audio/media.ts
@@ -11,6 +11,7 @@ import { ensureJobThumbnail } from '@/server/thumbnails';
 import { ensureExecutableFfmpegPath } from '@/server/ffmpeg-runtime';
 import { uploadFileBuffer } from '@/server/storage';
 import type { AudioIntensity } from '@/lib/audio-generation';
+import { buildVideoPreservingMuxArgs } from './video-mux-args';
 
 const requireForRuntime = createRequire(import.meta.url);
 
@@ -277,31 +278,7 @@ export async function muxAudioBufferIntoVideo(params: {
     await writeFile(sourcePath, source.bytes);
     await writeFile(audioPath, params.audioBuffer);
 
-    const args = [
-      '-y',
-      '-protocol_whitelist',
-      'file,pipe',
-      '-format_whitelist',
-      'mov,matroska,webm',
-      '-i',
-      sourcePath,
-      '-i',
-      audioPath,
-      '-map',
-      '0:v:0',
-      '-map',
-      '1:a:0',
-      '-c:v',
-      'copy',
-      '-c:a',
-      'aac',
-      '-b:a',
-      '192k',
-      '-movflags',
-      '+faststart',
-      '-shortest',
-      outputPath,
-    ];
+    const args = buildVideoPreservingMuxArgs(sourcePath, audioPath, outputPath);
 
     await new Promise<void>((resolve, reject) => {
       execFile(executableFfmpegPath, args, (error) => {

--- a/frontend/src/server/audio/video-mux-args.ts
+++ b/frontend/src/server/audio/video-mux-args.ts
@@ -1,0 +1,7 @@
+/** Pad short audio with silence; only the video stream defines the final duration. */
+export function buildVideoPreservingMuxArgs(sourcePath: string, audioPath: string, outputPath: string): string[] {
+  return ['-y', '-protocol_whitelist', 'file,pipe', '-format_whitelist', 'mov,matroska,webm',
+    '-i', sourcePath, '-i', audioPath, '-map', '0:v:0', '-map', '1:a:0',
+    '-c:v', 'copy', '-af', 'apad', '-c:a', 'aac', '-b:a', '192k',
+    '-movflags', '+faststart', '-shortest', outputPath];
+}

--- a/frontend/src/server/tools/upscale-acceptance.ts
+++ b/frontend/src/server/tools/upscale-acceptance.ts
@@ -1,0 +1,37 @@
+import { createHash } from 'node:crypto';
+import { query, type QueryExecutor } from '@/lib/db';
+import type { UpscaleToolRequest, UpscaleToolResponse } from '@/types/tools-upscale';
+import { UpscaleToolError } from './upscale-errors';
+
+export function upscaleRequestIdentity(input: UpscaleToolRequest & { userId: string }) {
+  if (!input.requestId || !/^[a-zA-Z0-9_-]{16,128}$/.test(input.requestId)) {
+    throw new UpscaleToolError('Refresh the page before starting this upscale.', { status: 400, code: 'request_id_required' });
+  }
+  const digest = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
+  const { requestId, userId } = input;
+  const payload = Object.fromEntries(Object.entries(input).filter(([key]) => !['requestId', 'userId', 'acceptedQuote'].includes(key)));
+  return {
+    jobId: `tool_upscale_${digest([userId, requestId])}`,
+    fingerprint: digest(Object.keys(payload).sort().map(key => [key, payload[key as keyof typeof payload] ?? null])),
+  };
+}
+
+export async function readAcceptedUpscale(jobId: string, fingerprint: string, executor: QueryExecutor = { query }): Promise<UpscaleToolResponse | null> {
+  const [job] = await executor.query<{
+    job_id: string; status: string; engine_id: UpscaleToolResponse['engineId']; engine_label: string;
+    provider_job_id: string | null; final_price_cents: number; currency: string; video_url: string | null;
+    thumb_url: string | null; message: string | null; settings_snapshot: { requestFingerprint?: string };
+  }>('SELECT job_id, status, engine_id, engine_label, provider_job_id, final_price_cents, currency, video_url, thumb_url, message, settings_snapshot FROM app_jobs WHERE job_id = $1', [jobId]);
+  if (!job) return null;
+  if (job.settings_snapshot?.requestFingerprint !== fingerprint) {
+    throw new UpscaleToolError('This request ID was already used for different settings.', { status: 409, code: 'idempotency_conflict' });
+  }
+  return {
+    ok: true, jobId, engineId: job.engine_id, engineLabel: job.engine_label, mediaType: 'video',
+    status: job.status === 'completed' ? 'completed' : job.status === 'failed' ? 'failed' : 'pending',
+    providerJobId: job.provider_job_id, requestId: job.provider_job_id, latencyMs: 0,
+    pricing: { totalCents: job.final_price_cents, estimatedCostUsd: job.final_price_cents / 100, estimatedCredits: job.final_price_cents, currency: job.currency },
+    output: job.status === 'completed' && job.video_url ? { url: job.video_url, thumbUrl: job.thumb_url } : null,
+    ...(job.status === 'failed' ? { error: { code: 'upscale_failed', message: job.message ?? 'Upscale failed.' } } : {}),
+  };
+}

--- a/frontend/src/server/tools/upscale-job-persistence.ts
+++ b/frontend/src/server/tools/upscale-job-persistence.ts
@@ -206,6 +206,28 @@ export async function createAtomicInitialUpscaleJob(params: CreateUpscaleInitial
   }
 }
 
+export async function persistQueuedUpscaleRequest(jobId: string, providerJobId: string): Promise<void> {
+  const updated = await query<{ job_id: string }>(
+    `UPDATE app_jobs
+        SET provider_job_id = $2,
+            provider = 'fal',
+            status = 'queued',
+            provisional = FALSE,
+            updated_at = NOW()
+      WHERE job_id = $1
+        AND status = 'pending'
+        AND provider_job_id IS NULL
+      RETURNING job_id`,
+    [jobId, providerJobId]
+  );
+  if (!updated.length) {
+    throw new UpscaleToolError('Failed to save the accepted upscale request.', {
+      status: 500,
+      code: 'provider_job_persist_failed',
+    });
+  }
+}
+
 export async function insertUpscaleToolEvent(params: {
   jobId: string;
   engineId: UpscaleToolEngineId;

--- a/frontend/src/server/tools/upscale-job-persistence.ts
+++ b/frontend/src/server/tools/upscale-job-persistence.ts
@@ -8,6 +8,7 @@ import type { UpscaleToolEngineId } from '@/types/tools-upscale';
 import { UPSCALE_PLACEHOLDER_THUMB, UPSCALE_TOOL_EVENT_NAME } from './upscale-constants';
 import { UpscaleToolError } from './upscale-errors';
 import { UPSCALE_SURFACE } from './upscale-request-utils';
+import { readAcceptedUpscale } from './upscale-acceptance';
 
 export type PendingUpscaleReceipt = {
   userId: string;
@@ -23,6 +24,7 @@ export type PendingUpscaleReceipt = {
 };
 
 export type CreateUpscaleInitialJobParams = {
+  requestFingerprint?: string;
   userId: string;
   jobId: string;
   description: string;
@@ -41,8 +43,11 @@ export type CreateUpscaleInitialJobParams = {
 };
 
 export async function recordUpscaleRefundReceipt(receipt: PendingUpscaleReceipt, label: string, priceOnly: boolean) {
-  try {
-    await query(
+  await withDbTransaction(async executor => {
+    const [job] = await executor.query<{ payment_status: string }>('SELECT payment_status FROM app_jobs WHERE job_id = $1 FOR UPDATE', [receipt.jobId]);
+    if (job?.payment_status === 'refunded_wallet') return;
+    if (job?.payment_status !== 'paid_wallet') throw new Error('Upscale refund requires a paid job.');
+    await executor.query(
       `INSERT INTO app_receipts (
          user_id,
          type,
@@ -75,9 +80,10 @@ export async function recordUpscaleRefundReceipt(receipt: PendingUpscaleReceipt,
         priceOnly ? null : receipt.vendorAccountId,
       ]
     );
-  } catch (error) {
-    console.warn('[tools/upscale] failed to record refund receipt', error);
-  }
+    const refunds = await executor.query<{ id: number }>("SELECT id FROM app_receipts WHERE job_id = $1 AND type = 'refund'", [receipt.jobId]);
+    if (refunds.length !== 1) throw new Error('Upscale refund was not persisted.');
+    await executor.query("UPDATE app_jobs SET payment_status = 'refunded_wallet', status = 'failed', updated_at = NOW() WHERE job_id = $1", [receipt.jobId]);
+  });
 }
 
 async function insertProvisionalUpscaleJob(
@@ -190,11 +196,13 @@ async function createUpscaleInitialJobInExecutor(
   });
 }
 
-export async function createAtomicInitialUpscaleJob(params: CreateUpscaleInitialJobParams): Promise<void> {
+export async function createAtomicInitialUpscaleJob(params: CreateUpscaleInitialJobParams): Promise<boolean> {
   try {
-    await withDbTransaction(async (executor) => {
+    return await withDbTransaction(async (executor) => {
       await executor.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [params.jobId]);
+      if (params.requestFingerprint && await readAcceptedUpscale(params.jobId, params.requestFingerprint, executor)) return false;
       await createUpscaleInitialJobInExecutor(executor, params);
+      return true;
     });
   } catch (error) {
     if (error instanceof UpscaleToolError) throw error;

--- a/frontend/src/server/tools/upscale-provider-submission.ts
+++ b/frontend/src/server/tools/upscale-provider-submission.ts
@@ -1,0 +1,38 @@
+type UpscaleFalQueue = {
+  submit(
+    modelId: string,
+    options: { input: Record<string, unknown> }
+  ): Promise<{ request_id?: string | null }>;
+  subscribeToStatus(
+    modelId: string,
+    options: {
+      requestId: string;
+      mode: 'polling';
+      onQueueUpdate(update: unknown): void;
+    }
+  ): Promise<unknown>;
+  result(modelId: string, options: { requestId: string }): Promise<unknown>;
+};
+
+export async function runDurablyTrackedUpscaleRequest(params: {
+  modelId: string;
+  input: Record<string, unknown>;
+  persistProviderJobId(requestId: string): Promise<void>;
+  onQueueUpdate(update: unknown): void;
+  queue: UpscaleFalQueue;
+}): Promise<{ providerJobId: string; result: unknown }> {
+  const queued = await params.queue.submit(params.modelId, { input: params.input });
+  const providerJobId = queued.request_id?.trim();
+  if (!providerJobId) {
+    throw new Error('Fal queue response did not contain a request ID.');
+  }
+
+  await params.persistProviderJobId(providerJobId);
+  await params.queue.subscribeToStatus(params.modelId, {
+    requestId: providerJobId,
+    mode: 'polling',
+    onQueueUpdate: params.onQueueUpdate,
+  });
+  const result = await params.queue.result(params.modelId, { requestId: providerJobId });
+  return { providerJobId, result };
+}

--- a/frontend/src/server/tools/upscale-request-utils.ts
+++ b/frontend/src/server/tools/upscale-request-utils.ts
@@ -336,6 +336,11 @@ export function cloneUpscalePricingWithDynamicTotal(
   };
 }
 
+export function usdToCredits(value: number | null | undefined): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return null;
+  return Math.max(1, Math.round(value * 100));
+}
+
 export function toUpscaleValidationMessage(error: ValidationError): string {
   const messages = error.fieldErrors
     .map((entry) => {

--- a/frontend/src/server/tools/upscale-video-submission.ts
+++ b/frontend/src/server/tools/upscale-video-submission.ts
@@ -1,0 +1,25 @@
+import { ApiError } from '@fal-ai/client';
+import { readAcceptedUpscale } from './upscale-acceptance';
+import { submitFalQueueOnce } from '@/lib/fal-queue-submit';
+import { persistQueuedUpscaleRequest, insertUpscaleToolEvent } from './upscale-job-persistence';
+import type { UpscaleToolEngineDefinition } from '@/types/tools-upscale';
+import { query } from '@/lib/db';
+
+export async function acceptVideoUpscale(engine: UpscaleToolEngineDefinition, input: Record<string, unknown>, identity: { jobId: string; fingerprint: string }) {
+  let providerJobId: string | null = null;
+  try {
+    providerJobId = await submitFalQueueOnce(engine.falModelId, input, identity.jobId);
+    await persistQueuedUpscaleRequest(identity.jobId, providerJobId);
+  } catch (error) {
+    if (error instanceof ApiError && [400, 401, 403, 404, 422].includes(error.status)) throw error;
+    await insertUpscaleToolEvent({ jobId: identity.jobId, engineId: engine.id, providerJobId, payload: { status: 'submission_unknown' } });
+    if (providerJobId) {
+      // Retrying persistence is safe; retrying the paid submission is not.
+      await persistQueuedUpscaleRequest(identity.jobId, providerJobId).catch(() => undefined);
+    }
+    await query(`UPDATE app_jobs SET message = $2, updated_at = NOW() WHERE job_id = $1 AND status = 'pending'`,
+      [identity.jobId, 'Checking whether the upscale was accepted. Please keep this job; contact support if the status does not update.']);
+    // Preserve the reservation and identity: a lost acknowledgment never authorizes another POST.
+  }
+  return (await readAcceptedUpscale(identity.jobId, identity.fingerprint))!;
+}

--- a/frontend/src/server/tools/upscale.ts
+++ b/frontend/src/server/tools/upscale.ts
@@ -37,11 +37,12 @@ import { resolveUpscalePricingContext } from './upscale-pricing-context';
 import {
   createAtomicInitialUpscaleJob,
   insertUpscaleToolEvent,
+  persistQueuedUpscaleRequest,
   recordUpscaleRefundReceipt,
   type PendingUpscaleReceipt,
 } from './upscale-job-persistence';
 import { persistUpscaleOutput } from './upscale-output-persistence';
-
+import { runDurablyTrackedUpscaleRequest } from './upscale-provider-submission';
 
 type RunUpscaleToolInput = UpscaleToolRequest & {
   userId: string;
@@ -178,17 +179,24 @@ export async function runUpscaleToolBase(
   const startedAt = Date.now();
 
   try {
-    const result = await falClient.subscribe(engine.falModelId, {
+    const trackedRequest = await runDurablyTrackedUpscaleRequest({
+      queue: falClient.queue,
+      modelId: engine.falModelId,
       input: falInput,
-      mode: 'polling',
-      onEnqueue(requestId) {
-        providerJobId = providerJobId ?? requestId;
+      persistProviderJobId: async (requestId) => {
+        providerJobId = requestId;
+        await persistQueuedUpscaleRequest(jobId, requestId);
       },
       onQueueUpdate(update) {
-        if (update?.request_id) providerJobId = providerJobId ?? update.request_id;
+        const queueUpdate = update as { request_id?: string } | null;
+        if (queueUpdate?.request_id) providerJobId = providerJobId ?? queueUpdate.request_id;
         lastQueueUpdate = update;
       },
     });
+    const result = trackedRequest.result as {
+      data: unknown;
+      requestId?: string | null;
+    };
 
     const output = extractUpscaleOutput(result.data, mediaType);
     if (!output) {

--- a/frontend/src/server/tools/upscale.ts
+++ b/frontend/src/server/tools/upscale.ts
@@ -15,10 +15,7 @@ import {
   resolveUpscaleOutputFormat,
   resolveUpscaleTargetResolution,
 } from '@/lib/tools-upscale';
-import type {
-  UpscaleToolRequest,
-  UpscaleToolResponse,
-} from '@/types/tools-upscale';
+import type { UpscaleToolRequest, UpscaleToolResponse } from '@/types/tools-upscale';
 import {
   UPSCALE_SURFACE,
   buildUpscaleFalInput,
@@ -28,6 +25,7 @@ import {
   extractUpscaleOutput,
   parseUpscaleRequestId,
   toUpscaleValidationMessage,
+  usdToCredits,
   type VideoMetadata,
 } from './upscale-request-utils';
 import { UPSCALE_PLACEHOLDER_THUMB, UPSCALE_TOOL_EVENT_NAME } from './upscale-constants';
@@ -43,6 +41,8 @@ import {
 } from './upscale-job-persistence';
 import { persistUpscaleOutput } from './upscale-output-persistence';
 import { runDurablyTrackedUpscaleRequest } from './upscale-provider-submission';
+import { readAcceptedUpscale, upscaleRequestIdentity } from './upscale-acceptance';
+import { acceptVideoUpscale } from './upscale-video-submission';
 
 type RunUpscaleToolInput = UpscaleToolRequest & {
   userId: string;
@@ -63,11 +63,6 @@ export type RunUpscaleToolDependencies = {
   detectVideoMetadata?: (videoUrl: string, options?: { timeoutMs?: number }) => Promise<VideoMetadata | null>;
 };
 
-function usdToCredits(value: number | null | undefined): number | null {
-  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return null;
-  return Math.max(1, Math.round(value * 100));
-}
-
 export async function runUpscaleToolBase(
   input: RunUpscaleToolInput,
   dependencies: RunUpscaleToolDependencies = {}
@@ -78,7 +73,12 @@ export async function runUpscaleToolBase(
   const upscaleFactor = clampUpscaleFactor(engine, input.upscaleFactor);
   const targetResolution = resolveUpscaleTargetResolution(engine, input.targetResolution);
   const outputFormat = resolveUpscaleOutputFormat(engine, input.outputFormat);
-  const jobId = `tool_upscale_${randomUUID()}`;
+  const identity = mediaType === 'video' ? upscaleRequestIdentity(input) : null;
+  const jobId = identity?.jobId ?? `tool_upscale_${randomUUID()}`;
+  if (identity) {
+    const existing = await readAcceptedUpscale(jobId, identity.fingerprint);
+    if (existing) return existing;
+  }
   const billingProductKey = engine.billingProductKey;
   const priceOnlyReceipts = receiptsPriceOnlyEnabled();
 
@@ -131,7 +131,7 @@ export async function runUpscaleToolBase(
     outputFormat,
   });
   const pricingSnapshotJson = JSON.stringify(pricing);
-  const settingsSnapshotJson = JSON.stringify(settingsSnapshot);
+  const settingsSnapshotJson = JSON.stringify({ ...settingsSnapshot, requestFingerprint: identity?.fingerprint });
   const pendingReceipt: PendingUpscaleReceipt = {
     userId: input.userId,
     amountCents: pricing.totalCents,
@@ -146,7 +146,8 @@ export async function runUpscaleToolBase(
   };
 
   const preferredCurrency = await getUserPreferredCurrency(input.userId);
-  await createAtomicInitialUpscaleJob({
+  const created = await createAtomicInitialUpscaleJob({
+    requestFingerprint: identity?.fingerprint,
     userId: input.userId,
     jobId,
     description: pendingReceipt.description,
@@ -163,6 +164,7 @@ export async function runUpscaleToolBase(
     settingsSnapshotJson,
     preferredCurrency,
   });
+  if (!created && identity) return (await readAcceptedUpscale(jobId, identity.fingerprint))!;
 
   const falInput = buildUpscaleFalInput({
     engine,
@@ -173,14 +175,14 @@ export async function runUpscaleToolBase(
     outputFormat,
     metadata: videoMetadata,
   });
-  const falClient = getFalClient();
   let providerJobId: string | null = null;
   let lastQueueUpdate: unknown = null;
   const startedAt = Date.now();
 
   try {
+    if (identity) return await acceptVideoUpscale(engine, falInput, identity);
     const trackedRequest = await runDurablyTrackedUpscaleRequest({
-      queue: falClient.queue,
+      queue: getFalClient().queue,
       modelId: engine.falModelId,
       input: falInput,
       persistProviderJobId: async (requestId) => {
@@ -261,7 +263,6 @@ export async function runUpscaleToolBase(
            render_ids = COALESCE($9::jsonb, render_ids),
            hero_render_id = COALESCE($10, hero_render_id),
            message = NULL,
-           payment_status = 'paid_wallet',
            provisional = FALSE,
            updated_at = NOW()
        WHERE job_id = $1`,
@@ -368,6 +369,8 @@ export async function runUpscaleToolBase(
       output: persistedOutput,
     };
   } catch (error) {
+    // A persistence/read failure after submission is not proof that Fal rejected the job.
+    if (identity && !(error instanceof ApiError && [400, 401, 403, 404, 422].includes(error.status))) throw error;
     const latencyMs = Date.now() - startedAt;
     let message = error instanceof Error ? error.message : 'Upscale generation failed';
     let status = 502;
@@ -398,7 +401,6 @@ export async function runUpscaleToolBase(
          SET status = 'failed',
              progress = 0,
              provider_job_id = COALESCE($2, provider_job_id),
-             payment_status = 'refunded_wallet',
              message = $3,
              provisional = FALSE,
              updated_at = NOW()

--- a/frontend/types/tools-upscale.ts
+++ b/frontend/types/tools-upscale.ts
@@ -16,6 +16,7 @@ export type UpscaleTargetResolution = '720p' | '1080p' | '1440p' | '2160p';
 export type UpscaleOutputFormat = 'jpg' | 'png' | 'webp' | 'mp4' | 'webm' | 'mov' | 'gif';
 
 export interface UpscaleToolRequest {
+  requestId?: string;
   acceptedQuote?: AcceptedToolQuote;
   mediaType: UpscaleMediaType;
   mediaUrl: string;
@@ -58,6 +59,7 @@ export interface UpscaleToolPricing {
 }
 
 export interface UpscaleToolResponse {
+  status?: 'pending' | 'completed' | 'failed';
   ok: boolean;
   jobId?: string | null;
   engineId: UpscaleToolEngineId;

--- a/tests/fal-enqueue-generation.test.ts
+++ b/tests/fal-enqueue-generation.test.ts
@@ -11,11 +11,11 @@ test('MCP enqueue returns the accepted request without subscribing to a long ren
   t.after(() => { ENV.FAL_API_KEY = previousKey; });
   const client = getFalClient();
   let submits = 0;
-  t.mock.method(client.queue, 'submit', async (model: string, options: { input: Record<string, unknown> }) => {
+  t.mock.method(globalThis, 'fetch', async (url: URL, options: RequestInit) => {
     submits += 1;
-    assert.equal(model, 'minimax/h3/reference-to-video');
-    assert.equal(options.input.submissionMode, undefined);
-    return { request_id: 'accepted-request' };
+    assert.equal(url.pathname, '/minimax/h3/reference-to-video');
+    assert.equal(JSON.parse(String(options.body)).submissionMode, undefined);
+    return new Response(JSON.stringify({ request_id: 'accepted-request' }));
   });
   t.mock.method(client, 'subscribe', async () => {
     throw new Error('Must not wait for rendering inside MCP confirmation');
@@ -52,9 +52,9 @@ test('an enqueue rejection preserves the provider error and never submits a repl
   t.after(() => { ENV.FAL_API_KEY = previousKey; });
   const client = getFalClient();
   let submits = 0;
-  t.mock.method(client.queue, 'submit', async () => {
+  t.mock.method(globalThis, 'fetch', async () => {
     submits += 1;
-    throw Object.assign(new Error('Rejected input'), { status: 422, body: { detail: 'Invalid reference' } });
+    return new Response(JSON.stringify({ detail: 'Invalid reference' }), { status: 422 });
   });
   t.mock.method(client, 'subscribe', async () => { throw new Error('Unexpected subscription'); });
   await assert.rejects(generateVideo({

--- a/tests/fal-long-running-poll.test.ts
+++ b/tests/fal-long-running-poll.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { runFalPoll } from '../frontend/server/fal-poll';
+
+test('real Fal poll keeps old jobs active through transient errors and only fails confirmed provider failures', async () => {
+  for (const scenario of ['running', 'offline', 'result-unavailable', 'completed', 'failed']) {
+    const updates: Array<Record<string, unknown>> = [];
+    const events: string[] = [];
+    let submissions = 0;
+    const dependencies = {
+      query: async <T>(sql: string, values?: readonly unknown[]): Promise<T[]> => {
+        if (sql.includes('SELECT job_id, surface, engine_id')) return [{ job_id: 'one', engine_id: 'seedvr-video', surface: 'upscale', provider_job_id: 'fal-one', status: 'running', created_at: new Date(Date.now() - 4 * 3600_000).toISOString(), updated_at: new Date(Date.now() - 10 * 60_000).toISOString() }] as T[];
+        if (sql.includes('COUNT(*)::int')) return [{ attempts: 0, last_attempt_at: null }] as T[];
+        if (sql.includes('INSERT INTO fal_queue_log')) events.push(String(values?.[4]));
+        assert.doesNotMatch(sql, /SET status = 'failed'/, 'transient problems must never use the DB failure fallback');
+        return [];
+      },
+      getFalClient: () => ({ queue: {
+        submit: async () => { submissions++; throw new Error('No resubmission allowed'); },
+        status: async () => {
+          if (scenario === 'offline') throw new Error('connection lost');
+          return { status: scenario === 'running' ? 'IN_PROGRESS' : scenario === 'failed' ? 'FAILED' : 'COMPLETED' };
+        },
+        result: async () => {
+          if (scenario === 'result-unavailable') throw new Error('temporary read failure');
+          return { data: { video: { url: 'https://example.test/full.mp4' } } };
+        },
+      } }),
+      updateJobFromFalWebhook: async (value: unknown) => { updates.push(value as Record<string, unknown>); },
+      reconcileStaleFalProvisionals: async () => ({ failed: 0 }),
+      reconcileFinishingJobs: async () => ({ checked: 0, reconciled: 0, failures: 0 }),
+      backfillCompletedMcpJobOutputs: async () => ({ promoted: 0, failed: 0 }),
+    } as unknown as Parameters<typeof runFalPoll>[0];
+    await runFalPoll(dependencies);
+    assert.equal(submissions, 0);
+    if (scenario === 'failed') assert.equal(updates[0]?.auto_refund_eligible, true);
+    else if (scenario === 'completed') assert.equal(updates[0]?.status, 'completed');
+    else { assert.equal(updates.length, 0); assert.ok(events.includes('poll:deferred')); }
+  }
+});

--- a/tests/fal-poll-refund-policy.test.ts
+++ b/tests/fal-poll-refund-policy.test.ts
@@ -34,6 +34,19 @@ test('Fal poll timeout failures remain wallet-refund eligible', () => {
   );
 });
 
+test('Fal poll transactionally refunds stale charged jobs that never received a provider id', () => {
+  assert.match(
+    falPollSource,
+    /import \{ reconcileStaleFalProvisionals \} from '@\/server\/fal-stale-provisionals';/,
+    'stale provisional settlement should live in its transaction-focused module'
+  );
+  assert.match(
+    falPollSource,
+    /const \{ failed: provisionalFailures \} = await reconcileStaleFalProvisionals\(\);/,
+    'the Fal poll should run stale provisional settlement before processing provider jobs'
+  );
+});
+
 test('Fal poll repairs recent completed jobs that still point at Fal media', () => {
   assert.match(
     falPollSource,

--- a/tests/fal-poll-refund-policy.test.ts
+++ b/tests/fal-poll-refund-policy.test.ts
@@ -7,30 +7,30 @@ const root = process.cwd();
 const falPollPath = join(root, 'frontend/server/fal-poll.ts');
 const falPollSource = readFileSync(falPollPath, 'utf8');
 
-test('Fal poll timeout failures remain wallet-refund eligible', () => {
+test('Fal poll preserves accepted requests through timeouts and read failures', () => {
   assert.match(falPollSource, /getFalPollTiming\(job\.engine_id, job\.created_at, now\)/);
   assert.match(
     falPollSource,
-    /const markRefundEligiblePollFailure = async \(reason: string\) => \{[\s\S]*autoRefundEligible: true,[\s\S]*failureOrigin: 'poll_internal'/,
-    'poll timeout failures should pass auto-refund eligibility through the webhook handler'
+    /const deferPoll = async \(reason: string\)/,
+    'poll read failures must stay recoverable'
   );
 
   for (const reason of [
     'Unable to determine render engine for this job.',
     'Render status remained unavailable after timeout grace period.',
-    'Render polling exceeded expected window after timeout grace period.',
+    'Render still processing beyond the expected window.',
   ]) {
     assert.match(
       falPollSource,
-      new RegExp(`markRefundEligiblePollFailure\\(['"]${reason.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}['"]`),
-      `${reason} should use the timeout refund helper`
+      new RegExp(`deferPoll\\(['"]${reason.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}['"]`),
+      `${reason} should defer without refunding`
     );
   }
 
   assert.match(
     falPollSource,
-    /markRefundEligiblePollFailure\(providerError \?\? 'Render returned no result after timeout grace period\.'\)/,
-    'missing-result timeout failures should use the timeout refund helper'
+    /deferPoll\(providerError \?\? 'Render returned no result after timeout grace period\.'\)/,
+    'a temporarily missing result must remain recoverable'
   );
 });
 

--- a/tests/fal-poll-timing.test.ts
+++ b/tests/fal-poll-timing.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { getFalPollTiming } from '../frontend/server/fal-poll-timing';
 
-test('H3 stays recoverable through observed 65-minute renders but has a bounded 90-minute deadline', () => {
+test('H3 has a 90-minute attention threshold, not a render cancellation deadline', () => {
   const createdAt = '2026-09-07T00:00:00Z';
   const timing = (minutes: number, engine = 'minimax-h3') =>
     getFalPollTiming(engine, createdAt, Date.parse(createdAt) + minutes * 60_000);

--- a/tests/fal-stale-provisional-refund-postgres.test.ts
+++ b/tests/fal-stale-provisional-refund-postgres.test.ts
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import test from 'node:test';
+import { getDb } from '../frontend/src/lib/db';
+import {
+  createPaidGenerationTestSchema,
+  missingDisposablePostgresCommand,
+  startDisposablePostgres,
+} from './helpers/disposable-postgres';
+
+const modulePath = `${process.cwd()}/frontend/server/fal-stale-provisionals.ts`;
+
+test('stale charged Fal provisionals fail with one exact wallet refund', { timeout: 60_000 }, async (t) => {
+  const missing = missingDisposablePostgresCommand();
+  if (missing) return t.skip(`${missing} is unavailable`);
+  assert.ok(existsSync(modulePath), 'the stale Fal provisional reconciler should exist');
+  const reconciliationModule = await import(pathToFileURL(modulePath).href) as {
+    reconcileStaleFalProvisionals?: (options?: { limit?: number }) => Promise<{ failed: number }>;
+  };
+  assert.equal(typeof reconciliationModule.reconcileStaleFalProvisionals, 'function');
+
+  const database = await startDisposablePostgres('fal-stale-refund');
+  const previousUrl = process.env.DATABASE_URL;
+  process.env.DATABASE_URL = database.databaseUrl;
+  t.after(async () => {
+    await getDb().end();
+    if (previousUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = previousUrl;
+    await database.cleanup();
+  });
+  await createPaidGenerationTestSchema(database.pool);
+  await database.pool.query(`
+    CREATE TABLE fal_queue_log (
+      id bigserial PRIMARY KEY,
+      job_id text,
+      provider text,
+      provider_job_id text,
+      engine_id text,
+      status text,
+      payload jsonb,
+      created_at timestamptz NOT NULL DEFAULT clock_timestamp()
+    )
+  `);
+
+  const jobId = 'tool_upscale_stale_paid';
+  const pricing = { totalCents: 558, currency: 'USD', source: 'fixture' };
+  await database.pool.query(`INSERT INTO app_jobs (
+    job_id,user_id,surface,billing_product_key,engine_id,engine_label,duration_sec,
+    status,progress,provider_job_id,payment_status,final_price_cents,currency,
+    pricing_snapshot,settings_snapshot,provisional,created_at,updated_at
+  ) VALUES (
+    $1,'customer-1','upscale','upscale-video-seedvr','seedvr-video','SeedVR2 Video Upscale',10,
+    'pending',0,NULL,'paid_wallet',558,'USD',$2::jsonb,'{}',TRUE,
+    clock_timestamp() - INTERVAL '10 minutes',clock_timestamp() - INTERVAL '10 minutes'
+  )`, [jobId, JSON.stringify(pricing)]);
+  await database.pool.query(`INSERT INTO app_receipts (
+    user_id,type,amount_cents,currency,description,job_id,surface,billing_product_key,
+    pricing_snapshot,application_fee_cents,vendor_account_id
+  ) VALUES (
+    'customer-1','charge',558,'USD','SeedVR2 Video Upscale upscale run',$1,
+    'upscale','upscale-video-seedvr',$2::jsonb,0,NULL
+  )`, [jobId, JSON.stringify(pricing)]);
+
+  assert.deepEqual(
+    await reconciliationModule.reconcileStaleFalProvisionals!(),
+    { failed: 1 }
+  );
+  assert.deepEqual(
+    await reconciliationModule.reconcileStaleFalProvisionals!(),
+    { failed: 0 }
+  );
+
+  const state = await database.pool.query(`SELECT status,payment_status,provisional,
+    (SELECT count(*)::int FROM app_receipts r WHERE r.job_id=j.job_id AND r.type='refund') AS refunds,
+    (SELECT COALESCE(sum(amount_cents),0)::int FROM app_receipts r WHERE r.job_id=j.job_id AND r.type='refund') AS refunded_cents,
+    (SELECT count(*)::int FROM fal_queue_log q WHERE q.job_id=j.job_id AND q.status='poll:not-started') AS failure_events
+    FROM app_jobs j WHERE job_id=$1`, [jobId]);
+  assert.deepEqual(state.rows[0], {
+    status: 'failed',
+    payment_status: 'refunded_wallet',
+    provisional: false,
+    refunds: 1,
+    refunded_cents: 558,
+    failure_events: 1,
+  });
+
+  const retryJobId = 'tool_upscale_stale_refund_retry';
+  await database.pool.query(`INSERT INTO app_jobs (
+    job_id,user_id,surface,billing_product_key,engine_id,engine_label,duration_sec,
+    status,progress,provider_job_id,payment_status,final_price_cents,currency,
+    pricing_snapshot,settings_snapshot,provisional,created_at,updated_at
+  ) VALUES (
+    $1,'customer-1','upscale','upscale-video-seedvr','seedvr-video','SeedVR2 Video Upscale',10,
+    'pending',0,NULL,'paid_wallet',558,'USD',$2::jsonb,'{}',TRUE,
+    clock_timestamp() - INTERVAL '10 minutes',clock_timestamp() - INTERVAL '10 minutes'
+  )`, [retryJobId, JSON.stringify(pricing)]);
+  await database.pool.query(`INSERT INTO app_receipts (
+    user_id,type,amount_cents,currency,description,job_id,surface,billing_product_key,
+    pricing_snapshot,application_fee_cents,vendor_account_id
+  ) VALUES (
+    'customer-1','charge',558,'USD','SeedVR2 Video Upscale upscale run',$1,
+    'upscale','upscale-video-seedvr',$2::jsonb,0,NULL
+  )`, [retryJobId, JSON.stringify(pricing)]);
+  await database.pool.query(`ALTER TABLE app_receipts ADD CONSTRAINT reject_stale_refund
+    CHECK (job_id <> 'tool_upscale_stale_refund_retry' OR type <> 'refund')`);
+
+  assert.deepEqual(
+    await reconciliationModule.reconcileStaleFalProvisionals!(),
+    { failed: 0 },
+    'a failed refund write must not settle the charged job'
+  );
+  const retryPending = await database.pool.query(`SELECT status,payment_status,provisional,
+    (SELECT count(*)::int FROM app_receipts r WHERE r.job_id=j.job_id AND r.type='refund') AS refunds,
+    (SELECT count(*)::int FROM fal_queue_log q WHERE q.job_id=j.job_id AND q.status='poll:not-started') AS failure_events
+    FROM app_jobs j WHERE job_id=$1`, [retryJobId]);
+  assert.deepEqual(retryPending.rows[0], {
+    status: 'pending',
+    payment_status: 'paid_wallet',
+    provisional: true,
+    refunds: 0,
+    failure_events: 0,
+  });
+
+  await database.pool.query('ALTER TABLE app_receipts DROP CONSTRAINT reject_stale_refund');
+  assert.deepEqual(
+    await reconciliationModule.reconcileStaleFalProvisionals!(),
+    { failed: 1 },
+    'the same job should settle after the refund store recovers'
+  );
+});

--- a/tests/provider-video-original-copy.test.ts
+++ b/tests/provider-video-original-copy.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFile, access } from 'node:fs/promises';
+import { copyProviderVideoOriginal } from '../frontend/server/provider-video-original-copy';
+
+test('direct provider copy retains every byte and removes only its temporary file', async () => {
+  const bytes = new Uint8Array(100_000).map((_, i) => i % 251);
+  let uploaded = '';
+  const url = await copyProviderVideoOriginal(new Response(bytes, { headers: { 'content-length': String(bytes.length) } }), { jobId: 'job', userId: 'owner' }, {
+    maxBytes: 200_000,
+    upload: async params => {
+      assert.equal(params.sizeBytes, bytes.length);
+      assert.equal(params.userId, 'owner');
+      uploaded = params.path;
+      assert.deepEqual(new Uint8Array(await readFile(params.path)), bytes);
+      return { url: 'https://example.test/original.mp4', key: 'renders/owner/original' };
+    },
+  });
+  assert.equal(url, 'https://example.test/original.mp4');
+  await assert.rejects(access(uploaded));
+});
+
+test('over-budget and truncated downloads cannot publish an incomplete original', async () => {
+  let uploads = 0;
+  const deps = { maxBytes: 100, upload: async () => { uploads++; return { url: '', key: '' }; } };
+  await assert.rejects(copyProviderVideoOriginal(new Response(new Uint8Array(101)), { jobId: 'job' }, deps), /budget/);
+  await assert.rejects(copyProviderVideoOriginal(new Response(new Uint8Array(10), { headers: { 'content-length': '20' } }), { jobId: 'job' }, deps), /incomplete/);
+  assert.equal(uploads, 0);
+});

--- a/tests/upscale-idempotency-postgres.test.ts
+++ b/tests/upscale-idempotency-postgres.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createPaidGenerationTestSchema, startDisposablePostgres } from './helpers/disposable-postgres';
+import { getDb } from '../frontend/src/lib/db';
+import { createAtomicInitialUpscaleJob } from '../frontend/src/server/tools/upscale-job-persistence';
+import { rejectTruncatedUpscale } from '../frontend/server/upscale-duration-integrity';
+
+test('concurrent upscale retries reserve once; conflicting payloads cannot charge or submit', { timeout: 60_000 }, async t => {
+  const database = await startDisposablePostgres('upscale-idempotency');
+  const previous = process.env.DATABASE_URL;
+  process.env.DATABASE_URL = database.databaseUrl;
+  t.after(async () => { await getDb().end(); if (previous) process.env.DATABASE_URL = previous; else delete process.env.DATABASE_URL; await database.cleanup(); });
+  await createPaidGenerationTestSchema(database.pool);
+  await database.pool.query("INSERT INTO app_receipts (user_id,type,amount_cents,currency) VALUES ('alice','topup',1000,'USD')");
+  const params = {
+    userId: 'alice', jobId: 'tool_upscale_same-request', requestFingerprint: 'fingerprint', description: 'upscale',
+    amountCents: 100, currency: 'USD', billingProductKey: 'upscale-video-seedvr', pricingSnapshotJson: '{}',
+    applicationFeeCents: null, vendorAccountId: null, engineId: 'seedvr-video' as const, engineLabel: 'SeedVR',
+    durationSec: 6, promptSummary: 'upscale', settingsSnapshotJson: '{"requestFingerprint":"fingerprint"}', preferredCurrency: 'usd' as const,
+  };
+  const created = await Promise.all(Array.from({ length: 12 }, () => createAtomicInitialUpscaleJob(params)));
+  assert.equal(created.filter(Boolean).length, 1, 'only the winning reservation can submit to Fal');
+  await assert.rejects(createAtomicInitialUpscaleJob({ ...params, requestFingerprint: 'different' }), /different settings/);
+  const { rows } = await database.pool.query("SELECT (SELECT count(*) FROM app_jobs) AS jobs, (SELECT count(*) FROM app_receipts WHERE type='charge') AS charges");
+  assert.deepEqual(rows[0], { jobs: '1', charges: '1' });
+  await database.pool.query(`CREATE FUNCTION fail_refund() RETURNS trigger LANGUAGE plpgsql AS $$
+    BEGIN IF NEW.type = 'refund' THEN RAISE EXCEPTION 'simulated database failure'; END IF; RETURN NEW; END $$`);
+  await database.pool.query('CREATE TRIGGER fail_refund BEFORE INSERT ON app_receipts FOR EACH ROW EXECUTE FUNCTION fail_refund()');
+  await assert.rejects(rejectTruncatedUpscale(params.jobId, 'fal-request', 'https://example.com/output.mp4'), /simulated database failure/);
+  const unchanged = await database.pool.query('SELECT status, payment_status FROM app_jobs');
+  assert.deepEqual(unchanged.rows[0], { status: 'pending', payment_status: 'paid_wallet' });
+  await database.pool.query('DROP TRIGGER fail_refund ON app_receipts');
+  await Promise.all(Array.from({ length: 12 }, () => rejectTruncatedUpscale(params.jobId, 'fal-request', 'https://example.com/output.mp4')));
+  const refunded = await database.pool.query("SELECT amount_cents FROM app_receipts WHERE type='refund'");
+  assert.deepEqual(refunded.rows, [{ amount_cents: 100 }]);
+  const settled = await database.pool.query('SELECT status, payment_status FROM app_jobs');
+  assert.deepEqual(settled.rows[0], { status: 'failed', payment_status: 'refunded_wallet' });
+  assert.equal(await createAtomicInitialUpscaleJob(params), false, 'even a refunded job cannot be resubmitted with the same intent');
+});

--- a/tests/upscale-long-running.test.ts
+++ b/tests/upscale-long-running.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { upscaleRequestIdentity, readAcceptedUpscale } from '../frontend/src/server/tools/upscale-acceptance';
+import { submitFalQueueOnce } from '../frontend/src/lib/fal-queue-submit';
+import { waitForUpscale } from '../frontend/lib/upscale-client-lifecycle';
+import { upscaleDurationIsComplete } from '../frontend/server/upscale-duration-integrity';
+import type { UpscaleToolResponse } from '../frontend/types/tools-upscale';
+import type { JobStatusResult } from '../frontend/lib/api-job-status';
+
+test('upscale intent identity is stable, owner-scoped, and binds all media settings', () => {
+  const input = { userId: 'alice', requestId: 'request-1234567890', mediaType: 'video' as const, mediaUrl: 'https://example.test/v.mp4' };
+  const a = upscaleRequestIdentity(input);
+  assert.deepEqual(upscaleRequestIdentity({ ...input }), a);
+  assert.notEqual(upscaleRequestIdentity({ ...input, userId: 'bob' }).jobId, a.jobId);
+  assert.equal(upscaleRequestIdentity({ ...input, targetResolution: '2160p' }).jobId, a.jobId);
+  assert.notEqual(upscaleRequestIdentity({ ...input, targetResolution: '2160p' }).fingerprint, a.fingerprint);
+  assert.throws(() => upscaleRequestIdentity({ ...input, requestId: undefined }));
+});
+
+test('lost queue acknowledgment and server errors never repeat a paid POST', async () => {
+  for (const failure of ['network', '500', 'invalid-json']) {
+    let calls = 0;
+    const fetchFn = (async () => {
+      calls++;
+      if (failure === 'network') throw new Error('connection lost after acceptance');
+      return new Response(failure === 'invalid-json' ? 'oops' : '{}', { status: failure === 'invalid-json' ? 200 : 500 });
+    }) as typeof fetch;
+    await assert.rejects(submitFalQueueOnce('fal-ai/seedvr/upscale/video', {}, 'job', fetchFn));
+    assert.equal(calls, 1);
+  }
+});
+
+test('a long accepted upscale survives status outages and completes from the same job', async () => {
+  const accepted: UpscaleToolResponse = { ok: true, status: 'pending', jobId: 'one-job', mediaType: 'video', engineId: 'seedvr-video', engineLabel: 'SeedVR', latencyMs: 0, pricing: { estimatedCostUsd: 1, estimatedCredits: 100 } };
+  let polls = 0, waits = 0, terminals = 0;
+  const result = await waitForUpscale(accepted, {
+    isCurrent: () => true, onTerminal: () => { terminals++; }, sleep: async () => { waits++; },
+    getStatus: async jobId => {
+      assert.equal(jobId, 'one-job'); polls++;
+      if (polls % 10 === 0) throw new Error('429 / network unavailable');
+      return { status: polls > 1000 ? 'completed' : 'pending', videoUrl: polls > 1000 ? 'https://example.test/full.mp4' : null } as JobStatusResult;
+    },
+  });
+  assert.equal(waits, 1001); // More than 80 minutes at the real polling interval.
+  assert.equal(terminals, 1);
+  assert.equal(result.output?.url, 'https://example.test/full.mp4');
+});
+
+test('upscale duration tolerance never grows with clip length or silence', () => {
+  for (const duration of [6.041667, 30, 300, 1800]) {
+    assert.equal(upscaleDurationIsComplete(duration, duration, 24), true);
+    assert.equal(upscaleDurationIsComplete(duration, duration - 1 / 24, 24), true);
+    for (const missing of [0.375, 0.5, 5, 30]) {
+      if (duration > missing) assert.equal(upscaleDurationIsComplete(duration, duration - missing, 24), false);
+    }
+  }
+});
+
+test('replayed accepted jobs preserve terminal failure and reject a different payload', async () => {
+  const executor = { query: async <T>() => [{ job_id: 'job', status: 'failed', settings_snapshot: { requestFingerprint: 'same' }, final_price_cents: 100 }] as T[] };
+  assert.equal((await readAcceptedUpscale('job', 'same', executor))?.status, 'failed');
+  await assert.rejects(readAcceptedUpscale('job', 'changed', executor), /different settings/);
+});

--- a/tests/upscale-provider-tracking.test.ts
+++ b/tests/upscale-provider-tracking.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import test from 'node:test';
+
+const modulePath = `${process.cwd()}/frontend/src/server/tools/upscale-provider-submission.ts`;
+
+test('upscale provider tracking is durable before the long Fal status wait starts', async () => {
+  assert.ok(existsSync(modulePath), 'the durable upscale provider submission helper should exist');
+  const submissionModule = await import(pathToFileURL(modulePath).href) as {
+    runDurablyTrackedUpscaleRequest?: (params: {
+      modelId: string;
+      input: Record<string, unknown>;
+      persistProviderJobId(requestId: string): Promise<void>;
+      onQueueUpdate(update: unknown): void;
+      queue: {
+        submit(modelId: string, options: { input: Record<string, unknown> }): Promise<{ request_id: string }>;
+        subscribeToStatus(modelId: string, options: {
+          requestId: string;
+          mode: 'polling';
+          onQueueUpdate(update: unknown): void;
+        }): Promise<unknown>;
+        result(modelId: string, options: { requestId: string }): Promise<unknown>;
+      };
+    }) => Promise<{ providerJobId: string; result: unknown }>;
+  };
+  assert.equal(typeof submissionModule.runDurablyTrackedUpscaleRequest, 'function');
+
+  let releasePersistence!: () => void;
+  let persistenceStarted!: () => void;
+  const persistenceGate = new Promise<void>((resolve) => { releasePersistence = resolve; });
+  const enteredPersistence = new Promise<void>((resolve) => { persistenceStarted = resolve; });
+  const events: string[] = [];
+  const providerResult = {
+    requestId: 'fal-upscale-request',
+    data: { video: { url: 'https://example.test/upscaled.mp4' } },
+  };
+
+  const request = submissionModule.runDurablyTrackedUpscaleRequest!({
+    modelId: 'fal-ai/seedvr/upscale/video',
+    input: { video_url: 'https://example.test/source.mp4' },
+    persistProviderJobId: async (requestId) => {
+      assert.equal(requestId, 'fal-upscale-request');
+      events.push('persist:start');
+      persistenceStarted();
+      await persistenceGate;
+      events.push('persist:done');
+    },
+    onQueueUpdate: () => { events.push('queue:update'); },
+    queue: {
+      async submit() {
+        events.push('submit');
+        return { request_id: 'fal-upscale-request' };
+      },
+      async subscribeToStatus(_modelId, options) {
+        assert.equal(options.requestId, 'fal-upscale-request');
+        events.push('status:wait');
+        options.onQueueUpdate({ status: 'COMPLETED', request_id: options.requestId });
+      },
+      async result(_modelId, options) {
+        assert.equal(options.requestId, 'fal-upscale-request');
+        events.push('result');
+        return providerResult;
+      },
+    },
+  });
+
+  await enteredPersistence;
+  assert.deepEqual(events, ['submit', 'persist:start']);
+  releasePersistence();
+
+  assert.deepEqual(await request, {
+    providerJobId: 'fal-upscale-request',
+    result: providerResult,
+  });
+  assert.deepEqual(events, [
+    'submit',
+    'persist:start',
+    'persist:done',
+    'status:wait',
+    'queue:update',
+    'result',
+  ]);
+});

--- a/tests/upscale-server-architecture.test.ts
+++ b/tests/upscale-server-architecture.test.ts
@@ -8,6 +8,7 @@ const serverPath = join(root, 'frontend/src/server/tools/upscale.ts');
 const requestUtilsPath = join(root, 'frontend/src/server/tools/upscale-request-utils.ts');
 const pricingContextPath = join(root, 'frontend/src/server/tools/upscale-pricing-context.ts');
 const jobPersistencePath = join(root, 'frontend/src/server/tools/upscale-job-persistence.ts');
+const providerSubmissionPath = join(root, 'frontend/src/server/tools/upscale-provider-submission.ts');
 const outputPersistencePath = join(root, 'frontend/src/server/tools/upscale-output-persistence.ts');
 const errorsPath = join(root, 'frontend/src/server/tools/upscale-errors.ts');
 const constantsPath = join(root, 'frontend/src/server/tools/upscale-constants.ts');
@@ -16,6 +17,7 @@ const serverSource = readFileSync(serverPath, 'utf8');
 const requestUtilsSource = readFileSync(requestUtilsPath, 'utf8');
 const pricingContextSource = readFileSync(pricingContextPath, 'utf8');
 const jobPersistenceSource = readFileSync(jobPersistencePath, 'utf8');
+const providerSubmissionSource = readFileSync(providerSubmissionPath, 'utf8');
 const outputPersistenceSource = readFileSync(outputPersistencePath, 'utf8');
 const errorsSource = readFileSync(errorsPath, 'utf8');
 const constantsSource = readFileSync(constantsPath, 'utf8');
@@ -24,6 +26,7 @@ test('upscale server delegates request and provider normalization helpers', () =
   assert.ok(existsSync(requestUtilsPath), 'upscale request helpers should live in a server-local utility module');
   assert.ok(existsSync(pricingContextPath), 'upscale pricing context should live in a focused server module');
   assert.ok(existsSync(jobPersistencePath), 'upscale job persistence should live in a focused server module');
+  assert.ok(existsSync(providerSubmissionPath), 'upscale provider submission should live in a focused server module');
   assert.ok(existsSync(outputPersistencePath), 'upscale output persistence should live in a focused server module');
   assert.ok(existsSync(errorsPath), 'upscale errors should live in a small shared server module');
   assert.ok(existsSync(constantsPath), 'upscale constants should live in a small shared server module');
@@ -34,6 +37,7 @@ test('upscale server delegates request and provider normalization helpers', () =
   );
   assert.match(serverSource, /from '\.\/upscale-pricing-context'/);
   assert.match(serverSource, /from '\.\/upscale-job-persistence'/);
+  assert.match(serverSource, /from '\.\/upscale-provider-submission'/);
   assert.match(serverSource, /from '\.\/upscale-output-persistence'/);
   assert.match(serverSource, /from '\.\/upscale-errors'/);
   assert.match(serverSource, /from '\.\/upscale-constants'/);
@@ -104,9 +108,15 @@ test('upscale persistence modules expose job, event, output, and error contracts
   assert.match(pricingContextSource, /computeBillingProductSnapshot/);
   assert.match(pricingContextSource, /estimateImageUpscaleCostUsd/);
   assert.match(pricingContextSource, /estimateVideoUpscaleCostUsd/);
-  for (const exportName of ['recordUpscaleRefundReceipt', 'createAtomicInitialUpscaleJob', 'insertUpscaleToolEvent']) {
+  for (const exportName of [
+    'recordUpscaleRefundReceipt',
+    'createAtomicInitialUpscaleJob',
+    'persistQueuedUpscaleRequest',
+    'insertUpscaleToolEvent',
+  ]) {
     assert.match(jobPersistenceSource, new RegExp(`export async function ${exportName}`));
   }
+  assert.match(providerSubmissionSource, /export async function runDurablyTrackedUpscaleRequest/);
   assert.match(jobPersistenceSource, /export type PendingUpscaleReceipt/);
   assert.match(jobPersistenceSource, /export type CreateUpscaleInitialJobParams/);
   assert.match(outputPersistenceSource, /export async function persistUpscaleOutput/);

--- a/tests/video-mux-duration.test.ts
+++ b/tests/video-mux-duration.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { buildVideoPreservingMuxArgs } from '../frontend/src/server/audio/video-mux-args';
+
+test('real mux preserves every video frame with 0.5s and 30s missing audio tails and longer audio', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'mux-duration-'));
+  const run = (args: string[]) => execFileSync('ffmpeg', ['-v', 'error', ...args], { timeout: 30_000 });
+  const frames = (file: string) => JSON.parse(execFileSync('ffprobe', ['-v', 'error', '-select_streams', 'v:0', '-count_frames', '-show_entries', 'stream=nb_read_frames', '-of', 'json', file], { encoding: 'utf8' })).streams[0].nb_read_frames;
+  try {
+    const video = join(dir, 'video.mp4'), audio = join(dir, 'audio.m4a'), output = join(dir, 'out.mp4');
+    for (const [videoSec, audioSec] of [[2, 1.5], [31, 1], [2, 5]]) {
+      run(['-y', '-f', 'lavfi', '-i', 'testsrc2=s=64x64:r=24', '-t', String(videoSec), '-c:v', 'libx264', video]);
+      run(['-y', '-f', 'lavfi', '-i', 'sine=frequency=440:sample_rate=48000', '-t', String(audioSec), '-c:a', 'aac', audio]);
+      run(buildVideoPreservingMuxArgs(video, audio, output));
+      assert.equal(frames(output), frames(video), `${videoSec}s video / ${audioSec}s audio`);
+    }
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
## Summary
- enqueue Fal video and upscale work so server request limits do not terminate long renders
- make video upscale intent, wallet debit, provider tracking, and refund recovery idempotent
- preserve full video duration through audio muxing and reject/refund truncated upscale outputs transactionally
- stream larger provider originals to bounded temporary storage and document remaining long-running risks

## Verification
- 146 focused tests passed, including PostgreSQL concurrency/refund rollback and real ffmpeg duration cases
- frontend lint, server lint, exposure check, TypeScript, and production build passed
- full repository suite passes except two Studio integration tests that intentionally require Node 22; local installed runtimes are Node 23/24, so remote CI is the authoritative run
- six PostgreSQL Studio tests pass when run with the required PostgreSQL 17

## Production follow-up
- wait for preview and CI checks
- merge only when green
- run one explicitly budgeted small video upscale and confirm one app job, debit, and Fal request