### PR TITLE
Preserve Fal content refusal diagnostics across job lifecycle

### DIFF
--- a/docs/engineering/fal-job-failures.md
+++ b/docs/engineering/fal-job-failures.md
@@ -1,0 +1,33 @@
+# Fal job failure diagnostics
+
+Fal webhooks place model output or validation details in `payload`. Keep legacy
+`result`, `response` and `data` compatibility, but do not discard the native
+envelope. An outer `Unexpected status code: 422` is transport context, not the
+failure cause. SDK result reads expose the equivalent details in `Error.body`.
+
+`frontend/server/fal-webhook-errors.ts` owns diagnostic extraction. It follows
+diagnostic containers only and must not echo rejected inputs, media URLs, request
+IDs or metrics as error messages. A typed `content_policy_violation` is a content
+refusal; a bare 422 does not establish moderation.
+
+The webhook passes that explanation through the shared user-facing sanitizer to
+the job, refund helper and lifecycle log. Safety guidance covers prompts and
+reference media, not only prompt wording. Admin audit prioritizes lifecycle logs
+and refund metadata over the job message, so a historical description repair
+must keep all three aligned and preserve the original values in an audit trail.
+
+Queue `COMPLETED` means processing ended, not necessarily successful inference.
+Polling can settle a structured 422 result as a terminal rejection. Authentication,
+missing-result, rate-limit and server read errors must not authorize refunds.
+Never resubmit a paid generation to diagnose its status.
+
+Wallet credits and provider spending are distinct. A refunded job that later
+delivers output is an improper wallet refund; a content refusal with no output
+is not proof of an improper refund. Pricing snapshots are estimates, not billing
+events. Do not add wallet refunds to provider costs and call the sum a loss.
+
+Focused regression checks:
+
+```sh
+frontend/node_modules/.bin/tsx --tsconfig frontend/tsconfig.json --test tests/fal-webhook-errors.test.ts tests/fal-webhook-content-persistence.test.ts tests/fal-long-running-poll.test.ts tests/user-facing-failure-messages.test.ts
+```

--- a/frontend/server/fal-poll.ts
+++ b/frontend/server/fal-poll.ts
@@ -9,6 +9,7 @@ import { backfillCompletedMcpJobOutputs } from '@/server/media-library/mcp-outpu
 import { toUserFacingFailureMessage } from '@/server/user-facing-failure-messages';
 import { getFalPollTiming } from '@/server/fal-poll-timing';
 import { reconcileStaleFalProvisionals } from '@/server/fal-stale-provisionals';
+import { extractFalErrorMessage } from '@/server/fal-webhook-errors';
 
 type FalPendingJob = {
   job_id: string;
@@ -275,7 +276,19 @@ export async function runFalPoll(dependencies: Partial<typeof defaults> = {}) {
         continue;
       }
 
-      const result = await falClient.queue.result(falModel, { requestId: job.provider_job_id });
+      let result: Awaited<ReturnType<typeof falClient.queue.result>>;
+      try {
+        result = await falClient.queue.result(falModel, { requestId: job.provider_job_id });
+      } catch (error) {
+        const failure = error as { status?: number; body?: { detail?: unknown } } | null;
+        // COMPLETED is the queue state, not proof of successful inference. A
+        // structured 422 result is a terminal input rejection, unlike a read error.
+        const reason = state && COMPLETED_STATES.has(state) && failure?.status === 422 && failure.body?.detail
+          ? extractFalErrorMessage({ error: failure.body }) : null;
+        if (!reason) throw error;
+        await markJobFailed(reason, { autoRefundEligible: true, failureOrigin: 'provider_terminal' });
+        continue;
+      }
       if (!result) {
         if (timedOut && !beyondTimeoutGrace) {
           await recordPollEvent(

--- a/frontend/server/fal-webhook-errors.ts
+++ b/frontend/server/fal-webhook-errors.ts
@@ -40,66 +40,51 @@ function normalizeErrorText(value: unknown): string | null {
 }
 
 function findFirstErrorMessage(payload: unknown): string | null {
-  if (!payload || typeof payload !== 'object') {
-    return normalizeErrorText(payload);
-  }
-
   const visited = new Set<unknown>();
   const stack: unknown[] = [payload];
+  let transportFallback: string | null = null;
 
   while (stack.length) {
     const current = stack.pop();
     if (!current || typeof current !== 'object') {
       const text = normalizeErrorText(current);
-      if (text) return text;
+      if (text) {
+        if (isTransportError(text)) transportFallback ??= text;
+        else return text;
+      }
       continue;
     }
     if (visited.has(current)) continue;
     visited.add(current);
-
-    const record = current as Record<string, unknown>;
-    for (const key of ERROR_MESSAGE_KEYS) {
-      if (key in record) {
-        const candidate = normalizeErrorText(record[key]);
-        if (candidate) return candidate;
-      }
+    if (Array.isArray(current)) {
+      stack.push(...current.slice(0, 50).reverse());
+      continue;
     }
-
-    for (const value of Object.values(record)) {
-      if (value && typeof value === 'object') {
-        stack.push(value);
-      } else {
-        const text = normalizeErrorText(value);
-        if (text) return text;
-      }
+    const record = current as Record<string, unknown>;
+    if (record.type === 'content_policy_violation') {
+      return 'The request content was blocked by safety checks. Review the prompt and reference media before trying again.';
+    }
+    // Traverse diagnostic containers only. Never treat echoed input, media URLs,
+    // request IDs, status values, metrics or seeds as a failure explanation.
+    const keys = ['payload', 'body', ...ERROR_MESSAGE_KEYS, 'result', 'response', 'data'];
+    for (const key of keys.reverse()) {
+      if (record[key] != null) stack.push(record[key]);
     }
   }
+  return transportFallback;
+}
 
-  return null;
+function isTransportError(message: string): boolean {
+  return /^(?:(?:unexpected|invalid)\s+)?(?:http\s+)?status(?:\s+code)?\s*:?\s*\d{3}\b|^unprocessable entity$/i.test(message);
 }
 
 export function extractFalErrorMessage(payload: FalWebhookPayload, additionalContext?: unknown): string | null {
-  const direct = normalizeErrorText(payload.error);
-  if (direct) return direct;
-
-  const nestedSources: unknown[] = [];
-  if (payload.error && typeof payload.error === 'object') {
-    nestedSources.push(payload.error);
-  }
-  if (payload.result) nestedSources.push(payload.result);
-  if (payload.response) nestedSources.push(payload.response);
-  if (payload.data) nestedSources.push(payload.data);
-  if (additionalContext && typeof additionalContext === 'object') {
-    nestedSources.push(additionalContext);
-  }
-
-  for (const source of nestedSources) {
+  let fallback: string | null = null;
+  for (const source of [payload.payload, additionalContext, payload.error, payload.result, payload.response, payload.data, payload]) {
     const candidate = findFirstErrorMessage(source);
-    if (candidate) return candidate;
+    if (!candidate) continue;
+    if (!isTransportError(candidate)) return candidate;
+    fallback ??= candidate;
   }
-
-  const fallback = findFirstErrorMessage(payload);
-  if (fallback) return fallback;
-
-  return null;
+  return fallback;
 }

--- a/frontend/server/fal-webhook-handler.ts
+++ b/frontend/server/fal-webhook-handler.ts
@@ -148,7 +148,8 @@ export async function updateJobFromFalWebhook(rawPayload: unknown): Promise<void
     ? normalizeMediaUrl(job.hero_render_id) ?? job.hero_render_id
     : null;
 
-  let finalPayload = payload.result ?? payload.response ?? payload.data ?? null;
+  let finalPayload = payload.payload ?? payload.result ?? payload.response ?? payload.data ?? null;
+  let resultFailureContext: unknown = null;
   const statusInfo = normalizeStatus(payload.status, job.status, job.progress);
   let nextStatus = statusInfo.status;
   let nextProgress = statusInfo.progress;
@@ -171,6 +172,9 @@ export async function updateJobFromFalWebhook(rawPayload: unknown): Promise<void
         }
       }
     } catch (error) {
+      // SDK ValidationError.body contains the actual rejection; its message may
+      // contain only "Unprocessable Entity". Keep it available to diagnostics.
+      resultFailureContext = error;
       if (nextStatus === 'completed') {
         console.warn('[fal-webhook] Failed to fetch final result', error);
       }
@@ -265,7 +269,7 @@ export async function updateJobFromFalWebhook(rawPayload: unknown): Promise<void
     }
   }
 
-  const extractedErrorMessage = extractFalErrorMessage(payload, nextStatus === 'failed' ? finalPayload : null);
+  const extractedErrorMessage = extractFalErrorMessage(payload, nextStatus === 'failed' ? resultFailureContext ?? finalPayload : null);
   let nextMessage =
     extractedErrorMessage ??
     (nextStatus === 'failed'

--- a/frontend/server/fal-webhook-mapping-types.ts
+++ b/frontend/server/fal-webhook-mapping-types.ts
@@ -2,6 +2,8 @@ export type FalWebhookPayload = {
   request_id?: string;
   requestId?: string;
   status?: string;
+  payload?: unknown;
+  payload_error?: unknown;
   response?: unknown;
   data?: unknown;
   result?: unknown;

--- a/frontend/server/user-facing-failure-messages.ts
+++ b/frontend/server/user-facing-failure-messages.ts
@@ -180,7 +180,7 @@ function messageForCategory(category: FailureCategory): string {
     case 'no_output':
       return 'The render finished without a usable output. Please retry or contact support with your request ID if it happens again.';
     case 'safety':
-      return 'This request was blocked by safety checks. Try rephrasing it with safer, more neutral wording.';
+      return 'This request was blocked by safety checks. Review the prompt and any reference images, video, or audio before trying again.';
     case 'start':
       return 'MaxVideoAI could not start this render. Please retry in a few moments.';
     case 'storage':

--- a/tests/fal-long-running-poll.test.ts
+++ b/tests/fal-long-running-poll.test.ts
@@ -2,6 +2,42 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { runFalPoll } from '../frontend/server/fal-poll';
 
+test('completed queue with a structured content rejection settles as failed, while read errors remain pending', async () => {
+  const rejection = { detail: [{ type: 'content_policy_violation', loc: ['body', 'prompt'], msg: 'Flagged by a content checker.' }] };
+  const cases = [
+    ...[422, 401, 404, 429, 500].map(httpStatus => ({ httpStatus, state: 'COMPLETED', body: rejection, terminal: httpStatus === 422 })),
+    { httpStatus: 422, state: 'COMPLETED', body: {}, terminal: false },
+    { httpStatus: 422, state: 'COMPLETED', body: { detail: [] }, terminal: false },
+    { httpStatus: 422, state: 'UNKNOWN', body: rejection, terminal: false },
+  ];
+  for (const { httpStatus, state, body, terminal } of cases) {
+    const updates: Array<Record<string, unknown>> = [];
+    const dependencies = {
+      query: async <T>(sql: string): Promise<T[]> => {
+        if (sql.includes('SELECT job_id, surface, engine_id')) return [{ job_id: 'content-rejection', engine_id: 'seedvr-video', surface: 'video', provider_job_id: 'fal-request', status: 'running', created_at: '2026-01-01', updated_at: '2026-01-01' }] as T[];
+        if (sql.includes('COUNT(*)::int')) return [{ attempts: 0, last_attempt_at: null }] as T[];
+        return [];
+      },
+      getFalClient: () => ({ queue: {
+        status: async () => ({ status: state }),
+        result: async () => { throw Object.assign(new Error('Unprocessable Entity'), { status: httpStatus, body }); },
+      } }),
+      updateJobFromFalWebhook: async (payload: unknown) => { updates.push(payload as Record<string, unknown>); },
+      reconcileStaleFalProvisionals: async () => ({ failed: 0 }),
+      reconcileFinishingJobs: async () => ({ checked: 0, reconciled: 0, failures: 0 }),
+      backfillCompletedMcpJobOutputs: async () => ({ promoted: 0, failed: 0 }),
+    } as unknown as Parameters<typeof runFalPoll>[0];
+    await runFalPoll(dependencies);
+    if (terminal) {
+      assert.equal(updates.length, 1);
+      assert.equal(updates[0]?.status, 'failed');
+      assert.equal(updates[0]?.auto_refund_eligible, true);
+      assert.equal(updates[0]?.failure_origin, 'provider_terminal');
+      assert.match(JSON.stringify(updates[0]), /safety checks/);
+    } else assert.equal(updates.length, 0, 'HTTP read errors alone cannot authorize a refund');
+  }
+});
+
 test('real Fal poll keeps old jobs active through transient errors and only fails confirmed provider failures', async () => {
   for (const scenario of ['running', 'offline', 'result-unavailable', 'completed', 'failed']) {
     const updates: Array<Record<string, unknown>> = [];

--- a/tests/fal-webhook-content-persistence.test.ts
+++ b/tests/fal-webhook-content-persistence.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import path from 'node:path';
+import { runInNewContext } from 'node:vm';
+import { build } from 'esbuild';
+
+test('real webhook persists the same content refusal in job, output, refund and audit log', async () => {
+  const frontend = path.join(process.cwd(), 'frontend');
+  const stubs: Record<string, string> = {
+    '@/lib/db': 'export const query = (...args) => fixture.query(...args);',
+    './fal-webhook-refunds': 'export const maybeAutoRefundWalletCharge = async (...args) => fixture.refunds.push(args);',
+    './fal-webhook-provisional': 'export const createProvisionalJobFromWebhook = async () => { throw Error("Unexpected provisional"); };',
+    '@/lib/fal-client': 'export const getFalClient = () => ({ queue: { result: async () => { fixture.reads++; throw fixture.readError; } } });',
+    '@/lib/fal-catalog': 'export const resolveFalModelId = async () => "fixture/model";',
+    '@/config/falEngines': 'export const getFalEngineById = () => ({ category: "video" });',
+    './fal-webhook-engine': 'export const inferEngineFromPayload = async () => ({}); export const getUpscaleToolMediaType = () => null;',
+    '@/server/thumbnails': 'export const ensureJobThumbnail = async () => null; export const isPlaceholderThumbnail = () => true;',
+    '@/server/video-faststart': 'export const ensureFastStartVideo = async () => null;',
+    '@/server/video-keyframes': 'export const generateAndPersistJobKeyframes = async () => {};',
+    '@/server/video-preview': 'export const generateAndPersistJobPreviewVideo = async () => {};',
+    '@/server/fal-job-sync': 'export const fetchFalJobMedia = async () => ({});',
+    '@/server/media/detect-has-audio': 'export const detectHasAudioStream = async () => false; export const detectVideoDimensions = async () => null;',
+    '@/server/media-library': 'export const upsertLegacyJobOutputs = async (value) => fixture.outputs.push(value);',
+    './upscale-duration-integrity': 'export const checkUpscaleDuration = async () => "complete"; export const rejectTruncatedUpscale = async () => {};',
+  };
+  const bundle = await build({
+    absWorkingDir: frontend, bundle: true, format: 'cjs', platform: 'node', write: false,
+    tsconfig: path.join(frontend, 'tsconfig.json'),
+    entryPoints: ['server/fal-webhook-handler.ts'],
+    plugins: [{ name: 'external-boundaries', setup(builder) {
+      builder.onResolve({ filter: /.*/ }, args => args.path in stubs ? { path: args.path, namespace: 'fixture' } : undefined);
+      builder.onLoad({ filter: /.*/, namespace: 'fixture' }, args => ({ contents: stubs[args.path], loader: 'js', resolveDir: frontend }));
+    } }],
+  });
+  const detail = [{ type: 'content_policy_violation', loc: ['body', 'image_url'], input: 'PRIVATE_REFERENCE', msg: 'Flagged by content checker.' }];
+  for (const nativePayload of [true, false]) {
+    const updates: unknown[][] = [];
+    const logs: unknown[][] = [];
+    const fixture = {
+      reads: 0, refunds: [] as unknown[][], outputs: [] as { status: string }[],
+      readError: Object.assign(new Error('Unprocessable Entity'), { status: 422, body: { detail } }),
+      query: async (sql: string, params: unknown[]) => {
+        if (sql.startsWith('SELECT')) return [{
+          job_id: 'job_fixture', engine_id: 'minimax-h3', engine_label: 'MiniMax H3',
+          status: 'running', progress: 30, payment_status: 'paid_wallet', user_id: 'fixture-owner',
+          video_url: null, render_ids: [], created_at: '2026-09-11T12:00:00Z',
+        }];
+        if (sql.startsWith('UPDATE')) { updates.push(params); return [{ job_id: 'job_fixture' }]; }
+        if (sql.startsWith('INSERT INTO fal_queue_log')) { logs.push(params); return []; }
+        throw new Error('Unexpected SQL boundary');
+      },
+    };
+    const module = { exports: {} as { updateJobFromFalWebhook(payload: unknown): Promise<void> } };
+    runInNewContext(bundle.outputFiles[0].text, { module, exports: module.exports, fixture, URL, process: { env: {} }, console: { info() {}, warn() {}, error() {} } });
+    await module.exports.updateJobFromFalWebhook({
+      request_id: 'provider-fixture', status: 'ERROR', error: 'Unexpected status code: 422',
+      ...(nativePayload ? { payload: { detail } } : {}),
+    });
+    assert.equal(updates.length, 1);
+    assert.equal(updates[0][1], 'failed');
+    const message = updates[0][6] as string;
+    assert.match(message, /blocked by safety checks/);
+    assert.match(message, /reference images, video, or audio/);
+    assert.doesNotMatch(message, /422|PRIVATE_REFERENCE/);
+    assert.equal(fixture.reads, nativePayload ? 0 : 1);
+    assert.equal(fixture.outputs[0].status, 'failed');
+    assert.equal(fixture.refunds.length, 1);
+    assert.equal((fixture.refunds[0][1] as { failureMessage: string }).failureMessage, message);
+    assert.equal(JSON.parse(logs[0][5] as string).message, message);
+  }
+});

--- a/tests/fal-webhook-errors.test.ts
+++ b/tests/fal-webhook-errors.test.ts
@@ -2,6 +2,59 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { extractFalErrorMessage } from '../frontend/server/fal-webhook-errors.ts';
+import { toUserFacingFailureMessage, toUserFacingRefundReason } from '../frontend/server/user-facing-failure-messages.ts';
+
+const contentError = {
+  detail: [{ type: 'content_policy_violation', loc: ['body', 'image_url'],
+    msg: 'The content could not be processed because it contained material flagged by a content checker.',
+    input: 'https://private.test/reference?token=secret' }],
+};
+
+test('official Fal webhook payload keeps content refusal instead of the transport 422 wrapper', () => {
+  const message = extractFalErrorMessage({ status: 'ERROR', error: 'Unexpected status code: 422', payload: contentError });
+  assert.match(toUserFacingFailureMessage(message), /safety checks/);
+  assert.match(toUserFacingRefundReason(message), /safety checks/);
+  assert.doesNotMatch(message ?? '', /private|token|secret|422/);
+});
+
+test('SDK result failure body wins over its generic Error message', () => {
+  const sdkError = Object.assign(new Error('Unprocessable Entity'), { status: 422, body: contentError });
+  assert.match(toUserFacingFailureMessage(extractFalErrorMessage({ error: sdkError })), /safety checks/);
+});
+
+test('provider type alone can identify content refusal without echoing rejected input', () => {
+  const message = extractFalErrorMessage({ status: 'ERROR', payload: {
+    detail: [{ type: 'content_policy_violation', loc: ['body', 'prompt'], input: 'private rejected prompt' }],
+  } });
+  assert.match(toUserFacingFailureMessage(message), /safety checks/);
+  assert.doesNotMatch(message ?? '', /private rejected prompt/);
+});
+
+test('422 validation without content evidence must not be labeled moderation', () => {
+  const message = extractFalErrorMessage({ status: 'ERROR', error: 'Unexpected status code: 422', payload: {
+    detail: [{ type: 'value_error', loc: ['body', 'duration'], msg: 'Unsupported duration.', input: 20 }],
+  } });
+  assert.match(toUserFacingFailureMessage(message), /not supported/);
+  assert.doesNotMatch(toUserFacingFailureMessage(message), /safety/);
+});
+
+test('successful payload identifiers, metrics and media are never error messages', () => {
+  assert.equal(extractFalErrorMessage({ request_id: 'request-identifier', status: 'OK', payload: {
+    video: { url: 'https://private.test/output.mp4' }, seed: 12, metrics: { inference_time: 3 },
+  } }), null);
+});
+
+test('nested diagnostic message wins over sibling type and location fields', () => {
+  assert.equal(extractFalErrorMessage({ error: { type: 'validation_error', detail: [
+    { type: 'value_error', loc: ['body', 'prompt'], msg: 'Unsupported duration.' },
+  ] } }), 'Unsupported duration.');
+});
+
+test('cyclic and arbitrary context does not become an error or loop forever', () => {
+  const cyclic: Record<string, unknown> = { input: 'secret', request_id: 'opaque' };
+  cyclic.detail = cyclic;
+  assert.equal(extractFalErrorMessage({ error: cyclic }), null);
+});
 
 test('Fal webhook diagnostics prefer a nested provider message over an error type token', () => {
   const message = extractFalErrorMessage({

--- a/tests/user-facing-failure-messages.test.ts
+++ b/tests/user-facing-failure-messages.test.ts
@@ -9,6 +9,12 @@ import {
 
 const forbidden = /fal(?:\.ai)?|fail\.ai|byteplus|modelark|google\s+vertex|kling\s+direct|provider/i;
 
+test('content refusals explain that reference media may also need changing', () => {
+  const message = toUserFacingFailureMessage('The request content was blocked by safety checks.');
+  assert.match(message, /Review the prompt and any reference images, video, or audio/);
+  assert.doesNotMatch(message, /retry in a few moments/i);
+});
+
 test('user-facing failure messages hide provider and internal wording', () => {
   const message = toUserFacingFailureMessage('Fal returned no result after timeout grace period.');
 


### PR DESCRIPTION
## Summary

- preserve Fal's native `payload.detail` and SDK error-body diagnostics instead of reducing content refusals to an outer HTTP 422
- propagate one sanitized, actionable content-policy message through jobs, wallet refund metadata, lifecycle logs, and admin audit
- settle only `COMPLETED` queue results with a structured 422 as terminal; authentication, missing-result, rate-limit, and server read errors remain pending
- document the failure/refund boundary and add integration and regression coverage

No engine is disabled or rerouted. This change does not resubmit generations, rebill users, or alter wallet amounts.

## Incident evidence

The September 11 production audit re-read 25 Fal video failures. Every retained result returned HTTP 422 with `content_policy_violation`; 17 jobs had shown a generic technical-failure message. Their existing wallet refunds were appropriate because no output was delivered. Historical display metadata was corrected separately with amounts and payment states preserved.

## Validation

- `75/75` focused Fal/refund/admin tests on Node 22
- TypeScript `--noEmit`
- frontend and touched-file ESLint
- public-exposure check
- `git diff --check`
- full Next.js build, including registry/media prebuild gates and 871 static pages
- independent review: no critical or important findings
- full suite under Node 22/PostgreSQL 17: 5,382 passed, 3 concurrent Studio/MCP fixture timeouts; the three affected files then passed sequentially (10/10)

No paid end-to-end generation was submitted.
